### PR TITLE
feat: auto create pull request when tests pass

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,47 @@
+name: Auto Pull Request
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  test-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - name: Run tests
+        run: deno test -A
+      - name: Create pull request
+        if: ${{ success() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open',
+            });
+            if (pulls.length === 0) {
+              await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: branch,
+                base: 'main',
+                title: `Auto PR from ${branch}`,
+                body: 'This pull request was automatically generated because Deno tests passed.',
+              });
+            } else {
+              core.info('Pull request already exists');
+            }


### PR DESCRIPTION
## Summary
- add workflow to run Deno tests on branch pushes and auto-create a PR when tests pass

## Testing
- `deno test -A`


------
https://chatgpt.com/codex/tasks/task_e_68955cdc16ec83228222a2f58cecb70e