### PR TITLE
Fix useToast listener registration

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,9 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // The effect should only register the listener once
+    // to avoid accumulating multiple subscriptions on state changes.
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent multiple listener registrations in `useToast`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68961408edbc8322baef204709e054dc