### PR TITLE
refactor: reuse miniapp env helper

### DIFF
--- a/supabase/functions/_shared/miniapp.ts
+++ b/supabase/functions/_shared/miniapp.ts
@@ -1,10 +1,18 @@
 import { envOrSetting } from "./config.ts";
 
-export async function readMiniAppEnv() {
-  const urlRaw = (await envOrSetting("MINI_APP_URL")) || "";
-  const short = (await envOrSetting("MINI_APP_SHORT_NAME")) || "";
-  const url = urlRaw.startsWith("https://")
-    ? urlRaw.endsWith("/") ? urlRaw : urlRaw + "/"
-    : "";
-  return { url, short, ready: !!url || !!short };
+interface MiniAppEnv {
+  url: string | null;
+  short: string | null;
+  ready?: boolean;
+}
+
+export async function readMiniAppEnv(): Promise<MiniAppEnv> {
+  const urlRaw = await envOrSetting<string>("MINI_APP_URL");
+  const short = await envOrSetting<string>("MINI_APP_SHORT_NAME");
+
+  const url = urlRaw?.startsWith("https://")
+    ? (urlRaw.endsWith("/") ? urlRaw : `${urlRaw}/`)
+    : null;
+
+  return { url, short: short ?? null, ready: Boolean(url || short) };
 }

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -17,7 +17,7 @@ import { createClient } from "../_shared/client.ts";
 type SupabaseClient = ReturnType<typeof createClient>;
 import { envOrSetting, getContent, getFlag } from "../_shared/config.ts";
 import { buildMainMenu, type MenuSection } from "./menu.ts";
-import { readMiniAppEnv } from "./_miniapp.ts";
+import { readMiniAppEnv } from "../_shared/miniapp.ts";
 import {
   buildAdminCommandHandlers,
   type CommandContext,


### PR DESCRIPTION
## Summary
- reuse shared readMiniAppEnv helper in telegram bot
- ensure miniapp environment helper returns nullable url and short with ready flag

## Testing
- `npx eslint supabase/functions/_shared/miniapp.ts supabase/functions/telegram-bot/index.ts`
- `npm test` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b6f94a0483229f2fb910861d1d49