### PR TITLE
Use enum for promotion discount types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -964,7 +964,7 @@ export type Database = {
           created_at: string
           current_uses: number | null
           description: string | null
-          discount_type: string
+          discount_type: Database["public"]["Enums"]["discount_type_enum"]
           discount_value: number
           id: string
           is_active: boolean | null
@@ -978,7 +978,7 @@ export type Database = {
           created_at?: string
           current_uses?: number | null
           description?: string | null
-          discount_type: string
+          discount_type: Database["public"]["Enums"]["discount_type_enum"]
           discount_value: number
           id?: string
           is_active?: boolean | null
@@ -992,7 +992,7 @@ export type Database = {
           created_at?: string
           current_uses?: number | null
           description?: string | null
-          discount_type?: string
+          discount_type?: Database["public"]["Enums"]["discount_type_enum"]
           discount_value?: number
           id?: string
           is_active?: boolean | null
@@ -1377,6 +1377,7 @@ export type Database = {
     Enums: {
       content_type_enum: "text" | "html" | "markdown"
       trigger_type_enum: "keyword" | "regex" | "command"
+      discount_type_enum: "percentage" | "fixed"
     }
     CompositeTypes: {
       [_ in never]: never

--- a/supabase/functions/_shared/promo.ts
+++ b/supabase/functions/_shared/promo.ts
@@ -1,6 +1,10 @@
 // >>> DC BLOCK: promo-shared (start)
-export function calcFinalAmount(price: number, type: string, value: number): number {
-  const discount = type === "percent" ? price * (value / 100) : value;
+export function calcFinalAmount(
+  price: number,
+  type: "percentage" | "fixed",
+  value: number,
+): number {
+  const discount = type === "percentage" ? price * (value / 100) : value;
   const final = price - discount;
   return final < 0 ? 0 : Math.round(final * 100) / 100;
 }

--- a/supabase/migrations/20250816000000_add_discount_type_enum.sql
+++ b/supabase/migrations/20250816000000_add_discount_type_enum.sql
@@ -1,0 +1,55 @@
+-- Create enum type for discount types and update related objects
+DO $$ BEGIN
+    CREATE TYPE discount_type_enum AS ENUM ('percentage', 'fixed');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Alter promotions.discount_type to use the enum
+ALTER TABLE promotions
+    ALTER COLUMN discount_type TYPE discount_type_enum
+        USING discount_type::discount_type_enum;
+
+-- Update validate_promo_code to return the enum
+CREATE OR REPLACE FUNCTION validate_promo_code(p_code text, p_telegram_user_id text)
+RETURNS TABLE(
+    valid boolean,
+    reason text,
+    promotion_id uuid,
+    discount_type discount_type_enum,
+    discount_value numeric
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE pr RECORD;
+BEGIN
+    SELECT * INTO pr FROM promotions WHERE code = p_code;
+
+    IF pr IS NULL THEN
+        RETURN QUERY SELECT false, 'not_found', NULL::uuid, NULL::discount_type_enum, NULL::numeric; RETURN;
+    END IF;
+
+    IF pr.is_active = false THEN
+        RETURN QUERY SELECT false, 'inactive', pr.id, NULL::discount_type_enum, NULL::numeric; RETURN;
+    END IF;
+
+    IF pr.valid_until < now() OR pr.valid_from > now() THEN
+        RETURN QUERY SELECT false, 'out_of_window', pr.id, NULL::discount_type_enum, NULL::numeric; RETURN;
+    END IF;
+
+    IF pr.max_uses IS NOT NULL AND pr.current_uses >= pr.max_uses THEN
+        RETURN QUERY SELECT false, 'maxed_out', pr.id, NULL::discount_type_enum, NULL::numeric; RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM promotion_usage
+        WHERE promotion_id = pr.id AND telegram_user_id = p_telegram_user_id
+    ) THEN
+        RETURN QUERY SELECT false, 'already_used', pr.id, NULL::discount_type_enum, NULL::numeric; RETURN;
+    END IF;
+
+    RETURN QUERY SELECT true, NULL::text, pr.id, pr.discount_type, pr.discount_value;
+END;
+$fn$;

--- a/tests/promo.test.ts
+++ b/tests/promo.test.ts
@@ -15,7 +15,7 @@ import { calcFinalAmount, redeemKey } from "../supabase/functions/_shared/promo.
 import { makeReferralLink } from "../supabase/functions/referral-link/index.ts";
 
 registerTest("promo validation math", () => {
-  assertEquals(calcFinalAmount(100, "percent", 20), 80);
+  assertEquals(calcFinalAmount(100, "percentage", 20), 80);
   assertEquals(calcFinalAmount(100, "fixed", 30), 70);
 });
 

--- a/types/telegram-bot.ts
+++ b/types/telegram-bot.ts
@@ -193,7 +193,7 @@ export interface Promotion {
   id: string;
   code: string;
   description?: string;
-  discount_type: "percentage" | "fixed";
+  discount_type: DiscountType;
   discount_value: number;
   max_uses?: number;
   current_uses: number;


### PR DESCRIPTION
## Summary
- define `discount_type_enum` and convert promotions.discount_type and `validate_promo_code` to use it
- type supabase promotions and app interfaces with `discount_type_enum`
- standardize promo math to `percentage`|`fixed` discount types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c72f9577883229a14ee4d3814bd20