### PR TITLE
chore(db): add Splinter FK index scripts

### DIFF
--- a/.github/workflows/splinter-fk-index.yml
+++ b/.github/workflows/splinter-fk-index.yml
@@ -1,0 +1,35 @@
+name: DB Lint + Auto FK Index PR
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'   # Mondays at 03:00 UTC
+jobs:
+  splinter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Run Splinter + generate migration
+        env:
+          DB_URL: ${{ secrets.SUPABASE_DB_URL }}   # Session pooler string
+        run: |
+          bash scripts/splinter_run.sh
+          bash scripts/gen_fk_indexes.sh || true
+          if [ -s .out/fk_indexes_file.txt ]; then
+            FILE=$(cat .out/fk_indexes_file.txt)
+            echo "Generated $FILE"
+          else
+            echo "No FK indexes to add."
+          fi
+      - name: Commit & PR if changes
+        if: ${{ hashFiles('supabase/migrations/**_add_fk_indexes.sql') != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BR="chore/add-fk-indexes-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$BR"
+          git add supabase/migrations/**_add_fk_indexes.sql .out/splinter_report.csv
+          git commit -m "chore(db): add indexes for unindexed foreign keys (Splinter)"
+          git push -u origin "$BR"
+          gh pr create --fill --title "Add FK indexes (Splinter)" --body "Auto-generated from Splinter report." || true

--- a/scripts/fk_index_seed.sql
+++ b/scripts/fk_index_seed.sql
@@ -1,0 +1,5 @@
+-- Safe seed for obvious FKs (only runs if Splinter misses them)
+CREATE INDEX IF NOT EXISTS idx_investments_investor_id ON public.investments (investor_id);
+CREATE INDEX IF NOT EXISTS idx_profit_distributions_investor_id ON public.profit_distributions (investor_id);
+CREATE INDEX IF NOT EXISTS idx_profit_distributions_fund_cycle_id ON public.profit_distributions (fund_cycle_id);
+CREATE INDEX IF NOT EXISTS idx_withdrawal_requests_investor_id ON public.withdrawal_requests (investor_id);

--- a/scripts/gen_fk_indexes.sh
+++ b/scripts/gen_fk_indexes.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+in=".out/splinter_report.csv"
+outdir="supabase/migrations"
+ts="$(date +%Y%m%d%H%M%S)"
+outfile="$outdir/${ts}_add_fk_indexes.sql"
+
+[ -f "$in" ] || { echo "Missing $in. Run scripts/splinter_run.sh first." ; exit 1; }
+mkdir -p "$outdir"
+
+# Filter rows where title mentions "unindexed foreign key" (case-insensitive).
+# Expect metadata to contain table/column (format varies; handle common patterns).
+# We’ll parse using awk and fall back to heuristics from description/detail.
+awk -F',' 'BEGIN{IGNORECASE=1}
+  /unindexed foreign key/ {
+    print $0
+  }' "$in" > .out/unindexed_fk_rows.csv || true
+
+if [ ! -s .out/unindexed_fk_rows.csv ]; then
+  echo "No unindexed foreign key findings. Nothing to do."
+  exit 0
+fi
+
+echo "-- Auto-generated indexes for unindexed foreign keys" > "$outfile"
+echo "-- Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$outfile"
+echo >> "$outfile"
+
+# Try to extract table & column from metadata (last column) or detail/description.
+# Common patterns: metadata like {"table":"public.investments","column":"investor_id"}
+# Fallback regex grabs table.column from free text.
+while IFS= read -r line; do
+  meta=$(echo "$line" | awk -F',' '{print $NF}')
+  tbl=""
+  col=""
+  if echo "$meta" | grep -q '"table"'; then
+    tbl=$(echo "$meta" | sed -n 's/.*"table":"\([^"\]*\)".*/\1/p')
+    col=$(echo "$meta" | sed -n 's/.*"column":"\([^"\]*\)".*/\1/p')
+  fi
+  if [ -z "$tbl" ] || [ -z "$col" ]; then
+    # fallback: scan whole line for schema.table(column)
+    guess=$(echo "$line" | sed -n 's/.*\b\([a-zA-Z0-9_]\+\.[a-zA-Z0-9_]\+\)\.\([a-zA-Z0-9_]\+\).*/\1 \2/p' | head -1)
+    tbl=$(echo "$guess" | awk '{print $1}')
+    col=$(echo "$guess" | awk '{print $2}')
+  fi
+  if [ -z "$tbl" ] || [ -z "$col" ]; then
+    echo "-- WARN: could not parse table/column from: $line" >> "$outfile"
+    continue
+  fi
+  # normalize name parts
+  schema=$(echo "$tbl" | awk -F'.' '{print $1}')
+  table=$(echo "$tbl" | awk -F'.' '{print $2}')
+  idx="idx_${table}_${col}"
+  echo "CREATE INDEX IF NOT EXISTS ${idx} ON ${schema}.${table} (${col});" >> "$outfile"
+done < .out/unindexed_fk_rows.csv
+
+echo "Wrote $outfile"
+echo "$outfile" > .out/fk_indexes_file.txt

--- a/scripts/splinter_fk_index_pr.sh
+++ b/scripts/splinter_fk_index_pr.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DB_URL:?Set DB_URL to your Supabase session pooler URL}"
+
+bash scripts/splinter_run.sh
+bash scripts/gen_fk_indexes.sh || true
+
+file="$(cat .out/fk_indexes_file.txt 2>/dev/null || true)"
+if [ -z "$file" ] || [ ! -s "$file" ]; then
+  echo "No FK indexes to add. Exiting."
+  exit 0
+fi
+
+branch="chore/add-fk-indexes-$(date +%Y%m%d%H%M%S)"
+git checkout -b "$branch"
+git add "$file" .out/splinter_report.csv
+git commit -m "chore(db): add indexes for unindexed foreign keys (Splinter)"
+git push -u origin "$branch" || true
+
+# If GitHub CLI is available, open PR
+if command -v gh >/dev/null 2>&1; then
+  gh pr create --fill --title "Add FK indexes (Splinter)" --body "Adds indexes for FKs flagged by Supabase Splinter. Auto-generated."
+fi

--- a/scripts/splinter_run.sh
+++ b/scripts/splinter_run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+: "${DB_URL:?Set DB_URL to your Supabase session pooler URL}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+curl -fsSL https://raw.githubusercontent.com/supabase/splinter/main/splinter.sql -o "$workdir/splinter.sql"
+# CSV: name,title,level,description,detail,remediation,metadata (no header)
+psql "$DB_URL" -v ON_ERROR_STOP=1 -t -A -F',' -f "$workdir/splinter.sql" > "$workdir/splinter_report.csv"
+cat "$workdir/splinter_report.csv"
+
+# Save artifacts
+mkdir -p .out
+cp "$workdir/splinter_report.csv" .out/splinter_report.csv
+echo "Report saved to .out/splinter_report.csv"


### PR DESCRIPTION
## Summary
- add scripts to run Supabase Splinter and generate foreign key index migrations
- add helper SQL seed and one-shot script for auto PRs
- add CI workflow to lint DB and open PRs for missing FK indexes

## Testing
- `bash scripts/splinter_run.sh` *(failed: connection refused)*
- `bash scripts/gen_fk_indexes.sh` *(failed: Missing .out/splinter_report.csv)*
- `npm test` *(failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6897da9b505c83228e5830fa46108423