### PR TITLE
Ensure start command replies without mini app

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -102,20 +102,16 @@ function buildWebAppButton(label = "Open Mini App") {
 async function sendMiniAppLink(chatId: number): Promise<void> {
   if (!BOT_TOKEN) return;
   const enabled = await getFlag("mini_app_enabled", false);
-  if (!enabled) return;
-  const button = buildWebAppButton("Open Mini App");
+  const button = enabled ? buildWebAppButton("Open Mini App") : null;
   const reply_markup = button ? { inline_keyboard: [[button]] } : undefined;
+  const text = button
+    ? "Open the Dynamic Capital mini app"
+    : "Mini app not configured yet.";
 
   await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      chat_id: chatId,
-      text: button
-        ? "Open the Dynamic Capital mini app"
-        : "Mini app not configured yet.",
-      reply_markup,
-    }),
+    body: JSON.stringify({ chat_id: chatId, text, reply_markup }),
   });
 }
 


### PR DESCRIPTION
## Summary
- Always reply to /start by sending a mini-app message even if the mini app feature flag is disabled

## Testing
- `npx supabase --version`
- `deno test -A --unsafely-ignore-certificate-errors` *(fails: feature flag workflow)*

------
https://chatgpt.com/codex/tasks/task_e_68981a5f1d808322922fa3d4493942ae