### PR TITLE
fix: satisfy deno lint

### DIFF
--- a/apps/mini/src/components/NetworkPicker.tsx
+++ b/apps/mini/src/components/NetworkPicker.tsx
@@ -12,16 +12,17 @@ interface Props {
 export default function NetworkPicker({ options, value, onChange }: Props) {
   return (
     <div className="flex flex-wrap gap-2">
-      {options.map((o) => (
-        <button
-          key={o.id}
-          className={`dc-chip ${value === o.id ? 'dc-btn--primary' : 'dc-btn--glass'}`}
-          onClick={() => onChange(o.id)}
-          aria-pressed={value === o.id}
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
-  );
-}
+        {options.map((o) => (
+          <button
+            key={o.id}
+            type="button"
+            className={`dc-chip ${value === o.id ? 'dc-btn--primary' : 'dc-btn--glass'}`}
+            onClick={() => onChange(o.id)}
+            aria-pressed={value === o.id}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    );
+  }

--- a/apps/mini/src/hooks/useTelegram.ts
+++ b/apps/mini/src/hooks/useTelegram.ts
@@ -14,7 +14,7 @@ interface TelegramWebApp {
 }
 
 function getWebApp(): TelegramWebApp | undefined {
-  return (window as unknown as { Telegram?: { WebApp?: TelegramWebApp } }).Telegram?.WebApp;
+  return (globalThis as unknown as { Telegram?: { WebApp?: TelegramWebApp } }).Telegram?.WebApp;
 }
 
 export function useTelegram() {
@@ -26,9 +26,9 @@ export function useTelegram() {
     Object.entries(params).forEach(([k, v]) => {
       root.style.setProperty(`--tg-${k}`, String(v));
     });
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      root.style.setProperty('--dc-motion', 'none');
-    }
+      if (globalThis.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) {
+        root.style.setProperty('--dc-motion', 'none');
+      }
     webApp.ready();
   }, []);
 }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -38,8 +38,8 @@ const localStorageMock = (() => {
 registerTest("clearCache only removes cached entries", async () => {
   localStorage.setItem("external", "keep");
 
-  await getCached("foo", 1000, async () => "foo");
-  await getCached("bar", 1000, async () => "bar");
+  await getCached("foo", 1000, () => Promise.resolve("foo"));
+  await getCached("bar", 1000, () => Promise.resolve("bar"));
 
   clearCache();
 


### PR DESCRIPTION
## Summary
- fix cache test to use promise factories instead of async callbacks
- use `globalThis` in Telegram hook and optional matchMedia
- add missing `type="button"` to NetworkPicker

## Testing
- `deno lint --fix`
- `deno test -A --unsafely-ignore-certificate-errors=registry.npmjs.org,deno.land`


------
https://chatgpt.com/codex/tasks/task_e_68961ecfb75c8322a91a03e2d4f2e944