### PR TITLE
Handle crypto payment intent insert errors

### DIFF
--- a/supabase/functions/crypto-txid/index.ts
+++ b/supabase/functions/crypto-txid/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { verifyInitDataAndGetUser } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
-import { ok, bad, unauth, mna } from "../_shared/http.ts";
+import { bad, mna, ok, unauth } from "../_shared/http.ts";
 
 serve(async (req) => {
   if (req.method !== "POST") return mna();
@@ -24,14 +24,15 @@ serve(async (req) => {
   }
 
   if (supa && body.txid) {
-    await supa.from("payment_intents").insert({
+    const { error } = await supa.from("payment_intents").insert({
       user_id: crypto.randomUUID(),
       method: "crypto",
       expected_amount: 0,
       currency: "USD",
       status: "pending",
       notes: body.txid,
-    }).catch(() => null);
+    });
+    if (error) console.error(error);
   }
 
   return ok();


### PR DESCRIPTION
## Summary
- handle insertion failures for crypto `payment_intents`

## Testing
- `npm test` *(fails: process hung after starting server)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c87759548322bfa0e0296fab5067