### PR TITLE
feat: modernize bot messages and configurable admin ids

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -136,34 +136,40 @@ export const AdminDashboard = () => {
 
   const exportData = async (tableName: string) => {
     try {
-      let data: any[] = [];
+      let data: unknown[] = [];
       
       // Type-safe table queries
       switch (tableName) {
-        case 'bot_users':
+        case 'bot_users': {
           const { data: users } = await supabase.from('bot_users').select('*');
           data = users || [];
           break;
-        case 'payments':
+        }
+        case 'payments': {
           const { data: payments } = await supabase.from('payments').select('*');
           data = payments || [];
           break;
-        case 'user_subscriptions':
+        }
+        case 'user_subscriptions': {
           const { data: subscriptions } = await supabase.from('user_subscriptions').select('*');
           data = subscriptions || [];
           break;
-        case 'education_enrollments':
+        }
+        case 'education_enrollments': {
           const { data: enrollments } = await supabase.from('education_enrollments').select('*');
           data = enrollments || [];
           break;
-        case 'promotions':
+        }
+        case 'promotions': {
           const { data: promotions } = await supabase.from('promotions').select('*');
           data = promotions || [];
           break;
-        case 'daily_analytics':
+        }
+        case 'daily_analytics': {
           const { data: analytics } = await supabase.from('daily_analytics').select('*');
           data = analytics || [];
           break;
+        }
         default:
           throw new Error('Invalid table name');
       }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -107,5 +108,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- allow configuring Telegram admin users via ADMIN_USER_IDS env var
- update bot welcome and feedback texts for a friendlier tone
- support NEXT_PUBLIC_* Supabase env vars and recognize `/admin@botname` commands
- load additional admin IDs from Supabase `bot_users` table for dynamic management
- clean up Tailwind plugin import and fix dashboard export switch for linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 8 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689240cd74988322bd4901ec993ace7e