### PR TITLE
Prioritize promo-code input over receipt uploads

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -5547,6 +5547,17 @@ serve(async (req: Request): Promise<Response> => {
         return new Response("OK", { status: 200 });
       }
 
+      // Check if user is waiting for promo code input before processing other message types
+      const promoSession = userSessions.get(userId);
+      if (promoSession && promoSession.type === 'waiting_promo_code') {
+        if (!text) {
+          await sendMessage(chatId, "❌ Promo codes must be sent as text. Please try again.");
+        } else {
+          await handlePromoCodeInput(chatId, userId, text.trim().toUpperCase(), promoSession);
+        }
+        return new Response("OK", { status: 200 });
+      }
+
       // Handle photo/document uploads (receipts)
       if (update.message.photo || update.message.document) {
         await handleReceiptUpload(update.message, userId, firstName);
@@ -5556,13 +5567,6 @@ serve(async (req: Request): Promise<Response> => {
       // Handle unknown commands with auto-reply
       if (text?.startsWith('/')) {
         await handleUnknownCommand(chatId, userId, text);
-        return new Response("OK", { status: 200 });
-      }
-
-      // Check if user is waiting for promo code input
-      const promoSession = userSessions.get(userId);
-      if (promoSession && promoSession.type === 'waiting_promo_code') {
-        await handlePromoCodeInput(chatId, userId, text.trim().toUpperCase(), promoSession);
         return new Response("OK", { status: 200 });
       }
 


### PR DESCRIPTION
## Summary
- Ensure promo-code sessions are handled before receipt uploads
- Warn users if promo codes are sent without text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957763f5208322a12faa902e7e674c