### PR TITLE
refactor telegram bot table management content

### DIFF
--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -47,7 +47,7 @@ export async function sendMessage(
 
 // Enhanced table management handlers
 export async function handleTableManagement(chatId: number, userId: string): Promise<void> {
-const tableMessage = `🗃️ *Database Table Management*
+  const defaultTableMessage = `🗃️ *Database Table Management*
 
 📊 *Available Tables:*
 • 👥 **Bot Users** - User management & admin status
@@ -67,6 +67,9 @@ const tableMessage = `🗃️ *Database Table Management*
 
 🔧 *Management Actions:*
 View, Create, Edit, Delete, Export data for any table.`;
+
+  const tableMessage =
+    (await getBotContent('table_management_message')) || defaultTableMessage;
 
   const tableKeyboard = {
     inline_keyboard: [

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -511,27 +511,6 @@ async function setBotContent(contentKey: string, contentValue: string, adminId: 
   }
 }
 
-async function getBotSetting(settingKey: string): Promise<string | null> {
-  try {
-    console.log(`⚙️ Fetching setting: ${settingKey}`);
-    const { data, error } = await supabaseAdmin
-      .from('bot_settings')
-      .select('setting_value')
-      .eq('setting_key', settingKey)
-      .eq('is_active', true)
-      .single();
-
-    if (error && error.code !== 'PGRST116') { // PGRST116 is "not found"
-      console.error(`❌ Error fetching setting ${settingKey}:`, error);
-    }
-
-    return data?.setting_value || null;
-  } catch (error) {
-    console.error(`🚨 Exception fetching setting ${settingKey}:`, error);
-    return null;
-  }
-}
-
 async function setBotSetting(settingKey: string, settingValue: string, adminId: string): Promise<boolean> {
   try {
     console.log(`⚙️ Setting bot setting: ${settingKey} = ${settingValue}`);


### PR DESCRIPTION
## Summary
- fetch table management message from Supabase so admins can update it without code changes
- remove duplicate `getBotSetting` function to prevent redeclaration

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68952e76997c83229fa9c3bc8d4d1062