### PR TITLE
fix: display discounted price after promo

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -2171,10 +2171,17 @@ async function handleShowPaymentMethods(chatId: number, userId: string, packageI
       return;
     }
 
+    // Check if a promo code was applied for this user and package
+    const session = userSessions.get(userId);
+    let priceLine = `💰 **Price:** $${pkg.price} USD`;
+    if (session && session.type === 'promo_applied' && session.packageId === packageId) {
+      priceLine = `💰 **Price after promo:** $${session.finalPrice.toFixed(2)} USD`;
+    }
+
     const message = `💳 **Payment Methods**
 
 📦 **Package:** ${pkg.name}
-💰 **Price:** $${pkg.price} USD
+${priceLine}
 
 🎯 **Choose your payment method:**`;
 


### PR DESCRIPTION
## Summary
- show discounted price when viewing payment methods after applying a promo code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68957763f5208322a12faa902e7e674c