### PR TITLE
fix: use boolean for deno nodeModulesDir

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "check": "deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
     "serve": "supabase functions serve"
   },
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": true,
   "compilerOptions": {
     "types": ["./types/tesseract.d.ts"]
   }


### PR DESCRIPTION
## Summary
- fix `deno.json` config by using a boolean for `nodeModulesDir`

## Testing
- `deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts` (fails: invalid peer certificate)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e1d8957c83228db4ca5ea65f96aa