### PR TITLE
chore: add script to set telegram secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,23 @@
+## Core runtime secrets required by edge functions
 SUPABASE_URL=
-SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_WEBHOOK_SECRET=
+MINI_APP_URL=
+
+## Additional Supabase credentials
+SUPABASE_ANON_KEY=
 SUPABASE_PROJECT_ID=
 SUPABASE_ACCESS_TOKEN=
 SUPABASE_DB_PASSWORD=
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_WEBHOOK_SECRET=
+
 # Comma-separated Telegram user IDs for admin-only endpoints
 TELEGRAM_ADMIN_IDS=225513686,8411280111
+
+# Optional tuning knobs / feature flags
 BENEFICIARY_TABLE=
 OPENAI_API_KEY=
 OPENAI_ENABLED=
 FAQ_ENABLED=
 WINDOW_SECONDS=
 AMOUNT_TOLERANCE=
-# e.g. https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
-MINI_APP_URL=

--- a/docs/CONFIG_SECRETS.md
+++ b/docs/CONFIG_SECRETS.md
@@ -4,3 +4,26 @@ Supabase Edge secrets are the single source of truth for configuration. Never
 commit `.env` files or hard-coded secrets. When a webhook secret exists in the
 database (`bot_settings.TELEGRAM_WEBHOOK_SECRET`), it overrides the
 `TELEGRAM_WEBHOOK_SECRET` environment value.
+
+## Required secrets
+
+The following secrets must be present so edge functions can run:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_WEBHOOK_SECRET`
+- `MINI_APP_URL`
+
+You can set them with the Supabase CLI or run
+`scripts/setup-telegram-webhook.sh` which reads the values from your local
+environment and uploads them:
+
+```bash
+SUPABASE_URL=... \
+SUPABASE_SERVICE_ROLE_KEY=... \
+TELEGRAM_BOT_TOKEN=... \
+TELEGRAM_WEBHOOK_SECRET=... \
+MINI_APP_URL=... \
+scripts/setup-telegram-webhook.sh
+```

--- a/scripts/setup-telegram-webhook.sh
+++ b/scripts/setup-telegram-webhook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Configure Supabase secrets required by Telegram edge functions.
+#
+# Reads values from the current shell environment and uploads them via the
+# Supabase CLI so that deployed edge functions can access them at runtime.
+#
+# Usage:
+#   SUPABASE_URL=... \
+#   SUPABASE_SERVICE_ROLE_KEY=... \
+#   TELEGRAM_BOT_TOKEN=... \
+#   TELEGRAM_WEBHOOK_SECRET=... \
+#   MINI_APP_URL=... \
+#   scripts/setup-telegram-webhook.sh
+#
+# The Supabase CLI must be installed and authenticated. The project is derived
+# from `supabase/config.toml` when run from the repo root.
+set -euo pipefail
+
+: "${SUPABASE_URL:?Missing SUPABASE_URL}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?Missing SUPABASE_SERVICE_ROLE_KEY}"
+: "${TELEGRAM_BOT_TOKEN:?Missing TELEGRAM_BOT_TOKEN}"
+: "${TELEGRAM_WEBHOOK_SECRET:?Missing TELEGRAM_WEBHOOK_SECRET}"
+: "${MINI_APP_URL:?Missing MINI_APP_URL}"
+
+supabase secrets set \
+  SUPABASE_URL="$SUPABASE_URL" \
+  SUPABASE_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY" \
+  TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
+  TELEGRAM_WEBHOOK_SECRET="$TELEGRAM_WEBHOOK_SECRET" \
+  MINI_APP_URL="$MINI_APP_URL"


### PR DESCRIPTION
## Summary
- document core environment secrets in `.env.example`
- add `scripts/setup-telegram-webhook.sh` to push required secrets to Supabase
- note required secrets and setup script in `docs/CONFIG_SECRETS.md`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7d84467c8322a22ba5b65486f068