### PR TITLE
refactor: use edge function for feature flags

### DIFF
--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -1,5 +1,5 @@
 import { enqueue } from "../queue/index.ts";
-import { getFlag } from "../utils/config.ts";
+import { configClient } from "../utils/config.ts";
 
 export interface PlanBroadcastOptions {
   segment: number[] | { userIds: number[] };
@@ -24,7 +24,7 @@ function sleep(ms: number) {
 }
 
 export async function planBroadcast(opts: PlanBroadcastOptions) {
-  if (!(await getFlag("broadcasts_enabled"))) {
+  if (!(await configClient.getFlag("broadcasts_enabled"))) {
     throw new Error("Broadcasts disabled");
   }
   const { segment, text, media, chunkSize = 25, pauseMs = 500 } = opts;

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -21,7 +21,7 @@ import { VipPlansManager } from "@/components/admin/VipPlansManager";
 import { BotDiagnostics } from "@/components/admin/BotDiagnostics";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { preview, setFlag, publish, rollback } from "@/utils/config";
+import { configClient } from "@/utils/config";
 import {
   CreditCard,
   DollarSign,
@@ -101,7 +101,7 @@ export const AdminDashboard = () => {
   }, []);
 
   const loadFlags = async () => {
-    const snap = await preview();
+    const snap = await configClient.preview();
     setFlags({
       payments_enabled: !!snap.data.payments_enabled,
       vip_sync_enabled: !!snap.data.vip_sync_enabled,
@@ -112,16 +112,16 @@ export const AdminDashboard = () => {
 
   const handleToggleFlag = async (name: string, value: boolean) => {
     setFlags((prev) => ({ ...prev, [name]: value }));
-    await setFlag(name, value);
+    await configClient.setFlag(name, value);
   };
 
   const handlePublish = async () => {
-    await publish();
+    await configClient.publish();
     await loadFlags();
   };
 
   const handleRollback = async () => {
-    await rollback();
+    await configClient.rollback();
     await loadFlags();
   };
 

--- a/supabase/functions/config/index.ts
+++ b/supabase/functions/config/index.ts
@@ -1,0 +1,115 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import {
+  getConfig,
+  setConfig,
+  getFlag as getFlagBase,
+  setFlag as setFlagBase,
+} from "../_shared/config.ts";
+import { createClient } from "../_shared/client.ts";
+
+interface FlagSnapshot { ts: number; data: Record<string, boolean> }
+
+async function preview(): Promise<FlagSnapshot> {
+  return await getConfig<FlagSnapshot>("features:draft", {
+    ts: Date.now(),
+    data: {},
+  });
+}
+
+async function publish(adminId?: string): Promise<void> {
+  const draft = await getConfig<FlagSnapshot>("features:draft", {
+    ts: Date.now(),
+    data: {},
+  });
+  const current = await getConfig<FlagSnapshot>("features:published", {
+    ts: Date.now(),
+    data: {},
+  });
+  await setConfig("features:rollback", { ts: current.ts, data: { ...current.data } });
+  await setConfig("features:published", { ts: draft.ts, data: { ...draft.data } });
+  const client = createClient();
+  try {
+    await client.from("audit_log").insert({
+      admin_id: adminId ?? null,
+      action: "publish",
+      from: current,
+      to: draft,
+      ts: new Date().toISOString(),
+    });
+  } catch (_e) {
+    // ignore
+  }
+}
+
+async function rollback(adminId?: string): Promise<void> {
+  const published = await getConfig<FlagSnapshot>("features:published", {
+    ts: Date.now(),
+    data: {},
+  });
+  const previous = await getConfig<FlagSnapshot>("features:rollback", {
+    ts: Date.now(),
+    data: {},
+  });
+  await setConfig("features:published", { ts: previous.ts, data: { ...previous.data } });
+  await setConfig("features:rollback", { ts: published.ts, data: { ...published.data } });
+  const client = createClient();
+  try {
+    await client.from("audit_log").insert({
+      admin_id: adminId ?? null,
+      action: "rollback",
+      from: published,
+      to: previous,
+      ts: new Date().toISOString(),
+    });
+  } catch (_e) {
+    // ignore
+  }
+}
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  let body: Record<string, unknown> = {};
+  try {
+    body = await req.json();
+  } catch {
+    // ignore
+  }
+  const action = String(body.action || "");
+  try {
+    switch (action) {
+      case "getFlag": {
+        const name = String(body.name || "");
+        const def = Boolean(body.def);
+        const val = await getFlagBase(name, def);
+        return json({ data: val });
+      }
+      case "setFlag": {
+        const name = String(body.name || "");
+        const value = Boolean(body.value);
+        await setFlagBase(name, value);
+        return json({ ok: true });
+      }
+      case "preview": {
+        return json(await preview());
+      }
+      case "publish": {
+        await publish(body.adminId as string | undefined);
+        return json({ ok: true });
+      }
+      case "rollback": {
+        await rollback(body.adminId as string | undefined);
+        return json({ ok: true });
+      }
+      default:
+        return json({ error: "invalid action" }, 400);
+    }
+  } catch (e) {
+    return json({ error: String(e) }, 500);
+  }
+});


### PR DESCRIPTION
## Summary
- replace service-role client in config utilities with edge function calls
- update admin dashboard and broadcast planner to use edge config client
- add `config` edge function to manage feature flag operations

## Testing
- `npm run lint` *(fails: Unexpected any in supabase/functions/_tests)*
- `npx eslint src/utils/config.ts src/components/admin/AdminDashboard.tsx src/broadcast/index.ts supabase/functions/config/index.ts`
- `npm test`
- `npm run build`
- `npm run build:miniapp`
- `rg SUPABASE_SERVICE_ROLE_KEY dist supabase/functions/miniapp/static`


------
https://chatgpt.com/codex/tasks/task_e_68a155aef0088322ae516b7fb8cf62ac