### PR TITLE
Handle HEAD requests for miniapp root paths

### DIFF
--- a/supabase/functions/miniapp/head.test.ts
+++ b/supabase/functions/miniapp/head.test.ts
@@ -1,0 +1,13 @@
+import handler from "./index.ts";
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test("HEAD requests return security headers", async () => {
+  for (const path of ["/", "/miniapp", "/miniapp/", "/miniapp/version"]) {
+    const res = await handler(
+      new Request(`http://example.com${path}`, { method: "HEAD" }),
+    );
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("x-content-type-options"), "nosniff");
+    assertEquals(await res.text(), "");
+  }
+});

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -132,7 +132,12 @@ export async function handler(req: Request): Promise<Response> {
     );
   }
   if (req.method === "HEAD") {
-    if (url.pathname === "/miniapp/" || url.pathname === "/miniapp/version") {
+    if (
+      url.pathname === "/" ||
+      url.pathname === "/miniapp" ||
+      url.pathname === "/miniapp/" ||
+      url.pathname === "/miniapp/version"
+    ) {
       return new Response(null, {
         status: 200,
         headers: withSec(new Headers()),
@@ -152,7 +157,9 @@ export async function handler(req: Request): Promise<Response> {
   }
   if (url.pathname.startsWith("/assets/")) {
     let rel = posix.normalize(decodeURIComponent(url.pathname));
-    if (!rel.startsWith("/assets/") || rel.includes("..") || rel.includes("\\")) {
+    if (
+      !rel.startsWith("/assets/") || rel.includes("..") || rel.includes("\\")
+    ) {
       return nf("Not Found");
     }
     rel = rel.replace(/^\//, "");


### PR DESCRIPTION
## Summary
- support HEAD requests for `/`, `/miniapp`, `/miniapp/`, and `/miniapp/version`
- add regression tests ensuring HEAD requests return security headers

## Testing
- `deno test --no-npm --unsafely-ignore-certificate-errors=deno.land --no-check supabase/functions/miniapp/*.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a0723a184083228982d008d42948dc