### PR TITLE
feat: improve caching and status checks

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -7,22 +7,70 @@ interface CacheEntry<T> {
 
 const cache = new Map<string, CacheEntry<unknown>>();
 
+function getStorage() {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch {
+    // accessing localStorage can throw in some environments
+  }
+  return undefined;
+}
+
+const storage = getStorage();
+
 export async function getCached<T>(key: string, ttlMs: number, fetcher: Fetcher<T>): Promise<T> {
   const now = Date.now();
+
+  // memory cache check
   const existing = cache.get(key);
   if (existing && existing.expiry > now) {
     return existing.value as T;
   }
+
+  // localStorage cache check
+  if (storage) {
+    try {
+      const raw = storage.getItem(key);
+      if (raw) {
+        const parsed = JSON.parse(raw) as CacheEntry<T>;
+        if (parsed.expiry > now) {
+          cache.set(key, parsed);
+          return parsed.value;
+        }
+      }
+    } catch {
+      // ignore JSON errors
+    }
+  }
+
   const value = await fetcher();
-  cache.set(key, { value, expiry: now + ttlMs });
+  const entry: CacheEntry<T> = { value, expiry: now + ttlMs };
+  cache.set(key, entry);
+  try {
+    storage?.setItem(key, JSON.stringify(entry));
+  } catch {
+    // ignore storage write errors
+  }
   return value;
 }
 
 export function clearCache(key?: string) {
   if (key) {
     cache.delete(key);
+    try {
+      storage?.removeItem(key);
+    } catch {
+      // ignore storage remove errors
+    }
   } else {
     cache.clear();
+    try {
+      storage?.clear();
+    } catch {
+      // ignore storage clear errors
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- persist cached values in localStorage to avoid repeated fetches
- parallelize edge function and table status checks for reduced latency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689523b783908322a85b7d7b6c8359ff