### PR TITLE
fix: handle Telegram start command parameters

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5070,7 +5070,9 @@ serve(async (req) => {
       }
 
       // Handle /start command with dynamic welcome message
-      if (text === '/start') {
+      // Telegram's deep linking can include parameters after the command,
+      // so we only check that the message *starts* with "/start".
+      if (text.startsWith('/start')) {
         console.log(`🚀 Start command from: ${userId} (${firstName})`);
         
         // Add timeout to prevent hanging


### PR DESCRIPTION
## Summary
- handle /start command when deep link parameters are present

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953f06be348322a49e4f36edc18c28