### PR TITLE
feat: use enums for status fields

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -59,7 +59,7 @@ export type Database = {
           is_active: boolean
           message_template: string
           name: string
-          trigger_type: string
+          trigger_type: Database["public"]["Enums"]["auto_reply_trigger_type"]
           updated_at: string
         }
         Insert: {
@@ -70,7 +70,7 @@ export type Database = {
           is_active?: boolean
           message_template: string
           name: string
-          trigger_type: string
+          trigger_type: Database["public"]["Enums"]["auto_reply_trigger_type"]
           updated_at?: string
         }
         Update: {
@@ -81,7 +81,7 @@ export type Database = {
           is_active?: boolean
           message_template?: string
           name?: string
-          trigger_type?: string
+          trigger_type?: Database["public"]["Enums"]["auto_reply_trigger_type"]
           updated_at?: string
         }
         Relationships: []
@@ -299,7 +299,7 @@ export type Database = {
         Row: {
           content: string | null
           created_at: string | null
-          delivery_status: string | null
+          delivery_status: Database["public"]["Enums"]["broadcast_status_enum"] | null
           failed_deliveries: number | null
           id: string
           media_file_id: string | null
@@ -319,7 +319,7 @@ export type Database = {
         Insert: {
           content?: string | null
           created_at?: string | null
-          delivery_status?: string | null
+          delivery_status?: Database["public"]["Enums"]["broadcast_status_enum"] | null
           failed_deliveries?: number | null
           id?: string
           media_file_id?: string | null
@@ -339,7 +339,7 @@ export type Database = {
         Update: {
           content?: string | null
           created_at?: string | null
-          delivery_status?: string | null
+          delivery_status?: Database["public"]["Enums"]["broadcast_status_enum"] | null
           failed_deliveries?: number | null
           id?: string
           media_file_id?: string | null
@@ -579,14 +579,14 @@ export type Database = {
           completion_date: string | null
           created_at: string
           enrollment_date: string
-          enrollment_status: string
+          enrollment_status: Database["public"]["Enums"]["enrollment_status_enum"]
           id: string
           notes: string | null
           package_id: string
           payment_amount: number | null
           payment_method: string | null
           payment_reference: string | null
-          payment_status: string
+          payment_status: Database["public"]["Enums"]["payment_status_enum"]
           progress_percentage: number | null
           receipt_file_path: string | null
           receipt_telegram_file_id: string | null
@@ -603,14 +603,14 @@ export type Database = {
           completion_date?: string | null
           created_at?: string
           enrollment_date?: string
-          enrollment_status?: string
+          enrollment_status?: Database["public"]["Enums"]["enrollment_status_enum"]
           id?: string
           notes?: string | null
           package_id: string
           payment_amount?: number | null
           payment_method?: string | null
           payment_reference?: string | null
-          payment_status?: string
+          payment_status?: Database["public"]["Enums"]["payment_status_enum"]
           progress_percentage?: number | null
           receipt_file_path?: string | null
           receipt_telegram_file_id?: string | null
@@ -627,14 +627,14 @@ export type Database = {
           completion_date?: string | null
           created_at?: string
           enrollment_date?: string
-          enrollment_status?: string
+          enrollment_status?: Database["public"]["Enums"]["enrollment_status_enum"]
           id?: string
           notes?: string | null
           package_id?: string
           payment_amount?: number | null
           payment_method?: string | null
           payment_reference?: string | null
-          payment_status?: string
+          payment_status?: Database["public"]["Enums"]["payment_status_enum"]
           progress_percentage?: number | null
           receipt_file_path?: string | null
           receipt_telegram_file_id?: string | null
@@ -800,7 +800,7 @@ export type Database = {
           payment_method: string
           payment_provider_id: string | null
           plan_id: string
-          status: string
+          status: Database["public"]["Enums"]["payment_status_enum"]
           updated_at: string
           user_id: string
           webhook_data: Json | null
@@ -813,7 +813,7 @@ export type Database = {
           payment_method: string
           payment_provider_id?: string | null
           plan_id: string
-          status?: string
+          status?: Database["public"]["Enums"]["payment_status_enum"]
           updated_at?: string
           user_id: string
           webhook_data?: Json | null
@@ -826,7 +826,7 @@ export type Database = {
           payment_method?: string
           payment_provider_id?: string | null
           plan_id?: string
-          status?: string
+          status?: Database["public"]["Enums"]["payment_status_enum"]
           updated_at?: string
           user_id?: string
           webhook_data?: Json | null
@@ -1186,7 +1186,7 @@ export type Database = {
           is_active: boolean | null
           payment_instructions: string | null
           payment_method: string | null
-          payment_status: string | null
+          payment_status: Database["public"]["Enums"]["payment_status_enum"] | null
           plan_id: string | null
           receipt_file_path: string | null
           receipt_telegram_file_id: string | null
@@ -1203,7 +1203,7 @@ export type Database = {
           is_active?: boolean | null
           payment_instructions?: string | null
           payment_method?: string | null
-          payment_status?: string | null
+          payment_status?: Database["public"]["Enums"]["payment_status_enum"] | null
           plan_id?: string | null
           receipt_file_path?: string | null
           receipt_telegram_file_id?: string | null
@@ -1220,7 +1220,7 @@ export type Database = {
           is_active?: boolean | null
           payment_instructions?: string | null
           payment_method?: string | null
-          payment_status?: string | null
+          payment_status?: Database["public"]["Enums"]["payment_status_enum"] | null
           plan_id?: string | null
           receipt_file_path?: string | null
           receipt_telegram_file_id?: string | null
@@ -1375,7 +1375,12 @@ export type Database = {
       }
     }
     Enums: {
-      [_ in never]: never
+      auto_reply_trigger_type: "keyword" | "regex" | "command"
+      payment_status_enum: "pending" | "completed" | "failed" | "refunded"
+      enrollment_status_enum: "pending" | "active" | "completed" | "cancelled"
+      broadcast_status_enum: "draft" | "scheduled" | "sending" | "completed" | "failed"
+      payment_intent_status_enum: "pending" | "approved" | "manual_review" | "rejected"
+      receipt_verdict_enum: "approved" | "manual_review" | "rejected"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -1502,6 +1507,13 @@ export type CompositeTypes<
 
 export const Constants = {
   public: {
-    Enums: {},
+    Enums: {
+      auto_reply_trigger_type: ["keyword", "regex", "command"],
+      payment_status_enum: ["pending", "completed", "failed", "refunded"],
+      enrollment_status_enum: ["pending", "active", "completed", "cancelled"],
+      broadcast_status_enum: ["draft", "scheduled", "sending", "completed", "failed"],
+      payment_intent_status_enum: ["pending", "approved", "manual_review", "rejected"],
+      receipt_verdict_enum: ["approved", "manual_review", "rejected"],
+    },
   },
 } as const

--- a/supabase/migrations/20250817000000_add_status_enums.sql
+++ b/supabase/migrations/20250817000000_add_status_enums.sql
@@ -1,0 +1,82 @@
+-- Add enums for trigger types and various status fields
+
+-- Rename existing trigger_type_enum to auto_reply_trigger_type if present
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'trigger_type_enum') THEN
+    ALTER TYPE trigger_type_enum RENAME TO auto_reply_trigger_type;
+  END IF;
+END $$;
+
+-- Ensure auto_reply_trigger_type enum exists
+DO $$ BEGIN
+  CREATE TYPE auto_reply_trigger_type AS ENUM ('keyword', 'regex', 'command');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Alter auto_reply_templates.trigger_type to use enum
+ALTER TABLE auto_reply_templates
+  ALTER COLUMN trigger_type TYPE auto_reply_trigger_type USING trigger_type::auto_reply_trigger_type;
+
+-- Payment status enum shared by multiple tables
+DO $$ BEGIN
+  CREATE TYPE payment_status_enum AS ENUM ('pending', 'completed', 'failed', 'refunded');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE payments
+  DROP CONSTRAINT IF EXISTS payments_status_check,
+  ALTER COLUMN status TYPE payment_status_enum USING status::payment_status_enum,
+  ALTER COLUMN status SET DEFAULT 'pending';
+
+ALTER TABLE education_enrollments
+  ALTER COLUMN payment_status TYPE payment_status_enum USING payment_status::payment_status_enum,
+  ALTER COLUMN payment_status SET DEFAULT 'pending';
+
+ALTER TABLE user_subscriptions
+  ALTER COLUMN payment_status TYPE payment_status_enum USING payment_status::payment_status_enum,
+  ALTER COLUMN payment_status SET DEFAULT 'pending';
+
+-- Enrollment status enum for education enrollments
+DO $$ BEGIN
+  CREATE TYPE enrollment_status_enum AS ENUM ('pending', 'active', 'completed', 'cancelled');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE education_enrollments
+  ALTER COLUMN enrollment_status TYPE enrollment_status_enum USING enrollment_status::enrollment_status_enum,
+  ALTER COLUMN enrollment_status SET DEFAULT 'pending';
+
+-- Broadcast delivery status
+DO $$ BEGIN
+  CREATE TYPE broadcast_status_enum AS ENUM ('draft', 'scheduled', 'sending', 'completed', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE broadcast_messages
+  ALTER COLUMN delivery_status TYPE broadcast_status_enum USING delivery_status::broadcast_status_enum,
+  ALTER COLUMN delivery_status SET DEFAULT 'draft';
+
+-- Payment intent status and receipt verdict enums
+DO $$ BEGIN
+  CREATE TYPE payment_intent_status_enum AS ENUM ('pending', 'approved', 'manual_review', 'rejected');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE payment_intents
+  ALTER COLUMN status TYPE payment_intent_status_enum USING status::payment_intent_status_enum,
+  ALTER COLUMN status SET DEFAULT 'pending';
+
+DO $$ BEGIN
+  CREATE TYPE receipt_verdict_enum AS ENUM ('approved', 'manual_review', 'rejected');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE receipts
+  ALTER COLUMN verdict TYPE receipt_verdict_enum USING verdict::receipt_verdict_enum,
+  ALTER COLUMN verdict SET DEFAULT 'manual_review';

--- a/types/telegram-bot.ts
+++ b/types/telegram-bot.ts
@@ -8,6 +8,8 @@
  * @version 1.0.0
  */
 
+import type { Database } from "../src/integrations/supabase/types";
+
 // ============================================
 // Core Bot Interfaces
 // ============================================
@@ -169,7 +171,7 @@ export interface EducationEnrollment {
   student_last_name?: string;
   student_email?: string;
   student_phone?: string;
-  enrollment_status: "pending" | "active" | "completed" | "cancelled";
+  enrollment_status: EnrollmentStatus;
   payment_status: PaymentStatus;
   payment_method?: string;
   payment_amount?: number;
@@ -481,26 +483,22 @@ export type DatabaseTable =
   | "broadcast_messages"
   | "admin_logs";
 
-export const PAYMENT_STATUSES = [
+export const PAYMENT_STATUSES: Database["public"]["Enums"]["payment_status_enum"][] = [
   "pending",
   "completed",
   "failed",
   "refunded",
 ] as const;
-export type PaymentStatus = (typeof PAYMENT_STATUSES)[number];
+export type PaymentStatus = Database["public"]["Enums"]["payment_status_enum"];
 
 export function isValidPaymentStatus(
   status: string,
 ): status is PaymentStatus {
   return (PAYMENT_STATUSES as readonly string[]).includes(status);
 }
+export type EnrollmentStatus = Database["public"]["Enums"]["enrollment_status_enum"];
+export type BroadcastStatus = Database["public"]["Enums"]["broadcast_status_enum"];
 export type SubscriptionStatus = "pending" | "active" | "expired" | "cancelled";
-export type BroadcastStatus =
-  | "draft"
-  | "scheduled"
-  | "sending"
-  | "completed"
-  | "failed";
 export type UserRole = "user" | "vip" | "admin";
 export type ContentType = "text" | "html" | "markdown";
 export type SettingType = "string" | "number" | "boolean" | "json";


### PR DESCRIPTION
## Summary
- add database enums for trigger types and multiple status columns
- switch tables and TypeScript types to use the new enums
- update type helpers to expose enum values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689db563585c83228990d72f5594ac0b