### PR TITLE
Add retry and broadcast validation

### DIFF
--- a/tests/broadcast-segment.test.ts
+++ b/tests/broadcast-segment.test.ts
@@ -1,0 +1,20 @@
+import { assertEquals, assertRejects } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { resolveTargets } from "../src/broadcast/index.ts";
+
+Deno.test("resolveTargets accepts array", async () => {
+  const ids = await resolveTargets([1, 2]);
+  assertEquals(ids, [1, 2]);
+});
+
+Deno.test("resolveTargets accepts object with userIds", async () => {
+  const ids = await resolveTargets({ userIds: [3, 4] });
+  assertEquals(ids, [3, 4]);
+});
+
+Deno.test("resolveTargets rejects invalid input", async () => {
+  await assertRejects(
+    () => resolveTargets({ foo: "bar" } as unknown as number[]),
+    Error,
+    "Invalid broadcast segment",
+  );
+});


### PR DESCRIPTION
## Summary
- retry config edge-function requests
- validate broadcast segments and log invalid inputs
- type ChatAssistantWidget telegram data and limit stored history

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee1820e80832288e73006183c4f12