### PR TITLE
feat: add in-process job queue and broadcast planner

### DIFF
--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -1,0 +1,40 @@
+import { enqueue } from '../queue/index.ts';
+
+export interface PlanBroadcastOptions {
+  segment: number[] | { userIds: number[] };
+  text: string;
+  media?: string;
+  chunkSize?: number;
+  pauseMs?: number;
+}
+
+const featureFlags = { broadcasts_enabled: true };
+export function setBroadcastsEnabled(v: boolean) {
+  featureFlags.broadcasts_enabled = v;
+}
+
+export async function resolveTargets(segment: PlanBroadcastOptions['segment']): Promise<number[]> {
+  if (Array.isArray(segment)) return segment;
+  if (segment && Array.isArray((segment as { userIds?: number[] }).userIds)) {
+    return (segment as { userIds: number[] }).userIds;
+  }
+  return [];
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function planBroadcast(opts: PlanBroadcastOptions) {
+  if (!featureFlags.broadcasts_enabled) {
+    throw new Error('Broadcasts disabled');
+  }
+  const { segment, text, media, chunkSize = 25, pauseMs = 500 } = opts;
+  const targets = await resolveTargets(segment);
+  for (let i = 0; i < targets.length; i += chunkSize) {
+    const chunk = targets.slice(i, i + chunkSize);
+    enqueue('broadcast:sendBatch', { userIds: chunk, text, media }, { maxAttempts: 5, backoff: 'exp' });
+    if (pauseMs) await sleep(pauseMs);
+  }
+  return { total: targets.length, chunks: Math.ceil(targets.length / chunkSize) };
+}

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -1,0 +1,168 @@
+// Simple in-process job queue with optional persistence
+// Jobs are processed FIFO with exponential backoff retry logic.
+
+export type BackoffStrategy = 'exp';
+
+export interface EnqueueOptions {
+  maxAttempts?: number;
+  backoff?: BackoffStrategy;
+  delayMs?: number;
+}
+
+export interface JobRecord {
+  id: number;
+  type: string;
+  payload: unknown;
+  status: 'pending' | 'completed' | 'failed';
+  attempts: number;
+  maxAttempts: number;
+  nextRunAt: number;
+  lastError?: string;
+}
+
+export type Processor = (payload: unknown, job: JobRecord) => Promise<void>;
+export type ProcessorMap = Record<string, Processor>;
+
+let processors: ProcessorMap = {};
+let running = false;
+let jobIdCounter = 1;
+const jobStore = new Map<number, JobRecord>();
+let queue: number[] = [];
+let backoffBaseMs = 1000; // can be tuned for tests
+const backoffCapMs = 30000;
+let loopPromise: Promise<void> | null = null;
+
+// Optional persistence via Supabase if available
+let supabaseClient: unknown = null;
+export function setSupabase(client: unknown) {
+  supabaseClient = client;
+}
+
+function sortQueue() {
+  queue.sort((a, b) => {
+    const ja = jobStore.get(a)!;
+    const jb = jobStore.get(b)!;
+    return ja.nextRunAt - jb.nextRunAt;
+  });
+}
+
+async function persist(job: JobRecord) {
+  if (!supabaseClient) return;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabaseClient as any).from('jobs').upsert({
+      id: job.id,
+      type: job.type,
+      payload: job.payload,
+      status: job.status,
+      attempts: job.attempts,
+      next_run_at: new Date(job.nextRunAt).toISOString(),
+      last_error: job.lastError ?? null,
+    });
+  } catch (_) {
+    // ignore persistence errors
+  }
+}
+
+export function setBackoffBase(ms: number) {
+  backoffBaseMs = ms;
+}
+
+export function enqueue(type: string, payload: unknown, opts: EnqueueOptions = {}) {
+  const job: JobRecord = {
+    id: jobIdCounter++,
+    type,
+    payload,
+    status: 'pending',
+    attempts: 0,
+    maxAttempts: opts.maxAttempts ?? 5,
+    nextRunAt: Date.now() + (opts.delayMs ?? 0),
+  };
+  jobStore.set(job.id, job);
+  queue.push(job.id);
+  sortQueue();
+  persist(job);
+  return job.id;
+}
+
+function calculateBackoff(attempt: number): number {
+  const delay = backoffBaseMs * Math.pow(2, attempt - 1);
+  return Math.min(delay, backoffCapMs);
+}
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function processJob(job: JobRecord) {
+  const processor = processors[job.type];
+  if (!processor) {
+    job.status = 'failed';
+    job.lastError = 'no processor';
+    await persist(job);
+    return;
+  }
+  try {
+    await processor(job.payload, job);
+    job.status = 'completed';
+    await persist(job);
+  } catch (err) {
+    job.attempts += 1;
+    job.lastError = err instanceof Error ? err.message : String(err);
+    if (job.attempts < job.maxAttempts) {
+      job.nextRunAt = Date.now() + calculateBackoff(job.attempts);
+      queue.push(job.id);
+      sortQueue();
+    } else {
+      job.status = 'failed';
+    }
+    await persist(job);
+  }
+}
+
+export async function workerLoop() {
+  while (running) {
+    if (queue.length === 0) {
+      await sleep(50);
+      continue;
+    }
+    const id = queue[0];
+    const job = jobStore.get(id);
+    if (!job) {
+      queue.shift();
+      continue;
+    }
+    const now = Date.now();
+    if (job.nextRunAt > now) {
+      await sleep(job.nextRunAt - now);
+      continue;
+    }
+    queue.shift();
+    await processJob(job);
+  }
+}
+
+export function startWorker(map: ProcessorMap) {
+  processors = map;
+  if (running) return;
+  running = true;
+  loopPromise = workerLoop();
+}
+
+export async function stopWorker() {
+  running = false;
+  if (loopPromise) {
+    await loopPromise;
+    loopPromise = null;
+  }
+}
+
+export function pendingJobs(): JobRecord[] {
+  return queue.map((id) => jobStore.get(id)!).filter(Boolean);
+}
+
+export function clearQueue() {
+  queue = [];
+  jobStore.clear();
+  jobIdCounter = 1;
+}

--- a/tests/broadcast-queue.test.ts
+++ b/tests/broadcast-queue.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck: cross-runtime test uses dynamic imports
+let registerTest;
+let assertEquals;
+let assertRejects;
+if (typeof Deno !== 'undefined') {
+  registerTest = (name, fn) => Deno.test(name, fn);
+  const asserts = await import('https://deno.land/std@0.224.0/testing/asserts.ts');
+  assertEquals = asserts.assertEquals;
+  assertRejects = asserts.assertRejects;
+} else {
+  const { test } = await import('node:test');
+  registerTest = (name, fn) => test(name, { concurrency: false }, fn);
+  const assert = (await import('node:assert')).strict;
+  assertEquals = (a, b, msg) => assert.equal(a, b, msg);
+  assertRejects = assert.rejects;
+}
+
+import { enqueue, startWorker, stopWorker, setBackoffBase, clearQueue, pendingJobs } from '../src/queue/index.ts';
+import { planBroadcast, setBroadcastsEnabled } from '../src/broadcast/index.ts';
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+registerTest('retries until success', async () => {
+  clearQueue();
+  setBackoffBase(10); // speed up for tests
+  let attempt = 0;
+  startWorker({
+    'broadcast:sendBatch': async () => {
+      attempt++;
+      if (attempt < 4) throw new Error('fail');
+    },
+  });
+  enqueue('broadcast:sendBatch', { userIds: [1], text: 'hi' }, { maxAttempts: 5, backoff: 'exp' });
+  await sleep(200); // allow retries
+  await stopWorker();
+  assertEquals(attempt, 4);
+});
+
+registerTest('chunking creates 8 jobs for 200 recipients', async () => {
+  clearQueue();
+  const ids = Array.from({ length: 200 }, (_, i) => i + 1);
+  await planBroadcast({ segment: ids, text: 'hello', chunkSize: 25, pauseMs: 0 });
+  const jobs = pendingJobs();
+  assertEquals(jobs.length, 8);
+  const total = jobs.reduce((sum, j) => sum + (j.payload as any).userIds.length, 0);
+  assertEquals(total, 200);
+});
+
+registerTest('broadcasts disabled blocks planning', async () => {
+  clearQueue();
+  setBroadcastsEnabled(false);
+  const ids = [1, 2, 3];
+  await assertRejects(() => planBroadcast({ segment: ids, text: 'nope' }));
+  setBroadcastsEnabled(true);
+});


### PR DESCRIPTION
## Summary
- introduce in-memory job queue with exponential backoff retries and optional persistence
- add broadcast planner that chunks user IDs and schedules sendBatch jobs
- cover queue retries, broadcast chunking, and feature flag blocking with tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897479df7b08322a26db8e311013bc1