### PR TITLE
Gate Mini App button via env and document local ping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,5 @@ OPENAI_ENABLED=
 FAQ_ENABLED=
 WINDOW_SECONDS=
 AMOUNT_TOLERANCE=
-MINI_APP_URL= # e.g. https://mini.dynamic.capital or https://dynamic-capital-mini.vercel.app
+# e.g. https://mini.dynamic.capital or https://dynamic-capital-mini.vercel.app
+MINI_APP_URL=

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -23,5 +23,5 @@ The project relies on a shared set of environment keys. Set them in your local `
 `✅` indicates where each key should be set.
 
 `MINI_APP_URL` should point to the deployed Telegram Mini App (for example,
-`https://mini.dynamic.capital/`). The function requires this value and will
-automatically append a trailing slash if missing to avoid redirect issues.
+`https://mini.dynamic.capital/`). If set, the bot shows a Mini App button and
+will automatically append a trailing slash if missing to avoid redirect issues.

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -10,15 +10,13 @@
 ## Local webhook smoke test
 
 ```bash
-# 1) Start Supabase local stack (API on :54321)
+# Start local stack
 supabase start
 
-# 2) Serve the function in another terminal
+# Serve the function (new terminal)
 supabase functions serve telegram-bot --no-verify-jwt
 
-# 3) Ping it locally (replace SECRET as needed)
-curl -i -X POST \
-  "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
-  -H "content-type: application/json" \
-  -d '{"test":"ping"}'
+# Ping (expects 200)
+curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
+  -H "content-type: application/json" -d '{"test":"ping"}'
 ```

--- a/supabase/functions/telegram-bot/admin-handlers.ts
+++ b/supabase/functions/telegram-bot/admin-handlers.ts
@@ -1487,7 +1487,6 @@ export function handleEnvStatus() {
     "SUPABASE_SERVICE_ROLE_KEY",
     "TELEGRAM_BOT_TOKEN",
     "TELEGRAM_WEBHOOK_SECRET",
-    "MINI_APP_URL",
   ]);
   return base;
 }

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -51,7 +51,6 @@ const REQUIRED_ENV_KEYS = [
   "SUPABASE_SERVICE_ROLE_KEY",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_WEBHOOK_SECRET",
-  "MINI_APP_URL",
 ];
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
@@ -100,12 +99,7 @@ async function notifyUser(chatId: number, text: string): Promise<void> {
 }
 
 async function sendMiniAppLink(chatId: number): Promise<void> {
-  if (!BOT_TOKEN) return;
-  if (!MINI_APP_URL) {
-    console.warn("MINI_APP_URL missing; skipping Mini App button");
-    await notifyUser(chatId, "Mini App URL not configured");
-    return;
-  }
+  if (!BOT_TOKEN || !MINI_APP_URL) return;
   await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Show Mini App button only when `MINI_APP_URL` env is set
- Clarify config and add local webhook smoke test docs
- Trim optional `MINI_APP_URL` from required env checks

## Testing
- `deno lint --fix supabase/functions/telegram-bot`
- `deno check --unsafely-ignore-certificate-errors=registry.npmjs.org supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts`
- `deno test -A --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org`
- `curl -s -X POST "http://127.0.0.1:8000/?secret=testsecret" -H "content-type: application/json" -d '{"test":"ping"}'`
- `curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getWebhookInfo"`


------
https://chatgpt.com/codex/tasks/task_e_68962351bcec8322b028ff82f5643894