### PR TITLE
Add miniapp edge host routing tests

### DIFF
--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import "../supabase/functions/miniapp/index.ts";
+
+Deno.test({
+  name: "miniapp edge host routes",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const base = "http://localhost:8000";
+
+    const resRoot = await fetch(`${base}/miniapp/`);
+    assertEquals(resRoot.status, 200);
+    await resRoot.arrayBuffer();
+
+    const resNotFound = await fetch(`${base}/miniapp/nope`);
+    assertEquals(resNotFound.status, 404);
+    await resNotFound.arrayBuffer();
+
+    const resPost = await fetch(`${base}/miniapp/`, { method: "POST" });
+    assertEquals(resPost.status, 405);
+    await resPost.arrayBuffer();
+  },
+});


### PR DESCRIPTION
## Summary
- test edge host routing for miniapp function
- cover GET root, GET unknown path, and POST method cases

## Testing
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A tests/miniapp-edge-host-routing.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689dc49e94cc8322b02805b8e6d6a19c