### PR TITLE
Add foreign key constraints for analytics tables

### DIFF
--- a/docs/supabase-audit-report.md
+++ b/docs/supabase-audit-report.md
@@ -271,3 +271,7 @@ Expected additional functions may be:
 - ⚠️ **Configuration**: Needs admin setup (70%)
 
 **The system is ready for scaling and production use.**
+---
+
+## 🔄 Recent Schema Updates
+- Added foreign key constraints linking analytics tables (`conversion_tracking`, `promo_analytics`, `user_surveys`) to `subscription_plans` for improved data integrity.

--- a/supabase/migrations/20250808041000_add_missing_foreign_keys.sql
+++ b/supabase/migrations/20250808041000_add_missing_foreign_keys.sql
@@ -1,0 +1,22 @@
+-- Add missing foreign key constraints for plan relations
+
+-- Ensure conversion_tracking.plan_id references subscription_plans
+ALTER TABLE conversion_tracking
+ADD CONSTRAINT conversion_tracking_plan_id_fkey
+  FOREIGN KEY (plan_id)
+  REFERENCES subscription_plans(id)
+  ON DELETE SET NULL;
+
+-- Ensure promo_analytics.plan_id references subscription_plans
+ALTER TABLE promo_analytics
+ADD CONSTRAINT promo_analytics_plan_id_fkey
+  FOREIGN KEY (plan_id)
+  REFERENCES subscription_plans(id)
+  ON DELETE SET NULL;
+
+-- Ensure user_surveys.recommended_plan_id references subscription_plans
+ALTER TABLE user_surveys
+ADD CONSTRAINT user_surveys_recommended_plan_id_fkey
+  FOREIGN KEY (recommended_plan_id)
+  REFERENCES subscription_plans(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- enforce referential integrity by linking conversion_tracking, promo_analytics, and user_surveys to subscription_plans
- document new schema links in Supabase audit report

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 31 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894e99e70608322af69176500e94f48