### PR TITLE
Add CI workflow and Supabase deployment scripts

### DIFF
--- a/.github/workflows/ci-deploy-dc.yml
+++ b/.github/workflows/ci-deploy-dc.yml
@@ -1,0 +1,74 @@
+name: CI & Deploy (DC)
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "supabase/functions/**"
+      - "deno.json"
+      - "scripts/**"
+  push:
+    branches: ["main"]
+    paths:
+      - "src/**"
+      - "supabase/functions/**"
+      - "deno.json"
+      - "scripts/**"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: denoland/setup-deno@v1
+        with: { deno-version: v1.x }
+      - name: Cache Deno deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/deno
+          key: ${{ runner.os }}-deno-${{ hashFiles('**/*.ts', 'deno.json') }}
+      - name: CI (fmt/lint/typecheck/test)
+        env:
+          DENO_TLS_CA_STORE: system
+          # DENO_CERT_FILE: ${{ secrets.DENO_CERT_FILE }}   # optional custom CA
+        run: |
+          chmod +x scripts/ci.sh scripts/typecheck.sh || true
+          deno task ci
+      - name: Detect changed functions
+        run: |
+          chmod +x scripts/changed_functions.sh || true
+          ./scripts/changed_functions.sh
+      - name: Upload function list
+        uses: actions/upload-artifact@v4
+        with:
+          name: changed-functions
+          path: .out/functions.txt
+
+  deploy:
+    needs: check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Download function list
+        uses: actions/download-artifact@v4
+        with:
+          name: changed-functions
+          path: .out
+      - name: Install Node (for Supabase CLI via npx)
+        uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - name: Deploy changed functions
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: |
+          chmod +x scripts/deploy_functions.sh || true
+          scripts/deploy_functions.sh .out/functions.txt

--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,18 @@
 {
   "tasks": {
     "check": "deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
-    "serve": "supabase functions serve"
+    "serve": "supabase functions serve",
+    "fmt": "deno fmt --check .",
+    "lint": "deno lint",
+    "typecheck": "bash scripts/typecheck.sh",
+    "ci": "bash scripts/ci.sh"
   },
   "nodeModulesDir": true,
   "compilerOptions": {
-    "types": ["./types/tesseract.d.ts"]
+    "types": ["./types/tesseract.d.ts"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "lib": ["deno.ns", "deno.window", "dom", "es2022"]
   },
   "importMap": "./supabase/functions/telegram-bot/vendor/import_map.json"
 }

--- a/scripts/changed_functions.sh
+++ b/scripts/changed_functions.sh
@@ -1,0 +1,47 @@
+# >>> DC BLOCK: changed-fns-core (start)
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR=".out"
+mkdir -p "$OUT_DIR"
+OUT="$OUT_DIR/functions.txt"
+: > "$OUT"
+
+# If DEPLOY_ALL=1, list all functions with index.ts
+if [ "${DEPLOY_ALL:-0}" = "1" ]; then
+  if [ -d supabase/functions ]; then
+    for d in supabase/functions/*; do
+      [ -d "$d" ] && [ -f "$d/index.ts" ] && basename "$d" >> "$OUT"
+    done
+  fi
+  cat "$OUT"; exit 0
+fi
+
+# Figure out diff range (GH Actions or local)
+BASE="${GITHUB_BASE_REF:-}"
+HEAD="${GITHUB_SHA:-}"
+if [ -n "$BASE" ] && [ -n "$HEAD" ]; then
+  MERGE_BASE=$(git merge-base "origin/$BASE" "$HEAD" || echo "")
+  RANGE="${MERGE_BASE}..${HEAD}"
+else
+  RANGE="${RANGE:-HEAD~1..HEAD}"
+fi
+
+# Collect changed function dirs that actually have index.ts
+git diff --name-only "$RANGE" \
+  | grep -E '^supabase/functions/[^/]+/' \
+  | cut -d/ -f3 \
+  | sort -u \
+  | while read -r fn; do
+      [ -f "supabase/functions/$fn/index.ts" ] && echo "$fn"
+    done >> "$OUT" || true
+
+# If none detected, allow [deploy] commit message to force all
+MSG="$(git log -1 --pretty=%B || echo "")"
+if [ ! -s "$OUT" ] && echo "$MSG" | grep -qi '\[deploy\]'; then
+  export DEPLOY_ALL=1
+  exec "$0"
+fi
+
+cat "$OUT"
+# <<< DC BLOCK: changed-fns-core (end)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,26 @@
+# >>> DC BLOCK: ci-core (start)
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DENO_TLS_CA_STORE="${DENO_TLS_CA_STORE:-system}"
+export DENO_NO_UPDATE_CHECK=1
+
+echo "== deno fmt =="
+deno fmt --check .
+
+echo "== deno lint =="
+deno lint
+
+echo "== typecheck =="
+bash scripts/typecheck.sh
+
+# Optional tests
+if ls test 1>/dev/null 2>&1 || ls **/*_test.ts 1>/dev/null 2>&1; then
+  echo "== deno test =="
+  deno test -A
+else
+  echo "No tests found, skipping."
+fi
+
+echo "CI checks passed."
+# <<< DC BLOCK: ci-core (end)

--- a/scripts/deploy_functions.sh
+++ b/scripts/deploy_functions.sh
@@ -1,0 +1,49 @@
+# >>> DC BLOCK: deploy-core (start)
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SUPABASE_PROJECT_REF:?SUPABASE_PROJECT_REF required}"
+: "${SUPABASE_ACCESS_TOKEN:?SUPABASE_ACCESS_TOKEN required}"
+
+LIST_FILE="${1:-.out/functions.txt}"
+if [ ! -s "$LIST_FILE" ]; then
+  echo "No functions to deploy. Exiting."
+  exit 0
+fi
+
+echo "== Supabase CLI =="
+npx supabase --version
+
+echo "== Link project =="
+npx supabase link --project-ref "$SUPABASE_PROJECT_REF" || true
+
+BASE="https://${SUPABASE_PROJECT_REF}.supabase.co/functions/v1"
+FAILED=0
+
+# Deploy only functions that actually exist locally
+while IFS= read -r fn; do
+  [ -z "$fn" ] && continue
+  if [ ! -f "supabase/functions/$fn/index.ts" ]; then
+    echo "Skip $fn (missing supabase/functions/$fn/index.ts)"
+    continue
+  fi
+  echo "---- Deploying $fn ----"
+  npx supabase functions deploy "$fn" --project-ref "$SUPABASE_PROJECT_REF"
+
+  # Probe GET/POST with tolerant codes
+  G=$(curl -sS -o /dev/null -w "%{http_code}" "$BASE/$fn" || echo 000)
+  P=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "content-type: application/json" -d '{"ping":"ok"}' "$BASE/$fn" || echo 000)
+  echo "Probe: $fn GET=$G POST=$P"
+  case "$G$P" in
+    *200*|*204*|*401*|*403*) echo "OK";;
+    *) echo "Probe failed for $fn"; FAILED=$((FAILED+1));;
+  esac
+done < "$LIST_FILE"
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "Deployment probe failed for $FAILED function(s)."
+  exit 1
+fi
+
+echo "All deployments probed OK."
+# <<< DC BLOCK: deploy-core (end)

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -28,3 +28,46 @@ if compgen -G "supabase/functions/*/index.ts" > /dev/null; then
     deno check $CERT_ARG "$f"
   done
 fi
+
+# >>> DC BLOCK: typecheck-core (start)
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use system trust store (corp proxies), allow optional custom CA
+export DENO_TLS_CA_STORE="${DENO_TLS_CA_STORE:-system}"
+export DENO_NO_UPDATE_CHECK=1
+
+CERT_ARG=""
+if [ -n "${DENO_CERT_FILE:-}" ] && [ -f "$DENO_CERT_FILE" ]; then
+  CERT_ARG="--cert $DENO_CERT_FILE"
+fi
+
+deno --version
+
+# Prefetch remotes (best-effort)
+if compgen -G "supabase/functions/*/index.ts" > /dev/null; then
+  deno cache $CERT_ARG --reload supabase/functions/*/index.ts || true
+fi
+if [ -d src ]; then
+  find src -name "*.ts" -maxdepth 4 -print0 | xargs -0 -n1 deno cache $CERT_ARG || true
+fi
+
+echo "== Type-check Edge Functions =="
+if compgen -G "supabase/functions/*/index.ts" > /dev/null; then
+  for f in supabase/functions/*/index.ts; do
+    echo "deno check $CERT_ARG --remote $f"
+    deno check $CERT_ARG --remote "$f"
+  done
+else
+  echo "No Edge Function entrypoints found."
+fi
+
+echo "== Type-check local src/*.ts =="
+if [ -d src ]; then
+  find src -name "*.ts" -print0 | xargs -0 -n1 deno check $CERT_ARG --remote
+else
+  echo "No src/ directory."
+fi
+
+echo "TypeScript check completed."
+# <<< DC BLOCK: typecheck-core (end)


### PR DESCRIPTION
## Summary
- extend deno.json with strict compiler options and fmt/lint/typecheck/ci tasks
- add scripts for type checking, CI gate, changed function detection, and Supabase deployment
- wire up new CI & deploy workflow using GitHub Actions

## Testing
- `bash scripts/ci.sh` *(fails: formatting differences)*


------
https://chatgpt.com/codex/tasks/task_e_6897a4af81208322b8d43fa8923904af