### PR TITLE
feat: add bank slip auto approval

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,19 @@
+name: Deno Check
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    env:
+      DENO_TLS_CA_STORE: system
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - run: deno check supabase/functions/telegram-bot/index.ts

--- a/README.md
+++ b/README.md
@@ -96,3 +96,12 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Dev tip
+
+If local TLS interception causes Deno to fail fetching remote modules, this function uses built-in `Deno.serve` to avoid std/http imports. For other dependencies, set:
+
+```
+macOS/Linux: export DENO_TLS_CA_STORE=system
+Windows PS:  $env:DENO_TLS_CA_STORE="system"
+```

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "check": "deno check supabase/functions/telegram-bot/index.ts",
+    "serve": "supabase functions serve"
+  },
+  "compilerOptions": {
+    "types": ["./types/tesseract.d.ts"]
+  }
+}

--- a/supabase/functions/telegram-bot/bank-parsers.ts
+++ b/supabase/functions/telegram-bot/bank-parsers.ts
@@ -1,0 +1,143 @@
+export type Bank = "BML" | "MIB" | "UNKNOWN";
+
+export interface ParsedSlip {
+  bank: Bank;
+  amount: number | null;
+  currency: string | null;
+  status: "SUCCESS" | "FAILED" | "PENDING" | null;
+  successWord: boolean;
+  reference: string | null;
+  fromName: string | null;
+  toName: string | null;
+  toAccount: string | null;
+  payCode: string | null;        // e.g. DC-XXXXXX from remarks/purpose/message
+  ocrTxnDateIso: string | null;  // with +05:00
+  ocrValueDateIso: string | null;// with +05:00
+  rawText: string;
+}
+
+function toIsoFromDmy(dateStr: string): string | null {
+  const m = dateStr.match(/(\d{2})\/(\d{2})\/(\d{4})\s+(\d{2}:\d{2}(?::\d{2})?)/);
+  if (!m) return null;
+  const [, dd, mm, yyyy, time] = m;
+  const t = time.length === 5 ? `${time}:00` : time;
+  return `${yyyy}-${mm}-${dd}T${t}+05:00`;
+}
+
+function toIsoFromYmd(dateStr: string): string | null {
+  const m = dateStr.match(/(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/);
+  if (!m) return null;
+  return `${m[1]}T${m[2]}+05:00`;
+}
+
+export function parseBankSlip(ocrText: string): ParsedSlip {
+  const rawText = ocrText;
+  const text = ocrText.replace(/\r/g, "");
+  const lines = text.split(/\n+/).map((l) => l.trim()).filter(Boolean);
+  const joined = lines.join(" ");
+
+  const bank: Bank = /Bank of Maldives/i.test(joined) || /\bBML\b/i.test(joined)
+    ? "BML"
+    : /Maldives Islamic Bank/i.test(joined) || /\bMIB\b/i.test(joined)
+    ? "MIB"
+    : "UNKNOWN";
+
+  // Amount & currency
+  let amount: number | null = null;
+  let currency: string | null = null;
+  let amtMatch = joined.match(/MVR\s*([0-9]{1,3}(?:,[0-9]{3})*\.[0-9]{2})/);
+  if (amtMatch) {
+    amount = parseFloat(amtMatch[1].replace(/,/g, ""));
+    currency = "MVR";
+  } else {
+    amtMatch = joined.match(/\b([0-9]{1,3}(?:,[0-9]{3})*\.[0-9]{2})\b/);
+    if (amtMatch) amount = parseFloat(amtMatch[1].replace(/,/g, ""));
+  }
+
+  const payCodeFromLines = () => {
+    for (const l of lines) {
+      if (/message|purpose|remarks/i.test(l)) {
+        const m = l.match(/\bDC-[A-Z0-9]{6}\b/i);
+        if (m) return m[0].toUpperCase();
+      }
+    }
+    const m = joined.match(/\bDC-[A-Z0-9]{6}\b/i);
+    return m ? m[0].toUpperCase() : null;
+  };
+
+  let status: "SUCCESS" | "FAILED" | "PENDING" | null = null;
+  let reference: string | null = null;
+  let fromName: string | null = null;
+  let toName: string | null = null;
+  let toAccount: string | null = null;
+  let ocrTxnDateIso: string | null = null;
+  let ocrValueDateIso: string | null = null;
+
+  if (bank === "BML") {
+    const statusMatch = joined.match(/Status\s*:?\s*(SUCCESS|PENDING|FAILED)/i);
+    if (statusMatch) status = statusMatch[1].toUpperCase() as any;
+
+    const refMatch = joined.match(/Reference\s*:?\s*([A-Z0-9-]{6,24})/i);
+    if (refMatch) reference = refMatch[1];
+
+    const txnMatch = joined.match(/Transaction Date\s*:?\s*(\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}(?::\d{2})?)/i);
+    if (txnMatch) ocrTxnDateIso = toIsoFromDmy(txnMatch[1]);
+
+    for (let i = 0; i < lines.length; i++) {
+      if (/^From\b/i.test(lines[i])) {
+        fromName = lines[i + 1] || null;
+      }
+      if (/^To\b/i.test(lines[i])) {
+        toName = lines[i + 1] || null;
+        const accMatch = (lines[i + 2] || "").match(/\d{9,20}/);
+        if (accMatch) toAccount = accMatch[0];
+      }
+    }
+  } else if (bank === "MIB") {
+    if (/Successful|Sucessful/i.test(joined)) status = "SUCCESS";
+
+    const refMatch = joined.match(/Reference\s*#?\s*([A-Z0-9-]{6,24})/i);
+    if (refMatch) reference = refMatch[1];
+
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i];
+      if (/^To Account/i.test(l)) {
+        const m = l.match(/To Account\s*(\d{9,20})\s*(.*)/i);
+        if (m) {
+          toAccount = m[1];
+          toName = m[2].trim() || null;
+        } else {
+          const accMatch = (lines[i + 1] || "").match(/\d{9,20}/);
+          if (accMatch) {
+            toAccount = accMatch[0];
+            toName = lines[i + 2] || null;
+          }
+        }
+      }
+    }
+
+    const txnMatch = joined.match(/Transaction Date\s*:?\s*(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/i);
+    if (txnMatch) ocrTxnDateIso = toIsoFromYmd(txnMatch[1]);
+
+    const valMatch = joined.match(/Value Date\s*:?\s*(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})/i);
+    if (valMatch) ocrValueDateIso = toIsoFromYmd(valMatch[1]);
+  }
+
+  const successWord = /\bsuccess|successful|sucessful\b/i.test(joined);
+
+  return {
+    bank,
+    amount,
+    currency,
+    status,
+    successWord,
+    reference,
+    fromName,
+    toName,
+    toAccount,
+    payCode: payCodeFromLines(),
+    ocrTxnDateIso,
+    ocrValueDateIso,
+    rawText,
+  };
+}

--- a/supabase/functions/telegram-bot/helpers/beneficiary.ts
+++ b/supabase/functions/telegram-bot/helpers/beneficiary.ts
@@ -1,0 +1,23 @@
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const BENEFICIARY_TABLE = Deno.env.get("BENEFICIARY_TABLE") ?? "beneficiaries";
+
+export function normalizeAccount(n: string) {
+  return n.replace(/\s+/g, "");
+}
+
+export async function getApprovedBeneficiaryByAccountNumber(
+  supabase: ReturnType<typeof createClient>,
+  accountNumber: string
+) {
+  const acct = normalizeAccount(accountNumber);
+  const { data, error } = await supabase
+    .from(BENEFICIARY_TABLE)
+    .select("*")
+    .eq("account_number", acct)
+    .eq("active", true)
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data; // may be null
+}

--- a/supabase/migrations/20250808070000_bank_auto_approval.sql
+++ b/supabase/migrations/20250808070000_bank_auto_approval.sql
@@ -1,0 +1,53 @@
+-- ensure payment_intents table and columns exist
+create table if not exists payment_intents (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  method text not null,
+  expected_amount numeric(18,2) not null,
+  currency text not null default 'USD',
+  pay_code text,
+  status text not null default 'pending',
+  created_at timestamptz not null default now(),
+  approved_at timestamptz,
+  notes text
+);
+
+alter table payment_intents add column if not exists expected_beneficiary_name text;
+alter table payment_intents add column if not exists expected_beneficiary_account_last4 text;
+
+-- ensure receipts table and columns exist
+create table if not exists receipts (
+  id uuid primary key default gen_random_uuid(),
+  payment_id uuid references payment_intents(id) on delete cascade,
+  user_id uuid not null,
+  file_url text not null,
+  image_sha256 text not null,
+  bank text,
+  ocr_text text,
+  ocr_amount numeric(18,2),
+  ocr_currency text,
+  ocr_status text,
+  ocr_success_word boolean,
+  ocr_reference text,
+  ocr_from_name text,
+  ocr_to_name text,
+  ocr_to_account text,
+  ocr_pay_code text,
+  ocr_txn_date timestamptz,
+  ocr_value_date timestamptz,
+  verdict text not null default 'manual_review',
+  reason text,
+  created_at timestamptz not null default now()
+);
+
+alter table receipts add column if not exists bank text;
+alter table receipts add column if not exists ocr_currency text;
+alter table receipts add column if not exists ocr_status text;
+alter table receipts add column if not exists ocr_success_word boolean;
+alter table receipts add column if not exists ocr_reference text;
+alter table receipts add column if not exists ocr_from_name text;
+alter table receipts add column if not exists ocr_to_name text;
+alter table receipts add column if not exists ocr_to_account text;
+alter table receipts add column if not exists ocr_txn_date timestamptz;
+alter table receipts add column if not exists ocr_value_date timestamptz;
+create unique index if not exists receipts_image_sha256_idx on receipts (image_sha256);

--- a/types/tesseract.d.ts
+++ b/types/tesseract.d.ts
@@ -1,0 +1,3 @@
+declare module "https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.esm.min.js" {
+  export function createWorker(): any;
+}


### PR DESCRIPTION
## Summary
- parse BML and MIB bank transfer slips
- auto-approve matching bank receipts via Telegram
- add migration ensuring required columns for intents and receipts
- swap std/http server for built-in `Deno.serve` and add TLS guidance

## Testing
- `DENO_TLS_CA_STORE=system deno check supabase/functions/telegram-bot/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_6895bd8caaa48322a860005faf27c486