### PR TITLE
Add Telegram webhook management Edge functions

### DIFF
--- a/supabase/functions/telegram-getwebhook/index.ts
+++ b/supabase/functions/telegram-getwebhook/index.ts
@@ -1,0 +1,23 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
+const BASE = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/,"");
+const FN = "telegram-webhook";
+const expected = BASE ? `${BASE}/functions/v1/${FN}` : null;
+
+function red(s: string, keep = 4) { return s ? s.slice(0, keep) + "...redacted" : ""; }
+
+serve(async () => {
+  if (!BOT) {
+    return new Response(JSON.stringify({ ok:false, error:"BOT_TOKEN missing" }), { headers:{"content-type":"application/json"}, status:500 });
+  }
+  const info = await fetch(`https://api.telegram.org/bot${BOT}/getWebhookInfo`).then(r=>r.json()).catch(e=>({ ok:false, error:String(e) }));
+  return new Response(JSON.stringify({
+    ok: true,
+    expected_url: expected,
+    has_secret: !!SECRET,
+    token_preview: red(BOT),
+    webhook_info: info
+  }), { headers: {"content-type":"application/json","cache-control":"no-store"} });
+});

--- a/supabase/functions/telegram-selftest/index.ts
+++ b/supabase/functions/telegram-selftest/index.ts
@@ -1,0 +1,54 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
+const BASE = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/,"");
+const WEBHOOK = `${BASE}/functions/v1/telegram-webhook`;
+
+function tg(method: string, payload: unknown) {
+  return fetch(`https://api.telegram.org/bot${BOT}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(8000),
+  });
+}
+
+serve(async (req) => {
+  // GET /?chat_id=123 : direct sendMessage to confirm token works and chat_id is valid.
+  // POST { "chat_id":123 } : server-to-server webhook simulation for /start.
+  try {
+    if (!BOT) return new Response(JSON.stringify({ ok:false, error:"BOT_TOKEN missing" }), { status:500, headers:{ "content-type":"application/json" }});
+
+    if (req.method === "GET") {
+      const chatId = Number(new URL(req.url).searchParams.get("chat_id") || 0);
+      if (!chatId) return new Response(JSON.stringify({ ok:false, error:"chat_id required" }), { status:400, headers:{ "content-type":"application/json" }});
+      const res = await tg("sendMessage", { chat_id: chatId, text: "Self-test ✅ Bot can send messages." });
+      const txt = await res.text().catch(()=> "");
+      return new Response(JSON.stringify({ ok: res.ok, status: res.status, body: txt.slice(0,300) }), { headers:{ "content-type":"application/json" }});
+    }
+
+    // POST path: simulate Telegram → Webhook with a /start update
+    const { chat_id } = await req.json().catch(()=>({}));
+    if (!chat_id) return new Response(JSON.stringify({ ok:false, error:"chat_id required in JSON" }), { status:400, headers:{ "content-type":"application/json" }});
+    const fakeUpdate = {
+      update_id: Date.now(),
+      message: { message_id: 1, date: Math.floor(Date.now()/1000), chat: { id: chat_id, type: "private" }, text: "/start" }
+    };
+    const resp = await fetch(WEBHOOK, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(SECRET ? { "x-telegram-bot-api-secret-token": SECRET } : {})
+      },
+      body: JSON.stringify(fakeUpdate),
+      signal: AbortSignal.timeout(8000),
+    });
+    const body = await resp.text().catch(()=> "");
+    return new Response(JSON.stringify({ ok: resp.ok, status: resp.status, webhook: WEBHOOK, body: body.slice(0,300) }), {
+      headers:{ "content-type":"application/json","cache-control":"no-store" }
+    });
+  } catch (e) {
+    return new Response(JSON.stringify({ ok:false, error: String(e) }), { status:500, headers:{ "content-type":"application/json" }});
+  }
+});

--- a/supabase/functions/telegram-setwebhook/index.ts
+++ b/supabase/functions/telegram-setwebhook/index.ts
@@ -1,0 +1,35 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const BOT = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const SECRET = Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || "";
+const BASE = (Deno.env.get("SUPABASE_URL") || "").replace(/\/$/,"");
+const FN = "telegram-webhook";
+const url = BASE ? `${BASE}/functions/v1/${FN}` : "";
+
+serve(async (req) => {
+  if (!BOT || !url) return new Response(JSON.stringify({ ok:false, error:"Missing BOT or BASE URL" }), { status:500, headers:{ "content-type":"application/json" }});
+  const u = new URL(req.url);
+  const drop = u.searchParams.get("drop") === "1"; // optional: delete webhook first
+  const dry = u.searchParams.get("dry") === "1";   // optional: dry-run
+
+  if (dry) {
+    return new Response(JSON.stringify({ ok:true, dry:true, target:url, uses_secret: !!SECRET }), { headers:{ "content-type":"application/json" }});
+  }
+
+  if (drop) {
+    await fetch(`https://api.telegram.org/bot${BOT}/deleteWebhook`, { method:"POST" }).catch(()=>null);
+  }
+  const form = new URLSearchParams();
+  form.set("url", url);
+  if (SECRET) form.set("secret_token", SECRET);
+
+  const res = await fetch(`https://api.telegram.org/bot${BOT}/setWebhook`, {
+    method:"POST",
+    headers:{ "content-type":"application/x-www-form-urlencoded" },
+    body: form
+  });
+  const json = await res.json().catch(()=>null);
+  return new Response(JSON.stringify({ ok: res.ok, status: res.status, result: json, target:url, used_secret: !!SECRET }), {
+    headers:{ "content-type":"application/json","cache-control":"no-store" }
+  });
+});


### PR DESCRIPTION
## Summary
- add `telegram-getwebhook` to inspect current webhook and secrets
- add `telegram-setwebhook` to register/delete webhooks with optional secret
- add `telegram-selftest` for sendMessage check and webhook simulation

## Testing
- `npm test` *(failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6897ca70ce5883229455cf0703a94a49