### PR TITLE
fix: rename plan edit handler

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -477,7 +477,7 @@ interface PlanEditSession {
   awaiting_input?: string;
 }
 
-export async function processPlaneEditInput(
+export async function processPlanEditInput(
   userId: string,
   inputText: string,
   sessionData: PlanEditSession,
@@ -690,7 +690,7 @@ export async function processPlaneEditInput(
         };
     }
   } catch (error) {
-    console.error("Error in processPlaneEditInput:", error);
+    console.error("Error in processPlanEditInput:", error);
     return {
       success: false,
       message: "❌ Unexpected error occurred. Please try again.",

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -428,6 +428,11 @@ async function handleCommand(update: TelegramUpdate): Promise<void> {
     return;
   }
 
+  // Handle pending admin plan edits before command parsing
+  const userId = String(msg.from?.id ?? chatId);
+  const handlers = await loadAdminHandlers();
+  if (await handlers.handlePlanEditInput(chatId, userId, text)) return;
+
   // Extract the command without bot mentions and gather arguments
   const [firstToken, ...args] = text.split(/\s+/);
   const command = firstToken.split("@")[0];


### PR DESCRIPTION
## Summary
- rename `processPlaneEditInput` to `processPlanEditInput`
- wire up `handlePlanEditInput` in admin handlers and index

## Testing
- `~/.deno/bin/deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check`

------
https://chatgpt.com/codex/tasks/task_e_689dbb93a8488322b5be7c24d1659307