### PR TITLE
feat: load admin ids from env

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -8,7 +8,12 @@ const BINANCE_SECRET_KEY = Deno.env.get("BINANCE_SECRET_KEY");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-const ADMIN_USER_IDS = ["225513686"];
+
+// Allow configuring admin IDs via environment variable (comma-separated)
+const ADMIN_USER_IDS = (Deno.env.get("ADMIN_USER_IDS")
+  ?.split(",")
+  .map((id) => id.trim())
+  .filter(Boolean)) ?? ["225513686"];
 
 // User sessions for features
 const userSessions = new Map();


### PR DESCRIPTION
## Summary
- allow configuring Telegram admin users via ADMIN_USER_IDS env var

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 59 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689240cd74988322bd4901ec993ace7e