### PR TITLE
fix: satisfy deno lint

### DIFF
--- a/supabase/functions/telegram-bot/helpers/beneficiary.ts
+++ b/supabase/functions/telegram-bot/helpers/beneficiary.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const BENEFICIARY_TABLE = Deno.env.get("BENEFICIARY_TABLE") ?? "beneficiaries";
 

--- a/supabase/functions/telegram-bot/ocr.ts
+++ b/supabase/functions/telegram-bot/ocr.ts
@@ -1,7 +1,7 @@
 import { createWorker } from "npm:tesseract.js@5";
 
 export async function ocrTextFromBlob(blob: Blob): Promise<string> {
-  const worker: any = await createWorker();
+  const worker = await createWorker();
   await worker.loadLanguage("eng");
   await worker.initialize("eng");
   await worker.setParameters({

--- a/types/tesseract.d.ts
+++ b/types/tesseract.d.ts
@@ -1,3 +1,11 @@
 declare module "tesseract.js" {
-  export function createWorker(): any;
+  interface Worker {
+    loadLanguage(lang: string): Promise<void>;
+    initialize(lang: string): Promise<void>;
+    setParameters(params: Record<string, string>): Promise<void>;
+    recognize(blob: Blob): Promise<{ data: { text: string } }>;
+    terminate(): Promise<void>;
+  }
+
+  export function createWorker(): Promise<Worker>;
 }


### PR DESCRIPTION
## Summary
- refine tesseract worker types
- drop unused createClient import
- rely on typed createWorker in OCR helper

## Testing
- `deno lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e4b8dbcc83228863c4f2c3a21e3d