### PR TITLE
Respect mini app configuration before displaying links

### DIFF
--- a/supabase/functions/_shared/miniapp.ts
+++ b/supabase/functions/_shared/miniapp.ts
@@ -21,5 +21,8 @@ export async function readMiniAppEnv(): Promise<MiniAppEnv> {
     url = autoUrl ? (autoUrl.endsWith("/") ? autoUrl : `${autoUrl}/`) : null;
   }
 
-  return { url, short: short ?? null, ready: Boolean(url || short) };
+  // "ready" should reflect explicit configuration, not auto-derived values
+  // so that features can gracefully disable Mini App integration when the
+  // required environment variables are absent.
+  return { url, short: short ?? null, ready: Boolean(urlRaw || short) };
 }

--- a/supabase/functions/checkout-init/index.ts
+++ b/supabase/functions/checkout-init/index.ts
@@ -85,8 +85,8 @@ export async function handler(req: Request): Promise<Response> {
     }
   }
 
-  // Use telegram_id from auth, initData, or body
-  const finalTelegramId = telegramId || body.telegram_id;
+  // Use telegram_id from auth or initData; allow body override only when auth header present
+  const finalTelegramId = telegramId || (authHeader ? body.telegram_id : null);
   if (!finalTelegramId) {
     return json({ error: "unauthorized" }, 401, corsHeaders);
   }

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -89,12 +89,12 @@ export async function handler(req: Request): Promise<Response> {
 
     const handlers: Record<string, CommandHandler> = {
       "/start": async (chatId) => {
-        const { url, short } = await readMiniAppEnv();
+        const { url, short, ready } = await readMiniAppEnv();
         const botUsername = (await envOrSetting("TELEGRAM_BOT_USERNAME")) || "";
         const btnText = await getContent("miniapp_button_text") ?? "Open VIP Mini App";
         const prompt = await getContent("miniapp_open_prompt") ?? "Join the VIP Mini App:";
 
-        if (url) {
+        if (ready && url) {
           await sendMessage(chatId, prompt, {
             reply_markup: {
               inline_keyboard: [[{ text: btnText, web_app: { url } }]],
@@ -103,7 +103,7 @@ export async function handler(req: Request): Promise<Response> {
           return;
         }
 
-        if (short && botUsername) {
+        if (ready && short && botUsername) {
           await sendMessage(chatId, prompt, {
             reply_markup: {
               inline_keyboard: [[{


### PR DESCRIPTION
## Summary
- only expose Mini App links when MINI_APP env is configured
- ensure webhook and bot handlers respect missing Mini App config
- reject checkout-init requests without valid auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be9488a2808322a4b2133d08f2f9a5