### PR TITLE
fix: resolve Deno lint warnings

### DIFF
--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -5,9 +5,9 @@ const memStore = new Map<string, unknown>();
 
 let supabase: ReturnType<typeof createClient> | null | undefined = undefined;
 
-async function getClient() {
+function getClient() {
   if (supabase !== undefined) return supabase;
-  
+
   try {
     supabase = createClient();
     return supabase;
@@ -19,7 +19,7 @@ async function getClient() {
 }
 
 async function getConfig<T = unknown>(key: string, def?: T): Promise<T> {
-  const client = await getClient();
+  const client = getClient();
   if (client) {
     try {
       const { data, error } = await client.from("kv_config").select("value").eq(
@@ -38,7 +38,7 @@ async function getConfig<T = unknown>(key: string, def?: T): Promise<T> {
 }
 
 async function setConfig(key: string, val: unknown): Promise<void> {
-  const client = await getClient();
+  const client = getClient();
   if (client) {
     try {
       const { error } = await client.from("kv_config").upsert({

--- a/supabase/functions/_tests/helpers.ts
+++ b/supabase/functions/_tests/helpers.ts
@@ -80,7 +80,7 @@ export const FakeSupa = () => ({
   }),
   storage: {
     from: () => ({
-      createSignedUrl: async () => ({
+      createSignedUrl: () => ({
         data: { signedUrl: "https://example/signed" },
         error: null,
       }),

--- a/supabase/functions/_tests/keeper_secret_test.ts
+++ b/supabase/functions/_tests/keeper_secret_test.ts
@@ -9,11 +9,11 @@ function mockSupa(setting: { setting_value: string } | null): SupabaseLike {
       const query = {
         eq: () => query,
         limit: () => query,
-        maybeSingle: async () => ({ data: setting }),
+        maybeSingle: () => ({ data: setting }),
       };
       return {
         select: () => query,
-        upsert: async () => ({ error: undefined }),
+        upsert: () => ({ error: undefined }),
       };
     },
   };

--- a/supabase/functions/keep-alive/index.ts
+++ b/supabase/functions/keep-alive/index.ts
@@ -49,7 +49,7 @@ serve((req) => {
     // Start keep-alive on first request
     startKeepAlive();
 
-    const botToken = getEnv("TELEGRAM_BOT_TOKEN");
+    getEnv("TELEGRAM_BOT_TOKEN");
 
     logger.info("Keep-alive service started for telegram bot");
 

--- a/supabase/functions/miniapp/src/pages/Bank.tsx
+++ b/supabase/functions/miniapp/src/pages/Bank.tsx
@@ -28,7 +28,7 @@ export default function Bank() {
       await navigator.clipboard.writeText(payCode);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (e) {
+    } catch {
       // no-op if clipboard isn't available
     }
   };

--- a/supabase/functions/ops-health/index.ts
+++ b/supabase/functions/ops-health/index.ts
@@ -23,7 +23,7 @@ serve(async (_req) => {
   // DB ping
   try {
     const supa = createClient();
-    const { data, error } = await supa.from("bot_users").select("id").limit(1);
+    const { error } = await supa.from("bot_users").select("id").limit(1);
     report.checks!["db"] = !error;
     if (error) report.ok = false;
   } catch {

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
-import { ok, mna, oops, unauth, bad, nf } from "../_shared/http.ts";
+import { ok, mna, oops } from "../_shared/http.ts";
 
 const need = (k: string) =>
   Deno.env.get(k) || (() => {

--- a/supabase/functions/tg-verify-init/index.ts
+++ b/supabase/functions/tg-verify-init/index.ts
@@ -36,7 +36,6 @@ async function verifyInitData(initData: string) {
   if (!BOT) throw new Error("BOT token missing");
   const { hash, dataCheckString } = parseInitData(initData);
   const secretKey = await sha256(text(BOT)); // secret_key = sha256(bot_token)
-  const signature = await sha256(text(dataCheckString));
   const hmacKey = await subtle().importKey(
     "raw",
     secretKey,


### PR DESCRIPTION
## Summary
- remove unused variables and dead code in edge functions
- simplify async helpers and config client retrieval
- drop unused constants and helpers from telegram bot

## Testing
- `deno lint supabase/functions --ignore=supabase/functions/**/vendor/** --ignore=supabase/functions/**/static/**`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16615e8888322bcc7f67df21a69ac