### PR TITLE
feat: allow custom Telegram API URL

### DIFF
--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -3,6 +3,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const TELEGRAM_API_URL =
+  Deno.env.get("TELEGRAM_API_URL") || "https://api.telegram.org";
 
 const supabaseAdmin = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!, {
   auth: { persistSession: false },
@@ -17,7 +19,7 @@ export async function sendMessage(
   replyMarkup?: Record<string, unknown>
 ) {
   const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
-  const url = `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`;
+  const url = `${TELEGRAM_API_URL}/bot${BOT_TOKEN}/sendMessage`;
   const payload = {
     chat_id: chatId,
     text: text,

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -439,6 +439,8 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const BOT_VERSION = Deno.env.get("BOT_VERSION") || "0.0.0";
 const WEBHOOK_SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET");
+const TELEGRAM_API_URL =
+  Deno.env.get("TELEGRAM_API_URL") || "https://api.telegram.org";
 
 console.log("🚀 Bot starting with environment check...");
 console.log("BOT_TOKEN exists:", !!BOT_TOKEN);
@@ -786,7 +788,7 @@ async function sendMessage(
     parseMode?: string;
   }
 ) {
-  const url = `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`;
+  const url = `${TELEGRAM_API_URL}/bot${BOT_TOKEN}/sendMessage`;
   const payload = {
     chat_id: chatId,
     text: text,
@@ -885,7 +887,7 @@ async function showAdvancedSettings(chatId: number, userId: string) {
 // Function to delete a specific message
 async function deleteMessage(chatId: number, messageId: number): Promise<boolean> {
   try {
-    const response = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/deleteMessage`, {
+    const response = await fetch(`${TELEGRAM_API_URL}/bot${BOT_TOKEN}/deleteMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -922,7 +924,7 @@ async function handleReceiptUpload(message: TelegramMessage, userId: string): Pr
     }
 
     const infoRes = await fetch(
-      `https://api.telegram.org/bot${BOT_TOKEN}/getFile?file_id=${fileId}`,
+      `${TELEGRAM_API_URL}/bot${BOT_TOKEN}/getFile?file_id=${fileId}`,
     );
     const info = await infoRes.json();
     const filePath = info.result?.file_path;
@@ -932,7 +934,7 @@ async function handleReceiptUpload(message: TelegramMessage, userId: string): Pr
     }
 
     const fileRes = await fetch(
-      `https://api.telegram.org/file/bot${BOT_TOKEN}/${filePath}`,
+      `${TELEGRAM_API_URL}/file/bot${BOT_TOKEN}/${filePath}`,
     );
     const blob = await fileRes.blob();
     const arrayBuffer = await blob.arrayBuffer();
@@ -1119,7 +1121,7 @@ async function addUserToVipChannel(telegramUserId: string): Promise<void> {
     for (const channelId of vipChannels) {
       try {
         // Add user to channel (requires bot to be admin in the channel)
-        await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/approveChatJoinRequest`, {
+        await fetch(`${TELEGRAM_API_URL}/bot${BOT_TOKEN}/approveChatJoinRequest`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -2104,7 +2106,7 @@ Join our VIP community for detailed analysis and insights.
     }
 
     // Send to results channel
-    const response = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+    const response = await fetch(`${TELEGRAM_API_URL}/bot${BOT_TOKEN}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -3282,7 +3284,7 @@ async function handleBotStatus(chatId: number, userId: string): Promise<void> {
 
     // Test Telegram API
     const tgStart = Date.now();
-    const tgTest = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/getMe`);
+    const tgTest = await fetch(`${TELEGRAM_API_URL}/bot${BOT_TOKEN}/getMe`);
     const tgTime = Date.now() - tgStart;
 
     // Get system info
@@ -6496,7 +6498,7 @@ ${Array.from(securityStats.suspiciousUsers).slice(-5).map(u => `• User ${u}`).
         }
 
         // Answer callback query to remove loading state
-        await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/answerCallbackQuery`, {
+        await fetch(`${TELEGRAM_API_URL}/bot${BOT_TOKEN}/answerCallbackQuery`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ callback_query_id: update.callback_query.id })
@@ -6507,7 +6509,7 @@ ${Array.from(securityStats.suspiciousUsers).slice(-5).map(u => `• User ${u}`).
         await sendMessage(chatId, "❌ An error occurred. Please try again or contact support.");
         
         // Still answer the callback query
-        await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/answerCallbackQuery`, {
+        await fetch(`${TELEGRAM_API_URL}/bot${BOT_TOKEN}/answerCallbackQuery`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ 


### PR DESCRIPTION
## Summary
- allow configuring Telegram API endpoint via `TELEGRAM_API_URL`
- replace hardcoded Telegram URLs with env-based constant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c5fad9b88322a804580d0d5ee9fb