### PR TITLE
feat: add bank account details

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1570,11 +1570,22 @@ async function getBankTransferInstructions(
     } else {
       console.log('⚠️ No active bank accounts found');
       bankDetails = `🏦 **Bank Account Details:**
-📧 Account Name: Dynamic Capital Ltd
-🔢 Account Number: \`Will be provided shortly\`
+1️⃣ **BML**
+📧 Account Name: ABDL.M.I.AFLHAL
+🔢 Account Number: \`7730000133061\`
+💱 Currency: MVR
+
+2️⃣ **MIB**
+📧 Account Name: Abdul M. I. A
+🔢 Account Number: \`90103101672241000\`
+💱 Currency: MVR
+
+3️⃣ **MIB**
+📧 Account Name: Abdul M. I. A
+🔢 Account Number: \`90103101672242000\`
 💱 Currency: USD
 
-⚠️ Contact @DynamicCapital_Support for complete bank details`;
+⚠️ Contact @DynamicCapital_Support for assistance`;
     }
 
     // Update subscription with bank details for reference

--- a/supabase/migrations/20250808060000_seed_bank_accounts.sql
+++ b/supabase/migrations/20250808060000_seed_bank_accounts.sql
@@ -1,0 +1,12 @@
+-- Seed bank account details
+INSERT INTO bank_accounts (bank_name, account_name, account_number, currency, is_active, display_order)
+VALUES
+  ('BML', 'ABDL.M.I.AFLHAL', '7730000133061', 'MVR', true, 1),
+  ('MIB', 'Abdul M. I. A', '90103101672241000', 'MVR', true, 2),
+  ('MIB', 'Abdul M. I. A', '90103101672242000', 'USD', true, 3)
+ON CONFLICT (account_number) DO UPDATE SET
+  bank_name = EXCLUDED.bank_name,
+  account_name = EXCLUDED.account_name,
+  currency = EXCLUDED.currency,
+  is_active = EXCLUDED.is_active,
+  display_order = EXCLUDED.display_order;


### PR DESCRIPTION
## Summary
- seed Supabase `bank_accounts` table with BML and MIB accounts in MVR and USD
- provide fallback bank account details in Telegram bot when database is empty

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895953b55108322912faddf5700d70d