### PR TITLE
feat: notify admins on new bot version

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -242,6 +242,9 @@ async function handleAdminCommand(chatId: number, userId: string): Promise<void>
 
 ## 👨‍💼 Admin Functions
 
+### Version Notifications
+The bot tracks its code version using the `BOT_VERSION` environment variable. When a new version is deployed, all admins receive a message with the updated version and the bot automatically refreshes its configuration and prompts.
+
 ### Dashboard Management
 ```typescript
 /**


### PR DESCRIPTION
## Summary
- notify admins when `BOT_VERSION` changes
- document auto version notification

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689572db9ac483229f5fe10f411c9829