### PR TITLE
refactor: handle payment intent insert errors

### DIFF
--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1025,7 +1025,7 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
       const payCode = `DC-${
         crypto.randomUUID().replace(/-/g, "").slice(0, 6).toUpperCase()
       }`;
-      await supa.from("payment_intents").insert({
+      const { error: piErr } = await supa.from("payment_intents").insert({
         user_id: userId,
         method: "bank",
         expected_amount: 0,
@@ -1033,7 +1033,10 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
         pay_code: payCode,
         status: "pending",
         notes: planId,
-      }).catch(() => null);
+      });
+      if (piErr) {
+        console.error("create bank payment intent error", piErr);
+      }
 
       const { data: banks } = await supa
         .from("bank_accounts")


### PR DESCRIPTION
## Summary
- handle bank payment intent insert errors in telegram-bot function

## Testing
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land -A --no-check --no-lock` *(fails: callback edits message instead of sending new one; miniapp edge host routes)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2c87b7050832288a4fa7eff2e7763