### PR TITLE
Fix default welcome message Markdown escaping

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1273,7 +1273,7 @@ async function getWelcomeMessage(firstName: string): Promise<FormattedMessage> {
     if (!template) {
       const escapedName = escapeMarkdownV2(firstName);
       // eslint-disable-next-line no-useless-escape
-      const defaultMessage = `*Welcome to* __Dynamic Capital VIP__, ${escapedName}\!\n\nWe're here to help you level up your trading with:\n\n• \`Quick market updates\`\n• _Beginner-friendly tips_\n• ||Exclusive learning resources||\n\nReady to get started? Pick an option below 👇`;
+      const defaultMessage = `*Welcome to* __Dynamic Capital VIP__, ${escapedName}\!\n\nWe're here to help you level up your trading with:\n\n• \`Quick market updates\`\n• _Beginner\-friendly tips_\n• ||Exclusive learning resources||\n\nReady to get started? Pick an option below 👇`;
       console.log(`📄 [getWelcomeMessage] Using default message for: ${firstName}`);
       return { text: defaultMessage, parseMode: 'MarkdownV2' };
     }


### PR DESCRIPTION
## Summary
- Escape hyphen in default welcome message to prevent Telegram MarkdownV2 parse errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895a26386e48322b801c69f6ac5843f