### PR TITLE
Include miniapp static assets in Supabase bundle

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,3 +56,4 @@ verify_jwt = false
 
 [functions.miniapp]
 verify_jwt = false
+included_files = ["supabase/functions/miniapp/static/**"]


### PR DESCRIPTION
## Summary
- ensure miniapp static files are bundled by Supabase by adding them to `included_files`

## Testing
- `npm test` (fails: sh: 1: deno: not found)
- `supabase functions deploy miniapp` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689ef2feb2b883228f1917652a288941