### PR TITLE
feat: add smoke scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ If tests present:
 deno test -A
 ```
 
+## Smoke checks
+
+Set `FUNCTIONS_BASE` to your deployed functions base URL, then run:
+
+```bash
+export FUNCTIONS_BASE=https://<PROJECT>.functions.supabase.co
+deno run -A scripts/smoke-miniapp.ts
+deno run -A scripts/smoke-bot.ts
+```
+
+These scripts perform simple HTTP requests and log status codes for key
+endpoints.
+
 ## Deployment
 
 See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for environment vars, tests,

--- a/scripts/smoke-bot.ts
+++ b/scripts/smoke-bot.ts
@@ -1,0 +1,35 @@
+// scripts/smoke-bot.ts
+/**
+ * Basic smoke checks for the telegram-bot function.
+ *
+ * Env:
+ *   FUNCTIONS_BASE  Base URL for your Supabase functions (e.g. https://xyz.functions.supabase.co)
+ *
+ * Usage:
+ *   FUNCTIONS_BASE=https://xyz.functions.supabase.co deno run -A scripts/smoke-bot.ts
+ *
+ * Performs simple HTTP requests and prints the status codes.
+ */
+
+const base = Deno.env.get("FUNCTIONS_BASE");
+if (!base) {
+  console.error("Set FUNCTIONS_BASE to your functions base URL.");
+  Deno.exit(1);
+}
+
+async function check(path: string, init?: RequestInit) {
+  try {
+    const res = await fetch(`${base}${path}`, init);
+    console.log(`${init?.method ?? "GET"} ${path} ->`, res.status);
+  } catch (err) {
+    console.error(`${init?.method ?? "GET"} ${path} -> error`, err);
+  }
+}
+
+await check("/telegram-bot/version");
+await check("/telegram-bot");
+await check("/telegram-bot", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: "{}",
+});

--- a/scripts/smoke-miniapp.ts
+++ b/scripts/smoke-miniapp.ts
@@ -1,0 +1,30 @@
+// scripts/smoke-miniapp.ts
+/**
+ * Basic smoke checks for the deployed Mini App.
+ *
+ * Env:
+ *   FUNCTIONS_BASE  Base URL for your Supabase functions (e.g. https://xyz.functions.supabase.co)
+ *
+ * Usage:
+ *   FUNCTIONS_BASE=https://xyz.functions.supabase.co deno run -A scripts/smoke-miniapp.ts
+ *
+ * Performs simple HTTP requests and prints the status codes.
+ */
+
+const base = Deno.env.get("FUNCTIONS_BASE");
+if (!base) {
+  console.error("Set FUNCTIONS_BASE to your functions base URL.");
+  Deno.exit(1);
+}
+
+async function check(path: string, init?: RequestInit) {
+  try {
+    const res = await fetch(`${base}${path}`, init);
+    console.log(`${init?.method ?? "GET"} ${path} ->`, res.status);
+  } catch (err) {
+    console.error(`${init?.method ?? "GET"} ${path} -> error`, err);
+  }
+}
+
+await check("/miniapp/", { method: "HEAD" });
+await check("/miniapp/version");


### PR DESCRIPTION
## Summary
- add smoke-miniapp.ts and smoke-bot.ts scripts for basic status-code checks
- document smoke scripts and usage in README

## Testing
- `deno lint scripts/smoke-miniapp.ts scripts/smoke-bot.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a042fec7d083229b4fe6525d8f26ea