### PR TITLE
Delay Telegram miniapp closure after deposit

### DIFF
--- a/miniapp/src/main.ts
+++ b/miniapp/src/main.ts
@@ -2,7 +2,7 @@ import './style.css';
 
 declare global {
   interface Window {
-    Telegram: any;
+    Telegram: unknown;
   }
 }
 
@@ -37,13 +37,14 @@ if (app) {
       const data = await res.json();
       if (res.ok && data.ok) {
         status.textContent = 'Deposit created!';
+        setTimeout(() => tg?.close(), 1500);
       } else {
         status.textContent = data.error || 'Failed to create deposit';
+        setTimeout(() => tg?.close(), 3000);
       }
     } catch (err) {
       status.textContent = 'Network error';
-    } finally {
-      tg?.close();
+      setTimeout(() => tg?.close(), 3000);
     }
   });
 }


### PR DESCRIPTION
## Summary
- delay closing of Telegram WebApp until deposit status is visible
- add explicit `unknown` type for Telegram global to satisfy lint

## Testing
- `npm test` *(fails: server process kept running; terminated manually)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2b4d9b78c8322b16d5d666c78e459