### PR TITLE
fix telegram bot start command

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -36,8 +36,6 @@ interface PaymentIntent {
 }
 
 const REQUIRED_ENV_KEYS = [
-  "SUPABASE_URL",
-  "SUPABASE_SERVICE_ROLE_KEY",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_WEBHOOK_SECRET",
 ];


### PR DESCRIPTION
## Summary
- relax required env vars so bot can respond to /start even without Supabase credentials

## Testing
- `npm test` *(fails: invalid peer certificate UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68974468387c8322befe75158f874512