### PR TITLE
chore: remove hard-coded credentials

### DIFF
--- a/src/components/admin/SystemStatus.tsx
+++ b/src/components/admin/SystemStatus.tsx
@@ -47,6 +47,10 @@ export const SystemStatus = () => {
   const { toast } = useToast();
   const supabasePublic = supabase.schema('public');
   const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
+  const projectId = import.meta.env.VITE_SUPABASE_PROJECT_ID ?? '';
+  const dashboardBaseUrl = projectId
+    ? `https://supabase.com/dashboard/project/${projectId}`
+    : 'https://supabase.com/dashboard';
 
   const edgeFunctions = [
     'telegram-bot',
@@ -536,26 +540,26 @@ export const SystemStatus = () => {
             </CardHeader>
             <CardContent>
               <div className="flex flex-wrap gap-2">
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
-                  onClick={() => window.open('https://supabase.com/dashboard/project/qeejuomcapbdlhnjqjcc', '_blank')}
+                  onClick={() => window.open(dashboardBaseUrl, '_blank')}
                 >
                   <Server className="h-4 w-4 mr-2" />
                   Supabase Dashboard
                 </Button>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
-                  onClick={() => window.open('https://supabase.com/dashboard/project/qeejuomcapbdlhnjqjcc/functions', '_blank')}
+                  onClick={() => window.open(`${dashboardBaseUrl}/functions`, '_blank')}
                 >
                   <Code className="h-4 w-4 mr-2" />
                   Functions Console
                 </Button>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
-                  onClick={() => window.open('https://supabase.com/dashboard/project/qeejuomcapbdlhnjqjcc/editor', '_blank')}
+                  onClick={() => window.open(`${dashboardBaseUrl}/editor`, '_blank')}
                 >
                   <Database className="h-4 w-4 mr-2" />
                   Database Editor

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,7 +2,7 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = process.env.SUPABASE_URL ?? "https://qeejuomcapbdlhnjqjcc.supabase.co";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "";
 const SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_ANON_KEY ?? "";
 
 const queryCounts: Record<string, number> = {};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "qeejuomcapbdlhnjqjcc"
+project_id = "YOUR_SUPABASE_PROJECT_ID"
 
 [functions.telegram-bot]
 verify_jwt = false

--- a/supabase/functions/binance-pay-checkout/index.ts
+++ b/supabase/functions/binance-pay-checkout/index.ts
@@ -10,7 +10,7 @@ const corsHeaders = {
 // Binance Pay API configuration
 const BINANCE_PAY_API_KEY = Deno.env.get('BINANCE_API_KEY')!;
 const BINANCE_PAY_SECRET_KEY = Deno.env.get('BINANCE_SECRET_KEY')!;
-const BINANCE_PAY_MERCHANT_ID = "59586072";
+const BINANCE_PAY_MERCHANT_ID = Deno.env.get('BINANCE_MERCHANT_ID') ?? "";
 const BINANCE_PAY_BASE_URL = "https://bpay.binanceapi.com";
 
 async function generateSignature(timestamp: string, nonce: string, body: string, secretKey: string): Promise<string> {

--- a/supabase/functions/reset-bot/index.ts
+++ b/supabase/functions/reset-bot/index.ts
@@ -33,7 +33,11 @@ serve(async (req) => {
     console.log("Cleared pending updates:", clearUpdatesResult);
 
     // 3. Re-establish the webhook
-    const webhookUrl = `https://qeejuomcapbdlhnjqjcc.supabase.co/functions/v1/telegram-bot`;
+    const projectUrl = Deno.env.get("SUPABASE_URL");
+    if (!projectUrl) {
+      throw new Error("SUPABASE_URL is not set");
+    }
+    const webhookUrl = `${projectUrl}/functions/v1/telegram-bot`;
     const setWebhookResponse = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
       method: 'POST',
       headers: {

--- a/supabase/functions/setup-webhook/index.ts
+++ b/supabase/functions/setup-webhook/index.ts
@@ -18,9 +18,13 @@ serve(async (req) => {
 
     console.log("Setting up Telegram webhook...");
 
-    // Get the webhook URL for our telegram-bot function
-    const webhookUrl = `https://qeejuomcapbdlhnjqjcc.supabase.co/functions/v1/telegram-bot`;
-    
+    // Build webhook URL from environment configuration
+    const projectUrl = Deno.env.get("SUPABASE_URL");
+    if (!projectUrl) {
+      throw new Error("SUPABASE_URL is not set");
+    }
+    const webhookUrl = `${projectUrl}/functions/v1/telegram-bot`;
+
     console.log("Webhook URL:", webhookUrl);
 
     // Delete any existing webhook first


### PR DESCRIPTION
## Summary
- strip Supabase project URL from client to avoid leaking deployment details
- derive webhook URLs from `SUPABASE_URL` in edge functions
- move Binance merchant id and dashboard links to environment configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895283a54548322bd2186f581b58aab