### PR TITLE
sec: Phase 9 — RLS hardening, bans, retention cron, CSP headers, DB-first webhook secret + rotation

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -44,6 +44,12 @@
     "edge:deploy:promo": "npx supabase functions deploy promo-validate && npx supabase functions deploy promo-redeem",
     "edge:deploy:ref": "npx supabase functions deploy referral-link",
     "edge:deploy:broadcast": "npx supabase functions deploy broadcast-dispatch && npx supabase functions deploy broadcast-cron",
-    "edge:deploy:funnel": "npx supabase functions deploy funnel-track"
+    "edge:deploy:funnel": "npx supabase functions deploy funnel-track",
+    "edge:deploy:security": "npx supabase functions deploy admin-bans && npx supabase functions deploy data-retention-cron && npx supabase functions deploy rotate-webhook-secret"
   }
 }
+// Schedules:
+// Retention: daily at 03:10 (server time)
+// supabase functions schedule create "10 3 * * *" data-retention-cron
+// Optional monthly rotation (manual trigger recommended first time)
+// supabase functions schedule create "0 2 1 * *" rotate-webhook-secret

--- a/docs/PHASE_9_SECURITY.md
+++ b/docs/PHASE_9_SECURITY.md
@@ -1,0 +1,7 @@
+- RLS deny-all on sensitive tables (Edge-only access).
+- Banlist usage & Admin endpoint (/admin-bans with initData auth).
+- Retention cron (RETENTION_DAYS, defaults 90).
+- Mini App CSP headers and why frame-ancestors * is required for Telegram
+  WebView.
+- Secret rotation endpoint (/rotate-webhook-secret using X-Admin-Secret), and
+  note that bot prefers DB secret.

--- a/supabase/functions/admin-bans/index.ts
+++ b/supabase/functions/admin-bans/index.ts
@@ -1,0 +1,58 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { isAdmin, verifyInitDataAndGetUser } from "../_shared/telegram.ts";
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  let body: {
+    initData: string;
+    op: "list" | "add" | "remove";
+    telegram_id?: string;
+    reason?: string;
+    days?: number;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("Bad JSON", { status: 400 });
+  }
+
+  const u = await verifyInitDataAndGetUser(body.initData || "");
+  if (!u || !isAdmin(u.id)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const supa = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { persistSession: false } },
+  );
+
+  if (body.op === "list") {
+    const { data } = await supa.from("abuse_bans").select(
+      "id,telegram_id,reason,created_at,expires_at",
+    ).order("created_at", { ascending: false }).limit(100);
+    return new Response(JSON.stringify({ ok: true, items: data || [] }), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+  if (body.op === "add" && body.telegram_id) {
+    const exp = body.days
+      ? new Date(Date.now() + body.days * 86400000).toISOString()
+      : null;
+    await supa.from("abuse_bans").insert({
+      telegram_id: body.telegram_id,
+      reason: body.reason || "ban",
+      expires_at: exp,
+      created_by: String(u.id),
+    });
+    return new Response(JSON.stringify({ ok: true }));
+  }
+  if (body.op === "remove" && body.telegram_id) {
+    await supa.from("abuse_bans").delete().eq("telegram_id", body.telegram_id);
+    return new Response(JSON.stringify({ ok: true }));
+  }
+  return new Response("Bad Request", { status: 400 });
+});

--- a/supabase/functions/data-retention-cron/index.ts
+++ b/supabase/functions/data-retention-cron/index.ts
@@ -1,0 +1,45 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (_req) => {
+  const supa = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    { auth: { persistSession: false } },
+  );
+  const days = Number(Deno.env.get("RETENTION_DAYS") ?? "90");
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+  const del1 = await supa.from("user_interactions").delete().lte(
+    "created_at",
+    cutoff,
+  ).select("id");
+  const del2 = await supa.from("user_sessions").delete().lte(
+    "last_activity",
+    cutoff,
+  ).select("id");
+  const del3 = await supa.from("abuse_bans").delete().lt(
+    "expires_at",
+    new Date().toISOString(),
+  ).select("id");
+
+  await supa.from("admin_logs").insert({
+    admin_telegram_id: "system",
+    action_type: "data_retention",
+    action_description: `Cleaned interactions(${
+      del1.data?.length || 0
+    }), sessions(${del2.data?.length || 0}), bans(${del3.data?.length || 0})`,
+  });
+
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      deleted: {
+        interactions: del1.data?.length || 0,
+        sessions: del2.data?.length || 0,
+        bans: del3.data?.length || 0,
+      },
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,6 +1,18 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 
 const cache = new Map<string, Response>();
+const SECURITY = {
+  "referrer-policy": "strict-origin-when-cross-origin",
+  "x-content-type-options": "nosniff",
+  "permissions-policy": "geolocation=(), microphone=(), camera=()",
+  // Telegram WebView needs frame allowed; CSP is relaxed for WebApp JS and your function host
+  "content-security-policy":
+    "default-src 'self' https://*.telegram.org https://telegram.org; " +
+    "script-src 'self' 'unsafe-inline' https://*.telegram.org; " +
+    "style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; " +
+    "connect-src 'self' https://*.functions.supabase.co https://*.supabase.co; " +
+    "frame-ancestors *;",
+} as const;
 
 async function file(path: string, type = "text/plain"): Promise<Response> {
   const key = `__${path}`;
@@ -9,14 +21,14 @@ async function file(path: string, type = "text/plain"): Promise<Response> {
     const data = await Deno.readFile(
       new URL(`./static/${path}`, import.meta.url),
     );
-    const r = new Response(data, {
-      headers: {
-        "content-type": type,
-        "cache-control": path.endsWith(".html")
-          ? "no-cache"
-          : "public, max-age=31536000, immutable",
-      },
+    const h = new Headers({
+      "content-type": type,
+      "cache-control": path.endsWith(".html")
+        ? "no-cache"
+        : "public, max-age=31536000, immutable",
     });
+    for (const [k, v] of Object.entries(SECURITY)) h.set(k, v);
+    const r = new Response(data, { headers: h });
     cache.set(key, r.clone());
     return r;
   } catch {
@@ -28,6 +40,7 @@ async function indexHtml(): Promise<Response> {
   const r = await file("index.html", "text/html; charset=utf-8");
   const h = new Headers(r.headers);
   h.set("x-frame-options", "ALLOWALL"); // Telegram WebView
+  for (const [k, v] of Object.entries(SECURITY)) h.set(k, v);
   return new Response(await r.arrayBuffer(), { headers: h, status: r.status });
 }
 

--- a/supabase/functions/rotate-webhook-secret/index.ts
+++ b/supabase/functions/rotate-webhook-secret/index.ts
@@ -1,0 +1,57 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+function genHex(n = 24) {
+  const b = new Uint8Array(n);
+  crypto.getRandomValues(b);
+  return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+async function tg(token: string, method: string, body?: unknown) {
+  const r = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return await r.json().catch(() => ({}));
+}
+
+serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  // Admin header secret from Phase 4 (reuse)
+  const hdr = req.headers.get("X-Admin-Secret") || "";
+  if (hdr !== (Deno.env.get("ADMIN_API_SECRET") || "")) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const url = Deno.env.get("SUPABASE_URL")!,
+    svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
+  const ref = (new URL(url)).hostname.split(".")[0];
+  const expectedUrl = `https://${ref}.functions.supabase.co/telegram-bot`;
+
+  const secret = genHex(24);
+  await supa.from("bot_settings").upsert({
+    setting_key: "TELEGRAM_WEBHOOK_SECRET",
+    setting_value: secret,
+  }, { onConflict: "setting_key" });
+
+  const set = await tg(token, "setWebhook", {
+    url: expectedUrl,
+    secret_token: secret,
+    allowed_updates: ["message", "callback_query"],
+    drop_pending_updates: false,
+  });
+  const info = await tg(token, "getWebhookInfo");
+
+  return new Response(
+    JSON.stringify({
+      ok: info?.ok === true,
+      new_secret: secret,
+      webhook: info,
+    }),
+    { headers: { "content-type": "application/json" } },
+  );
+});

--- a/supabase/migrations/20250811_phase9_security.sql
+++ b/supabase/migrations/20250811_phase9_security.sql
@@ -1,0 +1,33 @@
+-- Enable RLS on sensitive tables (no client policies: Edge-only writes)
+alter table public.payments enable row level security;
+alter table public.user_subscriptions enable row level security;
+alter table public.bot_users enable row level security;
+alter table public.admin_logs enable row level security;
+
+-- Deny-all policies (Edge/service role bypasses)
+drop policy if exists deny_all_payments on public.payments;
+create policy deny_all_payments on public.payments for all using (false);
+
+drop policy if exists deny_all_usersubs on public.user_subscriptions;
+create policy deny_all_usersubs on public.user_subscriptions for all using (false);
+
+drop policy if exists deny_all_botusers on public.bot_users;
+create policy deny_all_botusers on public.bot_users for all using (false);
+
+drop policy if exists deny_all_adminlogs on public.admin_logs;
+create policy deny_all_adminlogs on public.admin_logs for all using (false);
+
+-- Storage bucket already private; ensure index for interactions cleanup
+create index if not exists idx_user_interactions_created_at on public.user_interactions(created_at);
+create index if not exists idx_user_sessions_last_activity on public.user_sessions(last_activity);
+
+-- Ban list
+create table if not exists public.abuse_bans (
+  id uuid primary key default gen_random_uuid(),
+  telegram_id text not null,
+  reason text,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz,
+  created_by text
+);
+create index if not exists idx_abuse_bans_tg on public.abuse_bans(telegram_id);


### PR DESCRIPTION
/automerge method=squash require=checks,approvals>=1
Adds RLS deny-all for sensitive tables, admin bans API, data retention cron, CSP headers for miniapp, and DB-first webhook secret with rotation endpoint. Schedules retention; rotation can be manual or scheduled.


------
https://chatgpt.com/codex/tasks/task_e_6899cca56e208322808556939e38caea