### PR TITLE
docs: add verify initdata instructions

### DIFF
--- a/docs/VERIFY_INITDATA.md
+++ b/docs/VERIFY_INITDATA.md
@@ -1,0 +1,21 @@
+# Verify initData
+
+Capture the Telegram Mini App's `initData` and validate it against the backend.
+
+1. **Capture `initData` in the WebView**
+   ```js
+   // inside the Mini App running in Telegram
+   const initData = window.Telegram?.WebApp?.initData;
+   console.log(initData);
+   ```
+2. **Send it to the verification endpoint**
+   Replace `$BASE` with your Supabase Edge URL (e.g. `https://<project>.functions.supabase.co`).
+   ```bash
+   curl -s -X POST "$BASE/verify-initdata" \
+     -H 'content-type: application/json' \
+     -d '{"initData":"<copied initData>"}'
+   ```
+3. **Expect a success response**
+   ```json
+   {"ok": true}
+   ```


### PR DESCRIPTION
## Summary
- document how to capture Telegram WebApp `initData` and verify via `/verify-initdata`

## Testing
- `npm test` *(fails: binance webhook processes successful payment ... FAILED; admin approves payment via telegram ... FAILED)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ddb585b708322aa5d8796d27c405b