### PR TITLE
Add scroll-based services, promo rotation, hero vaporization, and receipt overlay

### DIFF
--- a/src/components/checkout/WebCheckout.tsx
+++ b/src/components/checkout/WebCheckout.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { motion, AnimatePresence } from "framer-motion";
 import { 
   CreditCard, 
   Shield, 
@@ -75,6 +76,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
   const [uploading, setUploading] = useState(false);
   const [isTelegram, setIsTelegram] = useState(false);
   const [telegramInitData, setTelegramInitData] = useState<string | null>(null);
+  const [showReceipt, setShowReceipt] = useState(false);
 
   const fetchPlans = useCallback(async () => {
     try {
@@ -318,7 +320,38 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
 
   const finalPrice = calculateFinalPrice();
 
+  useEffect(() => {
+    if (currentStep === "pending") {
+      setShowReceipt(true);
+    }
+  }, [currentStep]);
+
+  const DigitalReceipt = ({ onClose }: { onClose: () => void }) => (
+    <motion.div
+      initial={{ opacity: 0, y: 50 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 50 }}
+      className="fixed inset-0 flex items-center justify-center bg-background/80 backdrop-blur-sm z-50"
+    >
+      <Card className="w-80">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Digital Receipt
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div><strong>Plan:</strong> {selectedPlan?.name}</div>
+          <div><strong>Amount:</strong> ${finalPrice.toFixed(2)}</div>
+          {promoCode && <div><strong>Promo:</strong> {promoCode}</div>}
+          <Button className="mt-4 w-full" onClick={onClose}>Close</Button>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+
   return (
+    <>
     <div className="max-w-2xl mx-auto space-y-6">
       {/* Header */}
       <div className="text-center space-y-2">
@@ -663,6 +696,10 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
         </div>
       </div>
     </div>
+    <AnimatePresence>
+      {showReceipt && <DigitalReceipt onClose={() => setShowReceipt(false)} />}
+    </AnimatePresence>
+    </>
   );
 };
 

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -45,6 +45,11 @@ const MorphingText = dynamic(
 
 interface HeroSectionProps { onOpenTelegram: () => void; }
 
+const vaporVariants = {
+  hidden: { opacity: 0, filter: "blur(20px)", y: 20 },
+  show: { opacity: 1, filter: "blur(0px)", y: 0, transition: { duration: 1 } }
+};
+
 const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
   const isMobile = useIsMobile();
   const [showLoader, setShowLoader] = useState(true);
@@ -123,7 +128,12 @@ const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
           <MotionStagger className={`mx-auto ${isMobile ? 'max-w-lg' : 'max-w-5xl'} space-y-6`}>
             {/* Dynamic Floating Badge */}
             <ResponsiveMotion mobileVariant="fade" desktopVariant="bounce" delay={0.2}>
-              <div className={isMobile ? 'mb-6' : 'mb-8'}>
+              <motion.div
+                className={isMobile ? 'mb-6' : 'mb-8'}
+                variants={vaporVariants}
+                initial="hidden"
+                animate="show"
+              >
                 <Badge className={`bg-[hsl(var(--accent-light)/0.3)] text-[hsl(var(--accent-light))] border-[hsl(var(--accent-light)/0.5)] hover:bg-[hsl(var(--accent-light)/0.4)] ${isMobile ? 'text-sm px-4 py-1.5' : 'text-base px-6 py-2'} backdrop-blur-md shadow-xl`}>
                   <motion.div
                     animate={shouldReduceMotion ? undefined : { rotate: [0, 5, -5, 0] }}
@@ -143,13 +153,18 @@ const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
                     morphDuration={0.6}
                   />
                 </Badge>
-              </div>
+              </motion.div>
             </ResponsiveMotion>
 
             {/* New Hero Content */}
-            <h1 className={`${isMobile ? 'text-3xl sm:text-4xl' : 'text-4xl sm:text-5xl lg:text-6xl'} font-bold font-poppins text-[hsl(var(--accent-light))] drop-shadow-lg`}>
+            <motion.h1
+              className={`${isMobile ? 'text-3xl sm:text-4xl' : 'text-4xl sm:text-5xl lg:text-6xl'} font-bold font-poppins text-[hsl(var(--accent-light))] drop-shadow-lg`}
+              variants={vaporVariants}
+              initial="hidden"
+              animate="show"
+            >
               Dynamic Capital VIP
-            </h1>
+            </motion.h1>
 
             <div className="flex justify-center">
               <Separator className="w-24 h-[2px] bg-[hsl(var(--accent-light)/0.5)] rounded-full" />

--- a/src/components/shared/ActivePromosSection.tsx
+++ b/src/components/shared/ActivePromosSection.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface Promo {
+  code: string;
+  description: string;
+}
+
+const promos: Promo[] = [
+  { code: "SAVE10", description: "Save 10% on any plan" },
+  { code: "VIPBONUS", description: "Bonus month on VIP plan" },
+];
+
+export function ActivePromosSection() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % promos.length);
+    }, 4000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="relative h-32 w-full flex items-center justify-center" style={{ perspective: 1000 }}>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          initial={{ rotateY: -90, opacity: 0 }}
+          animate={{ rotateY: 0, opacity: 1 }}
+          exit={{ rotateY: 90, opacity: 0 }}
+          transition={{ duration: 0.6 }}
+          className="absolute"
+          style={{ transformStyle: "preserve-3d" }}
+        >
+          <Card className="w-64 shadow-lg">
+            <CardContent className="p-4 text-center">
+              <div className="font-bold text-lg">{promos[index].code}</div>
+              <p className="text-sm text-muted-foreground">{promos[index].description}</p>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default ActivePromosSection;

--- a/src/components/shared/LivePlansSection.tsx
+++ b/src/components/shared/LivePlansSection.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@/hooks/use-toast';
 import { callEdgeFunction, buildFunctionUrl } from '@/config/supabase';
 import PromoCodeInput from '@/components/billing/PromoCodeInput';
 import { formatPrice } from '@/lib/utils';
+import { ActivePromosSection } from '@/components/shared/ActivePromosSection';
 
 interface Plan {
   id: string;
@@ -126,9 +127,12 @@ export const LivePlansSection = ({
             )}
 
             {showPromo && (
-              <div className="mb-6">
-                <h4 className="font-medium mb-3">Have a promo code?</h4>
-                <PromoCodeInput planId={plans[0]?.id || ""} />
+              <div className="mb-6 space-y-6">
+                <div>
+                  <h4 className="font-medium mb-3">Have a promo code?</h4>
+                  <PromoCodeInput planId={plans[0]?.id || ""} />
+                </div>
+                <ActivePromosSection />
               </div>
             )}
 

--- a/src/components/shared/ServiceStack.tsx
+++ b/src/components/shared/ServiceStack.tsx
@@ -1,20 +1,16 @@
-import React, { useState, useEffect, useCallback } from "react";
-import { motion, AnimatePresence, useMotionValue, useTransform, useDragControls } from "framer-motion";
+import React, { useMemo } from "react";
+import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { 
-  TrendingUp, 
-  Star, 
-  Shield, 
-  Users, 
-  Sparkles, 
-  MessageSquare, 
+import {
+  TrendingUp,
+  Star,
+  Shield,
+  Users,
+  Sparkles,
+  MessageSquare,
   Award,
-  ChevronLeft,
-  ChevronRight
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { MagneticButton } from "@/components/ui/advanced-motion";
 
 interface ServiceStackProps {
   services: string;
@@ -26,405 +22,112 @@ interface ServiceItem {
   title: string;
   description: string;
   color: string;
-  gradient: string;
+}
+
+// Parse services string into structured data
+function parseServices(servicesText: string): ServiceItem[] {
+  const serviceLines = servicesText.split("\n").filter((s) => s.trim());
+  return serviceLines.map((service) => {
+    const clean = service
+      .replace(/\p{Extended_Pictographic}/gu, "")
+      .replace("•", "")
+      .trim();
+
+    const data = (text: string) => {
+      if (text.includes("Signal"))
+        return {
+          icon: TrendingUp,
+          title: "Trading Signals",
+          description: "Real-time market signals with entry and exit points",
+          color: "text-green-500",
+        };
+      if (text.includes("Analysis"))
+        return {
+          icon: Star,
+          title: "Market Analysis",
+          description: "Daily market research and technical insights",
+          color: "text-blue-500",
+        };
+      if (text.includes("Risk"))
+        return {
+          icon: Shield,
+          title: "Risk Management",
+          description: "Guidance on protecting your trading capital",
+          color: "text-primary",
+        };
+      if (text.includes("Mentor"))
+        return {
+          icon: Users,
+          title: "Personal Mentor",
+          description: "One-on-one coaching from experienced traders",
+          color: "text-orange-500",
+        };
+      if (text.includes("VIP"))
+        return {
+          icon: Sparkles,
+          title: "VIP Community",
+          description: "Exclusive access to premium trading community",
+          color: "text-accent",
+        };
+      if (text.includes("Support"))
+        return {
+          icon: MessageSquare,
+          title: "24/7 Support",
+          description: "Round-the-clock customer assistance",
+          color: "text-cyan-500",
+        };
+      return {
+        icon: Award,
+        title: clean,
+        description: "Premium service for VIP members",
+        color: "text-primary",
+      };
+    };
+
+    return data(clean);
+  });
 }
 
 export function ServiceStack({ services, className }: ServiceStackProps) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [direction, setDirection] = useState(0);
-  const dragControls = useDragControls();
+  const items = useMemo(() => parseServices(services), [services]);
 
-  const parseServices = (servicesText: string): ServiceItem[] => {
-    const serviceLines = servicesText.split('\n').filter(service => service.trim());
-    
-    return serviceLines.map((service) => {
-      const cleanService = service
-        .replace(/\p{Extended_Pictographic}/gu, '')
-        .replace('•', '')
-        .trim();
-      
-      const getServiceData = (text: string) => {
-        if (text.includes('Signal')) return { 
-          icon: TrendingUp, 
-          title: 'Trading Signals', 
-          description: 'Real-time market signals with entry and exit points for maximum profitability',
-          color: 'text-green-500',
-          gradient: 'from-green-500 to-emerald-600'
-        };
-        if (text.includes('Analysis')) return { 
-          icon: Star, 
-          title: 'Market Analysis', 
-          description: 'Daily comprehensive market research and technical analysis insights',
-          color: 'text-blue-500',
-          gradient: 'from-blue-500 to-cyan-600'
-        };
-        if (text.includes('Risk')) return { 
-          icon: Shield, 
-          title: 'Risk Management', 
-          description: 'Professional guidance on protecting and growing your trading capital',
-          color: 'text-primary',
-          gradient: 'from-primary to-accent'
-        };
-        if (text.includes('Mentor')) return { 
-          icon: Users, 
-          title: 'Personal Mentor', 
-          description: 'One-on-one guidance from experienced professional traders',
-          color: 'text-orange-500',
-          gradient: 'from-orange-500 to-dc-brand-dark'
-        };
-        if (text.includes('VIP')) return { 
-          icon: Sparkles, 
-          title: 'VIP Community', 
-          description: 'Exclusive access to premium trading community and networking',
-          color: 'text-accent',
-          gradient: 'from-accent to-primary'
-        };
-        if (text.includes('Support')) return { 
-          icon: MessageSquare, 
-          title: '24/7 Support', 
-          description: 'Round-the-clock customer support and technical assistance',
-          color: 'text-cyan-500',
-          gradient: 'from-cyan-500 to-blue-600'
-        };
-        
-        return { 
-          icon: Award, 
-          title: cleanService, 
-          description: 'Premium service designed exclusively for VIP members',
-          color: 'text-primary',
-          gradient: 'from-primary to-accent'
-        };
-      };
-      
-      return getServiceData(cleanService);
-    });
-  };
-
-  const serviceItems = parseServices(services);
-
-  const nextService = useCallback(() => {
-    setDirection(1);
-    setCurrentIndex((prev) => (prev + 1) % serviceItems.length);
-  }, [serviceItems.length]);
-
-  const prevService = () => {
-    setDirection(-1);
-    setCurrentIndex((prev) => (prev - 1 + serviceItems.length) % serviceItems.length);
-  };
-
-  // Auto-rotation effect
-  useEffect(() => {
-    const timer = setInterval(() => {
-      nextService();
-    }, 5000);
-
-    return () => clearInterval(timer);
-  }, [nextService]);
-
-  const stackVariants = {
-    enter: (direction: number) => ({
-      x: direction > 0 ? 300 : -300,
-      opacity: 0,
-      scale: 0.8,
-      rotateY: direction > 0 ? 45 : -45,
-    }),
-    center: {
-      zIndex: 1,
-      x: 0,
-      opacity: 1,
-      scale: 1,
-      rotateY: 0,
-    },
-    exit: (direction: number) => ({
-      zIndex: 0,
-      x: direction < 0 ? 300 : -300,
-      opacity: 0,
-      scale: 0.8,
-      rotateY: direction < 0 ? 45 : -45,
-    })
-  };
-
-  const backgroundCards = [-2, -1, 1, 2].map((offset) => {
-    const index = (currentIndex + offset + serviceItems.length) % serviceItems.length;
-    return { ...serviceItems[index], offset, index };
-  });
+  const cardHeight = 160; // approximate card height
+  const stackGap = 60; // vertical offset between cards
+  const containerHeight = cardHeight + stackGap * (items.length - 1);
 
   return (
-    <motion.div
-      className={cn("relative w-full max-w-4xl mx-auto", className)}
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8, ease: [0.6, -0.05, 0.01, 0.99] }}
+    <div
+      className={cn("relative max-w-md mx-auto", className)}
+      style={{ height: containerHeight }}
     >
-      <motion.div
-        initial={{ opacity: 0, y: -30 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, delay: 0.2 }}
-        className="text-center mb-12"
-      >
-        <motion.h2 
-          className="text-3xl md:text-4xl font-bold mb-4 bg-gradient-to-r from-primary via-accent to-accent bg-clip-text text-transparent"
-          animate={{
-            backgroundPosition: ['0% 50%', '100% 50%', '0% 50%']
-          }}
-          transition={{
-            duration: 5,
-            repeat: Infinity,
-            ease: "linear"
-          }}
-          style={{
-            backgroundSize: '200% 200%'
-          }}
-        >
-          Premium Services
-        </motion.h2>
-        <motion.p 
-          className="text-muted-foreground text-lg"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-        >
-          Comprehensive trading solutions for maximum success
-        </motion.p>
-      </motion.div>
-
-      <div className="relative h-[400px] perspective-1000">
-        {/* Background Stack Cards */}
-        {backgroundCards.map((item, stackIndex) => {
-          const Icon = item.icon;
-          const zIndex = 10 - Math.abs(item.offset);
-          const scale = 1 - Math.abs(item.offset) * 0.05;
-          const translateZ = -Math.abs(item.offset) * 20;
-          const rotateY = item.offset * 5;
-          const opacity = 1 - Math.abs(item.offset) * 0.15;
-          
-          return (
-            <motion.div
-              key={`${item.index}-${item.offset}`}
-              className="absolute inset-0"
-              style={{
-                zIndex,
-                scale,
-                rotateY,
-                opacity,
-                transformStyle: 'preserve-3d',
-              }}
-              animate={{
-                scale,
-                rotateY,
-                opacity,
-                x: item.offset * 15,
-                y: Math.abs(item.offset) * 10,
-              }}
-              transition={{ duration: 0.6, ease: "easeOut" }}
-            >
-              <Card className="w-full h-full bg-gradient-to-br from-card/60 to-muted/30 border border-border/50 backdrop-blur-sm">
-                <CardContent className="p-8 h-full flex flex-col justify-center items-center text-center">
-                  <div className={`p-4 rounded-full bg-gradient-to-br ${item.gradient} mb-6 shadow-lg`}>
-                    <Icon className="w-8 h-8 text-white" />
-                  </div>
-                  <h3 className="text-xl font-bold mb-3">{item.title}</h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    {item.description}
-                  </p>
-                </CardContent>
-              </Card>
-            </motion.div>
-          );
-        })}
-
-        {/* Main Active Card */}
-        <AnimatePresence mode="wait" custom={direction}>
+      {items.map((item, index) => {
+        const Icon = item.icon;
+        return (
           <motion.div
-            key={currentIndex}
-            custom={direction}
-            variants={stackVariants}
-            initial="enter"
-            animate="center"
-            exit="exit"
-            transition={{
-              x: { type: "spring", stiffness: 300, damping: 30 },
-              opacity: { duration: 0.3 },
-              scale: { duration: 0.4 },
-              rotateY: { duration: 0.5 }
-            }}
-            className="absolute inset-0"
-            style={{ zIndex: 20 }}
-            drag="x"
-            dragConstraints={{ left: 0, right: 0 }}
-            dragElastic={0.1}
-            onDragEnd={(e, { offset, velocity }) => {
-              const swipe = Math.abs(offset.x) > 50 || Math.abs(velocity.x) > 500;
-              if (swipe) {
-                if (offset.x > 0) {
-                  prevService();
-                } else {
-                  nextService();
-                }
-              }
-            }}
-            whileHover={{ scale: 1.02, rotateY: 2 }}
-            whileDrag={{ scale: 1.1, rotateY: 10 }}
+            key={index}
+            className="absolute left-0 right-0"
+            style={{ top: index * stackGap, zIndex: items.length - index }}
+            initial={{ opacity: 0, y: 50 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.6 }}
+            transition={{ duration: 0.6, delay: index * 0.1 }}
           >
-            <Card className="w-full h-full bg-gradient-to-br from-card to-card/80 border-2 border-primary/20 shadow-2xl shadow-primary/10 backdrop-blur-md">
-              <CardContent className="p-8 h-full flex flex-col justify-center items-center text-center relative overflow-hidden">
-                {/* Animated background gradient */}
-                <motion.div
-                  className="absolute inset-0 bg-gradient-to-r from-primary/5 via-accent/5 to-accent/5"
-                  animate={{
-                    backgroundPosition: ['0% 50%', '100% 50%', '0% 50%']
-                  }}
-                  transition={{
-                    duration: 8,
-                    repeat: Infinity,
-                    ease: "linear"
-                  }}
-                  style={{
-                    backgroundSize: '200% 200%'
-                  }}
-                />
-                
-                <motion.div
-                  className={`p-6 rounded-full bg-gradient-to-br ${serviceItems[currentIndex].gradient} mb-8 shadow-2xl relative z-10`}
-                  animate={{
-                    rotate: [0, 360],
-                    scale: [1, 1.1, 1]
-                  }}
-                  transition={{
-                    rotate: { duration: 20, repeat: Infinity, ease: "linear" },
-                    scale: { duration: 2, repeat: Infinity, ease: "easeInOut" }
-                  }}
-                >
-                  {React.createElement(serviceItems[currentIndex].icon, { className: "w-12 h-12 text-white" })}
-                </motion.div>
-                
-                <motion.h3 
-                  className="text-3xl font-bold mb-4 relative z-10"
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5, delay: 0.2 }}
-                >
-                  {serviceItems[currentIndex].title}
-                </motion.h3>
-                
-                <motion.p 
-                  className="text-muted-foreground text-lg leading-relaxed max-w-md relative z-10"
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.5, delay: 0.4 }}
-                >
-                  {serviceItems[currentIndex].description}
-                </motion.p>
-
-                {/* Floating particles effect */}
-                {[...Array(5)].map((_, i) => (
-                  <motion.div
-                    key={i}
-                    className="absolute w-2 h-2 bg-primary/30 rounded-full"
-                    animate={{
-                      x: [0, Math.random() * 100 - 50],
-                      y: [0, Math.random() * 100 - 50],
-                      opacity: [0, 1, 0],
-                      scale: [0, 1, 0]
-                    }}
-                    transition={{
-                      duration: 3 + Math.random() * 2,
-                      repeat: Infinity,
-                      delay: Math.random() * 2,
-                      ease: "easeInOut"
-                    }}
-                    style={{
-                      left: `${20 + Math.random() * 60}%`,
-                      top: `${20 + Math.random() * 60}%`
-                    }}
-                  />
-                ))}
+            <Card className="shadow-xl">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Icon className={cn("w-6 h-6", item.color)} />
+                  {item.title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="text-muted-foreground">
+                {item.description}
               </CardContent>
             </Card>
           </motion.div>
-        </AnimatePresence>
-
-        {/* Navigation Controls */}
-        <motion.button
-          className="absolute left-4 top-1/2 transform -translate-y-1/2 z-30 p-3 bg-background/80 backdrop-blur-sm rounded-full border border-border/50 shadow-lg hover:shadow-xl"
-          onClick={prevService}
-          whileHover={{ scale: 1.1, x: -2 }}
-          whileTap={{ scale: 0.9 }}
-          initial={{ opacity: 0, x: -20 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.5, delay: 0.8 }}
-        >
-          <ChevronLeft className="w-6 h-6 text-foreground" />
-        </motion.button>
-
-        <motion.button
-          className="absolute right-4 top-1/2 transform -translate-y-1/2 z-30 p-3 bg-background/80 backdrop-blur-sm rounded-full border border-border/50 shadow-lg hover:shadow-xl"
-          onClick={nextService}
-          whileHover={{ scale: 1.1, x: 2 }}
-          whileTap={{ scale: 0.9 }}
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.5, delay: 0.8 }}
-        >
-          <ChevronRight className="w-6 h-6 text-foreground" />
-        </motion.button>
-      </div>
-
-      {/* Dots Indicator */}
-      <motion.div 
-        className="flex justify-center mt-8 gap-3"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, delay: 1 }}
-      >
-        {serviceItems.map((_, index) => (
-          <motion.button
-            key={index}
-            onClick={() => {
-              setDirection(index > currentIndex ? 1 : -1);
-              setCurrentIndex(index);
-            }}
-            className={cn(
-              "rounded-full transition-all duration-300 border",
-              index === currentIndex 
-                ? "w-12 h-4 bg-gradient-to-r from-primary to-accent border-primary"
-                : "w-4 h-4 bg-muted-foreground/50 border-muted-foreground/50 hover:bg-muted-foreground/70"
-            )}
-            whileHover={{ scale: 1.2 }}
-            whileTap={{ scale: 0.9 }}
-            animate={index === currentIndex ? {
-              boxShadow: [
-                '0 0 0 0 rgba(var(--primary-rgb), 0)',
-                '0 0 0 10px rgba(var(--primary-rgb), 0.1)',
-                '0 0 0 0 rgba(var(--primary-rgb), 0)'
-              ]
-            } : {}}
-            transition={{
-              boxShadow: { duration: 1.5, repeat: Infinity }
-            }}
-          />
-        ))}
-      </motion.div>
-
-      {/* Progress bar */}
-      <motion.div 
-        className="w-full bg-muted/30 rounded-full h-1 mt-6 overflow-hidden"
-        initial={{ opacity: 0, scaleX: 0 }}
-        animate={{ opacity: 1, scaleX: 1 }}
-        transition={{ duration: 0.6, delay: 1.2 }}
-      >
-        <motion.div
-          className="h-full bg-gradient-to-r from-primary to-accent rounded-full"
-          animate={{ 
-            width: `${((currentIndex + 1) / serviceItems.length) * 100}%`,
-            x: [0, 2, 0]
-          }}
-          transition={{ 
-            width: { duration: 0.5, ease: "easeOut" },
-            x: { duration: 2, repeat: Infinity, ease: "easeInOut" }
-          }}
-        />
-      </motion.div>
-    </motion.div>
+        );
+      })}
+    </div>
   );
 }
+
+export default ServiceStack;


### PR DESCRIPTION
## Summary
- implement stacked-scroll animation for service cards
- show rotating active promotions with 3D spin
- vaporize effect for hero badge and headline
- animate digital receipt after checkout submission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0cafa31c832282e4d9292220b2cc