### PR TITLE
Refresh Telegram bot messages and add migration

### DIFF
--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -179,8 +179,9 @@ export async function handleSubscriptionPlansManagement(chatId: number, userId: 
       return;
     }
 
-    let planMessage = `💎 *VIP Subscription Plans Management*\n\n`;
-    planMessage += `📦 *Current Plans (${plans?.length || 0}):*\n\n`;
+    let planMessage = `💎 *VIP Plans Dashboard*\n\n`;
+    planMessage += `Manage all subscription packages here.\n\n`;
+    planMessage += `📦 *Active Plans (${plans?.length || 0}):*\n\n`;
 
     plans?.forEach((plan, index) => {
       const duration = plan.is_lifetime ? 'Lifetime' : `${plan.duration_months} months`;
@@ -799,8 +800,9 @@ export async function handleEducationPackagesManagement(chatId: number, userId: 
       .order('created_at', { ascending: false })
       .limit(10);
 
-    let packageMessage = `🎓 *Education Packages Management*\n\n`;
-    packageMessage += `📚 *Current Packages (${packages?.length || 0}):*\n\n`;
+    let packageMessage = `🎓 *Education Packages Dashboard*\n\n`;
+    packageMessage += `Organize and review learning bundles.\n\n`;
+    packageMessage += `📚 *Active Packages (${packages?.length || 0}):*\n\n`;
 
     packages?.forEach((pkg, index) => {
       const status = pkg.is_active ? '✅' : '❌';
@@ -852,7 +854,8 @@ export async function handlePromotionsManagement(chatId: number, userId: string)
       .select('count', { count: 'exact' })
       .eq('is_active', true);
 
-    let promoMessage = `💰 *Promotions Management*\n\n`;
+    let promoMessage = `🎁 *Promotion Codes Dashboard*\n\n`;
+    promoMessage += `Stay on top of discounts and usage.\n\n`;
     promoMessage += `📊 *Statistics:*\n`;
     promoMessage += `• Active Promotions: ${activeCount.count || 0}\n`;
     promoMessage += `• Total Promotions: ${promos?.length || 0}\n\n`;

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -40,13 +40,29 @@ export async function getBotContent(contentKey: string): Promise<string | null> 
 // Create default content for missing keys
 async function createDefaultContent(contentKey: string): Promise<string | null> {
   const defaultContents = {
-    'welcome_message': `🎯 Welcome to Dynamic Capital VIP Bot!
+      'welcome_message': `👋 Welcome to Dynamic Capital VIP Bot!
 
-📈 Get premium trading signals & education
-💎 Join our VIP community
+🚀 Ready to boost your trading journey?
 
-👇 Choose what you need:`,
-    'about_us': `🏢 About Dynamic Capital
+📦 Browse VIP packages
+🎁 Apply promo codes
+📚 Access education
+
+Use the menu below to get started ⬇️`,
+      'package_info': `📦 VIP Packages
+
+Pick a plan that fits your goals:
+• Monthly signals
+• Lifetime access
+• Education bundles
+
+Use /vip to view current offers.`,
+      'promo_info': `🎁 Promo Codes
+
+Have a discount code? Send it during checkout to save!
+
+Tip: Watch our channel for new promotions.`,
+      'about_us': `🏢 About Dynamic Capital
 
 We are a leading trading education and signals provider with years of experience in financial markets.
 

--- a/supabase/migrations/20250807030000_friendly_messages.sql
+++ b/supabase/migrations/20250807030000_friendly_messages.sql
@@ -1,0 +1,40 @@
+/*
+  # Improve default bot messages for beginner-friendly experience
+
+  - Update welcome message with clearer guidance
+  - Add package_info and promo_info content templates
+*/
+
+INSERT INTO bot_content (content_key, content_value, content_type, description, is_active, created_by, last_modified_by)
+VALUES
+  (
+    'welcome_message',
+    '👋 Welcome to Dynamic Capital VIP Bot!\n\n🚀 Ready to boost your trading journey?\n\n📦 Browse VIP packages\n🎁 Apply promo codes\n📚 Access education\n\nUse the menu below to get started ⬇️',
+    'text',
+    'Updated friendly welcome message',
+    true,
+    'system',
+    'system'
+  ),
+  (
+    'package_info',
+    '📦 VIP Packages\n\nPick a plan that fits your goals:\n• Monthly signals\n• Lifetime access\n• Education bundles\n\nUse /vip to view current offers.',
+    'text',
+    'Info about subscription packages',
+    true,
+    'system',
+    'system'
+  ),
+  (
+    'promo_info',
+    '🎁 Promo Codes\n\nHave a discount code? Send it during checkout to save!\n\nTip: Watch our channel for new promotions.',
+    'text',
+    'Info about promo code usage',
+    true,
+    'system',
+    'system'
+  )
+ON CONFLICT (content_key) DO UPDATE
+  SET content_value = EXCLUDED.content_value,
+      updated_at = now(),
+      last_modified_by = 'system';


### PR DESCRIPTION
## Summary
- make welcome content friendlier with emoji-rich guidance
- add package and promo templates for bot content
- modernize admin dashboards for plans, packages, and promo codes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in index.ts and existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd1d740c8322bc95f61a9f8a54c4