### PR TITLE
feat: centralize telegram user id parsing

### DIFF
--- a/supabase/functions/_tests/extract_telegram_user_id_test.ts
+++ b/supabase/functions/_tests/extract_telegram_user_id_test.ts
@@ -1,0 +1,13 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { extractTelegramUserId } from "../shared/telegram.ts";
+
+Deno.test("extractTelegramUserId parses id from initData", () => {
+  const user = { id: 42, first_name: "Alice" };
+  const initData = `user=${encodeURIComponent(JSON.stringify(user))}`;
+  assertEquals(extractTelegramUserId(initData), "42");
+});
+
+Deno.test("extractTelegramUserId returns empty string on malformed input", () => {
+  const initData = "user=%7Bbad json";
+  assertEquals(extractTelegramUserId(initData), "");
+});

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -2,6 +2,7 @@ import { mna, nf, json } from "../_shared/http.ts";
 import { optionalEnv, requireEnv } from "../_shared/env.ts";
 import { serveStatic, StaticOpts } from "../_shared/static.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { extractTelegramUserId } from "../shared/telegram.ts";
 
 // Env setup
 const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = requireEnv([
@@ -370,21 +371,6 @@ async function handleApiRoutes(req: Request, path: string): Promise<Response> {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
-  }
-
-  // Helper function to get Telegram user ID from initData
-  function extractTelegramUserId(initData: string): string {
-    try {
-      const params = new URLSearchParams(initData);
-      const userStr = params.get('user');
-      if (userStr) {
-        const user = JSON.parse(userStr);
-        return user.id?.toString() || '';
-      }
-    } catch (error) {
-      console.warn('Failed to parse telegram user ID:', error);
-    }
-    return '';
   }
 
   // POST /api/admin-check - Check admin status

--- a/supabase/functions/miniapp/src/hooks/useApi.ts
+++ b/supabase/functions/miniapp/src/hooks/useApi.ts
@@ -6,6 +6,8 @@
  * object with a `message` field) is thrown. Callers should handle these errors
  * with a `try/catch` block.
  */
+import { extractTelegramUserId } from "../../../shared/telegram.ts";
+
 export function useApi() {
   const getInitData = () =>
     (globalThis as unknown as { Telegram?: { WebApp?: { initData?: string } } })
@@ -142,20 +144,7 @@ export function useApi() {
   };
 
   // Helper function to extract telegram user ID from initData
-  const extractTelegramUserId = (initData: string): string => {
-    try {
-      // Parse initData to extract user info
-      const params = new URLSearchParams(initData);
-      const userStr = params.get('user');
-      if (userStr) {
-        const user = JSON.parse(userStr);
-        return user.id?.toString() || '';
-      }
-    } catch (error) {
-      console.warn('Failed to parse telegram user ID:', error);
-    }
-    return '';
-  };
+  // extractTelegramUserId imported from shared utility
 
   return {
     createIntent,

--- a/supabase/functions/shared/telegram.ts
+++ b/supabase/functions/shared/telegram.ts
@@ -1,0 +1,13 @@
+export function extractTelegramUserId(initData: string): string {
+  try {
+    const params = new URLSearchParams(initData);
+    const userStr = params.get("user");
+    if (userStr) {
+      const user = JSON.parse(userStr);
+      return user.id?.toString() ?? "";
+    }
+  } catch (err) {
+    console.warn("Failed to parse telegram user ID:", err);
+  }
+  return "";
+}


### PR DESCRIPTION
## Summary
- add shared extractTelegramUserId helper
- reuse helper in miniapp edge handler and React hook
- cover helper with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1b7a51948322903f8d423258c9c7