### PR TITLE
Handle /start command parameters in webhook

### DIFF
--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -60,11 +60,12 @@ export async function handler(req: Request): Promise<Response> {
     return new Response(JSON.stringify({ ok: true }), { headers });
   }
 
-  const text = update?.message?.text;
+  const text = update?.message?.text?.trim();
   const chatId = update?.message?.chat?.id;
 
-  // Reply to /start messages
-  if (text === "/start" && typeof chatId === "number") {
+  // Reply to /start messages (with optional parameters)
+  const command = text?.split(/\s+/)[0];
+  if (command === "/start" && typeof chatId === "number") {
     try {
       await sendMessage(chatId, "Bot activated. Replying to /start");
     } catch (err) {

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+Deno.test("webhook handles /start with params", async () => {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  const calls: Array<{ url: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { text: "/start deep", chat: { id: 1 } } }),
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0].url, "https://api.telegram.org/bottesttoken/sendMessage");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- Allow `/start` commands with parameters in Telegram webhook
- Add test covering `/start` parameter handling

## Testing
- `npm test` (fails: invalid peer certificate fetching npm packages)


------
https://chatgpt.com/codex/tasks/task_e_689900b2830c8322b20dde02cef866ae