### PR TITLE
feat: modernize bot messages and configurable admin ids

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+const SUPABASE_URL = import.meta.env.NEXT_PUBLIC_SUPABASE_URL || "https://qeejuomcapbdlhnjqjcc.supabase.co";
+const SUPABASE_PUBLISHABLE_KEY =
+  import.meta.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY ||
+  "sb_publishable_Kcp6zvAK3Qa4qwCW9tIHJQ_ERTLm8KA";
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- allow configuring Telegram admin users via ADMIN_USER_IDS env var
- update bot welcome and feedback texts for a friendlier tone
- support NEXT_PUBLIC_* Supabase env vars and recognize `/admin@botname` commands
- load additional admin IDs from Supabase `bot_users` table for dynamic management
- add startup checks for Supabase/Telegram connectivity and a basic `/help` command
- parallelize startup connectivity checks and load welcome message template from Supabase
- trim Supabase queries to essential columns for lighter responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 59 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689240cd74988322bd4901ec993ace7e