### PR TITLE
chore(receipt-submit): handle rpc errors

### DIFF
--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -7,9 +7,16 @@ async function activateSubscription(
   supa: ReturnType<typeof createClient>,
   paymentId: string,
 ) {
-  await supa.rpc("finalize_completed_payment", {
-    p_payment_id: paymentId,
-  }).catch(() => null);
+  try {
+    const { error } = await supa.rpc("finalize_completed_payment", {
+      p_payment_id: paymentId,
+    });
+    if (error) {
+      console.error("finalize_completed_payment failed", error);
+    }
+  } catch (err) {
+    console.error("finalize_completed_payment threw", err);
+  }
 }
 
 type Body = {


### PR DESCRIPTION
## Summary
- improve finalize_completed_payment RPC error handling in receipt-submit

## Testing
- `npm test` (fails: callback edits message instead of sending new one; miniapp edge host routes)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8796ba8832293a4658bbb150683