### PR TITLE
test: mock readFile for miniapp fallback

### DIFF
--- a/supabase/functions/miniapp/fallback.test.ts
+++ b/supabase/functions/miniapp/fallback.test.ts
@@ -1,17 +1,26 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
 
-Deno.test("returns 404 when index.html fails to load", async () => {
-  const original = Deno.readTextFile;
-  (Deno as unknown as { readTextFile: typeof Deno.readTextFile }).readTextFile =
-    () => {
-      throw new Error("boom");
-    };
+Deno.test("returns fallback HTML when index.html fails to load", async () => {
+  const original = Deno.readFile;
+  (Deno as unknown as { readFile: typeof Deno.readFile }).readFile = () => {
+    throw new Error("boom");
+  };
 
-  const { handler } = await import("./index.ts");
-  (Deno as unknown as { readTextFile: typeof Deno.readTextFile }).readTextFile =
-    original;
+  try {
+    const mod = await import("./index.ts");
+    const handler = (mod as {
+      handler: (req: Request) => Promise<Response>;
+    }).handler;
 
-  const res = await handler(new Request("http://example.com/"));
-  assertEquals(res.status, 404);
-  assertEquals(await res.text(), "Index file not found");
+    const res = await handler(new Request("http://example.com/"));
+    assertEquals(res.status, 200);
+    const body = await res.text();
+    assertStringIncludes(body, "Static `index.html` not found in bundle");
+  } finally {
+    (Deno as unknown as { readFile: typeof Deno.readFile }).readFile =
+      original;
+  }
 });


### PR DESCRIPTION
## Summary
- test miniapp fallback by mocking `Deno.readFile`
- ensure fallback HTML returns 200 and contains missing index message

## Testing
- `DENO_TLS_CA_STORE=system deno test --allow-net supabase/functions/miniapp/fallback.test.ts` *(fails: TypeError: handler is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689fe812b6a08322bdc2eb1e1696803d