### PR TITLE
fix: prevent duplicate toast listeners

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,8 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // Run effect only once on mount to avoid duplicate listeners
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid duplicate toast listeners by running effect only once

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 59 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68921dc87a208322b6ab845be2beb343