### PR TITLE
Handle invalid mini-app config for /start command

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -116,21 +116,32 @@ async function notifyUser(chatId: number, text: string): Promise<void> {
   await sendMessage(chatId, text);
 }
 
+function isValidHttpsUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    return u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 async function sendMiniAppLink(chatId: number): Promise<void> {
   if (!BOT_TOKEN) return;
   const miniUrl = optionalEnv("MINI_APP_URL");
   const short = optionalEnv("MINI_APP_SHORT_NAME");
-  if (!miniUrl && !short) {
+  let openUrl: string | null = null;
+  if (miniUrl) {
+    openUrl = miniUrl.endsWith("/") ? miniUrl : miniUrl + "/";
+  } else if (short && botUsername) {
+    openUrl = `https://t.me/${botUsername}?startapp=1`;
+  }
+  if (!openUrl || !isValidHttpsUrl(openUrl)) {
     await sendMessage(
       chatId,
       "Welcome! Mini app is being configured. Please try again soon.",
     );
     return;
   }
-  const openUrl = miniUrl
-    ? (miniUrl.endsWith("/") ? miniUrl : miniUrl + "/")
-    : `https://t.me/${botUsername}?startapp=1`;
-
   await sendMessage(chatId, "Open the VIP Mini App:", {
     reply_markup: {
       inline_keyboard: [[{

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -29,3 +29,30 @@ Deno.test("webhook handles /start with params", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+Deno.test("webhook falls back for invalid mini app url", async () => {
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "testtoken");
+  Deno.env.set("MINI_APP_URL", "http://invalid-url");
+  const calls: Array<{ url: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), body: init?.body ? String(init.body) : "" });
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+  try {
+    const mod = await import("../supabase/functions/telegram-webhook/index.ts");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: { text: "/start", chat: { id: 1 } } }),
+    });
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(calls.length, 1);
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(payload.text, "Bot activated. Mini app is being configured. Please try again soon.");
+    assertEquals(payload.chat_id, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- Validate mini-app URL before replying to /start
- Fallback to welcome text when mini-app URL is invalid
- Test invalid mini-app URL handling

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement)*

------
https://chatgpt.com/codex/tasks/task_e_689ac77934bc8322a23e339fd2dc4dd1