### PR TITLE
Handle legacy edit plan callbacks

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5904,8 +5904,14 @@ ${Array.from(securityStats.suspiciousUsers).slice(-5).map(u => `• User ${u}`).
             } else if (callbackData.startsWith('message_user_')) {
               const targetUserId = callbackData.replace('message_user_', '');
               await sendMessage(chatId, `📧 Direct messaging to user ${targetUserId}. Feature coming soon!`);
-            } else if (callbackData.startsWith('edit_plan_')) {
-              const planId = callbackData.replace('edit_plan_', '');
+            } else if (
+              callbackData.startsWith('edit_plan_') ||
+              callbackData.startsWith('editplan')
+            ) {
+              // Support both current `edit_plan_` prefix and legacy `editplan` format
+              const planId = callbackData
+                .replace('edit_plan_', '')
+                .replace('editplan', '');
               console.log(`🔧 Admin ${userId} editing plan: ${planId}`);
               
               if (!isAdmin(userId)) {

--- a/supabase/migrations/20250808040000_add_subscription_plan_columns.sql
+++ b/supabase/migrations/20250808040000_add_subscription_plan_columns.sql
@@ -1,0 +1,12 @@
+-- Ensure subscription_plans table has required columns for plan editing
+ALTER TABLE subscription_plans
+  ADD COLUMN IF NOT EXISTS currency text DEFAULT 'USD',
+  ADD COLUMN IF NOT EXISTS duration_months integer,
+  ADD COLUMN IF NOT EXISTS is_lifetime boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS features text[] DEFAULT ARRAY[]::text[];
+
+-- Maintain updated_at timestamp
+DROP TRIGGER IF EXISTS update_subscription_plans_updated_at ON subscription_plans;
+CREATE TRIGGER update_subscription_plans_updated_at
+  BEFORE UPDATE ON subscription_plans
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- Support legacy `editplan` callback data format alongside `edit_plan_`.
- Ensure `subscription_plans` table includes required columns for plan editing.

## Testing
- `npm run lint` *(fails: Parsing error '}' expected in telegram-bot/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6894e62db94c8322bcb06d4950a6c6b2