### PR TITLE
fix: use relative asset paths for mini app

### DIFF
--- a/apps/miniapp-react/index.html
+++ b/apps/miniapp-react/index.html
@@ -8,6 +8,6 @@
   </head>
   <body class="bg-slate-50 dark:bg-slate-900">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/apps/miniapp-react/vite.config.ts
+++ b/apps/miniapp-react/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/miniapp/index.html
+++ b/miniapp/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/supabase/functions/miniapp/static/index.html
+++ b/supabase/functions/miniapp/static/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Dynamic Capital — VIP</title>
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" crossorigin src="/assets/index-BHwarnKQ.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CNGF4XNV.css">
+    <script type="module" crossorigin src="assets/index-BHwarnKQ.js"></script>
+    <link rel="stylesheet" crossorigin href="assets/index-CNGF4XNV.css">
   </head>
   <body class="bg-slate-50 dark:bg-slate-900">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- ensure miniapp React build uses relative base path
- update miniapp static index to reference assets relatively

## Testing
- `npm test` *(fails: Module not found "@supabase/supabase-js@2" in telegram-webhook-keeper)*

------
https://chatgpt.com/codex/tasks/task_e_6899dfda9da88322888945ab808f0160