### PR TITLE
Fix /start command handling

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5061,7 +5061,7 @@ serve(async (req) => {
 
       // Check for command spam before processing commands
       if (text && text.startsWith('/')) {
-        const command = text.split(' ')[0];
+        const command = text.split(' ')[0].split('@')[0];
         if (isCommandSpam(userId, command) && !isUserAdmin) {
           const response = getSecurityResponse('command_spam');
           await sendMessage(chatId, response);
@@ -5070,7 +5070,7 @@ serve(async (req) => {
       }
 
       // Handle /start command with dynamic welcome message
-      if (text === '/start') {
+      if (text?.split(' ')[0]?.startsWith('/start')) {
         console.log(`🚀 Start command from: ${userId} (${firstName})`);
         
         // Add timeout to prevent hanging


### PR DESCRIPTION
## Summary
- Support /start commands with parameters or bot mentions
- Normalize command parsing for spam detection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953f06be348322a49e4f36edc18c28