### PR TITLE
refactor: handle receipts query errors

### DIFF
--- a/supabase/functions/receipts/index.ts
+++ b/supabase/functions/receipts/index.ts
@@ -27,7 +27,8 @@ serve(async (req) => {
   let query = supa.from("receipts").select("id, ocr_amount, verdict, created_at").order("created_at", { ascending: false }).limit(limit);
   if (status) query = query.eq("verdict", status);
   // In a real implementation, we'd filter by user here. For tests we fetch all.
-  const { data } = await query.catch(() => ({ data: [] }));
+  const { data, error } = await query;
+  if (error) return ok({ items: [] });
   interface ReceiptRow {
     id: string;
     ocr_amount: unknown;


### PR DESCRIPTION
## Summary
- handle query errors in `receipts` function without using `.catch`

## Testing
- `npm test` (fails: callback edits message instead of sending new one, miniapp edge host routes)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2c87846588322a45c21f3dade83ba