### PR TITLE
feat: show bot version and stats on admin start

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -244,7 +244,7 @@ async function handleAdminCommand(chatId: number, userId: string): Promise<void>
 ## 👨‍💼 Admin Functions
 
 ### Version Notifications
-The bot tracks its code version using the `BOT_VERSION` environment variable. When a new version is deployed, all admins receive a message with the updated version and the bot automatically refreshes its configuration and prompts.
+The bot tracks its code version (bot number) using the `BOT_VERSION` environment variable. When a new version is deployed, all admins receive a message with the updated version and the bot automatically refreshes its configuration and prompts. Admins also receive the current bot number and a status report whenever they start a new session with `/start`, ensuring the bot number stays current with each development.
 
 ### Dashboard Management
 ```typescript

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -2998,6 +2998,7 @@ async function handleAdminDashboard(chatId: number, userId: string): Promise<voi
     const adminMessage = `🔐 *Enhanced Admin Dashboard*
 
 📊 *System Status:* ${botStatus}
+🆔 *Bot Version:* ${BOT_VERSION}
 👤 *Admin:* ${userId}
 🕐 *Uptime:* ${uptime} minutes
 🕐 *Last Updated:* ${new Date().toLocaleString()}
@@ -3216,6 +3217,7 @@ async function handleBotStatus(chatId: number, userId: string): Promise<void> {
 
     const statusMessage = `📊 *Bot Status Report*
 
+🆔 *Bot Version:* ${BOT_VERSION}
 🕐 *Uptime:* ${hours}h ${minutes}m ${seconds}s
 📅 *Started:* ${BOT_START_TIME.toLocaleString()}
 
@@ -5542,7 +5544,10 @@ serve(async (req: Request): Promise<Response> => {
             console.log(`📤 Sending welcome message to user: ${userId}`);
             await sendMessage(chatId, welcomeMessage, keyboard);
             console.log(`✅ Welcome message sent successfully to user: ${userId}`);
-            
+            if (isAdmin(userId)) {
+              await handleBotStatus(chatId, userId);
+            }
+
             return new Response("OK", { status: 200 });
           } catch (error) {
             console.error(`❌ Error in /start command for user ${userId}:`, error);


### PR DESCRIPTION
## Summary
- display current bot version in admin dashboard and status report
- send bot status (with version) automatically when an admin starts a session
- document automatic version display on admin `/start`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958f45872c83229fba28b963ef84e8