### PR TITLE
feat: add dynamic contact links for support

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-prototype-builtins */
 // Database utility functions for the Telegram bot
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
@@ -696,6 +695,33 @@ export async function getActivePromotions(): Promise<Record<string, unknown>[]> 
     return data || [];
   } catch (error) {
     console.error('Error fetching promotions:', error);
+    return [];
+  }
+}
+
+// Contact link management functions
+interface ContactLink {
+  display_name: string;
+  url: string;
+  icon_emoji: string;
+}
+
+export async function getContactLinks(): Promise<ContactLink[]> {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('contact_links')
+      .select('display_name, url, icon_emoji')
+      .eq('is_active', true)
+      .order('display_order', { ascending: true });
+
+    if (error) {
+      console.error('Error fetching contact links:', error);
+      return [];
+    }
+
+    return data as ContactLink[];
+  } catch (error) {
+    console.error('Exception in getContactLinks:', error);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- source contact methods from `contact_links` table and expose via new helper
- show database-driven support options and messaging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956a7568708322a0bbdbb1d6ef113b