### PR TITLE
fix: base circuit breaker cooldown on failure time

### DIFF
--- a/src/utils/circuit.ts
+++ b/src/utils/circuit.ts
@@ -1,0 +1,22 @@
+export function circuit(maxFails = 5, coolMs = 30_000) {
+  let fails = 0;
+  let until = 0;
+  return {
+    async run<T>(fn: () => Promise<T>) {
+      const now = Date.now();
+      if (now < until) throw new Error('circuit_open');
+      try {
+        const result = await fn();
+        fails = 0;
+        return result;
+      } catch (err) {
+        if (++fails >= maxFails) {
+          // use current time when failure occurs rather than start time
+          until = Date.now() + coolMs;
+        }
+        throw err;
+      }
+    }
+  };
+}
+// usage: await breaker.run(() => fetch(...))

--- a/tests/circuit.test.ts
+++ b/tests/circuit.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck: cross-runtime test uses dynamic imports
+let registerTest;
+let assertEquals;
+let assertRejects;
+if (typeof Deno !== 'undefined') {
+  registerTest = (name, fn) => Deno.test(name, fn);
+  const asserts = await import('https://deno.land/std@0.224.0/testing/asserts.ts');
+  assertEquals = asserts.assertEquals;
+  assertRejects = asserts.assertRejects;
+} else {
+  const { test } = await import('node:test');
+  registerTest = (name, fn) => test(name, { concurrency: false }, fn);
+  const assert = (await import('node:assert')).strict;
+  assertEquals = (a, b, msg) => assert.equal(a, b, msg);
+  assertRejects = assert.rejects;
+}
+
+import { circuit } from '../src/utils/circuit.ts';
+
+registerTest('cooldown starts at failure time', async () => {
+  const originalNow = Date.now;
+  let t = 0;
+  // stub Date.now
+  Date.now = () => t;
+  try {
+    const breaker = circuit(1, 100);
+    const failing = async () => {
+      t = 50; // time passes before failure
+      throw new Error('fail');
+    };
+    await assertRejects(() => breaker.run(failing));
+    t = 120; // 70ms after failure but 120ms after start
+    let ran = false;
+    await assertRejects(
+      () =>
+        breaker.run(async () => {
+          ran = true;
+        }),
+      Error,
+    );
+    assertEquals(ran, false);
+  } finally {
+    Date.now = originalNow;
+  }
+});


### PR DESCRIPTION
## Summary
- add circuit breaker utility
- ensure cooldown is based on failure time

## Testing
- `npm test` *(fails: deno: not found)*
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any in src/utils/config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6897b97e26048322b7cf0d2025621a51