### PR TITLE
feat: make admin user ids configurable

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -8,7 +8,10 @@ const BINANCE_SECRET_KEY = Deno.env.get("BINANCE_SECRET_KEY");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-const ADMIN_USER_IDS = ["225513686"];
+const ADMIN_USER_IDS = (Deno.env.get("ADMIN_USER_IDS") || "225513686")
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
 
 // User sessions for features
 const userSessions = new Map();


### PR DESCRIPTION
## Summary
- allow configuring Telegram admin IDs via `ADMIN_USER_IDS` env var

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 51 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689240cd74988322bd4901ec993ace7e