### PR TITLE
chore: add supabase cli setup script

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -16,6 +16,7 @@ jobs:
         run: supabase link --project-ref $SUPABASE_PROJECT_ID
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
 
       - name: Apply migrations
         run: supabase db push --no-interactive

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ If you want to work locally using your own IDE, you can clone this repo and push
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
+### Supabase CLI
+
+Some development tasks require the [Supabase CLI](https://supabase.com/docs/guides/cli). Install it locally with:
+
+```sh
+npm run setup:supabase
+```
+
 Follow these steps:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "test": "node --test",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "setup:supabase": "bash scripts/setup-supabase-cli.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/setup-supabase-cli.sh
+++ b/scripts/setup-supabase-cli.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install Supabase CLI locally. Mirrors the setup used in
-# `.github/workflows/supabase-cli.yml`.
+# `.github/workflows/migrations.yml`.
 set -euo pipefail
 
 if command -v supabase >/dev/null 2>&1; then

--- a/scripts/setup-supabase-cli.sh
+++ b/scripts/setup-supabase-cli.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Install Supabase CLI locally. Mirrors the setup used in
+# `.github/workflows/supabase-cli.yml`.
+set -euo pipefail
+
+if command -v supabase >/dev/null 2>&1; then
+  echo "Supabase CLI already installed: $(supabase --version)"
+else
+  echo "Installing Supabase CLI..."
+  curl -fsSL https://cli.supabase.com/install.sh | sh
+  echo "Supabase CLI installed: $(supabase --version)"
+fi


### PR DESCRIPTION
## Summary
- add script to install Supabase CLI locally
- expose setup via npm script and document usage in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895651dfa2c8322bee99ba509413c10