### PR TITLE
feat: add FK index generator

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,18 @@ jobs:
           npm -v
           chmod +x scripts/audit/run.sh
           ./scripts/audit/run.sh
+      - name: Generate FK Index SQL
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          chmod +x scripts/audit/run_fk_index_gen.sh || true
+          scripts/audit/run_fk_index_gen.sh
+      - name: Upload FK SQL
+        uses: actions/upload-artifact@v4
+        with:
+          name: fk-indexes-sql
+          path: .audit/generated_fk_indexes.sql
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/audit/gen_fk_indexes.mjs
+++ b/scripts/audit/gen_fk_indexes.mjs
@@ -1,0 +1,68 @@
+import fs from 'fs';
+
+const url = process.env.SUPABASE_URL || process.env.A_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.A_SUPABASE_KEY || process.env.SUPABASE_ANON_KEY;
+
+if (!url || !key) {
+  console.error('Missing SUPABASE_URL and key (SUPABASE_SERVICE_ROLE_KEY or SUPABASE_ANON_KEY).');
+  process.exit(0);
+}
+
+async function get(path) {
+  const u = `${url.replace(/\/$/, '')}/rest/v1/${path}`;
+  const r = await fetch(u, { headers: { apikey: key, Authorization: `Bearer ${key}` } });
+  if (!r.ok) throw new Error(`GET ${path} -> ${r.status}`);
+  return r.json();
+}
+
+function arr(x){ return Array.isArray(x) ? x : (x ? [x] : []); }
+function normCols(cols){ return arr(cols).map(String).map(s => s.replace(/"/g,'').toLowerCase()); }
+function idxName(table, cols){ return `idx_${table}_${cols.join('_')}`.toLowerCase().replace(/[^a-z0-9_]/g,'_'); }
+
+function hasCoveringIndex(indexes, table, cols) {
+  const want = normCols(cols);
+  const list = indexes.filter(i => i.table === table);
+  for (const i of list) {
+    const ic = normCols(i.columns);
+    // treat "covering" as prefix match: index on (fk, ...) covers FK lookups
+    if (ic.length >= want.length && want.every((c, k) => ic[k] === c)) return true;
+  }
+  return false;
+}
+
+const fk = await get('pg_meta.foreign_keys?select=schema,table,columns,foreign_table,foreign_columns');
+const ix = await get('pg_meta.indexes?select=schema,table,name,columns,is_unique,is_primary');
+
+const publicFK = fk.filter(x => x.schema === 'public');
+const publicIX = ix.filter(x => x.schema === 'public').map(x => ({
+  table: x.table, name: x.name, columns: x.columns, is_primary: !!x.is_primary, is_unique: !!x.is_unique
+}));
+
+const statements = [];
+for (const f of publicFK) {
+  const table = f.table;
+  const cols = normCols(f.columns);
+  if (!cols.length) continue;
+
+  // skip if PK-like (already indexed) — crude filter; we rely on hasCoveringIndex anyway
+  if (hasCoveringIndex(publicIX, table, cols)) continue;
+
+  const name = idxName(table, cols);
+  const colsSQL = cols.map(c => `"${c}"`).join(', ');
+  statements.push(`CREATE INDEX CONCURRENTLY IF NOT EXISTS ${name} ON public."${table}" (${colsSQL});`);
+}
+
+const outDir = '.audit';
+fs.mkdirSync(outDir, { recursive: true });
+const out = `${outDir}/generated_fk_indexes.sql`;
+fs.writeFileSync(out, (statements.length
+  ? `-- Auto-generated FK index recommendations (CONCURRENTLY)\n${statements.join('\n')}\n`
+  : '-- No missing FK indexes detected.\n'
+));
+console.log(`Wrote ${out} (${statements.length} statement(s)).`);
+
+const repoOutDir = 'sql';
+try { fs.mkdirSync(repoOutDir, { recursive: true }); } catch {}
+const repoOut = `${repoOutDir}/generated_fk_indexes.sql`;
+fs.writeFileSync(repoOut, fs.readFileSync(out));
+console.log(`Copied to ${repoOut}.`);

--- a/scripts/audit/run_fk_index_gen.sh
+++ b/scripts/audit/run_fk_index_gen.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${SUPABASE_URL:?SUPABASE_URL required}"
+: "${SUPABASE_SERVICE_ROLE_KEY:=}"
+: "${SUPABASE_ANON_KEY:=}"
+
+node scripts/audit/gen_fk_indexes.mjs
+echo "== Done. See .audit/generated_fk_indexes.sql (and sql/generated_fk_indexes.sql) =="
+
+# Make executable
+! chmod +x scripts/audit/run_fk_index_gen.sh 2>/dev/null || true

--- a/sql/2025-08-10_fk_indexes.sql
+++ b/sql/2025-08-10_fk_indexes.sql
@@ -1,0 +1,39 @@
+-- Online-safe FK indexes (CONCURRENTLY). Run in Supabase SQL Editor.
+-- If your runner blocks CONCURRENTLY, switch to the NON-concurrent block at bottom.
+
+-- investments.investor_id -> investors.id
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_investments_investor_id
+  ON public.investments (investor_id);
+
+-- profit_distributions.investor_id -> investors.id
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_profit_distributions_investor_id
+  ON public.profit_distributions (investor_id);
+
+-- profit_distributions.fund_cycle_id -> fund_pool.id
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_profit_distributions_fund_cycle_id
+  ON public.profit_distributions (fund_cycle_id);
+
+-- withdrawal_requests.investor_id -> investors.id
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_withdrawal_requests_investor_id
+  ON public.withdrawal_requests (investor_id);
+
+-- bot_commands.created_by -> auth.users.id
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bot_commands_created_by
+  ON public.bot_commands (created_by);
+
+-- bot_notifications.created_by -> auth.users.id
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bot_notifications_created_by
+  ON public.bot_notifications (created_by);
+
+-- Optional helpful indexes (commented): join/filter hot paths
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payment_records_user_id ON public.payment_records (user_id);
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_user_id ON public.messages (user_id);
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payment_status_created ON public.payment_records (status, created_at);
+
+---- NON-CONCURRENT FALLBACK (use ONE block only)
+-- CREATE INDEX IF NOT EXISTS idx_investments_investor_id ON public.investments (investor_id);
+-- CREATE INDEX IF NOT EXISTS idx_profit_distributions_investor_id ON public.profit_distributions (investor_id);
+-- CREATE INDEX IF NOT EXISTS idx_profit_distributions_fund_cycle_id ON public.profit_distributions (fund_cycle_id);
+-- CREATE INDEX IF NOT EXISTS idx_withdrawal_requests_investor_id ON public.withdrawal_requests (investor_id);
+-- CREATE INDEX IF NOT EXISTS idx_bot_commands_created_by ON public.bot_commands (created_by);
+-- CREATE INDEX IF NOT EXISTS idx_bot_notifications_created_by ON public.bot_notifications (created_by);


### PR DESCRIPTION
## Summary
- add SQL template for online-safe FK indexes
- provide FK index generator and runner script
- update audit workflow to produce FK index SQL artifact

## Testing
- `npm run lint` *(fails: Unexpected any in src/utils/config.ts)*
- `npm test` *(fails: invalid peer certificate while fetching npm package)*

------
https://chatgpt.com/codex/tasks/task_e_6897a89a531483229cfce4c7d074c31b