### PR TITLE
Handle Telegram /start command with parameters

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5070,7 +5070,9 @@ serve(async (req) => {
       }
 
       // Handle /start command with dynamic welcome message
-      if (text === '/start') {
+      // Allow additional parameters (e.g. deep-linking) by checking prefix
+      // and trimming potential whitespace
+      if (text?.trim().startsWith('/start')) {
         console.log(`🚀 Start command from: ${userId} (${firstName})`);
         
         // Add timeout to prevent hanging


### PR DESCRIPTION
## Summary
- Relax /start command check to accept deep-linking parameters and whitespace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68953f06be348322a49e4f36edc18c28