### PR TITLE
feat: add audit scripts and workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,27 @@
+name: Supabase Project Audit
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"  # Mondays 03:00 UTC
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run Audit
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          node -v
+          npm -v
+          chmod +x scripts/audit/run.sh
+          ./scripts/audit/run.sh
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-report
+          path: .audit/*

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ supabase/functions/**/.edge/
 
 # Mini app build & deps
 apps/mini/dist/
+
+# Audit reports
+.audit/

--- a/scripts/audit/read_meta.mjs
+++ b/scripts/audit/read_meta.mjs
@@ -1,0 +1,34 @@
+import fs from 'fs';
+
+const url = process.env.A_SUPABASE_URL;
+const key = process.env.A_SUPABASE_KEY;
+if (!url || !key) {
+  fs.writeFileSync('.audit/meta.json', JSON.stringify({ ok:false, error:'Missing A_SUPABASE_URL/A_SUPABASE_KEY' }, null, 2));
+  process.exit(0);
+}
+
+async function r(path) {
+  const u = `${url.replace(/\/$/,'')}/rest/v1/${path}`;
+  const res = await fetch(u, { headers: { apikey: key, Authorization: `Bearer ${key}` }});
+  if (!res.ok) throw new Error(`GET ${path} -> ${res.status}`);
+  return res.json();
+}
+
+// pg_meta exposure
+let tables=[], indexes=[];
+try {
+  tables = await r('pg_meta.tables?select=schema,name');
+} catch(e) {}
+try {
+  indexes = await r('pg_meta.indexes?select=schema,table,name,is_unique,is_primary,columns');
+} catch(e) {}
+
+const meta = {
+  ok: true,
+  tables: tables.filter(t => t.schema === 'public').map(t => t.name).sort(),
+  indexes: indexes.filter(i => i.schema === 'public').map(i => ({
+    table: i.table, name: i.name, is_unique: !!i.is_unique, is_primary: !!i.is_primary, columns: i.columns
+  }))
+};
+
+fs.writeFileSync('.audit/meta.json', JSON.stringify(meta, null, 2));

--- a/scripts/audit/report.mjs
+++ b/scripts/audit/report.mjs
@@ -1,0 +1,80 @@
+import fs from 'fs';
+
+function j(p){ try { return JSON.parse(fs.readFileSync(p,'utf8')); } catch { return null; } }
+
+const code = j('.audit/code_scan.json') || { edge_functions:{present:[],referenced:[]}, callbacks:{defined:[],used_anywhere:[]}, tables:{referenced:[]} };
+const meta = j('.audit/meta.json') || { ok:false, tables:[], indexes:[] };
+
+const presentFns = new Set(code.edge_functions.present);
+const refFns = new Set(code.edge_functions.referenced);
+const unusedFns = [...presentFns].filter(x => !refFns.has(x)).sort();
+
+const cbDefined = new Set(code.callbacks.defined);
+const cbUsed = new Set(code.callbacks.used_anywhere);
+const unusedCallbacks = [...cbDefined].filter(x => !cbUsed.has(x)).sort();
+
+const codeTables = new Set(code.tables.referenced);
+const dbTables = new Set(meta.tables || []);
+const dbOnlyTables = [...dbTables].filter(t => !codeTables.has(t)).sort(); // exist in DB, never referenced in code
+const codeOnlyTables = [...codeTables].filter(t => !dbTables.has(t)).sort(); // referenced in code, not found in DB (typos?)
+
+const idx = Array.isArray(meta.indexes) ? meta.indexes : [];
+const suspectIndexes = idx
+  .filter(i => !codeTables.has(i.table)) // indexes on tables not referenced in code
+  .filter(i => !i.is_primary)            // ignore PK
+  .map(i => ({ table: i.table, name: i.name, columns: i.columns, is_unique: i.is_unique }))
+  .sort((a,b)=> (a.table+a.name).localeCompare(b.table+b.name));
+
+const report = {
+  summary: {
+    files_scanned: code.scanned_files || 0,
+    edge_functions: { total: presentFns.size, referenced: refFns.size, unused: unusedFns.length },
+    callbacks: { defined: cbDefined.size, used: cbUsed.size, unused: unusedCallbacks.length },
+    tables: { referenced_in_code: codeTables.size, in_db: dbTables.size, db_only: dbOnlyTables.length, code_only: codeOnlyTables.length },
+    suspect_indexes: suspectIndexes.length
+  },
+  details: {
+    unused_edge_functions: unusedFns,
+    unused_callbacks: unusedCallbacks,
+    db_only_tables: dbOnlyTables,
+    code_only_tables: codeOnlyTables,
+    suspect_indexes: suspectIndexes
+  }
+};
+
+fs.writeFileSync('.audit/audit_report.json', JSON.stringify(report, null, 2));
+
+// Markdown
+function table(rows, headers){
+  const h = `| ${headers.join(' | ')} |`;
+  const s = `| ${headers.map(()=>':--').join(' | ')} |`;
+  const b = rows.map(r => `| ${headers.map(k=>String(r[k] ?? '')).join(' | ')} |`).join('\n');
+  return [h,s,b].join('\n');
+}
+let md = `# Project Audit Report
+
+## Summary
+- Files scanned: ${report.summary.files_scanned}
+- Edge Functions: total ${report.summary.edge_functions.total}, referenced ${report.summary.edge_functions.referenced}, unused ${report.summary.edge_functions.unused}
+- Callbacks: defined ${report.summary.callbacks.defined}, used ${report.summary.callbacks.used}, unused ${report.summary.callbacks.unused}
+- Tables: referenced in code ${report.summary.tables.referenced_in_code}, in DB ${report.summary.tables.in_db}, DB-only ${report.summary.tables.db_only}, code-only ${report.summary.tables.code_only}
+- Suspect indexes (on tables not referenced in code, non-PK): ${report.summary.suspect_indexes}
+
+## Unused Edge Functions
+${report.details.unused_edge_functions.length ? report.details.unused_edge_functions.map(x=>`- ${x}`).join('\n') : '_None_'}
+
+## Unused Callback Keys
+${report.details.unused_callbacks.length ? report.details.unused_callbacks.map(x=>`- ${x}`).join('\n') : '_None_'}
+
+## Tables present in DB but never referenced in code
+${report.details.db_only_tables.length ? report.details.db_only_tables.map(x=>`- ${x}`).join('\n') : '_None_'}
+
+## Tables referenced in code but not found in DB
+${report.details.code_only_tables.length ? report.details.code_only_tables.map(x=>`- ${x}`).join('\n') : '_None_'}
+
+## Suspect Indexes
+${report.details.suspect_indexes.length
+  ? table(report.details.suspect_indexes, ['table','name','columns','is_unique'])
+  : '_None_'}
+`;
+fs.writeFileSync('.audit/audit_report.md', md);

--- a/scripts/audit/run.sh
+++ b/scripts/audit/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p .audit
+: "${SUPABASE_URL:?SUPABASE_URL required}"
+: "${SUPABASE_ANON_KEY:=}"
+: "${SUPABASE_SERVICE_ROLE_KEY:=}"
+
+export NODE_NO_WARNINGS=1
+export A_SUPABASE_URL="$SUPABASE_URL"
+export A_SUPABASE_KEY="${SUPABASE_SERVICE_ROLE_KEY:-$SUPABASE_ANON_KEY}"
+
+node scripts/audit/scan_code.mjs
+node scripts/audit/read_meta.mjs
+node scripts/audit/report.mjs
+
+echo "Report:"
+echo " - .audit/audit_report.json"
+echo " - .audit/audit_report.md"
+

--- a/scripts/audit/scan_code.mjs
+++ b/scripts/audit/scan_code.mjs
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = process.cwd();
+const SRC_DIRS = ['src', 'supabase/functions'];
+
+function walk(dir) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(p));
+    else if (/\.(ts|js|mjs|tsx|jsx|json)$/.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+function read(p){ try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } }
+
+const files = SRC_DIRS.flatMap(d => walk(path.join(ROOT, d)));
+
+const cbVals = new Set();     // callback_data values
+const cbDefs = new Set();     // where defined (constants)
+const fnDirs = new Set();     // edge functions (folder names)
+const fnRefs = new Set();     // code references to function names
+const tableRefs = new Set();  // db.from('table') table names
+
+// Edge functions present (by directory name)
+const FN_ROOT = path.join(ROOT, 'supabase', 'functions');
+if (fs.existsSync(FN_ROOT)) {
+  for (const e of fs.readdirSync(FN_ROOT, { withFileTypes: true })) {
+    if (e.isDirectory()) fnDirs.add(e.name);
+  }
+}
+
+// Regexes
+const reCallbackData = /callback_data\s*:\s*['"]([^'"]+)['"]/g;
+const reCBMapValue = /CB\.\w+\s*=\s*['"]([^'"]+)['"]/g; // in case of assignments
+const reCBObject = /export\s+const\s+CB\s*=\s*\{([\s\S]*?)\}\s*as\s*const/s;
+const reCBPair = /['"]?([A-Z0-9_]+)['"]?\s*:\s*['"]([^'"]+)['"]/g;
+const reFromTable = /\.from\(\s*['"]([a-zA-Z0-9_\.]+)['"]\s*\)/g;
+const reFuncFetch = /\/functions\/v1\/([a-zA-Z0-9\-_]+)/g;
+const reFuncNameStr = /['"`]([a-zA-Z0-9\-_]+)['"`]/g;
+
+for (const f of files) {
+  const s = read(f);
+  // find callback_data usage
+  for (const m of s.matchAll(reCallbackData)) cbVals.add(m[1]);
+
+  // find CB object values
+  const obj = s.match(reCBObject)?.[1];
+  if (obj) for (const m of obj.matchAll(reCBPair)) { cbVals.add(m[2]); cbDefs.add(m[2]); }
+  for (const m of s.matchAll(reCBMapValue)) { cbVals.add(m[1]); cbDefs.add(m[1]); }
+
+  // find table refs
+  for (const m of s.matchAll(reFromTable)) tableRefs.add(m[1]);
+
+  // find function refs via fetch URLs
+  for (const m of s.matchAll(reFuncFetch)) fnRefs.add(m[1]);
+  // also catch explicit string mentions if preceded by functions/v1 var builds
+  if (/functions\/v1/.test(s)) {
+    for (const m of s.matchAll(reFuncNameStr)) {
+      const name = m[1];
+      if (fnDirs.has(name)) fnRefs.add(name);
+    }
+  }
+}
+
+// Output
+const out = {
+  scanned_files: files.length,
+  edge_functions: { present: [...fnDirs].sort(), referenced: [...fnRefs].sort() },
+  callbacks: { defined: [...cbDefs].sort(), used_anywhere: [...cbVals].sort() },
+  tables: { referenced: [...tableRefs].sort() }
+};
+fs.writeFileSync('.audit/code_scan.json', JSON.stringify(out, null, 2));


### PR DESCRIPTION
## Summary
- add audit scripts to scan code, Supabase metadata, and generate reports
- schedule Supabase project audit workflow
- ignore generated audit reports

## Testing
- `npm test` *(fails: invalid peer certificate when downloading npm packages)*
- `SUPABASE_URL=http://example.com SUPABASE_SERVICE_ROLE_KEY=anon ./scripts/audit/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897a18713dc8322a25ffb1e88befbad