### PR TITLE
Add tests for miniapp and verify-initdata endpoints

### DIFF
--- a/supabase/functions/verify-initdata/index.ts
+++ b/supabase/functions/verify-initdata/index.ts
@@ -41,9 +41,11 @@ export async function verifyFromRaw(
   return !(windowSec > 0 && (isNaN(auth) || age > windowSec));
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   if (req.method !== "POST") return bad("Use POST");
   const { initData } = await req.json().catch(() => ({}));
   const passed = await verifyFromRaw(initData || "");
   return ok({ ok: passed });
-});
+}
+
+serve(handler);

--- a/tests/miniapp-edge-host-routing.test.ts
+++ b/tests/miniapp-edge-host-routing.test.ts
@@ -12,6 +12,10 @@ Deno.test({
     assertEquals(resRoot.status, 200);
     await resRoot.arrayBuffer();
 
+    const resVersion = await fetch(`${base}/miniapp/version`);
+    assertEquals(resVersion.status, 200);
+    await resVersion.arrayBuffer();
+
     const resNotFound = await fetch(`${base}/miniapp/nope`);
     assertEquals(resNotFound.status, 404);
     await resNotFound.arrayBuffer();

--- a/tests/verify-initdata-handler.test.ts
+++ b/tests/verify-initdata-handler.test.ts
@@ -1,0 +1,17 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { setTestEnv, makeTelegramInitData } from "../supabase/functions/_tests/helpers.ts";
+import { handler } from "../supabase/functions/verify-initdata/index.ts";
+
+Deno.test("verify-initdata handler accepts valid payload", async () => {
+  setTestEnv({ TELEGRAM_BOT_TOKEN: "test-token" });
+  const initData = await makeTelegramInitData({ id: 123, username: "alice" }, "test-token");
+  const req = new Request("http://local/verify-initdata", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ initData }),
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+  const json = await res.json();
+  assertEquals(json, { ok: true });
+});


### PR DESCRIPTION
## Summary
- export verify-initdata HTTP handler for direct testing
- test miniapp /version endpoint and ensure expected HTTP codes
- verify initdata endpoint handles valid payloads

## Testing
- `npm test -- tests/miniapp-edge-host-routing.test.ts tests/telegram-bot-security.test.ts tests/start-handler.test.ts tests/verify-initdata-handler.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689ddf486c3c83228341a130779820f9