### PR TITLE
Fix Tesseract OCR worker typing and update Deno workflow

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -26,8 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Deno
-        # uses: denoland/setup-deno@v1
-        uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
+        uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "check": "deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
     "serve": "supabase functions serve"
   },
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": true,
   "compilerOptions": {
     "types": ["./types/tesseract.d.ts"]
   }

--- a/supabase/functions/telegram-bot/helpers/beneficiary.ts
+++ b/supabase/functions/telegram-bot/helpers/beneficiary.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const BENEFICIARY_TABLE = Deno.env.get("BENEFICIARY_TABLE") ?? "beneficiaries";
 

--- a/types/tesseract.d.ts
+++ b/types/tesseract.d.ts
@@ -1,3 +1,9 @@
 declare module "tesseract.js" {
   export function createWorker(): any;
+  export type Worker = any;
+}
+
+declare module "npm:tesseract.js@5" {
+  export function createWorker(): any;
+  export type Worker = any;
 }

--- a/types/tesseract.d.ts
+++ b/types/tesseract.d.ts
@@ -1,9 +1,19 @@
-declare module "tesseract.js" {
-  export function createWorker(): any;
-  export type Worker = any;
+interface BaseWorker {
+  load(): Promise<void>;
+  loadLanguage(lang: string): Promise<void>;
+  initialize?(lang: string): Promise<void>;
+  reinitialize?(lang: string): Promise<void>;
+  setParameters(params: Record<string, string>): Promise<void>;
+  recognize(blob: Blob): Promise<{ data: { text: string } }>;
+  terminate(): Promise<void>;
 }
 
 declare module "npm:tesseract.js@5" {
-  export function createWorker(): any;
-  export type Worker = any;
+  export function createWorker(): Promise<BaseWorker>;
+  export type Worker = BaseWorker;
+}
+
+declare module "tesseract.js" {
+  export function createWorker(): Promise<BaseWorker>;
+  export type Worker = BaseWorker;
 }


### PR DESCRIPTION
## Summary
- fix Tesseract OCR worker typing and initialization
- declare tesseract.js types for Deno's npm imports
- use setup-deno@v1 with v1.x
- align deno.json for modern releases

## Testing
- `DENO_TLS_CA_STORE=system deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_6895ec7bfd8083228b7bc55575e16997