### PR TITLE
chore: remove exposed supabase project details

### DIFF
--- a/src/components/admin/SystemStatus.tsx
+++ b/src/components/admin/SystemStatus.tsx
@@ -48,6 +48,17 @@ export const SystemStatus = () => {
   const supabasePublic = supabase.schema('public');
   const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
 
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL ?? '';
+  const supabaseProjectId =
+    supabaseUrl.match(/https:\/\/([^.]+)\.supabase\.co/)?.[1] ?? '';
+  const openSupabase = (path: string) => {
+    if (!supabaseProjectId) return;
+    window.open(
+      `https://supabase.com/dashboard/project/${supabaseProjectId}${path}`,
+      '_blank'
+    );
+  };
+
   const edgeFunctions = [
     'telegram-bot',
     'test-bot-status',
@@ -536,26 +547,26 @@ export const SystemStatus = () => {
             </CardHeader>
             <CardContent>
               <div className="flex flex-wrap gap-2">
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
-                  onClick={() => window.open('https://supabase.com/dashboard/project/qeejuomcapbdlhnjqjcc', '_blank')}
+                  onClick={() => openSupabase('')}
                 >
                   <Server className="h-4 w-4 mr-2" />
                   Supabase Dashboard
                 </Button>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
-                  onClick={() => window.open('https://supabase.com/dashboard/project/qeejuomcapbdlhnjqjcc/functions', '_blank')}
+                  onClick={() => openSupabase('/functions')}
                 >
                   <Code className="h-4 w-4 mr-2" />
                   Functions Console
                 </Button>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
-                  onClick={() => window.open('https://supabase.com/dashboard/project/qeejuomcapbdlhnjqjcc/editor', '_blank')}
+                  onClick={() => openSupabase('/editor')}
                 >
                   <Database className="h-4 w-4 mr-2" />
                   Database Editor

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,7 +2,7 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = process.env.SUPABASE_URL ?? "https://qeejuomcapbdlhnjqjcc.supabase.co";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? import.meta.env.VITE_SUPABASE_URL ?? "";
 const SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_ANON_KEY ?? "";
 
 const queryCounts: Record<string, number> = {};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "qeejuomcapbdlhnjqjcc"
+project_id = "your-project-ref"
 
 [functions.telegram-bot]
 verify_jwt = false

--- a/supabase/functions/reset-bot/index.ts
+++ b/supabase/functions/reset-bot/index.ts
@@ -18,6 +18,11 @@ serve(async (req) => {
 
     console.log("Resetting Telegram bot...");
 
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    if (!supabaseUrl) {
+      throw new Error("SUPABASE_URL is not set");
+    }
+
     // 1. Delete the current webhook
     const deleteResponse = await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`, {
       method: 'POST',
@@ -33,7 +38,7 @@ serve(async (req) => {
     console.log("Cleared pending updates:", clearUpdatesResult);
 
     // 3. Re-establish the webhook
-    const webhookUrl = `https://qeejuomcapbdlhnjqjcc.supabase.co/functions/v1/telegram-bot`;
+    const webhookUrl = `${supabaseUrl}/functions/v1/telegram-bot`;
     const setWebhookResponse = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
       method: 'POST',
       headers: {

--- a/supabase/functions/setup-webhook/index.ts
+++ b/supabase/functions/setup-webhook/index.ts
@@ -18,8 +18,13 @@ serve(async (req) => {
 
     console.log("Setting up Telegram webhook...");
 
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    if (!supabaseUrl) {
+      throw new Error("SUPABASE_URL is not set");
+    }
+
     // Get the webhook URL for our telegram-bot function
-    const webhookUrl = `https://qeejuomcapbdlhnjqjcc.supabase.co/functions/v1/telegram-bot`;
+    const webhookUrl = `${supabaseUrl}/functions/v1/telegram-bot`;
     
     console.log("Webhook URL:", webhookUrl);
 


### PR DESCRIPTION
## Summary
- avoid hardcoding Supabase project URL in generated client
- build dashboard links from environment in SystemStatus admin view
- read SUPABASE_URL env in reset and setup webhook functions
- replace project ID in Supabase config with placeholder

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895283a54548322bd2186f581b58aab