### PR TITLE
feat(miniapp): Phase 3 — plans, checkout, receipt upload (Edge) + RLS/storage

### DIFF
--- a/apps/miniapp-react/src/routes/App.tsx
+++ b/apps/miniapp-react/src/routes/App.tsx
@@ -1,21 +1,34 @@
 import { Route, Routes, Navigate, Link, useLocation } from 'react-router-dom';
 import Landing from '@/routes/Landing';
 import Dashboard from '@/routes/Dashboard';
+import Plans from '@/routes/Plans';
+import Checkout from '@/routes/Checkout';
 
 export default function App() {
   const loc = useLocation();
+  const page =
+    loc.pathname === '/dashboard'
+      ? 'Dashboard'
+      : loc.pathname === '/plans'
+      ? 'Plans'
+      : loc.pathname === '/checkout'
+      ? 'Checkout'
+      : 'Home';
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 text-slate-900 dark:text-slate-100">
       <nav className="sticky top-0 z-10 backdrop-blur bg-white/60 dark:bg-slate-900/60 border-b border-slate-200/50 dark:border-slate-700/40">
         <div className="mx-auto max-w-xl px-4 h-14 flex items-center justify-between">
           <Link to="/" className="font-semibold">Dynamic Capital</Link>
-          <div className="text-sm opacity-70">{loc.pathname === '/dashboard' ? 'Dashboard' : 'Home'}</div>
+          <div className="text-sm opacity-70">{page}</div>
         </div>
       </nav>
       <main className="mx-auto max-w-xl p-4">
         <Routes>
           <Route path="/" element={<Landing />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/plans" element={<Plans />} />
+          <Route path="/checkout" element={<Checkout />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>

--- a/apps/miniapp-react/src/routes/Checkout.tsx
+++ b/apps/miniapp-react/src/routes/Checkout.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTelegram } from '@/shared/useTelegram';
+import {
+  checkoutInit,
+  requestReceiptUploadUrl,
+  submitReceipt,
+  type CheckoutInitResponse,
+} from '@/services/api';
+
+export default function Checkout() {
+  const [search] = useSearchParams();
+  const planId = search.get('plan') || '';
+  const { user } = useTelegram();
+  const [method, setMethod] = useState('bank_transfer');
+  const [payment, setPayment] = useState<CheckoutInitResponse | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function start() {
+    if (!user?.id || !planId) return;
+    const res = await checkoutInit(String(user.id), planId, method);
+    setPayment(res);
+  }
+
+  async function upload() {
+    if (!user?.id || !payment?.payment_id || !file) return;
+    const { signed, path } = await requestReceiptUploadUrl(
+      String(user.id),
+      payment.payment_id,
+      file.name,
+      file.type,
+    );
+    const form = new FormData();
+    form.append('file', file);
+    form.append('token', signed.token);
+    await fetch(signed.url, { method: 'POST', body: form });
+    const ok = await submitReceipt(
+      String(user.id),
+      payment.payment_id,
+      path,
+    );
+    setStatus(ok ? 'submitted' : 'failed');
+  }
+
+  return (
+    <section className="card space-y-4">
+      <h2 className="text-xl font-semibold">Checkout</h2>
+      {!payment && (
+        <div className="space-y-3">
+          <select
+            value={method}
+            onChange={(e) => setMethod(e.target.value)}
+            className="border p-2 rounded w-full"
+          >
+            <option value="bank_transfer">Bank Transfer</option>
+            <option value="binance_pay">Binance Pay</option>
+            <option value="crypto">Crypto</option>
+          </select>
+          <button
+            className="btn bg-blue-600 text-white hover:bg-blue-700"
+            onClick={start}
+          >
+            Start Checkout
+          </button>
+        </div>
+      )}
+      {payment && (
+        <div className="space-y-3">
+          <div className="text-sm opacity-80">Payment ID: {payment.payment_id}</div>
+          {payment.instructions && (
+            <pre className="text-xs bg-slate-100 dark:bg-slate-800 p-2 rounded overflow-x-auto">
+              {JSON.stringify(payment.instructions, null, 2)}
+            </pre>
+          )}
+          <input
+            type="file"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+          <button
+            className="btn bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+            onClick={upload}
+            disabled={!file}
+          >
+            Upload Receipt
+          </button>
+          {status && (
+            <div className="text-sm opacity-80">Status: {status}</div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/miniapp-react/src/routes/Dashboard.tsx
+++ b/apps/miniapp-react/src/routes/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useTelegram } from '@/shared/useTelegram';
 import { verifyInitData, getVipStatus, getPackages } from '@/services/api';
 import VipBadge from '@/shared/VipBadge';
@@ -8,6 +9,7 @@ type Pkg = { id: string; name: string; price: number; currency: string; thumbnai
 
 export default function Dashboard() {
   const { initData, user, haptic } = useTelegram();
+  const nav = useNavigate();
   const [vip, setVip] = useState<null | boolean>(null);
   const [pkgs, setPkgs] = useState<Pkg[] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -32,7 +34,13 @@ export default function Dashboard() {
         <h2 className="text-xl font-semibold mb-1">Membership</h2>
         <VipBadge value={vip} />
         <div className="mt-3 flex gap-3">
-          <button className="btn bg-emerald-600 text-white hover:bg-emerald-700" onClick={() => haptic('medium')}>
+          <button
+            className="btn bg-emerald-600 text-white hover:bg-emerald-700"
+            onClick={() => {
+              haptic('medium');
+              nav('/plans');
+            }}
+          >
             Renew / Upgrade
           </button>
           <button className="btn bg-slate-200 dark:bg-slate-700 text-slate-900 dark:text-slate-100" onClick={() => haptic('light')}>

--- a/apps/miniapp-react/src/routes/Plans.tsx
+++ b/apps/miniapp-react/src/routes/Plans.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { listPlans, type SubscriptionPlan } from '@/services/api';
+
+export default function Plans() {
+  const [plans, setPlans] = useState<SubscriptionPlan[]>([]);
+  const nav = useNavigate();
+
+  useEffect(() => {
+    (async () => {
+      const p = await listPlans();
+      setPlans(p);
+    })();
+  }, []);
+
+  return (
+    <section className="card space-y-3">
+      <h2 className="text-xl font-semibold">Subscription Plans</h2>
+      <div className="grid gap-3">
+        {plans.map((p) => (
+          <div key={p.id} className="border rounded p-3 space-y-1">
+            <div className="font-medium">{p.name}</div>
+            <div className="text-sm opacity-80">
+              {p.price} {p.currency}
+            </div>
+            <button
+              className="btn mt-2 bg-blue-600 text-white hover:bg-blue-700"
+              onClick={() => nav(`/checkout?plan=${p.id}`)}
+            >
+              Select
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/miniapp-react/src/services/api.ts
+++ b/apps/miniapp-react/src/services/api.ts
@@ -1,5 +1,50 @@
 import { anonKey, functionUrl, supabaseUrl } from "@/lib/edge";
 
+export interface EducationPackage {
+  id: string;
+  name: string;
+  price: number;
+  currency: string;
+  thumbnail_url?: string;
+  description?: string;
+  is_active?: boolean;
+}
+
+export interface SubscriptionPlan {
+  id: string;
+  name: string;
+  price: number;
+  currency: string;
+  duration_months?: number | null;
+  is_lifetime?: boolean;
+  features?: string[] | null;
+}
+
+export interface BankAccount {
+  bank_name: string;
+  account_name: string;
+  account_number: string;
+  currency: string;
+  is_active: boolean;
+}
+
+export type CheckoutInstructions =
+  | { type: 'bank_transfer'; banks: BankAccount[] }
+  | { type: 'binance_pay' | 'crypto'; note: string };
+
+export interface CheckoutInitResponse {
+  ok: boolean;
+  payment_id: string;
+  instructions: CheckoutInstructions;
+}
+
+export interface SignedUploadUrlResponse {
+  ok: boolean;
+  bucket: string;
+  path: string;
+  signed: { url: string; token: string };
+}
+
 export async function verifyInitData(initData: string): Promise<boolean> {
   const url = functionUrl("verify-initdata");
   if (!url || !initData) return false;
@@ -35,7 +80,7 @@ export async function getVipStatus(
   }
 }
 
-export async function getPackages(): Promise<any[]> {
+export async function getPackages(): Promise<EducationPackage[]> {
   const base = supabaseUrl();
   const anon = anonKey();
   if (!base || !anon) return [];
@@ -45,5 +90,62 @@ export async function getPackages(): Promise<any[]> {
     headers: { apikey: anon, Authorization: `Bearer ${anon}` },
   });
   if (!r.ok) return [];
-  return (await r.json()) as any[];
+  return (await r.json()) as EducationPackage[];
+}
+
+export async function listPlans(): Promise<SubscriptionPlan[]> {
+  const url = functionUrl('plans');
+  if (!url) return [];
+  const r = await fetch(url);
+  if (!r.ok) return [];
+  const j = (await r.json()) as { plans?: SubscriptionPlan[] };
+  return j.plans || [];
+}
+
+export async function checkoutInit(
+  telegram_id: string,
+  plan_id: string,
+  method: string,
+): Promise<CheckoutInitResponse> {
+  const url = functionUrl('checkout-init');
+  if (!url) throw new Error('no url');
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ telegram_id, plan_id, method }),
+  });
+  if (!r.ok) throw new Error('checkout failed');
+  return r.json() as Promise<CheckoutInitResponse>;
+}
+
+export async function requestReceiptUploadUrl(
+  telegram_id: string,
+  payment_id: string,
+  filename: string,
+  content_type?: string,
+): Promise<SignedUploadUrlResponse> {
+  const url = functionUrl('receipt-upload-url');
+  if (!url) throw new Error('no url');
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ telegram_id, payment_id, filename, content_type }),
+  });
+  if (!r.ok) throw new Error('signed url failed');
+  return r.json() as Promise<SignedUploadUrlResponse>;
+}
+
+export async function submitReceipt(
+  telegram_id: string,
+  payment_id: string,
+  storage_path: string,
+) {
+  const url = functionUrl('receipt-submit');
+  if (!url) throw new Error('no url');
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ telegram_id, payment_id, storage_path }),
+  });
+  return r.ok;
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -23,6 +23,10 @@
     "edge:deploy:verify": "npx supabase functions deploy verify-initdata",
     "edge:deploy:health": "npx supabase functions deploy miniapp-health",
     "tg:keeper:deploy": "npx supabase functions deploy telegram-webhook-keeper",
-    "tg:keeper:run": "curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-webhook-keeper | jq ."
+    "tg:keeper:run": "curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-webhook-keeper | jq .",
+    "edge:deploy:plans": "npx supabase functions deploy plans",
+    "edge:deploy:checkout": "npx supabase functions deploy checkout-init",
+    "edge:deploy:uploadurl": "npx supabase functions deploy receipt-upload-url",
+    "edge:deploy:receipt": "npx supabase functions deploy receipt-submit"
   }
 }

--- a/docs/PHASE_3_CHECKOUT.md
+++ b/docs/PHASE_3_CHECKOUT.md
@@ -1,0 +1,11 @@
+# Phase 3 Checkout Flow
+
+This phase wires basic payment handling for the Mini App.
+
+1. **Plans** – The mini app calls the `/plans` Edge function to list available subscription plans.
+2. **Checkout** – Users choose a plan and start checkout via the `/checkout-init` function, which creates a pending payment and returns method instructions.
+3. **Upload** – The client requests a signed URL from `/receipt-upload-url` and uploads the receipt directly to the private `receipts` storage bucket.
+4. **Submit** – After uploading, the client calls `/receipt-submit` to link the file to the payment and mark it for review.
+5. **Admin approval** – A later phase will handle verifying receipts and activating plans.
+
+Receipts are stored in a private Supabase Storage bucket and are only uploaded through signed URLs. All sensitive operations (payment creation, signed uploads, linking receipts) happen on Edge functions using the service role key.

--- a/supabase/functions/checkout-init/index.ts
+++ b/supabase/functions/checkout-init/index.ts
@@ -1,0 +1,104 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type Body = {
+  telegram_id: string;
+  plan_id: string;
+  method: "bank_transfer" | "binance_pay" | "crypto";
+};
+
+type BankAccount = {
+  bank_name: string;
+  account_name: string;
+  account_number: string;
+  currency: string;
+  is_active: boolean;
+};
+
+type BankInstructions = { type: "bank_transfer"; banks: BankAccount[] };
+type NoteInstructions = { type: "binance_pay" | "crypto"; note: string };
+type Instructions = BankInstructions | NoteInstructions;
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Bad JSON", { status: 400 });
+  }
+
+  const url = getEnv("SUPABASE_URL");
+  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supa = createClient(url, srv, { auth: { persistSession: false } });
+
+  const { data: bu } = await supa
+    .from("bot_users")
+    .select("id")
+    .eq("telegram_id", body.telegram_id)
+    .limit(1);
+  let userId = bu?.[0]?.id as string | undefined;
+  if (!userId) {
+    const { data: ins } = await supa
+      .from("bot_users")
+      .insert({ telegram_id: body.telegram_id })
+      .select("id")
+      .single();
+    userId = ins?.id;
+  }
+  if (!userId) {
+    return new Response(
+      JSON.stringify({ ok: false, error: "user_not_found" }),
+      { status: 500 },
+    );
+  }
+
+  const { data: pay, error: perr } = await supa
+    .from("payments")
+    .insert({
+      user_id: userId,
+      plan_id: body.plan_id,
+      amount: null,
+      currency: "USD",
+      payment_method: body.method,
+      status: "pending",
+    })
+    .select("id,created_at")
+    .single();
+  if (perr) {
+    return new Response(
+      JSON.stringify({ ok: false, error: perr.message }),
+      { status: 500 },
+    );
+  }
+
+  let instructions: Instructions;
+  if (body.method === "bank_transfer") {
+    const { data: banks } = await supa
+      .from("bank_accounts")
+      .select(
+        "bank_name,account_name,account_number,currency,is_active",
+      )
+      .eq("is_active", true)
+      .order("display_order");
+    instructions = { type: "bank_transfer", banks: (banks as BankAccount[]) || [] };
+  } else if (body.method === "binance_pay") {
+    instructions = {
+      type: "binance_pay",
+      note: "Open Binance Pay and pay to the presented QR/ID. Then upload receipt.",
+    };
+  } else {
+    instructions = {
+      type: "crypto",
+      note: "Send to the provided address (shown in UI). Then upload receipt.",
+    };
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, payment_id: pay!.id, instructions }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/plans/index.ts
+++ b/supabase/functions/plans/index.ts
@@ -1,0 +1,30 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  if (req.method !== "GET") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const url = getEnv("SUPABASE_URL");
+  const anon = getEnv("SUPABASE_ANON_KEY");
+  const supa = createClient(url, anon, { auth: { persistSession: false } });
+
+  const { data, error } = await supa
+    .from("subscription_plans")
+    .select("id,name,duration_months,price,currency,is_lifetime,features,created_at")
+    .order("price", { ascending: true });
+
+  if (error) {
+    return new Response(
+      JSON.stringify({ ok: false, error: error.message }),
+      { status: 500 },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, plans: data }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -1,0 +1,48 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type Body = {
+  telegram_id: string;
+  payment_id: string;
+  storage_path: string;
+  storage_bucket?: string;
+};
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Bad JSON", { status: 400 });
+  }
+
+  const url = getEnv("SUPABASE_URL");
+  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supa = createClient(url, srv, { auth: { persistSession: false } });
+
+  const { error } = await supa
+    .from("payments")
+    .update({
+      status: "pending",
+      webhook_data: {
+        storage_bucket: body.storage_bucket || "receipts",
+        storage_path: body.storage_path,
+      },
+    })
+    .eq("id", body.payment_id);
+  if (error) {
+    return new Response(
+      JSON.stringify({ ok: false, error: error.message }),
+      { status: 500 },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/receipt-upload-url/index.ts
+++ b/supabase/functions/receipt-upload-url/index.ts
@@ -1,0 +1,42 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { getEnv } from "../_shared/env.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type Body = {
+  telegram_id: string;
+  payment_id: string;
+  filename: string;
+  content_type?: string;
+};
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  let body: Body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Bad JSON", { status: 400 });
+  }
+
+  const url = getEnv("SUPABASE_URL");
+  const srv = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supa = createClient(url, srv, { auth: { persistSession: false } });
+
+  const key = `receipts/${body.telegram_id}/${crypto.randomUUID()}-${body.filename}`;
+  const { data: signed, error } = await supa.storage
+    .from("receipts")
+    .createSignedUploadUrl(key);
+  if (error) {
+    return new Response(
+      JSON.stringify({ ok: false, error: error.message }),
+      { status: 500 },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, bucket: "receipts", path: key, signed }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/migrations/20250811_phase3_payments_rls.sql
+++ b/supabase/migrations/20250811_phase3_payments_rls.sql
@@ -1,0 +1,25 @@
+-- Storage bucket for receipts (private)
+select storage.create_bucket('receipts', public := false);
+
+-- Indexes for faster lookups
+create index if not exists idx_bot_users_telegram_id on public.bot_users(telegram_id);
+create index if not exists idx_payments_user_plan on public.payments(user_id, plan_id);
+create index if not exists idx_subscription_plans_created on public.subscription_plans(created_at);
+
+-- Public read of active education packages via REST (client-side)
+alter table public.education_packages enable row level security;
+drop policy if exists ep_public_active_read on public.education_packages;
+create policy ep_public_active_read
+  on public.education_packages
+  for select
+  using (is_active = true);
+
+-- (Optional) Public read of featured subscription plans (no secrets). If you keep all plans public, allow select:
+alter table public.subscription_plans enable row level security;
+drop policy if exists sp_public_read on public.subscription_plans;
+create policy sp_public_read
+  on public.subscription_plans
+  for select
+  using (true);
+
+-- NOTE: Writes remain via Edge (service role). No client write policies are added.


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1
Adds plans, checkout-init, signed upload URL, and receipt-submit Edge functions; RLS for public reads; receipts storage bucket; client routes/services stubs. Sensitive operations stay on Edge with service role.

------
https://chatgpt.com/codex/tasks/task_e_6899b1eaa8808322a6127ebb0c775298