### PR TITLE
fix: escape bullet character in miniapp

### DIFF
--- a/supabase/functions/miniapp/index.html
+++ b/supabase/functions/miniapp/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width,initial-scale=1,viewport-fit=cover"
     />
-    <title>Dynamic Capital VIP • Mini App</title>
+    <title>Dynamic Capital VIP &bull; Mini App</title>
     <!-- Telegram WebApp SDK -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>


### PR DESCRIPTION
## Summary
- ensure miniapp title uses HTML entity for bullet to avoid encoding issues

## Testing
- `npm test` *(fails: start command includes Mini App button when env present FAILED; start command omits Mini App button when env missing FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a0cd11248322abcc13c9925e11fe