### PR TITLE
Harden RLS policies and move extensions to dedicated schema

### DIFF
--- a/docs/postgres-upgrade.md
+++ b/docs/postgres-upgrade.md
@@ -1,0 +1,15 @@
+# PostgreSQL Upgrade
+
+The database was flagged for missing recent security patches. Upgrade the PostgreSQL server to the latest patched release for its major version.
+
+## Recommended Steps
+1. Check current version:
+   ```sql
+   SELECT version();
+   ```
+2. Review [PostgreSQL release notes](https://www.postgresql.org/docs/release/) and choose the latest patch in the deployed major version (e.g. 15.x).
+3. Follow your hosting provider's guidance to perform the upgrade.
+4. Run regression tests and verify application functionality.
+5. Document the new version in deployment records.
+
+Keeping PostgreSQL updated ensures known vulnerabilities are patched and security fixes are applied promptly.

--- a/supabase/migrations/20250808054000_add_index_advisor_extension.sql
+++ b/supabase/migrations/20250808054000_add_index_advisor_extension.sql
@@ -1,4 +1,4 @@
--- Enable extensions required for PostgreSQL index advisor
-create extension if not exists hypopg cascade;
-create extension if not exists index_advisor cascade;
+create schema if not exists extensions;
+create extension if not exists hypopg with schema extensions cascade;
+create extension if not exists index_advisor with schema extensions cascade;
 

--- a/supabase/migrations/20250813091237_schema_hardening.sql
+++ b/supabase/migrations/20250813091237_schema_hardening.sql
@@ -1,8 +1,8 @@
 -- SCHEMA HARDENING — Dynamic-Chatty-Bot
 -- Safe & idempotent where possible
 
--- 1) Extension required by gen_random_uuid()
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 
 -- 2) Ensure array columns use text[]
 DO $$

--- a/supabase/migrations/20250909000000_add_pgvector_faq_embeddings.sql
+++ b/supabase/migrations/20250909000000_add_pgvector_faq_embeddings.sql
@@ -1,5 +1,5 @@
--- Enable pgvector extension and add FAQ embeddings table
-create extension if not exists vector;
+create schema if not exists extensions;
+create extension if not exists vector with schema extensions;
 
 create table if not exists faq_embeddings (
   id bigserial primary key,

--- a/supabase/migrations/20250910000100_lock_down_user_sessions_rls.sql
+++ b/supabase/migrations/20250910000100_lock_down_user_sessions_rls.sql
@@ -1,0 +1,46 @@
+-- Enforce strict RLS on user_sessions
+ALTER TABLE public.user_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Remove existing policies to prevent conflicts
+DROP POLICY IF EXISTS "Users can view own sessions only" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users can create own sessions only" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users can update own sessions only" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users can manage their sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Admins can manage all user sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Service role can manage user sessions" ON public.user_sessions;
+
+-- Regular users: access limited to their own rows
+CREATE POLICY "Users view own sessions"
+ON public.user_sessions
+FOR SELECT
+TO authenticated
+USING (auth.uid() = bot_user_id);
+
+CREATE POLICY "Users insert own sessions"
+ON public.user_sessions
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = bot_user_id);
+
+CREATE POLICY "Users update own sessions"
+ON public.user_sessions
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = bot_user_id)
+WITH CHECK (auth.uid() = bot_user_id);
+
+-- Admins can manage all sessions
+CREATE POLICY "Admins manage all sessions"
+ON public.user_sessions
+FOR ALL
+TO authenticated
+USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'))
+WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'));
+
+-- Service role has full access
+CREATE POLICY "Service role full access user_sessions"
+ON public.user_sessions
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);

--- a/supabase/migrations/20250910000200_restrict_payments_rls.sql
+++ b/supabase/migrations/20250910000200_restrict_payments_rls.sql
@@ -1,0 +1,47 @@
+-- Restrict payments visibility to owning user
+ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY;
+
+-- Remove existing conflicting policies
+DROP POLICY IF EXISTS "Users can view their payments" ON public.payments;
+DROP POLICY IF EXISTS "Users can insert their payments" ON public.payments;
+DROP POLICY IF EXISTS "Users can update their payments" ON public.payments;
+DROP POLICY IF EXISTS "Service role only for payments" ON public.payments;
+DROP POLICY IF EXISTS "Admins can view all payments" ON public.payments;
+DROP POLICY IF EXISTS "Admins can manage all payments" ON public.payments;
+DROP POLICY IF EXISTS "Service role can manage payments" ON public.payments;
+
+-- User policies
+CREATE POLICY "Users view own payments"
+ON public.payments
+FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Users insert own payments"
+ON public.payments
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users update own payments"
+ON public.payments
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+-- Admins full access
+CREATE POLICY "Admins manage all payments"
+ON public.payments
+FOR ALL
+TO authenticated
+USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'))
+WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'));
+
+-- Service role full access
+CREATE POLICY "Service role full access payments"
+ON public.payments
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);

--- a/supabase/migrations/20250910000300_move_extensions_to_schema.sql
+++ b/supabase/migrations/20250910000300_move_extensions_to_schema.sql
@@ -1,0 +1,9 @@
+-- Move existing extensions from public to extensions schema
+CREATE SCHEMA IF NOT EXISTS extensions;
+REVOKE ALL ON SCHEMA extensions FROM PUBLIC;
+GRANT USAGE ON SCHEMA extensions TO postgres;
+
+ALTER EXTENSION IF EXISTS pgcrypto SET SCHEMA extensions;
+ALTER EXTENSION IF EXISTS vector SET SCHEMA extensions;
+ALTER EXTENSION IF EXISTS hypopg SET SCHEMA extensions;
+ALTER EXTENSION IF EXISTS index_advisor SET SCHEMA extensions;


### PR DESCRIPTION
## Summary
- enforce row-level security on user_sessions with per-user policies and service/admin access
- restrict payments table access to owning user
- relocate database extensions into an isolated schema and document PostgreSQL upgrade guidance

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@next/eslint-plugin-next')*

------
https://chatgpt.com/codex/tasks/task_e_68bf08cf3b7c8322b6a4cdbba5c5e208