### PR TITLE
fix: handle quick diagnostic callback

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5582,6 +5582,7 @@ ${Array.from(securityStats.suspiciousUsers).slice(-5).map(u => `• User ${u}`).
             await handleBotUsageReport(chatId, userId, '30d');
             await sendMessage(chatId, "✅ **Export Complete!** All reports generated above.");
             break;
+          case 'quick_diagnostic':
             if (isAdmin(userId)) {
               const diagnostic = `🔧 *Quick Diagnostic*
 


### PR DESCRIPTION
## Summary
- handle `quick_diagnostic` callback case in Telegram bot

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68952e76997c83229fa9c3bc8d4d1062