### PR TITLE
Add healthcheck handlers to edge functions

### DIFF
--- a/supabase/functions/ai-faq-assistant/index.ts
+++ b/supabase/functions/ai-faq-assistant/index.ts
@@ -15,7 +15,16 @@ serve(async (req) => {
   }
 
   try {
-    const { question, context: _context } = await req.json();
+    const { question, context: _context, test } = await req
+      .json()
+      .catch(() => ({}));
+
+    if (test) {
+      return new Response(
+        JSON.stringify({ success: true, message: 'ai-faq-assistant OK' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
     if (!question) {
       return new Response(JSON.stringify({ error: 'Question is required' }), {

--- a/supabase/functions/binance-pay-checkout/index.ts
+++ b/supabase/functions/binance-pay-checkout/index.ts
@@ -47,10 +47,22 @@ serve(async (req) => {
 
   try {
     console.log('Binance Pay checkout request started');
-    const requestBody = await req.json();
+    const requestBody = await req.json().catch(() => ({}));
     console.log('Request body:', requestBody);
-    
-    const { planId, telegramUserId, telegramUsername: _telegramUsername } = requestBody;
+
+    const {
+      planId,
+      telegramUserId,
+      telegramUsername: _telegramUsername,
+      test,
+    } = requestBody;
+
+    if (test) {
+      return new Response(
+        JSON.stringify({ success: true, message: 'binance-pay-checkout OK' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
     if (!planId || !telegramUserId) {
       throw new Error('Missing required parameters: planId or telegramUserId');

--- a/supabase/functions/reset-bot/index.ts
+++ b/supabase/functions/reset-bot/index.ts
@@ -11,6 +11,14 @@ serve(async (req) => {
   }
 
   try {
+    const { test } = await req.json().catch(() => ({}));
+    if (test) {
+      return new Response(
+        JSON.stringify({ success: true, message: "reset-bot OK" }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
     const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
     if (!botToken) {
       throw new Error("TELEGRAM_BOT_TOKEN is not set");

--- a/supabase/functions/trade-helper/index.ts
+++ b/supabase/functions/trade-helper/index.ts
@@ -15,7 +15,16 @@ serve(async (req) => {
   }
 
   try {
-    const { instrument, command, context: _context } = await req.json();
+    const { instrument, command, context: _context, test } = await req
+      .json()
+      .catch(() => ({}));
+
+    if (test) {
+      return new Response(
+        JSON.stringify({ success: true, message: 'trade-helper OK' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
     if (!instrument) {
       return new Response(JSON.stringify({ error: 'Instrument is required' }), {


### PR DESCRIPTION
## Summary
- allow `reset-bot` to short-circuit when invoked with a `test` body
- add test flag handling for `ai-faq-assistant`, `trade-helper`, and `binance-pay-checkout` functions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68956d2d37208322b6974504d265134f