### PR TITLE
feat: add pgvector semantic FAQ search

### DIFF
--- a/supabase/functions/ai-faq-assistant/index.ts
+++ b/supabase/functions/ai-faq-assistant/index.ts
@@ -38,7 +38,7 @@ serve(async (req) => {
   }
 
   try {
-    const { question, context: _context, test } = await req
+    const { question, test } = await req
       .json()
       .catch(() => ({}));
 
@@ -102,15 +102,18 @@ Always end responses with: "💡 Need more help? Contact @DynamicCapital_Support
       });
     }
 
-    const context = matches
+    const faqContext = matches
       ?.map((m) => `Q: ${m.question}\nA: ${m.answer}`)
       .join("\n\n");
 
     const messages = [
       { role: "system", content: systemPrompt },
     ];
-    if (context) {
-      messages.push({ role: "system", content: `FAQ context:\n${context}` });
+    if (faqContext) {
+      messages.push({
+        role: "system",
+        content: `FAQ context:\n${faqContext}`,
+      });
     }
     messages.push({ role: "user", content: question });
 

--- a/supabase/migrations/20250909000000_add_pgvector_faq_embeddings.sql
+++ b/supabase/migrations/20250909000000_add_pgvector_faq_embeddings.sql
@@ -10,7 +10,7 @@ create table if not exists faq_embeddings (
 );
 
 create index if not exists faq_embeddings_embedding_idx on faq_embeddings
-  using ivfflat (embedding vector_l2_ops) with (lists = 100);
+  using ivfflat (embedding vector_cosine_ops) with (lists = 100);
 
 create or replace function match_faq(
   query_embedding vector(1536),


### PR DESCRIPTION
## Summary
- add migration enabling pgvector and FAQ embeddings table
- enhance ai-faq-assistant to query and store FAQ embeddings for semantic search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf15d8152883229e78e49b5ca6216f