### PR TITLE
Add Supabase log streaming script and alerting docs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,7 @@ The project relies on a shared set of environment keys. Set them in your local `
 | WINDOW_SECONDS            | ✅                           | ✅                               | ❌                          |
 | AMOUNT_TOLERANCE          | ✅                           | ✅                               | ❌                          |
 | MINI_APP_URL              | ✅                           | ✅                               | ✅                          |
+| LOGTAIL_SOURCE_TOKEN      | ✅                           | ❌                               | ❌                          |
 
 `✅` indicates where each key should be set.
 

--- a/docs/SUPABASE_LOG_STREAMING.md
+++ b/docs/SUPABASE_LOG_STREAMING.md
@@ -1,0 +1,36 @@
+# Supabase Log Streaming
+
+This project can forward Supabase logs to an external aggregator (Logtail, Grafana Loki, etc.).
+
+## Create a log drain
+
+1. Set the required environment variables:
+   - `SUPABASE_PROJECT_ID`
+   - `SUPABASE_ACCESS_TOKEN`
+   - `LOGTAIL_SOURCE_TOKEN` (token from Logtail or compatible service)
+   - optional `LOGTAIL_URL` if using a custom ingestion URL.
+2. Run the helper script:
+   ```bash
+   deno run -A scripts/setup-log-drain.ts
+   ```
+   This registers a Supabase log drain that streams logs to the aggregator.
+
+## Alerting
+
+Configure alerting within your logging platform to notify on server errors or webhook failures.
+
+### Logtail
+
+Create an alert with a query such as:
+```
+status:[500 TO 599] OR message:"webhook failure"
+```
+Send notifications via email, Slack, etc.
+
+### Grafana Loki
+
+If using Grafana/Loki, create a rule:
+```
+{app="supabase"} |~ "(status=5..|webhook.*failed)"
+```
+Trigger an alert if the count of matching logs over 5 minutes is greater than zero.

--- a/scripts/setup-log-drain.ts
+++ b/scripts/setup-log-drain.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env
+/**
+ * Registers a Supabase log drain that forwards logs to Logtail (or any
+ * compatible HTTP log collector).
+ *
+ * Required env vars:
+ *   SUPABASE_PROJECT_ID   - Project reference, e.g. abcdefghijklmnop
+ *   SUPABASE_ACCESS_TOKEN - Personal access token with project write access
+ *   LOGTAIL_SOURCE_TOKEN  - Ingestion token for Logtail/Better Stack
+ *
+ * Optional env vars:
+ *   LOGTAIL_URL           - Override ingestion URL (default https://in.logtail.com)
+ */
+
+const projectId = Deno.env.get("SUPABASE_PROJECT_ID");
+const accessToken = Deno.env.get("SUPABASE_ACCESS_TOKEN");
+const sourceToken = Deno.env.get("LOGTAIL_SOURCE_TOKEN");
+const sinkUrl = Deno.env.get("LOGTAIL_URL") ?? "https://in.logtail.com";
+
+if (!projectId) throw new Error("SUPABASE_PROJECT_ID missing");
+if (!accessToken) throw new Error("SUPABASE_ACCESS_TOKEN missing");
+if (!sourceToken) throw new Error("LOGTAIL_SOURCE_TOKEN missing");
+
+const body = {
+  name: "logtail",
+  type: "https",
+  sink: {
+    url: sinkUrl,
+    headers: { Authorization: `Bearer ${sourceToken}` },
+  },
+  enabled: true,
+};
+
+const resp = await fetch(
+  `https://api.supabase.com/v1/projects/${projectId}/log-drains`,
+  {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  },
+);
+
+const text = await resp.text();
+console.log(resp.status, text);
+if (!resp.ok) {
+  throw new Error(`Failed to create log drain: ${resp.status}`);
+}


### PR DESCRIPTION
## Summary
- add `setup-log-drain.ts` script to register a Supabase log drain to Logtail or similar aggregators
- document enabling log streaming and configuring alerts for 5xx responses or webhook failures
- record `LOGTAIL_SOURCE_TOKEN` in configuration keys

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c8febf87c83229a979e44bf6ab680