### PR TITLE
harden miniapp static file access

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -1,4 +1,5 @@
 import { mna, nf, ok } from "../_shared/http.ts";
+import { posix } from "https://deno.land/std@0.224.0/path/mod.ts";
 
 const STATIC_CACHE = new Map<string, Response>();
 
@@ -140,7 +141,11 @@ export async function handler(req: Request): Promise<Response> {
     return await maybeCompress(req, await indexHtml());
   }
   if (url.pathname.startsWith("/assets/")) {
-    const rel = url.pathname.replace(/^\//, "");
+    let rel = posix.normalize(decodeURIComponent(url.pathname));
+    if (!rel.startsWith("/assets/") || rel.includes("..") || rel.includes("\\")) {
+      return nf("Not Found");
+    }
+    rel = rel.replace(/^\//, "");
     return await maybeCompress(req, await readStatic(rel, mime(rel)));
   }
   return nf("Not Found");

--- a/supabase/functions/miniapp/traversal.test.ts
+++ b/supabase/functions/miniapp/traversal.test.ts
@@ -1,0 +1,23 @@
+import handler from "./index.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test("blocks .. path traversal", async () => {
+  const res = await handler(
+    new Request("http://example.com/assets/../secret.txt"),
+  );
+  assertEquals(res.status, 404);
+});
+
+Deno.test("blocks encoded .. path traversal", async () => {
+  const res = await handler(
+    new Request("http://example.com/assets/..%2Fsecret.txt"),
+  );
+  assertEquals(res.status, 404);
+});
+
+Deno.test("blocks backslash path traversal", async () => {
+  const res = await handler(
+    new Request("http://example.com/assets/%5Csecret.txt"),
+  );
+  assertEquals(res.status, 404);
+});


### PR DESCRIPTION
## Summary
- normalize asset paths and forbid `..` or backslashes before reading static files
- add tests to ensure path traversal attempts return 404

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06f55b374832288b2e8a13227d4b0