### PR TITLE
fix: export named miniapp handler

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -112,7 +112,7 @@ function mime(p: string) {
   return "application/octet-stream";
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return await maybeCompress(
@@ -145,6 +145,8 @@ export default async function handler(req: Request): Promise<Response> {
   }
   return nf("Not Found");
 }
+
+export default handler;
 
 if (import.meta.main) {
   Deno.serve(handler);


### PR DESCRIPTION
## Summary
- export miniapp handler as both named and default export to satisfy tests

## Testing
- `npm test`
- `npx --yes supabase login --token $SUPABASE_ACCESS_TOKEN` *(fails: flag needs an argument)*
- `npx --yes supabase functions deploy miniapp --project-ref qeejuomcapbdlhnjqjcc` *(fails: access token not provided)*
- `curl -sS https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/version | tee /tmp/mini.version.json`
- `curl -sS https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/ | head -c 200 | sed -n '1,10p'`


------
https://chatgpt.com/codex/tasks/task_e_68a04d5fc6408322a7b8069fd8e33487