### PR TITLE
feat: make admin ids configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Telegram bot configuration
+
+The Supabase edge function located at `supabase/functions/telegram-bot` reads several environment variables:
+
+- `TELEGRAM_BOT_TOKEN` – token for your Telegram bot.
+- `SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_URL` – Supabase project URL.
+- `SUPABASE_ANON_KEY` or `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` – Supabase anon key.
+- `ADMIN_USER_IDS` – comma‑separated list of Telegram user IDs allowed to access the `/admin` command.
+
+Ensure these variables are set when deploying the function so admin users can access the dashboard.

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5,10 +5,16 @@ const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
 const BINANCE_API_KEY = Deno.env.get("BINANCE_API_KEY");
 const BINANCE_SECRET_KEY = Deno.env.get("BINANCE_SECRET_KEY");
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
-const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
+const SUPABASE_URL =
+  Deno.env.get("SUPABASE_URL") || Deno.env.get("NEXT_PUBLIC_SUPABASE_URL");
+const SUPABASE_ANON_KEY =
+  Deno.env.get("SUPABASE_ANON_KEY") ||
+  Deno.env.get("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-const ADMIN_USER_IDS = ["225513686"];
+// Comma-separated list of Telegram user IDs allowed to access admin features
+const ADMIN_USER_IDS =
+  Deno.env.get("ADMIN_USER_IDS")?.split(",").map((id) => id.trim()).filter(Boolean) ??
+  ["225513686"];
 
 // User sessions for features
 const userSessions = new Map();


### PR DESCRIPTION
## Summary
- allow Telegram bot to read Supabase and admin IDs from env variables
- document required environment variables for the bot

## Testing
- `npm run lint` *(fails: Unexpected lexical declaration in case block)*
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_689240cd74988322bd4901ec993ace7e