### PR TITLE
Add Binance Pay webhook handler

### DIFF
--- a/supabase/functions/binance-pay-checkout/index.ts
+++ b/supabase/functions/binance-pay-checkout/index.ts
@@ -204,6 +204,18 @@ serve(async (req) => {
       );
     }
 
+    const providerId = orderResult?.data?.prepayId;
+    if (providerId) {
+      const { error: updateErr } = await supabase
+        .from("payments")
+        .update({ payment_provider_id: providerId })
+        .eq("id", payment.id)
+        .single();
+      if (updateErr) {
+        logger.error("Failed to update payment provider id:", updateErr);
+      }
+    }
+
     const checkoutData = {
       success: true,
       paymentId: payment.id,

--- a/supabase/functions/binancepay-webhook/index.ts
+++ b/supabase/functions/binancepay-webhook/index.ts
@@ -1,0 +1,119 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "../_shared/client.ts";
+import { requireEnv, optionalEnv } from "../_shared/env.ts";
+import { createLogger } from "../_shared/logger.ts";
+import { alertAdmins } from "../_shared/alerts.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const { BINANCE_API_KEY, BINANCE_SECRET_KEY } = requireEnv([
+  "BINANCE_API_KEY",
+  "BINANCE_SECRET_KEY",
+] as const);
+
+async function generateSignature(
+  timestamp: string,
+  nonce: string,
+  body: string,
+  secretKey: string,
+): Promise<string> {
+  const payload = timestamp + "\n" + nonce + "\n" + body + "\n";
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(secretKey);
+  const messageData = encoder.encode(payload);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    keyData,
+    { name: "HMAC", hash: "SHA-512" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, messageData);
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .toUpperCase();
+}
+
+function getLogger(req: Request) {
+  return createLogger({
+    function: "binancepay-webhook",
+    requestId:
+      req.headers.get("sb-request-id") ||
+      req.headers.get("x-request-id") ||
+      crypto.randomUUID(),
+  });
+}
+
+export async function handler(req: Request): Promise<Response> {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const logger = getLogger(req);
+  try {
+    const timestamp = req.headers.get("BinancePay-Timestamp") || "";
+    const nonce = req.headers.get("BinancePay-Nonce") || "";
+    const signature = req.headers.get("BinancePay-Signature") || "";
+    const certSn = req.headers.get("BinancePay-Certificate-SN") || "";
+    const bodyText = await req.text();
+
+    if (certSn !== BINANCE_API_KEY) {
+      logger.warn("Invalid certificate serial number", { certSn });
+      return new Response("Unauthorized", { status: 401, headers: corsHeaders });
+    }
+    const expected = await generateSignature(
+      timestamp,
+      nonce,
+      bodyText,
+      BINANCE_SECRET_KEY,
+    );
+    if (signature !== expected) {
+      logger.warn("Signature mismatch", { signature, expected });
+      return new Response("Unauthorized", { status: 401, headers: corsHeaders });
+    }
+
+    const payload = JSON.parse(bodyText || "{}");
+    logger.info("Webhook payload", payload);
+    const status = String(payload?.data?.status || payload?.bizStatus || "").toUpperCase();
+    if (status.includes("PAID")) {
+      const paymentId = payload?.data?.merchantTradeNo;
+      if (paymentId) {
+        const supabase = createClient();
+        const { data: payment, error } = await supabase
+          .from("payments")
+          .update({ status: "awaiting_admin", webhook_data: payload })
+          .eq("id", paymentId)
+          .select()
+          .single();
+        if (error) logger.error("Payment update error", error);
+        if (payment) {
+          const botUser = optionalEnv("TELEGRAM_BOT_USERNAME");
+          const cmd = `/approve ${payment.id}`;
+          const link = botUser
+            ? `<a href="https://t.me/${botUser}?start=approve_${payment.id}">${cmd}</a>`
+            : cmd;
+          await alertAdmins(`Payment ${payment.id} paid via Binance Pay. ${link}`);
+        }
+      }
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    logger.error("binancepay-webhook error", err);
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+}
+
+if (import.meta.main) serve(handler);
+

--- a/tests/binancepay-webhook.test.ts
+++ b/tests/binancepay-webhook.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+async function sign(ts: string, nonce: string, body: string, secret: string) {
+  const payload = ts + "\n" + nonce + "\n" + body + "\n";
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), {
+    name: "HMAC",
+    hash: "SHA-512",
+  }, false, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(payload));
+  return Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, "0")).join("").toUpperCase();
+}
+
+Deno.test("binancepay webhook marks payment awaiting_admin", async () => {
+  Deno.env.set("SUPABASE_URL", "https://supabase.test");
+  Deno.env.set("SUPABASE_ANON_KEY", "anon");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "svc");
+  Deno.env.set("BINANCE_API_KEY", "apiKey");
+  Deno.env.set("BINANCE_SECRET_KEY", "sec");
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "tbot");
+  Deno.env.set("TELEGRAM_ADMIN_IDS", "1");
+  Deno.env.set("TELEGRAM_BOT_USERNAME", "mybot");
+
+  const payments = [{
+    id: "p1",
+    status: "pending",
+    user_id: "u1",
+    plan_id: "plan1",
+    amount: 10,
+    currency: "USDT",
+    payment_method: "binance_pay",
+  }];
+  (globalThis as any).__SUPA_MOCK__ = { tables: { payments, admin_logs: [] } };
+
+  const calls: Array<{ url: string; body: string }> = [];
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (input: any, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.startsWith("https://api.telegram.org")) {
+      calls.push({ url, body: init?.body ? String(init.body) : "" });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const payload = { bizStatus: "PAY_SUCCESS", data: { merchantTradeNo: "p1", status: "PAID" } };
+    const body = JSON.stringify(payload);
+    const ts = Date.now().toString();
+    const nonce = "abc123";
+    const sig = await sign(ts, nonce, body, "sec");
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "BinancePay-Timestamp": ts,
+        "BinancePay-Nonce": nonce,
+        "BinancePay-Signature": sig,
+        "BinancePay-Certificate-SN": "apiKey",
+      },
+      body,
+    });
+    const mod = await import("../supabase/functions/binancepay-webhook/index.ts");
+    const res = await mod.handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(payments[0].status, "awaiting_admin");
+    assertEquals(payments[0].webhook_data.bizStatus, "PAY_SUCCESS");
+    assertEquals(calls.length, 1);
+    if (!calls[0].body.includes("/approve p1")) {
+      throw new Error("missing approve link");
+    }
+  } finally {
+    globalThis.fetch = origFetch;
+    Deno.env.delete("SUPABASE_URL");
+    Deno.env.delete("SUPABASE_ANON_KEY");
+    Deno.env.delete("SUPABASE_SERVICE_ROLE_KEY");
+    Deno.env.delete("BINANCE_API_KEY");
+    Deno.env.delete("BINANCE_SECRET_KEY");
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+    Deno.env.delete("TELEGRAM_ADMIN_IDS");
+    Deno.env.delete("TELEGRAM_BOT_USERNAME");
+  }
+});
+


### PR DESCRIPTION
## Summary
- store Binance `prepayId` on payment creation
- add `binancepay-webhook` function to process paid events and alert admins
- test webhook payment flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07493380c8322bf1fc9192b601bf5