### PR TITLE
Add verification suite for bot and mini app

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,21 @@
+name: Bot & MiniApp Verification
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Run verification
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: bash scripts/verify/verify_all.sh
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-report
+          path: .out/verify_report.md

--- a/scripts/verify/deployed_function_checks.sh
+++ b/scripts/verify/deployed_function_checks.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+R=".out/deployed_checks.txt"
+: > "$R"
+
+say "B) Deployed Function Checks"
+
+if [ -z "${SUPABASE_URL:-}" ]; then
+  echo "supabase_url=UNKNOWN" >> "$R"
+  echo "webhook_url=UNKNOWN" >> "$R"
+  echo "reachable=UNKNOWN" >> "$R"
+  exit 0
+fi
+
+# Expected webhook URL
+WEBHOOK_URL="${SUPABASE_URL%/}/functions/v1/telegram-webhook"
+echo "webhook_url=$WEBHOOK_URL" >> "$R"
+
+# Reachability (no secrets): first GET/HEAD then POST with dummy payload
+status=$(curl -s -o /dev/null -w "%{http_code}" -m 8 "$WEBHOOK_URL" || echo 000)
+echo "head_status=$status" >> "$R"
+
+post_status=$(curl -s -o /dev/null -w "%{http_code}" -m 8 -H "content-type: application/json" -d '{}' "$WEBHOOK_URL" || echo 000)
+echo "post_status=$post_status" >> "$R"
+
+if [ "$status" != "000" ] || [ "$post_status" != "000" ]; then
+  echo "reachable=PASS" >> "$R"
+else
+  echo "reachable=FAIL" >> "$R"
+fi
+
+say "Deployed function reachability checked."

--- a/scripts/verify/miniapp_safety.sh
+++ b/scripts/verify/miniapp_safety.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+R=".out/miniapp_safety.txt"
+: > "$R"
+
+say "D) Mini App Safety"
+
+if [ ! -d "miniapp" ]; then
+  echo "miniapp_present=UNKNOWN" >> "$R"
+  echo "client_token_leak=UNKNOWN" >> "$R"
+  echo "initdata_verify_usage=UNKNOWN" >> "$R"
+  exit 0
+fi
+
+echo "miniapp_present=PASS" >> "$R"
+
+# 1) Ensure no bot token or service keys are present in client code
+leaks=$(git ls-files 'miniapp/**' | xargs -I{} bash -lc 'grep -nE "TELEGRAM_BOT_TOKEN|SUPABASE_SERVICE_ROLE_KEY" "{}" || true' | wc -l)
+if [ "$leaks" -eq 0 ]; then
+  echo "client_token_leak=PASS" >> "$R"
+else
+  echo "client_token_leak=FAIL" >> "$R"
+fi
+
+# 2) Check use of initData verification endpoint (tg-verify-init)
+if git ls-files 'miniapp/**' | xargs -I{} bash -lc 'grep -q "tg-verify-init" "{}" && echo hit || true' | grep -q hit; then
+  echo "initdata_verify_usage=PASS" >> "$R"
+else
+  echo "initdata_verify_usage=FAIL" >> "$R"
+fi
+
+say "Mini app safety scan complete."

--- a/scripts/verify/runtime_wiring_checks.sh
+++ b/scripts/verify/runtime_wiring_checks.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+R=".out/runtime_checks.txt"
+: > "$R"
+
+say "C) Runtime Wiring Checks"
+
+if [ -z "${SUPABASE_URL:-}" ]; then
+  echo "getwebhook=UNKNOWN" >> "$R"
+  echo "startsim=UNKNOWN" >> "$R"
+  exit 0
+fi
+
+BASE="${SUPABASE_URL%/}"
+GETWEB="$BASE/functions/v1/telegram-getwebhook"
+STARTSIM="$BASE/functions/v1/telegram-start-sim"
+
+# telegram-getwebhook (if exists)
+code_gw=$(curl -s -o .out/_gw.json -w "%{http_code}" -m 8 "$GETWEB" || echo 000)
+if [ "$code_gw" = "200" ]; then
+  echo "getwebhook=PASS" >> "$R"
+  # try to extract and compare expected_url vs webhook_info.url
+  exp=$(jq -r '.expected_url // empty' .out/_gw.json 2>/dev/null || true)
+  cur=$(jq -r '.webhook_info.url // empty' .out/_gw.json 2>/dev/null || true)
+  if [ -n "$exp" ] && [ -n "$cur" ] && [ "$exp" = "$cur" ]; then
+    echo "webhook_match=PASS" >> "$R"
+  else
+    echo "webhook_match=FAIL" >> "$R"
+  fi
+else
+  echo "getwebhook=UNKNOWN" >> "$R"
+  echo "webhook_match=UNKNOWN" >> "$R"
+fi
+
+# telegram-start-sim (if exists) — use chat_id=1 as harmless probe
+code_ss=$(curl -s -o .out/_ss.json -w "%{http_code}" -m 8 "$STARTSIM?chat_id=1" || echo 000)
+if [ "$code_ss" = "200" ]; then
+  echo "startsim=PASS" >> "$R"
+else
+  echo "startsim=UNKNOWN" >> "$R"
+fi
+
+say "Runtime wiring checks complete."

--- a/scripts/verify/static_code_checks.sh
+++ b/scripts/verify/static_code_checks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+R=".out/static_checks.txt"
+: > "$R"
+
+say "A) Static Code Checks"
+
+# Find webhook handler
+WEBHOOK_FILE=$(git ls-files | grep -E '^supabase/functions/telegram-webhook/.+\.(ts|tsx)$' || true)
+if [ -z "$WEBHOOK_FILE" ]; then
+  WEBHOOK_FILE=$(git ls-files | xargs -I{} bash -lc 'grep -l "x-telegram-bot-api-secret-token" "{}" || true' | head -1 || true)
+fi
+
+if [ -n "$WEBHOOK_FILE" ]; then
+  echo "webhook_file=$WEBHOOK_FILE" >> "$R"
+else
+  echo "webhook_file=UNKNOWN" >> "$R"
+fi
+
+# Check for serve(), POST handler, safe parsing, /start, error logging, optional secret validation
+check_flag() {
+  local name="$1" patt="$2" file="$3"
+  if [ -n "$file" ] && grep -Eq "$patt" "$file"; then echo "$name=PASS" >> "$R"; else echo "$name=FAIL" >> "$R"; fi
+}
+check_flag "has_serve" "serve\\(" "${WEBHOOK_FILE:-}"
+check_flag "handles_post" "req\\.method\\s*!==\\s*\"POST\"|req\\.method\\s*===\\s*\"POST\"" "${WEBHOOK_FILE:-}"
+check_flag "parses_update" "await\\s+req\\.json\\(|update\\.message|edited_message|callback_query" "${WEBHOOK_FILE:-}"
+check_flag "handles_start" "\\/start" "${WEBHOOK_FILE:-}"
+check_flag "error_logging" "console\\.error\\(|!res\\.ok" "${WEBHOOK_FILE:-}"
+check_flag "secret_header" "x-telegram-bot-api-secret-token" "${WEBHOOK_FILE:-}"
+
+# DB-driven (soft-coded) indicators
+check_flag "uses_rest_bot_commands" "bot_commands\\?|rest\\/v1\\/bot_commands" "${WEBHOOK_FILE:-}"
+check_flag "uses_rest_templates" "bot_message_templates\\?|rest\\/v1\\/bot_message_templates" "${WEBHOOK_FILE:-}"
+check_flag "uses_rest_settings" "bot_settings\\?|rest\\/v1\\/bot_settings" "${WEBHOOK_FILE:-}"
+
+# Mini app presence
+MINI_DIR=$( [ -d miniapp/src ] && echo "miniapp/src" || echo "" )
+if [ -n "$MINI_DIR" ]; then
+  echo "miniapp_dir=miniapp/src" >> "$R"
+  # Telegram SDK present?
+  if grep -q "telegram-web-app.js" miniapp/index.html 2>/dev/null; then echo "miniapp_sdk=PASS" >> "$R"; else echo "miniapp_sdk=FAIL" >> "$R"; fi
+else
+  echo "miniapp_dir=UNKNOWN" >> "$R"
+fi
+
+say "Static code scan complete."

--- a/scripts/verify/utils.sh
+++ b/scripts/verify/utils.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+YELLOW='\033[1;33m'; RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+say() { printf "%b%s%b\n" "$BLUE" "$*" "$NC"; }
+warn() { printf "%b%s%b\n" "$YELLOW" "$*" "$NC"; }
+fail() { printf "%b%s%b\n" "$RED" "$*" "$NC"; }
+pass() { printf "%b%s%b\n" "$GREEN" "$*" "$NC"; }
+trim() { sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+ensure_out() { mkdir -p .out; }

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+
+# prerequisites
+if ! command -v jq >/dev/null 2>&1; then
+  warn "jq not found, installing lightweight version is recommended for JSON parsing."
+fi
+
+bash scripts/verify/static_code_checks.sh
+bash scripts/verify/deployed_function_checks.sh
+bash scripts/verify/runtime_wiring_checks.sh
+bash scripts/verify/miniapp_safety.sh
+
+# Build markdown report
+OUT=".out/verify_report.md"
+: > "$OUT"
+
+echo "# Verification Report" >> "$OUT"
+echo "" >> "$OUT"
+echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%SZ")" >> "$OUT"
+echo "" >> "$OUT"
+
+emit_section () {
+  local title="$1" file="$2"
+  echo "## $title" >> "$OUT"
+  echo "" >> "$OUT"
+  while IFS='=' read -r k v; do
+    [ -z "$k" ] && continue
+    echo "- **$k**: \`$v\`" >> "$OUT"
+  done < "$file"
+  echo "" >> "$OUT"
+}
+
+emit_section "A) Static Code Checks" ".out/static_checks.txt"
+emit_section "B) Deployed Function Checks" ".out/deployed_checks.txt"
+emit_section "C) Runtime Wiring Checks" ".out/runtime_checks.txt"
+emit_section "D) Mini App Safety" ".out/miniapp_safety.txt"
+
+echo "Report written to $OUT"
+say "Done."


### PR DESCRIPTION
## Summary
- add Bash verification scripts to scan static code, deployed functions, runtime wiring and mini app safety
- generate aggregated markdown report and publish via GitHub Action on PRs

## Testing
- `bash scripts/verify/verify_all.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897f2c9742c83229331dd8895e5ff06