### PR TITLE
feat: add dynamic capital mini app

### DIFF
--- a/apps/mini/README.md
+++ b/apps/mini/README.md
@@ -1,0 +1,19 @@
+# Dynamic Capital Mini App
+
+Telegram Mini App implementing a glassmorphism UI for simple deposit flows.
+
+## Development
+
+```
+npm install
+npm run dev
+```
+
+The app lives under `apps/mini`. It relies on existing Edge Function endpoints:
+- `POST /api/intent` for creating bank/crypto intents
+- `POST /api/receipt` for uploading deposit receipts
+- `POST /api/crypto-txid` for submitting crypto transactions
+- `GET /api/receipts` for recent receipts
+
+SVG placeholders live in `apps/mini/public` for the logo, bank tiles and QR frame;
+replace them with production assets as needed.

--- a/apps/mini/public/logo-dynamic-capital.svg
+++ b/apps/mini/public/logo-dynamic-capital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#ccc"/>
+  <text x="50" y="55" font-size="20" text-anchor="middle" fill="#000">Logo</text>
+</svg>

--- a/apps/mini/public/qr-frame.svg
+++ b/apps/mini/public/qr-frame.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="none" stroke="#000" stroke-width="4"/>
+</svg>

--- a/apps/mini/public/tile-bml.svg
+++ b/apps/mini/public/tile-bml.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee"/>
+  <text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">BML</text>
+</svg>

--- a/apps/mini/public/tile-mib.svg
+++ b/apps/mini/public/tile-mib.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#eee"/>
+  <text x="50" y="55" font-size="14" text-anchor="middle" fill="#000">MIB</text>
+</svg>

--- a/apps/mini/src/components/ApproveButton.tsx
+++ b/apps/mini/src/components/ApproveButton.tsx
@@ -1,0 +1,13 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export default function ApproveButton({ label, className = '', ...rest }: Props) {
+  return (
+    <button className={`dc-btn dc-btn--approve ${className}`} {...rest}>
+      {label}
+    </button>
+  );
+}

--- a/apps/mini/src/components/GlassPanel.tsx
+++ b/apps/mini/src/components/GlassPanel.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function GlassPanel({ children, className = "" }: Props) {
+  return <div className={`dc-panel ${className}`}>{children}</div>;
+}

--- a/apps/mini/src/components/GlassRow.tsx
+++ b/apps/mini/src/components/GlassRow.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  left: ReactNode;
+  right?: ReactNode;
+  className?: string;
+}
+
+export default function GlassRow({ left, right, className = "" }: Props) {
+  return (
+    <div className={`dc-row ${className}`}>
+      <div>{left}</div>
+      {right && <div>{right}</div>}
+    </div>
+  );
+}

--- a/apps/mini/src/components/NetworkPicker.tsx
+++ b/apps/mini/src/components/NetworkPicker.tsx
@@ -1,0 +1,27 @@
+interface Option {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  options: Option[];
+  value: string;
+  onChange: (id: string) => void;
+}
+
+export default function NetworkPicker({ options, value, onChange }: Props) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((o) => (
+        <button
+          key={o.id}
+          className={`dc-chip ${value === o.id ? 'dc-btn--primary' : 'dc-btn--glass'}`}
+          onClick={() => onChange(o.id)}
+          aria-pressed={value === o.id}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/mini/src/components/PrimaryButton.tsx
+++ b/apps/mini/src/components/PrimaryButton.tsx
@@ -1,0 +1,13 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export default function PrimaryButton({ label, className = '', ...rest }: Props) {
+  return (
+    <button className={`dc-btn dc-btn--primary ${className}`} {...rest}>
+      {label}
+    </button>
+  );
+}

--- a/apps/mini/src/components/ReceiptUploader.tsx
+++ b/apps/mini/src/components/ReceiptUploader.tsx
@@ -1,0 +1,31 @@
+import { useState, ChangeEvent } from 'react';
+
+interface Props {
+  onChange: (file: File | null) => void;
+}
+
+export default function ReceiptUploader({ onChange }: Props) {
+  const [preview, setPreview] = useState<string>('');
+
+  function handle(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] || null;
+    onChange(file);
+    if (file) setPreview(URL.createObjectURL(file));
+    else setPreview('');
+  }
+
+  return (
+    <div>
+      {preview && (
+        <img src={preview} alt="Receipt preview" className="mb-2 w-full rounded-lg" />
+      )}
+      <input
+        type="file"
+        accept="image/*"
+        onChange={handle}
+        className="dc-input"
+        aria-label="Upload receipt"
+      />
+    </div>
+  );
+}

--- a/apps/mini/src/components/RejectButton.tsx
+++ b/apps/mini/src/components/RejectButton.tsx
@@ -1,0 +1,13 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export default function RejectButton({ label, className = '', ...rest }: Props) {
+  return (
+    <button className={`dc-btn dc-btn--reject ${className}`} {...rest}>
+      {label}
+    </button>
+  );
+}

--- a/apps/mini/src/components/SecondaryButton.tsx
+++ b/apps/mini/src/components/SecondaryButton.tsx
@@ -1,0 +1,13 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export default function SecondaryButton({ label, className = '', ...rest }: Props) {
+  return (
+    <button className={`dc-btn dc-btn--glass ${className}`} {...rest}>
+      {label}
+    </button>
+  );
+}

--- a/apps/mini/src/components/StatusPill.tsx
+++ b/apps/mini/src/components/StatusPill.tsx
@@ -1,0 +1,16 @@
+const variants = {
+  AWAITING: 'dc-pill--awaiting',
+  VERIFIED: 'dc-pill--verified',
+  REJECTED: 'dc-pill--rejected',
+  REVIEW: 'dc-pill--review',
+} as const;
+
+type Status = keyof typeof variants;
+
+interface Props {
+  status: Status;
+}
+
+export default function StatusPill({ status }: Props) {
+  return <span className={`dc-chip ${variants[status]}`}>{status}</span>;
+}

--- a/apps/mini/src/components/Toast.tsx
+++ b/apps/mini/src/components/Toast.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+interface Props {
+  message: string;
+  type: 'success' | 'warn' | 'error';
+  onClose: () => void;
+}
+
+export default function Toast({ message, type, onClose }: Props) {
+  useEffect(() => {
+    const id = setTimeout(onClose, 3000);
+    return () => clearTimeout(id);
+  }, [onClose]);
+
+  const map = {
+    success: 'dc-pill--verified',
+    warn: 'dc-pill--awaiting',
+    error: 'dc-pill--rejected',
+  } as const;
+
+  return (
+    <div className={`dc-chip ${map[type]} fixed bottom-4 left-1/2 -translate-x-1/2`}>{message}</div>
+  );
+}

--- a/apps/mini/src/components/TopBar.tsx
+++ b/apps/mini/src/components/TopBar.tsx
@@ -1,0 +1,15 @@
+import SecondaryButton from './SecondaryButton';
+
+interface Props {
+  title: string;
+  onLogout?: () => void;
+}
+
+export default function TopBar({ title, onLogout }: Props) {
+  return (
+    <div className="mb-4 flex items-center justify-between">
+      <h1 className="text-lg font-semibold">{title}</h1>
+      <SecondaryButton label="Log out" onClick={onLogout} />
+    </div>
+  );
+}

--- a/apps/mini/src/hooks/useApi.ts
+++ b/apps/mini/src/hooks/useApi.ts
@@ -1,0 +1,57 @@
+export function useApi() {
+  const createIntent = async (payload: Record<string, unknown>) => {
+    const res = await fetch('/api/intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return res.json();
+  };
+
+  const uploadReceipt = async (file: File) => {
+    const form = new FormData();
+    form.append('image', file);
+    const res = await fetch('/api/receipt', {
+      method: 'POST',
+      body: form,
+    });
+    return res.json();
+  };
+
+  const submitTxid = async (payload: { txid: string }) => {
+    const res = await fetch('/api/crypto-txid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return res.json();
+  };
+
+  const getReceipts = async (limit: number) => {
+    const res = await fetch(`/api/receipts?limit=${limit}`);
+    return res.json();
+  };
+
+  const getPending = async () => {
+    const res = await fetch('/api/receipts?status=manual_review');
+    return res.json();
+  };
+
+  const approve = async (id: string) => {
+    await fetch(`/api/receipt/${id}/approve`, { method: 'POST' });
+  };
+
+  const reject = async (id: string) => {
+    await fetch(`/api/receipt/${id}/reject`, { method: 'POST' });
+  };
+
+  return {
+    createIntent,
+    uploadReceipt,
+    submitTxid,
+    getReceipts,
+    getPending,
+    approve,
+    reject,
+  };
+}

--- a/apps/mini/src/hooks/useTelegram.ts
+++ b/apps/mini/src/hooks/useTelegram.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+
+interface TelegramWebApp {
+  themeParams?: Record<string, string>;
+  ready: () => void;
+  MainButton: {
+    setText: (text: string) => void;
+    enable: () => void;
+    disable: () => void;
+    onClick: (cb: () => void) => void;
+    offClick: (cb: () => void) => void;
+    show: () => void;
+  };
+}
+
+function getWebApp(): TelegramWebApp | undefined {
+  return (window as unknown as { Telegram?: { WebApp?: TelegramWebApp } }).Telegram?.WebApp;
+}
+
+export function useTelegram() {
+  useEffect(() => {
+    const webApp = getWebApp();
+    if (!webApp) return;
+    const root = document.documentElement;
+    const params = webApp.themeParams || {};
+    Object.entries(params).forEach(([k, v]) => {
+      root.style.setProperty(`--tg-${k}`, String(v));
+    });
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      root.style.setProperty('--dc-motion', 'none');
+    }
+    webApp.ready();
+  }, []);
+}
+
+export function useTelegramMainButton(
+  enabled: boolean,
+  text: string,
+  onClick: () => void,
+) {
+  useEffect(() => {
+    const webApp = getWebApp();
+    if (!webApp) return;
+    const btn = webApp.MainButton;
+    btn.setText(text);
+    if (enabled) btn.enable(); else btn.disable();
+    btn.onClick(onClick);
+    btn.show();
+    return () => btn.offClick(onClick);
+  }, [enabled, text, onClick]);
+}

--- a/apps/mini/src/main.tsx
+++ b/apps/mini/src/main.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { HashRouter } from 'react-router-dom';
+import AppRouter from './router';
+import './styles/theme.css';
+import { useTelegram } from './hooks/useTelegram';
+
+function App() {
+  useTelegram();
+  return <AppRouter />;
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <HashRouter>
+      <App />
+    </HashRouter>
+  </React.StrictMode>,
+);

--- a/apps/mini/src/pages/Admin.tsx
+++ b/apps/mini/src/pages/Admin.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import GlassRow from '../components/GlassRow';
+import ApproveButton from '../components/ApproveButton';
+import RejectButton from '../components/RejectButton';
+import TopBar from '../components/TopBar';
+import { useApi } from '../hooks/useApi';
+
+interface Receipt {
+  id: string;
+  amount: number;
+}
+
+export default function Admin() {
+  const api = useApi();
+  const [items, setItems] = useState<Receipt[]>([]);
+
+  useEffect(() => {
+    api.getPending().then(setItems);
+  }, [api]);
+
+  return (
+    <div className="dc-screen">
+      <TopBar title="Admin" />
+      {items.map((r) => (
+        <GlassRow
+          key={r.id}
+          left={<span className="text-sm">{r.id.slice(0,6)}…</span>}
+          right={
+            <div className="flex gap-2">
+              <ApproveButton label="Approve" onClick={() => api.approve(r.id)} />
+              <RejectButton label="Reject" onClick={() => api.reject(r.id)} />
+            </div>
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/mini/src/pages/Bank.tsx
+++ b/apps/mini/src/pages/Bank.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import TopBar from '../components/TopBar';
+import NetworkPicker from '../components/NetworkPicker';
+import GlassPanel from '../components/GlassPanel';
+import ReceiptUploader from '../components/ReceiptUploader';
+import PrimaryButton from '../components/PrimaryButton';
+import { useApi } from '../hooks/useApi';
+import { useTelegramMainButton } from '../hooks/useTelegram';
+
+export default function Bank() {
+  const api = useApi();
+  const [bank, setBank] = useState('');
+  const [payCode, setPayCode] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (bank) {
+      api.createIntent({ type: 'bank', bank }).then((r) => setPayCode(r.pay_code));
+    }
+  }, [bank, api]);
+
+  const handleSubmit = async () => {
+    if (file) {
+      await api.uploadReceipt(file);
+    }
+  };
+
+  useTelegramMainButton(!!file, 'Submit', handleSubmit);
+
+  return (
+    <div className="dc-screen">
+      <TopBar title="Bank Deposit" />
+      <NetworkPicker
+        options={[{ id: 'BML', label: 'BML' }, { id: 'MIB', label: 'MIB' }]}
+        value={bank}
+        onChange={setBank}
+      />
+      {payCode && (
+        <GlassPanel className="mt-4 text-center">
+          <p>Your deposit code</p>
+          <p className="font-mono text-lg">{payCode}</p>
+          <p className="text-sm">Add this in Remarks</p>
+        </GlassPanel>
+      )}
+      <div className="mt-4">
+        <p className="mb-2 text-sm">Upload receipt</p>
+        <ReceiptUploader onChange={setFile} />
+      </div>
+      <PrimaryButton
+        label="Submit for verification"
+        onClick={handleSubmit}
+        className="fixed bottom-4 left-4 right-4"
+        disabled={!file}
+      />
+    </div>
+  );
+}

--- a/apps/mini/src/pages/Crypto.tsx
+++ b/apps/mini/src/pages/Crypto.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import TopBar from '../components/TopBar';
+import NetworkPicker from '../components/NetworkPicker';
+import GlassPanel from '../components/GlassPanel';
+import PrimaryButton from '../components/PrimaryButton';
+import SecondaryButton from '../components/SecondaryButton';
+import { useApi } from '../hooks/useApi';
+import { useTelegramMainButton } from '../hooks/useTelegram';
+
+export default function Crypto() {
+  const api = useApi();
+  const [network, setNetwork] = useState('TRON');
+  const [address, setAddress] = useState('');
+  const [txid, setTxid] = useState('');
+
+  useEffect(() => {
+    api.createIntent({ type: 'crypto', network }).then((r) => setAddress(r.deposit_address));
+  }, [network, api]);
+
+  const handleSubmit = async () => {
+    if (txid) await api.submitTxid({ txid });
+  };
+
+  useTelegramMainButton(!!txid, 'Submit TXID', handleSubmit);
+
+  return (
+    <div className="dc-screen">
+      <TopBar title="Crypto Deposit" />
+      <p className="mb-2 text-sm">Network</p>
+      <NetworkPicker
+        options={[{ id: 'TRON', label: 'TRON/USDT' }]}
+        value={network}
+        onChange={setNetwork}
+      />
+      {address && (
+        <GlassPanel className="mt-4 text-center">
+          <p>Your deposit address</p>
+          <p className="break-all font-mono text-sm">{address}</p>
+          <div className="mt-2">
+            <SecondaryButton
+              label="Copy address"
+              onClick={() => navigator.clipboard.writeText(address)}
+            />
+          </div>
+          <img src="/qr-frame.svg" alt="QR code" className="mx-auto mt-2 w-32 h-32" />
+        </GlassPanel>
+      )}
+      <div className="mt-4">
+        <input
+          type="text"
+          placeholder="Paste TXID"
+          value={txid}
+          onChange={(e) => setTxid(e.target.value)}
+          className="dc-input"
+          aria-label="Paste TXID"
+        />
+      </div>
+      <PrimaryButton
+        label="Submit TXID"
+        onClick={handleSubmit}
+        className="fixed bottom-4 left-4 right-4"
+        disabled={!txid}
+      />
+    </div>
+  );
+}

--- a/apps/mini/src/pages/Home.tsx
+++ b/apps/mini/src/pages/Home.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+import GlassPanel from '../components/GlassPanel';
+import TopBar from '../components/TopBar';
+
+export default function Home() {
+  return (
+    <div className="dc-screen">
+      <TopBar title="Home" />
+      <div className="grid gap-4">
+        <Link to="/bank">
+          <GlassPanel className="text-center">
+            <p>Bank Deposit</p>
+          </GlassPanel>
+        </Link>
+        <Link to="/crypto">
+          <GlassPanel className="text-center">
+            <p>Crypto Deposit</p>
+          </GlassPanel>
+        </Link>
+        <Link to="/me">
+          <GlassPanel className="text-center">
+            <p>My Receipts</p>
+          </GlassPanel>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/mini/src/pages/Me.tsx
+++ b/apps/mini/src/pages/Me.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import GlassRow from '../components/GlassRow';
+import StatusPill from '../components/StatusPill';
+import TopBar from '../components/TopBar';
+import { useApi } from '../hooks/useApi';
+
+interface Receipt {
+  id: string;
+  amount: number;
+  status: 'AWAITING' | 'VERIFIED' | 'REJECTED' | 'REVIEW';
+  created_at: string;
+}
+
+export default function Me() {
+  const api = useApi();
+  const [receipts, setReceipts] = useState<Receipt[]>([]);
+
+  useEffect(() => {
+    api.getReceipts(5).then(setReceipts);
+  }, [api]);
+
+  return (
+    <div className="dc-screen">
+      <TopBar title="My Receipts" />
+      {receipts.map((r) => (
+        <GlassRow
+          key={r.id}
+          left={<span className="text-sm">{r.id.slice(0, 6)}…</span>}
+          right={<><span className="mr-2 text-sm">{r.amount}</span><StatusPill status={r.status} /></>}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/mini/src/router.tsx
+++ b/apps/mini/src/router.tsx
@@ -1,0 +1,18 @@
+import { Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import Bank from './pages/Bank';
+import Crypto from './pages/Crypto';
+import Me from './pages/Me';
+import Admin from './pages/Admin';
+
+export default function AppRouter() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/bank" element={<Bank />} />
+      <Route path="/crypto" element={<Crypto />} />
+      <Route path="/me" element={<Me />} />
+      <Route path="/admin" element={<Admin />} />
+    </Routes>
+  );
+}

--- a/apps/mini/src/styles/theme.css
+++ b/apps/mini/src/styles/theme.css
@@ -1,0 +1,125 @@
+:root {
+  --dc-brand:#2FD2C5;
+  --dc-ink:#0B3D3A;
+
+  --dc-bg:#0B0E11;
+  --dc-text:#E9F3F4;
+  --dc-text-dim:#C8D6D8;
+
+  --dc-glass:rgba(255,255,255,.08);
+  --dc-glass-stroke:rgba(255,255,255,.18);
+  --dc-blur:16px;
+  --dc-shadow:0 8px 30px rgba(0,0,0,.25);
+
+  --dc-good:#10D07A;
+  --dc-warn:#FFD166;
+  --dc-bad:#FF6B6B;
+  --dc-info:#9AA8FF;
+
+  --r-sm:10px;
+  --r-md:16px;
+  --r-lg:22px;
+
+  --sp-1:8px;
+  --sp-2:12px;
+  --sp-3:16px;
+  --sp-4:24px;
+  --sp-5:32px;
+}
+
+.dc-screen {
+  background: var(--dc-bg);
+  color: var(--dc-text);
+  padding: var(--sp-4);
+  min-height: 100vh;
+}
+
+.dc-panel {
+  background: var(--dc-glass);
+  backdrop-filter: blur(var(--dc-blur));
+  border: 1px solid var(--dc-glass-stroke);
+  border-radius: var(--r-lg);
+  box-shadow: var(--dc-shadow);
+  padding: var(--sp-4);
+}
+
+.dc-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-3);
+  border-bottom: 1px solid var(--dc-glass-stroke);
+}
+
+.dc-chip {
+  display: inline-block;
+  padding: 0 var(--sp-2);
+  border-radius: 12px;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.dc-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-md);
+  min-height: 44px;
+  transition: transform .15s ease;
+}
+
+.dc-btn:active {
+  transform: scale(0.96);
+}
+
+.dc-btn--primary {
+  background: var(--dc-brand);
+  color: var(--dc-ink);
+}
+
+.dc-btn--glass {
+  background: var(--dc-glass);
+  color: var(--dc-text);
+  backdrop-filter: blur(var(--dc-blur));
+  border: 1px solid var(--dc-glass-stroke);
+}
+
+.dc-btn--approve {
+  background: var(--dc-good);
+  color: var(--dc-ink);
+}
+
+.dc-btn--reject {
+  background: var(--dc-bad);
+  color: var(--dc-ink);
+}
+
+.dc-pill--awaiting {
+  background: var(--dc-warn);
+  color: var(--dc-ink);
+}
+
+.dc-pill--verified {
+  background: var(--dc-good);
+  color: var(--dc-ink);
+}
+
+.dc-pill--rejected {
+  background: var(--dc-bad);
+  color: var(--dc-ink);
+}
+
+.dc-pill--review {
+  background: var(--dc-info);
+  color: var(--dc-ink);
+}
+
+.dc-input {
+  background: var(--dc-glass);
+  border: 1px solid var(--dc-glass-stroke);
+  border-radius: var(--r-md);
+  padding: var(--sp-3);
+  color: var(--dc-text);
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- add glassmorphism theme tokens and utility classes for mini app
- implement reusable components, pages and hooks for Dynamic Capital deposits
- wire API helper to existing intent, receipt, crypto-txid and receipts endpoints
- replace binary placeholders with SVG assets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896026a3618832291af5d8aaebb5267