### PR TITLE
feat: add wrapper integration examples

### DIFF
--- a/docs/WRAPPERS_INTEGRATION.md
+++ b/docs/WRAPPERS_INTEGRATION.md
@@ -1,0 +1,52 @@
+# Wrapper Integration
+
+This project can interact with external services through Postgres foreign data wrappers (FDWs). Wrappers let the app query APIs and storage services using regular SQL via Supabase.
+
+## Installation
+
+Enable the extensions in your database:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS redis_wrapper;
+CREATE EXTENSION IF NOT EXISTS auth0_wrapper;
+CREATE EXTENSION IF NOT EXISTS s3_wrapper;
+```
+
+Create servers for each service:
+
+```sql
+CREATE SERVER redis_server FOREIGN DATA WRAPPER redis_fdw OPTIONS (...);
+CREATE SERVER auth0_server FOREIGN DATA WRAPPER auth0_fdw OPTIONS (...);
+CREATE SERVER s3_server   FOREIGN DATA WRAPPER s3_fdw   OPTIONS (...);
+```
+
+Map remote resources to tables:
+
+```sql
+CREATE FOREIGN TABLE redis_sessions (
+  session_id TEXT,
+  payload    JSONB
+) SERVER redis_server OPTIONS (key_prefix 'session:');
+
+CREATE FOREIGN TABLE auth0_users (
+  user_id TEXT,
+  email   TEXT,
+  profile JSONB
+) SERVER auth0_server;
+
+CREATE FOREIGN TABLE s3_files (
+  filename TEXT,
+  url      TEXT,
+  metadata JSONB
+) SERVER s3_server;
+```
+
+## Application Usage
+
+Wrapper-backed tables can be queried from both the Vite React app and the Telegram bot. Helper functions are provided in `src/integrations/wrappers/queries.ts`:
+
+```ts
+import { getRedisSession, getAuth0User, listS3Files } from "@/integrations/wrappers";
+```
+
+Use these functions to fetch cached sessions, authenticated users, or file metadata through the unified SQL interface.

--- a/src/integrations/wrappers/index.ts
+++ b/src/integrations/wrappers/index.ts
@@ -1,0 +1,1 @@
+export * from "./queries.ts";

--- a/src/integrations/wrappers/queries.ts
+++ b/src/integrations/wrappers/queries.ts
@@ -1,0 +1,42 @@
+import { supabase } from "../supabase/client.ts";
+
+/**
+ * Fetch a user record from Auth0 via the auth0_wrapper foreign table.
+ */
+export async function getAuth0User(userId: string) {
+  const { data, error } = await supabase
+    .from("auth0_users")
+    .select("*")
+    .eq("user_id", userId)
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Retrieve a cached session payload from Redis using redis_wrapper.
+ */
+export async function getRedisSession(sessionId: string) {
+  const { data, error } = await supabase
+    .from("redis_sessions")
+    .select("payload")
+    .eq("session_id", sessionId)
+    .single();
+
+  if (error) throw error;
+  return data?.payload ?? null;
+}
+
+/**
+ * List files stored in S3 through the s3_wrapper foreign table.
+ */
+export async function listS3Files(prefix = "") {
+  const { data, error } = await supabase
+    .from("s3_files")
+    .select("*")
+    .like("filename", `${prefix}%`);
+
+  if (error) throw error;
+  return data ?? [];
+}


### PR DESCRIPTION
## Summary
- document how to configure auth0/redis/s3 wrappers
- expose helper functions to query wrapper-backed tables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf298d165483229da90e4ad5bcaacb