### PR TITLE
refactor: centralize Supabase client for functions

### DIFF
--- a/supabase/functions/_shared/client.ts
+++ b/supabase/functions/_shared/client.ts
@@ -1,0 +1,13 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { requireEnv } from "./env.ts";
+
+const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv([
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+] as const);
+
+export const supabase = createClient(
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } },
+);

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { supabase } from "../_shared/client.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { ok, bad, nf, mna, unauth } from "../_shared/http.ts";
 
@@ -19,10 +19,8 @@ serve(async (req) => {
   const u = await verifyInitDataAndGetUser(body.initData || "");
   if (!u || !isAdmin(u.id)) return unauth();
 
-  const url = Deno.env.get("SUPABASE_URL")!;
-  const svc = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   const bot = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
-  const supa = createClient(url, svc, { auth: { persistSession: false } });
+  const supa = supabase;
 
   // Load payment + user + plan
   const { data: p } = await supa.from("payments").select("id,status,user_id,plan_id,amount,currency,created_at").eq("id", body.payment_id).maybeSingle();

--- a/supabase/functions/binance-pay-webhook/index.ts
+++ b/supabase/functions/binance-pay-webhook/index.ts
@@ -1,7 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.53.0";
-import { optionalEnv, requireEnv } from "../_shared/env.ts";
+import { optionalEnv } from "../_shared/env.ts";
+import { supabase } from "../_shared/client.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -74,15 +74,6 @@ serve(async (req) => {
     }
 
     console.log("Binance Pay webhook received:", webhookData);
-
-    // Initialize Supabase client
-    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv(
-      [
-        "SUPABASE_URL",
-        "SUPABASE_SERVICE_ROLE_KEY",
-      ] as const,
-    );
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
     const { bizType, data } = webhookData;
 


### PR DESCRIPTION
## Summary
- add shared Supabase admin client helper
- use shared client in binance-pay-webhook function
- use shared client in admin-act-on-payment function

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c72e19b0483228c44a329f74793fd