### PR TITLE
Use Next.js router and guard browser-only hooks

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from 'react';
 import './globals.css';
 
+export const metadata = {
+  title: 'Dynamic Capital VIP',
+  description: 'Premium trading platform with Next.js'
+};
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,8 +15,10 @@ import TestimonialsSection from "@/components/landing/TestimonialsSection";
 import FeatureGrid from "@/components/landing/FeatureGrid";
 import CTASection from "@/components/landing/CTASection";
 import { Award, Crown, Target, DollarSign, TrendingUp, Zap, CheckCircle, Sparkles } from "lucide-react";
+import { useRouter } from "next/navigation";
 
 const Landing = () => {
+  const router = useRouter();
   const handleOpenTelegram = () => {
     const botUsername = "Dynamic_VIP_BOT";
     const telegramUrl = `https://t.me/${botUsername}`;
@@ -32,9 +34,9 @@ const Landing = () => {
     );
 
     if (isInTelegram) {
-      window.location.href = '/miniapp?tab=plan';
+      router.push('/miniapp?tab=plan');
     } else {
-      window.location.href = '/plans';
+      router.push('/plans');
     }
   };
 

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -1,47 +1,18 @@
 import { useEffect, useState } from "react";
 import { motion, useReducedMotion, useScroll, useTransform } from "framer-motion";
-import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Crown, ArrowRight, MessageCircle } from "lucide-react";
 
-const Badge = dynamic(() => import("@/components/ui/badge").then((m) => m.Badge), { ssr: false });
-const Separator = dynamic(() => import("@/components/ui/separator").then((m) => m.Separator), { ssr: false });
-const RotatingWords = dynamic(
-  () => import("@/components/ui/rotating-words").then((m) => m.RotatingWords),
-  { ssr: false, loading: () => <span /> }
-);
-const EnhancedButton = dynamic(
-  () => import("@/components/ui/enhanced-button").then((m) => m.EnhancedButton),
-  { ssr: false }
-);
-const StatefulButton = dynamic(
-  () => import("@/components/ui/stateful-button").then((m) => m.StatefulButton),
-  { ssr: false }
-);
-const TextLoader = dynamic(
-  () => import("@/components/ui/text-loader").then((m) => m.TextLoader),
-  { ssr: false, loading: () => <span /> }
-);
-const MotionFadeIn = dynamic(
-  () => import("@/components/ui/motion-components").then((m) => m.MotionFadeIn),
-  { ssr: false }
-);
-const MotionStagger = dynamic(
-  () => import("@/components/ui/motion-components").then((m) => m.MotionStagger),
-  { ssr: false }
-);
-const MotionCounter = dynamic(
-  () => import("@/components/ui/motion-components").then((m) => m.MotionCounter),
-  { ssr: false }
-);
-const ResponsiveMotion = dynamic(
-  () => import("@/components/ui/responsive-motion").then((m) => m.ResponsiveMotion),
-  { ssr: false }
-);
-const MorphingText = dynamic(
-  () => import("@/components/ui/animated-text").then((m) => m.MorphingText),
-  { ssr: false }
-);
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { RotatingWords } from "@/components/ui/rotating-words";
+import { EnhancedButton } from "@/components/ui/enhanced-button";
+import { StatefulButton } from "@/components/ui/stateful-button";
+import { TextLoader } from "@/components/ui/text-loader";
+import { MotionFadeIn, MotionStagger, MotionCounter } from "@/components/ui/motion-components";
+import { ResponsiveMotion } from "@/components/ui/responsive-motion";
+import { MorphingText } from "@/components/ui/animated-text";
 
 interface HeroSectionProps { onOpenTelegram: () => void; }
 
@@ -52,6 +23,7 @@ const vaporVariants = {
 
 const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
   const isMobile = useIsMobile();
+  const router = useRouter();
   const [showLoader, setShowLoader] = useState(true);
   const shouldReduceMotion = useReducedMotion();
   const { scrollY } = useScroll();
@@ -212,9 +184,9 @@ const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
                       );
                       setTimeout(() => {
                         if (isInTelegram) {
-                          window.location.href = "/miniapp?tab=plan";
+                          router.push("/miniapp?tab=plan");
                         } else {
-                          window.location.href = "/plans";
+                          router.push("/plans");
                         }
                         resolve(undefined);
                       }, 600);


### PR DESCRIPTION
## Summary
- replace `window.location.href` with Next.js router pushes
- export default title/description metadata
- statically import simple UI components to enable SSR
- guard browser APIs in `useCurrency` and `useAnalytics`

## Testing
- `npm test` *(fails: Relative import path "mime-types" not prefixed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf2fd517008322a997b1e0b141ded0