### PR TITLE
Ensure MINI_APP_URL is set and normalized

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -21,3 +21,7 @@ The project relies on a shared set of environment keys. Set them in your local `
 | MINI_APP_URL | ✅ | ✅ | ✅ |
 
 `✅` indicates where each key should be set.
+
+`MINI_APP_URL` should point to the deployed Telegram Mini App (for example,
+`https://mini.dynamic.capital/`). The function requires this value and will
+automatically append a trailing slash if missing to avoid redirect issues.

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1487,11 +1487,9 @@ export function handleEnvStatus() {
     "SUPABASE_SERVICE_ROLE_KEY",
     "TELEGRAM_BOT_TOKEN",
     "TELEGRAM_WEBHOOK_SECRET",
+    "MINI_APP_URL",
   ]);
-  return {
-    ...base,
-    MINI_APP_URL: Deno.env.get("MINI_APP_URL") ? "present" : "missing",
-  };
+  return base;
 }
 
 export async function handleReviewList() {

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -51,6 +51,7 @@ const REQUIRED_ENV_KEYS = [
   "SUPABASE_SERVICE_ROLE_KEY",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_WEBHOOK_SECRET",
+  "MINI_APP_URL",
 ];
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
@@ -58,7 +59,12 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ||
   "";
 const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const WEBHOOK_SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
-const MINI_APP_URL = Deno.env.get("MINI_APP_URL");
+// Ensure MINI_APP_URL always includes a trailing slash to avoid redirects
+const MINI_APP_URL = (() => {
+  const url = Deno.env.get("MINI_APP_URL");
+  if (!url) return null;
+  return url.endsWith("/") ? url : `${url}/`;
+})();
 
 // Optional feature flags (currently unused)
 const _OPENAI_ENABLED = Deno.env.get("OPENAI_ENABLED") === "true";


### PR DESCRIPTION
## Summary
- Require MINI_APP_URL in Telegram bot function
- Normalize MINI_APP_URL with trailing slash to avoid redirects
- Document MINI_APP_URL usage in configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960e4746988322b1291d80217db14d