### PR TITLE
feat: implement telegram webhook handler

### DIFF
--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -11,18 +11,20 @@ async function sendMessage(chatId: number, text: string) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ chat_id: chatId, text }),
     });
-  } catch (_) {
-    // ignore network errors
+  } catch (err) {
+    console.error("sendMessage error", err);
   }
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   const headers = { "Content-Type": "application/json" };
 
+  // Only accept POST requests
   if (req.method !== "POST") {
     return new Response(JSON.stringify({ ok: true }), { headers });
   }
 
+  // Validate optional secret
   if (WEBHOOK_SECRET) {
     const url = new URL(req.url);
     const headerSecret = req.headers.get("x-telegram-bot-api-secret-token");
@@ -32,20 +34,32 @@ serve(async (req) => {
     }
   }
 
+  // Parse the incoming update
   let update: any = null;
   try {
     update = await req.json();
-  } catch (_) {
-    // ignore parse errors
+  } catch (err) {
+    console.error("failed to parse update", err);
+    return new Response(JSON.stringify({ ok: true }), { headers });
   }
 
   const text: string | undefined = update?.message?.text;
   const chatId: number | undefined = update?.message?.chat?.id;
 
+  // Reply to /start messages
   if (text === "/start" && typeof chatId === "number") {
-    await sendMessage(chatId, "Bot activated. Replying to /start");
+    try {
+      await sendMessage(chatId, "Bot activated. Replying to /start");
+    } catch (err) {
+      console.error("error handling /start", err);
+    }
   }
 
   return new Response(JSON.stringify({ ok: true }), { headers });
-});
+}
+
+// Start the HTTP server when run as a standalone script
+if (import.meta.main) {
+  serve(handler);
+}
 


### PR DESCRIPTION
## Summary
- add Telegram webhook handler with secret validation and /start response
- log parsing and send errors for reliability

## Testing
- `deno check supabase/functions/telegram-webhook/index.ts --no-npm` *(failed: invalid peer certificate: UnknownIssuer)*
- `npm test` *(failed: invalid peer certificate: UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_6897f1aefbbc8322837f0a06fb069a7b