### PR TITLE
Switch VIP Mini App prompts to Join wording

### DIFF
--- a/scripts/set-chat-menu-button.ts
+++ b/scripts/set-chat-menu-button.ts
@@ -31,7 +31,7 @@ if (shortName) {
 const payload = {
   menu_button: {
     type: "web_app",
-    text: "Open VIP Mini App",
+    text: "Join",
     web_app: { url },
   },
 };

--- a/scripts/tg-chat-menu.ts
+++ b/scripts/tg-chat-menu.ts
@@ -25,7 +25,7 @@ if (mode === "get") {
   await call("setChatMenuButton", {
     menu_button: {
       type: "web_app",
-      text: "Open VIP Mini App",
+      text: "Join",
       web_app: { url: urlArg },
     },
   });

--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -146,7 +146,7 @@ serve(async (req) => {
       const set = await tg(token, "setChatMenuButton", {
         menu_button: {
           type: "web_app",
-          text: "Open VIP Mini App",
+          text: "Join",
           web_app: { url: targetMenu },
         },
       });

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -234,10 +234,10 @@ export async function sendMiniAppLink(chatId: number) {
   }
 
   if (miniUrl) {
-    await sendMessage(chatId, "Open the VIP Mini App:", {
+    await sendMessage(chatId, "Join the VIP Mini App:", {
       reply_markup: {
         inline_keyboard: [[{
-          text: "Open VIP Mini App",
+          text: "Join",
           web_app: { url: miniUrl },
         }]],
       },
@@ -249,7 +249,7 @@ export async function sendMiniAppLink(chatId: number) {
     const deepLink = `https://t.me/${botUsername}/${short}`;
     await sendMessage(
       chatId,
-      `Open the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
+      `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
     );
     return;
   }

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -105,10 +105,10 @@ export async function handler(req: Request): Promise<Response> {
         }
 
         if (miniUrl) {
-          await sendMessage(chatId, "Open the VIP Mini App:", {
+          await sendMessage(chatId, "Join the VIP Mini App:", {
             reply_markup: {
               inline_keyboard: [[{
-                text: "Open VIP Mini App",
+                text: "Join",
                 web_app: { url: miniUrl },
               }]],
             },
@@ -120,7 +120,7 @@ export async function handler(req: Request): Promise<Response> {
           const deepLink = `https://t.me/${botUsername}/${short}`;
           await sendMessage(
             chatId,
-            `Open the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
+            `Join the VIP Mini App: ${deepLink}\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)`,
           );
           return;
         }

--- a/tests/start-handler.test.ts
+++ b/tests/start-handler.test.ts
@@ -158,7 +158,7 @@ Deno.test("/start deep-link used when MINI_APP_URL missing", async () => {
     const second = JSON.parse(calls[1].body);
     assertEquals(
       second.text,
-      "Open the VIP Mini App: https://t.me/mybot/shorty\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
+      "Join the VIP Mini App: https://t.me/mybot/shorty\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
     );
     assertEquals(second.reply_markup, undefined);
   } finally {

--- a/tests/telegram-webhook.test.ts
+++ b/tests/telegram-webhook.test.ts
@@ -65,7 +65,7 @@ Deno.test("webhook uses short name when URL absent", async () => {
     const payload = JSON.parse(calls[0].body);
     assertEquals(
       payload.text,
-      "Open the VIP Mini App: https://t.me/mybot/shorty\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
+      "Join the VIP Mini App: https://t.me/mybot/shorty\n\n(Setup MINI_APP_URL for the in-button WebApp experience.)",
     );
     assertEquals(payload.reply_markup, undefined);
   } finally {


### PR DESCRIPTION
## Summary
- Replace "Open VIP Mini App" menu button text with "Join"
- Update telegram bot and webhook prompts to "Join the VIP Mini App"
- Adjust tests for new "Join" wording

## Testing
- `deno test` *(fails: invalid peer certificate when fetching @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_689e2b930fa4832282b46a927806b587