### PR TITLE
feat: restrict miniapp handler to GET

### DIFF
--- a/miniapp/src/main.ts
+++ b/miniapp/src/main.ts
@@ -1,8 +1,18 @@
 import './style.css';
 
+interface TelegramWebApp {
+  ready: () => void;
+  close: () => void;
+  initData?: string;
+}
+
+interface TelegramNamespace {
+  WebApp?: TelegramWebApp;
+}
+
 declare global {
   interface Window {
-    Telegram: any;
+    Telegram?: TelegramNamespace;
   }
 }
 

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -124,8 +124,15 @@ const HTML_CONTENT = `<!DOCTYPE html>
 </html>`;
 
 export function handler(req: Request): Response {
+  if (!["GET", "HEAD"].includes(req.method)) {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    });
+  }
+
   const url = new URL(req.url);
-  
+
   console.log(`[miniapp] Request: ${req.method} ${url.pathname} - Full URL: ${req.url}`);
   
   // Security headers
@@ -149,13 +156,15 @@ export function handler(req: Request): Response {
   if (url.pathname.includes("/version")) {
     headers.set("content-type", "application/json; charset=utf-8");
     return new Response(
-      JSON.stringify({ name: "miniapp", ts: new Date().toISOString() }),
+      req.method === "HEAD"
+        ? null
+        : JSON.stringify({ name: "miniapp", ts: new Date().toISOString() }),
       { headers }
     );
   }
 
   // Handle all other requests with HTML
-  return new Response(HTML_CONTENT, { headers });
+  return new Response(req.method === "HEAD" ? null : HTML_CONTENT, { headers });
 }
 
 export default handler;


### PR DESCRIPTION
## Summary
- return 405 for non-GET/HEAD requests to miniapp handler
- ensure HEAD requests return proper headers without body
- add Allow header and typed Telegram namespace

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2b4db4dac83228ecd9eaa787651ea