### PR TITLE
feat: add mini app short name support

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -17,6 +17,16 @@ supabase start
 supabase functions serve telegram-bot --no-verify-jwt
 
 # Ping (expects 200)
-curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
-  -H "content-type: application/json" -d '{"test":"ping"}'
-```
+  curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot?secret=$TELEGRAM_WEBHOOK_SECRET" \
+    -H "content-type: application/json" -d '{"test":"ping"}'
+  ```
+
+### Mini App launch options
+- Preferred: set `MINI_APP_SHORT_NAME` (from BotFather, e.g. `dynamic_pay`)
+- Fallback: set `MINI_APP_URL` (full https URL)
+
+### Set a persistent chat menu button (optional)
+# Requires TELEGRAM_BOT_TOKEN set in your shell
+curl -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setChatMenuButton" \
+  -H "content-type: application/json" \
+  -d '{"menu_button":{"type":"web_app","text":"Dynamic Pay","web_app":{"short_name":"dynamic_pay"}}}'


### PR DESCRIPTION
## Summary
- support optional `MINI_APP_SHORT_NAME` env for launching mini app via Telegram short_name
- centralize web app button builder and update `/start` and new `/app` command to use it
- document mini app launch options and menu button setup

## Testing
- `deno lint supabase/functions/telegram-bot/index.ts`
- `deno check supabase/functions/telegram-bot/index.ts` *(fails: Cannot find module 'file:///workspace/types/tesseract.d.ts')*
- `deno test` *(fails: client error invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68963a5da5448322962636200bd6e849