### PR TITLE
fix: include auth header for miniapp verify

### DIFF
--- a/miniapp/src/api.ts
+++ b/miniapp/src/api.ts
@@ -1,7 +1,10 @@
 /* >>> DC BLOCK: api-core (start) */
 const base = import.meta.env.VITE_SUPABASE_URL?.replace(/\/$/, "") ||
   window.location.origin;
-const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const anonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  new URLSearchParams(location.search).get("anon") ||
+  "";
 
 function getInitData(): string {
   return window.Telegram?.WebApp?.initData || "";


### PR DESCRIPTION
## Summary
- send Supabase anon key in verify request

## Testing
- `npm test` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b076a58d88322b21b2cd0ff0b66a3