### PR TITLE
Add bank receipt OCR processing and payment intent tables

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -20,6 +20,7 @@ import {
   handleBotSettingsManagement,
   handleTableStatsOverview
 } from "./admin-handlers.ts";
+import { ocrTextFromBlob, parseReceipt } from "./ocr.ts";
 
 const DEFAULT_BOT_SETTINGS: Record<string, string> = {
   session_timeout_minutes: "30",
@@ -431,6 +432,7 @@ const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const BOT_VERSION = Deno.env.get("BOT_VERSION") || "0.0.0";
+const WEBHOOK_SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET");
 
 console.log("🚀 Bot starting with environment check...");
 console.log("BOT_TOKEN exists:", !!BOT_TOKEN);
@@ -1077,6 +1079,136 @@ Review the receipt and approve or reject the payment.`;
     
   } catch (error) {
     console.error('🚨 Error notifying admins about receipt:', error);
+  }
+}
+
+async function handleBankReceipt(message: TelegramMessage, userId: string): Promise<void> {
+  try {
+    const chatId = message.chat.id;
+    const fileId = message.photo
+      ? message.photo[message.photo.length - 1].file_id
+      : message.document?.file_id;
+    if (!fileId) {
+      await sendMessage(chatId, "❌ Unable to process the uploaded file. Please try again.");
+      return;
+    }
+
+    const fileInfoRes = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/getFile?file_id=${fileId}`);
+    const fileInfo = await fileInfoRes.json();
+    const filePath = fileInfo.result?.file_path;
+    if (!filePath) {
+      await sendMessage(chatId, "❌ Could not fetch file info from Telegram.");
+      return;
+    }
+
+    const fileRes = await fetch(`https://api.telegram.org/file/bot${BOT_TOKEN}/${filePath}`);
+    const blob = await fileRes.blob();
+    const arrayBuffer = await blob.arrayBuffer();
+    const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
+
+    const { data: dup } = await supabaseAdmin
+      .from('receipts')
+      .select('id')
+      .eq('image_sha256', hashHex)
+      .maybeSingle();
+    if (dup) {
+      await sendMessage(chatId, "⚠️ This receipt was already submitted.");
+      return;
+    }
+
+    const storagePath = `${userId}/${hashHex}`;
+    await supabaseAdmin.storage.from('receipts').upload(storagePath, blob, {
+      contentType: fileRes.headers.get('content-type') || undefined,
+    });
+    const { data: urlData } = supabaseAdmin.storage
+      .from('receipts')
+      .getPublicUrl(storagePath);
+    const fileUrl = urlData.publicUrl;
+
+    const text = await ocrTextFromBlob(blob);
+    const ocr = parseReceipt(text);
+
+    let intent = null;
+    if (ocr.payCode) {
+      const { data } = await supabaseAdmin
+        .from('payment_intents')
+        .select('*')
+        .eq('pay_code', ocr.payCode)
+        .maybeSingle();
+      intent = data;
+    }
+    if (!intent) {
+      const { data } = await supabaseAdmin
+        .from('payment_intents')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('method', 'bank')
+        .eq('status', 'pending')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      intent = data;
+    }
+
+    if (!intent) {
+      await supabaseAdmin.from('receipts').insert({
+        user_id: userId,
+        file_url: fileUrl,
+        image_sha256: hashHex,
+        ocr_text: ocr.text,
+        ocr_amount: ocr.total,
+        ocr_timestamp: ocr.dateText ? new Date(ocr.dateText).toISOString() : null,
+        ocr_beneficiary: ocr.beneficiary,
+        ocr_pay_code: ocr.payCode,
+        reason: 'no_intent_found',
+      });
+      await sendMessage(chatId, "❓ Receipt received but no matching payment found. Our team will review it.");
+      return;
+    }
+
+    const windowSeconds = 180;
+    const amtOK = ocr.total != null &&
+      Math.abs(ocr.total - intent.expected_amount) / intent.expected_amount <= 0.02;
+    const ocrDate = ocr.dateText ? new Date(ocr.dateText) : undefined;
+    const timeOK = ocrDate
+      ? Math.abs(ocrDate.getTime() - new Date(intent.created_at).getTime()) / 1000 <= windowSeconds
+      : false;
+    const beneficiaryOK = (ocr.beneficiary ?? "").toLowerCase().includes("dynamic");
+    const payCodeOK = intent.pay_code && ocr.payCode === intent.pay_code;
+    const approve = (amtOK && timeOK && beneficiaryOK) && (ocr.success || payCodeOK);
+
+    await supabaseAdmin.from('receipts').insert({
+      payment_id: intent.id,
+      user_id: userId,
+      file_url: fileUrl,
+      image_sha256: hashHex,
+      ocr_text: ocr.text,
+      ocr_amount: ocr.total,
+      ocr_timestamp: ocrDate?.toISOString(),
+      ocr_beneficiary: ocr.beneficiary,
+      ocr_pay_code: ocr.payCode,
+      verdict: approve ? 'approved' : 'manual_review',
+      reason: approve ? null : 'auto_rules_failed',
+    });
+
+    if (approve) {
+      await supabaseAdmin
+        .from('payment_intents')
+        .update({ status: 'approved', approved_at: new Date().toISOString() })
+        .eq('id', intent.id);
+      await sendMessage(chatId, "✅ Payment verified successfully!");
+    } else {
+      await supabaseAdmin
+        .from('payment_intents')
+        .update({ status: 'manual_review' })
+        .eq('id', intent.id);
+      await sendMessage(chatId, "📥 Receipt received. It will be reviewed shortly.");
+    }
+  } catch (error) {
+    console.error('🚨 Error processing bank receipt:', error);
+    await sendMessage(message.chat.id, "❌ An error occurred processing your receipt.");
   }
 }
 
@@ -5404,6 +5536,11 @@ async function handleMessageUser(
 serve(async (req: Request): Promise<Response> => {
   console.log(`📥 Request received: ${req.method} ${req.url}`);
 
+  const url = new URL(req.url);
+  if (url.searchParams.get("secret") !== WEBHOOK_SECRET) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
   // Check for new deployments on each request to notify admins
   await checkBotVersion();
 
@@ -5642,7 +5779,7 @@ serve(async (req: Request): Promise<Response> => {
 
       // Handle photo/document uploads (receipts)
       if (update.message.photo || update.message.document) {
-        await handleReceiptUpload(update.message, userId, firstName);
+        await handleBankReceipt(update.message, userId);
         return new Response("OK", { status: 200 });
       }
 

--- a/supabase/functions/telegram-bot/ocr.ts
+++ b/supabase/functions/telegram-bot/ocr.ts
@@ -1,0 +1,31 @@
+import { createWorker } from "https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.esm.min.js";
+
+export async function ocrTextFromBlob(blob: Blob): Promise<string> {
+  const worker = await createWorker();
+  await worker.loadLanguage("eng");
+  await worker.initialize("eng");
+  await worker.setParameters({
+    tessedit_char_whitelist: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ$€₹:. -/()",
+    preserve_interword_spaces: "1",
+    user_defined_dpi: "300",
+  });
+  const { data } = await worker.recognize(blob);
+  await worker.terminate();
+  return data.text;
+}
+
+export function parseReceipt(text: string) {
+  const lines = text.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+  const join = lines.join(" ");
+  const amtMatch = join.match(/([0-9]+[.,][0-9]{2})/);
+  const total = amtMatch ? Number(amtMatch[1].replace(",", ".")) : null;
+
+  const dtMatch = join.match(/\b(20\d{2}[./-]\d{1,2}[./-]\d{1,2})[ T]*(\d{1,2}:\d{2}(:\d{2})?)\b/);
+  const dateText = dtMatch ? `${dtMatch[1]} ${dtMatch[2]}` : null;
+
+  const success = /\b(successful|completed|processed)\b/i.test(join);
+  const beneficiary = lines.find(l => /\b(Dynamic|Capital)\b/i) || null;
+  const payCode = (join.match(/\bDC-[A-Z0-9]{6}\b/) || [null])[0];
+
+  return { text, total, dateText, success, beneficiary, payCode };
+}

--- a/supabase/migrations/20250808054910_bank_receipts.sql
+++ b/supabase/migrations/20250808054910_bank_receipts.sql
@@ -1,0 +1,36 @@
+-- payments / intents
+create table if not exists payment_intents (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  method text not null check (method in ('bank','crypto')),
+  expected_amount numeric(18,2) not null,
+  currency text not null default 'USD',
+  pay_code text,
+  status text not null default 'pending' check (status in ('pending','approved','manual_review','rejected')),
+  created_at timestamptz not null default now(),
+  approved_at timestamptz,
+  notes text
+);
+
+create index on payment_intents (user_id, status, created_at desc);
+create index on payment_intents (pay_code);
+
+-- receipts
+create table if not exists receipts (
+  id uuid primary key default gen_random_uuid(),
+  payment_id uuid not null references payment_intents(id) on delete cascade,
+  user_id uuid not null,
+  file_url text not null,
+  image_sha256 text not null,
+  ocr_text text,
+  ocr_amount numeric(18,2),
+  ocr_currency text,
+  ocr_timestamp timestamptz,
+  ocr_beneficiary text,
+  ocr_pay_code text,
+  verdict text not null default 'manual_review' check (verdict in ('approved','manual_review','rejected')),
+  reason text,
+  created_at timestamptz not null default now()
+);
+
+create unique index on receipts (image_sha256);


### PR DESCRIPTION
## Summary
- add migration for `payment_intents` and `receipts` tables
- integrate Tesseract OCR helper for receipt parsing
- enhance Telegram bot to verify webhook secret and automatically parse and approve bank receipts

## Testing
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958f88764c8322b62e4e29d759bd3f