### PR TITLE
feat: add copyable text component

### DIFF
--- a/apps/miniapp-react/src/routes/Checkout.tsx
+++ b/apps/miniapp-react/src/routes/Checkout.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import CopyableText from '@/shared/CopyableText';
 import { useTelegram } from '@/shared/useTelegram';
 import {
   checkoutInit,
   requestReceiptUploadUrl,
   submitReceipt,
   type CheckoutInitResponse,
+  type BankAccount,
 } from '@/services/api';
 
 export default function Checkout() {
@@ -67,11 +69,36 @@ export default function Checkout() {
       )}
       {payment && (
         <div className="space-y-3">
-          <div className="text-sm opacity-80">Payment ID: {payment.payment_id}</div>
+          <div className="text-sm opacity-80 flex items-center gap-2">
+            <span>Payment ID:</span>
+            <CopyableText text={payment.payment_id} />
+          </div>
           {payment.instructions && (
-            <pre className="text-xs bg-slate-100 dark:bg-slate-800 p-2 rounded overflow-x-auto">
-              {JSON.stringify(payment.instructions, null, 2)}
-            </pre>
+            <div className="space-y-2 text-sm">
+              {payment.instructions.type === 'bank_transfer' &&
+                (payment.instructions.banks as (BankAccount & { amount?: number | string })[]).map((b) => (
+                  <div key={b.account_number} className="space-y-1">
+                    <div className="font-medium">{b.bank_name}</div>
+                    <div className="flex items-center gap-2">
+                      <span>Account Name:</span>
+                      <CopyableText text={b.account_name} />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span>Account Number:</span>
+                      <CopyableText text={b.account_number} />
+                    </div>
+                    {b.amount !== undefined && (
+                      <div className="flex items-center gap-2">
+                        <span>Amount:</span>
+                        <CopyableText text={String(b.amount)} />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              {payment.instructions.type !== 'bank_transfer' && (
+                <CopyableText text={payment.instructions.note} />
+              )}
+            </div>
           )}
           <input
             type="file"

--- a/apps/miniapp-react/src/shared/CopyableText.tsx
+++ b/apps/miniapp-react/src/shared/CopyableText.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+export default function CopyableText({ text, className }: { text: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <div className={`inline-flex items-center gap-2 ${className || ''}`}>
+      <span className="truncate">{text}</span>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy to clipboard"
+        className="p-1 rounded hover:bg-slate-200 focus:outline-none focus:ring"
+      >
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      </button>
+      {copied && (
+        <span role="status" className="text-xs text-green-600">
+          Copied!
+        </span>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add copyable text component with clipboard support
- use copyable text for payment ID and instructions in checkout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dad604458832296669d9d7f50eee9