### PR TITLE
feat: guard receipt OCR and process asynchronously

### DIFF
--- a/supabase/functions/ocr-worker/index.ts
+++ b/supabase/functions/ocr-worker/index.ts
@@ -1,0 +1,15 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// TODO: If ocr_jobs already exists, re-use it; otherwise create idempotently.
+// This scheduled worker should process pending OCR jobs.
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});
+
+Deno.serve(async () => {
+  // TODO: fetch pending jobs, run OCR + parse + decision, update DB, send Telegram updates.
+  return new Response("ok");
+});


### PR DESCRIPTION
## Summary
- guard webhook to only OCR when an image or image-document is present
- process receipt OCR asynchronously and always return 200 quickly
- stub ocr-worker edge function for future scheduled processing

## Testing
- `deno check supabase/functions/telegram-bot/index.ts` *(fails: Parameter 'item' implicitly has an 'any' type ...)*
- `deno check supabase/functions/ocr-worker/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_6895d10f555483229ffdd2b2660722cf