### PR TITLE
refactor: handle subscription activation errors

### DIFF
--- a/supabase/functions/crypto-webhook/index.ts
+++ b/supabase/functions/crypto-webhook/index.ts
@@ -15,10 +15,17 @@ async function activateSubscription(
   supa: ReturnType<typeof createClient>,
   paymentId: string,
 ) {
-  await supa.rpc("finalize_completed_payment", { p_payment_id: paymentId })
-    .catch(
-      () => {},
+  try {
+    const { error } = await supa.rpc(
+      "finalize_completed_payment",
+      { p_payment_id: paymentId },
     );
+    if (error) {
+      console.error("finalize_completed_payment error", error);
+    }
+  } catch (err) {
+    console.error("finalize_completed_payment exception", err);
+  }
 }
 
 serve(async (req) => {


### PR DESCRIPTION
## Summary
- improve crypto-webhook subscription activation error handling with try/catch

## Testing
- `PATH=$PATH:/root/.deno/bin npm test` (fails: callback edits message instead of sending new one, miniapp edge host routes)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2c87c91888322be115d276f1d5763