### PR TITLE
chore: add Supabase-verified asset cleanup pipeline

### DIFF
--- a/.github/workflows/assets_audit.yml
+++ b/.github/workflows/assets_audit.yml
@@ -1,0 +1,25 @@
+name: Assets Audit
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run assets audit (dry-run)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: bash scripts/cleanup/report.sh
+
+  # Optional job to perform deletion only on manual dispatch with label:
+  # (Keep disabled unless you really want automation)

--- a/scripts/cleanup/cleanup_pr.sh
+++ b/scripts/cleanup/cleanup_pr.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/cleanup/utils.sh
+
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+ensure_out
+PLAN=".out/removal_candidates_supabase_checked.txt"
+
+if [ ! -s "$PLAN" ]; then
+  echo "No removal plan found. Run scripts/cleanup/report.sh first."
+  exit 0
+fi
+
+# CI safety: require PR label or env APPROVE_CLEANUP=1
+if [ $APPLY -ne 1 ]; then
+  echo "This is a dry-run. To actually delete, run: bash scripts/cleanup/cleanup_pr.sh --apply"
+  exit 0
+fi
+
+if [ -n "${GITHUB_EVENT_PATH:-}" ]; then
+  # In CI: require label safe-cleanup
+  if command -v jq >/dev/null 2>&1; then
+    LABEL_OK=$(jq -r '.pull_request.labels[].name // empty' "$GITHUB_EVENT_PATH" | grep -q '^safe-cleanup$' && echo yes || echo no)
+    if [ "$LABEL_OK" != "yes" ]; then
+      echo "Missing required PR label: safe-cleanup"
+      exit 1
+    fi
+  fi
+else
+  # Local: require explicit approval flag or env
+  if [ "${APPROVE_CLEANUP:-0}" != "1" ]; then
+    echo "Set APPROVE_CLEANUP=1 to allow removals locally."
+    exit 1
+  fi
+fi
+
+# Build removal list (ignore comments)
+REM_LIST=$(mktemp)
+grep -v "^#" "$PLAN" > "$REM_LIST"
+
+if [ ! -s "$REM_LIST" ]; then
+  echo "Nothing to remove."
+  exit 0
+fi
+
+BR="chore/cleanup-static-$(date +%Y%m%d%H%M%S)"
+git checkout -b "$BR"
+xargs -a "$REM_LIST" -I{} git rm -f "{}" || true
+
+if git diff --cached --quiet; then
+  echo "No changes staged."
+  exit 0
+fi
+
+git commit -m "chore: remove orphan/duplicate static assets (Supabase-verified)"
+git push -u origin "$BR" || true
+if command -v gh >/dev/null 2>&1; then
+  gh pr create --fill --title "Cleanup: Supabase-verified static removals" --body "Automated removal using content hash + reference scan + Supabase DB cross-check. Review required."
+fi

--- a/scripts/cleanup/find_dupes.sh
+++ b/scripts/cleanup/find_dupes.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/cleanup/utils.sh
+. scripts/cleanup/guard_rules.sh
+ensure_out
+REPORT=".out/duplicates.txt"; : > "$REPORT"
+KEEPERS=".out/dupe_keepers.txt"; : > "$KEEPERS"
+REMOVALS=".out/dupe_remove_candidates.txt"; : > "$REMOVALS"
+
+say "Scanning for duplicate files by SHA-256 (with safeguards)"
+FILES=$(git ls-files | grep -E '^(public|miniapp/public|miniapp/assets|assets|static|docs)/' || true)
+
+: > .out/_hash_map.txt
+for f in $FILES; do
+  [ -f "$f" ] || continue
+  is_protected "$f" && continue
+  h=$(sha256sum "$f" | awk '{print $1}')
+  echo "$h $f" >> .out/_hash_map.txt
+done
+
+# hash -> file list
+awk '{count[$1]++; files[$1]=files[$1]" "$2} END{ for(h in count){ if(count[h]>1){ print h":"files[h] }}}' .out/_hash_map.txt \
+  | sort -u > "$REPORT" || true
+
+# choose keeper & removal candidates
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  hash=$(echo "$line" | cut -d: -f1)
+  files=$(echo "$line" | cut -d: -f2-)
+  # pick canonical keeper
+  keeper=""
+  for f in $files; do
+    [ -z "$keeper" ] && keeper="$f" && continue
+    if prefer_over "$f" "$keeper"; then keeper="$f"; fi
+  done
+  echo "$hash $keeper" >> "$KEEPERS"
+
+  # propose others for removal unless denied
+  for f in $files; do
+    [ "$f" = "$keeper" ] && continue
+    is_denied "$f" && continue
+    echo "$f" >> "$REMOVALS"
+  done
+ done < "$REPORT"
+
+sort -u "$REMOVALS" -o "$REMOVALS"
+echo "Duplicates map: $REPORT"
+echo "Proposed duplicate removals (pre-DB-check): $REMOVALS"

--- a/scripts/cleanup/find_orphans.sh
+++ b/scripts/cleanup/find_orphans.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/cleanup/utils.sh
+. scripts/cleanup/guard_rules.sh
+ensure_out
+REF=".out/ref_map.txt"
+REPORT=".out/orphans.txt"; : > "$REPORT"
+
+say "Scanning for orphan assets (with safeguards)"
+CANDS=$(git ls-files | grep -E '^(public|miniapp/public|miniapp/assets|assets|static|docs|\.github)/' || true)
+
+awk '{print $0}' "$REF" 2>/dev/null | sed 's#^\./##' | sort -u > .out/_refs_all.txt || true
+awk -F/ '{print $NF}' .out/_refs_all.txt 2>/dev/null | sort -u > .out/_refs_names.txt || true
+
+for f in $CANDS; do
+  [ -f "$f" ] || continue
+  is_protected "$f" && continue
+  is_denied "$f" && continue
+
+  # path or basename referenced?
+  if grep -qx "$f" .out/_refs_all.txt 2>/dev/null; then continue; fi
+  base=$(basename "$f")
+  if grep -qx "$base" .out/_refs_names.txt 2>/dev/null; then continue; fi
+
+  echo "$f" >> "$REPORT"
+done
+
+echo "Orphan candidates (pre-DB-check): $REPORT"

--- a/scripts/cleanup/gate_supabase.sh
+++ b/scripts/cleanup/gate_supabase.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/cleanup/utils.sh
+. scripts/cleanup/supabase_verify.sh  # loads SB and helper
+
+ensure_out
+IN_ORPHANS=".out/orphans.txt"
+IN_DUPES=".out/dupe_remove_candidates.txt"
+OUT_FILTERED=".out/removal_candidates_supabase_checked.txt"
+: > "$OUT_FILTERED"
+
+say "Cross-checking candidates against Supabase content…"
+
+emit_checked() {
+  local f="$1"
+  local base="$(basename "$f")"
+  # if filename appears anywhere in DB content, skip removal
+  if db_refs_file "$base"; then
+    echo "# kept (referenced in DB): $f" >> "$OUT_FILTERED"
+  else
+    echo "$f" >> "$OUT_FILTERED"
+  fi
+}
+
+# Orphans
+if [ -s "$IN_ORPHANS" ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    emit_checked "$f"
+  done < "$IN_ORPHANS"
+fi
+
+# Duplicates (non-keepers)
+if [ -s "$IN_DUPES" ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    emit_checked "$f"
+  done < "$IN_DUPES"
+fi
+
+sort -u "$OUT_FILTERED" -o "$OUT_FILTERED"
+echo "Supabase-filtered removal list: $OUT_FILTERED"

--- a/scripts/cleanup/guard_rules.sh
+++ b/scripts/cleanup/guard_rules.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hard-protected (never remove)
+PROTECTED_GLOBS=(
+  "supabase/**"
+  "supabase/functions/**"
+  "supabase/migrations/**"
+  "scripts/**"
+  ".github/**"
+  "miniapp/src/**"
+)
+
+# Preferred canonical locations when duplicates exist (keep these)
+PREFERRED_CANON=(
+  "miniapp/public/**"
+  "public/**"
+  "miniapp/assets/**"
+)
+
+# Safe remove denylist (never propose)
+DENYLIST=(
+  "*.svg"          # often shared icons, referenced indirectly
+  "**/favicon.*"
+  "**/*.ico"
+  "**/*.icns"
+)
+
+is_protected() {
+  local f="$1"
+  for g in "${PROTECTED_GLOBS[@]}"; do
+    [[ "$f" == $g ]] && return 0
+  done
+  return 1
+}
+
+is_denied() {
+  local f="$1"
+  for g in "${DENYLIST[@]}"; do
+    [[ "$f" == $g ]] && return 0
+  done
+  return 1
+}
+
+# Return 0 if A is a better canonical path than B (shorter path + preferred folders)
+prefer_over() {
+  local A="$1" B="$2"
+  # prefer preferred folders
+  for p in "${PREFERRED_CANON[@]}"; do
+    [[ "$A" == $p ]] && [[ "$B" != $p ]] && return 0
+  done
+  for p in "${PREFERRED_CANON[@]}"; do
+    [[ "$B" == $p ]] && [[ "$A" != $p ]] && return 1
+  done
+  # else prefer shorter path
+  [ ${#A} -le ${#B} ]
+}

--- a/scripts/cleanup/report.sh
+++ b/scripts/cleanup/report.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/cleanup/utils.sh
+
+ensure_out
+OUT=".out/assets_audit_report.md"; : > "$OUT"
+
+say "Running asset cleanup scan (dry-run)"
+
+bash scripts/cleanup/find_dupes.sh
+bash scripts/cleanup/find_orphans.sh
+
+echo "# Assets Audit" >> "$OUT"
+
+# Duplicates section
+echo "## Duplicate Files" >> "$OUT"
+if [ -s .out/dupe_remove_candidates.txt ]; then
+  echo "" >> "$OUT"
+  printf '```\n' >> "$OUT"
+  cat .out/dupe_remove_candidates.txt >> "$OUT"
+  printf '```\n' >> "$OUT"
+else
+  echo "- No duplicate removal candidates" >> "$OUT"
+fi
+
+# Orphans section
+echo "## Orphan Files" >> "$OUT"
+if [ -s .out/orphans.txt ]; then
+  echo "" >> "$OUT"
+  printf '```\n' >> "$OUT"
+  cat .out/orphans.txt >> "$OUT"
+  printf '```\n' >> "$OUT"
+else
+  echo "- No orphan candidates" >> "$OUT"
+fi
+
+# --- Supabase cross-check & final plan ---
+bash scripts/cleanup/gate_supabase.sh
+
+echo "## Removal Plan (after Supabase cross-check)" >> "$OUT"
+if grep -vq "^#" .out/removal_candidates_supabase_checked.txt 2>/dev/null; then
+  echo "" >> "$OUT"
+  printf '```\n' >> "$OUT"
+  grep -v "^#" .out/removal_candidates_supabase_checked.txt >> "$OUT"
+  printf '```\n' >> "$OUT"
+else
+  echo "- No files eligible for removal after Supabase cross-check ✅" >> "$OUT"
+fi
+
+say "Report written to $OUT"

--- a/scripts/cleanup/supabase_verify.sh
+++ b/scripts/cleanup/supabase_verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/cleanup/guard_rules.sh
+
+: "${SUPABASE_URL:?Set SUPABASE_URL}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?Set SUPABASE_SERVICE_ROLE_KEY}"
+
+SB="${SUPABASE_URL%/}"
+HDR=(-H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}")
+
+# Fetch text-bearing columns we care about; expand easily later.
+fetch_table_col() {
+  local table="$1" sel="$2" out="$3"
+  curl -fsS "${HDR[@]}" "$SB/rest/v1/$table?select=$sel&limit=100000" > "$out" || echo "[]" > "$out"
+}
+
+ensure_out(){ mkdir -p .out; }
+
+ensure_out
+fetch_table_col "bot_message_templates" "template_key,message_text,keyboard_layout" ".out/_db_templates.json"
+fetch_table_col "bot_settings" "setting_key,setting_value" ".out/_db_settings.json"
+# add more if needed:
+# fetch_table_col "bot_notifications" "title,message" ".out/_db_notifications.json"
+
+# Return 0 if filename appears in any DB text/json
+db_refs_file() {
+  local fname="$1"
+  jq -e --arg f "$fname" '
+    (.. | strings? | select(test($f; "i"))) as $hit
+  ' .out/_db_templates.json .out/_db_settings.json >/dev/null 2>&1
+}

--- a/scripts/cleanup/utils.sh
+++ b/scripts/cleanup/utils.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+YELLOW='\033[1;33m'; RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+say() { printf "%b%s%b\n" "$BLUE" "$*" "$NC"; }
+warn() { printf "%b%s%b\n" "$YELLOW" "$*" "$NC"; }
+fail() { printf "%b%s%b\n" "$RED" "$*" "$NC"; }
+pass() { printf "%b%s%b\n" "$GREEN" "$*" "$NC"; }
+trim() { sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+ensure_out() { mkdir -p .out; }


### PR DESCRIPTION
## Summary
- add guard rules and Supabase cross-check scripts for asset cleanup
- wire asset audit report and gated deletion script
- add CI workflow using Supabase service role secrets

## Testing
- `bash scripts/cleanup/report.sh`
- `npm test` *(fails: sh: 1: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f874d6e4832294e678fee92b48b6