### PR TITLE
feat: enforce single promo use per user

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -130,6 +130,7 @@ CREATE TABLE bot_content (
 - `payments` → `subscription_plans` (many-to-one)
 - `education_enrollments` → `education_packages` (many-to-one)
 - `promotion_usage` → `promotions` (many-to-one)
+  - Unique usage enforced: each `telegram_user_id` can apply a given promotion only once
 
 ---
 

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -208,7 +208,7 @@ const relationships = {
   // Activity tracking
   'user_interactions.telegram_user_id': 'bot_users.telegram_id',
   'bot_sessions.telegram_user_id': 'bot_users.telegram_id',
-  'promotion_usage.telegram_user_id': 'bot_users.telegram_id',
+  'promotion_usage.telegram_user_id': 'bot_users.telegram_id', // one use per promotion enforced
 };
 ```
 

--- a/supabase/migrations/20250808055000_enforce_unique_promo_usage.sql
+++ b/supabase/migrations/20250808055000_enforce_unique_promo_usage.sql
@@ -1,0 +1,13 @@
+-- Enforce single promo usage per user
+-- Each telegram user can apply a given promotion only once
+CREATE UNIQUE INDEX IF NOT EXISTS idx_promotion_usage_unique_user_per_promo
+ON promotion_usage (promotion_id, telegram_user_id);
+
+-- Ensure RLS and policy for service role
+ALTER TABLE promotion_usage ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Bot can manage promotion usage" ON promotion_usage;
+CREATE POLICY "Bot can manage promotion usage"
+ON promotion_usage
+FOR ALL
+TO service_role
+USING (true);


### PR DESCRIPTION
## Summary
- enforce unique promo usage per user via SQL migration
- document single-use promo code rule
- note promo uniqueness in code structure docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689585651fa4832281d9435584a56987