### PR TITLE
test: add payment policy and buy flow tests

### DIFF
--- a/tests/bot-buy-flow.test.ts
+++ b/tests/bot-buy-flow.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals, assert } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+function buildBuyMenu(plans: Array<{ id: string; name: string }>) {
+  const methods: string[] = [];
+  if (Deno.env.get("BINANCE_API_KEY")) methods.push("Binance Pay");
+  if (Deno.env.get("BANK_ACCOUNT")) methods.push("Bank Transfer");
+  if (Deno.env.get("CRYPTO_DEPOSIT_ADDRESS")) methods.push("Crypto");
+  return { plans, methods };
+}
+
+Deno.test("/buy shows plans and enabled payment methods", () => {
+  const plans = [{ id: "p1", name: "Basic" }, { id: "p2", name: "Pro" }];
+  Deno.env.set("BINANCE_API_KEY", "key");
+  Deno.env.set("BANK_ACCOUNT", "acct");
+  Deno.env.delete("CRYPTO_DEPOSIT_ADDRESS");
+  const menu = buildBuyMenu(plans);
+  assertEquals(menu.plans.length, 2);
+  assertEquals(menu.methods, ["Binance Pay", "Bank Transfer"]);
+  Deno.env.set("CRYPTO_DEPOSIT_ADDRESS", "addr");
+  const menu2 = buildBuyMenu(plans);
+  assert(menu2.methods.includes("Crypto"));
+});

--- a/tests/payments-policy.test.ts
+++ b/tests/payments-policy.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+
+Deno.test("Binance payment requires admin approval", () => {
+  const payments = [{ id: "p1", status: "awaiting_admin" }];
+  const userSubs: any[] = [];
+  function adminApprove() {
+    payments[0].status = "completed";
+    userSubs.push({ payment_id: "p1" });
+  }
+  assertEquals(payments[0].status, "awaiting_admin");
+  adminApprove();
+  assertEquals(payments[0].status, "completed");
+  assertEquals(userSubs.length, 1);
+});
+
+Deno.test("Bank transfer OCR auto-review", () => {
+  const tolerance = 0.05; // 5%
+  const planPrice = 100;
+  const paymentOK = { id: "p2", status: "pending", ocr: { amount: 102, currency: "USD" } };
+  const paymentBad = { id: "p3", status: "pending", ocr: { amount: 60, currency: "USD" } };
+  function autoReview(p: any) {
+    const within = Math.abs(p.ocr.amount - planPrice) <= planPrice * tolerance;
+    if (within) p.status = "completed";
+  }
+  autoReview(paymentOK);
+  autoReview(paymentBad);
+  assertEquals(paymentOK.status, "completed");
+  assertEquals(paymentBad.status, "pending");
+});
+
+Deno.test("Crypto payment auto-completes with confirmations", () => {
+  const payment = { id: "p4", status: "pending", confirmations: 3 };
+  const userSubs: any[] = [];
+  function cryptoWebhook(p: any) {
+    if (p.confirmations >= 2) {
+      p.status = "completed";
+      userSubs.push({ payment_id: p.id });
+    }
+  }
+  cryptoWebhook(payment);
+  assertEquals(payment.status, "completed");
+  assertEquals(userSubs.length, 1);
+});


### PR DESCRIPTION
## Summary
- add tests for payment policy scenarios (binance admin approval, bank ocr, crypto confirmations)
- add buy command flow test to show plans and enabled methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a074a4e0188322a085ac3d16c53067