### PR TITLE
Enable admin direct messaging to users

### DIFF
--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck: cross-runtime test uses dynamic imports
 let registerTest;
 if (typeof Deno !== "undefined") {
   registerTest = Deno.test;


### PR DESCRIPTION
## Summary
- Allow admins to forward custom messages to individual users via `message_user_*`
- Log direct messages with `logAdminAction`
- Remove obsolete `@ts-nocheck` from placeholder test to satisfy lint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895591687e08322a60f532df7683854