### PR TITLE
feat: add VIP price switcher

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import HeroSection from "@/components/landing/HeroSection";
 import TestimonialsSection from "@/components/landing/TestimonialsSection";
 import FeatureGrid from "@/components/landing/FeatureGrid";
 import CTASection from "@/components/landing/CTASection";
+import VipPriceSwitcher from "@/components/landing/VipPriceSwitcher";
 import { Award, Crown, Target, DollarSign, TrendingUp, Zap, CheckCircle, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -91,7 +92,8 @@ const Landing = () => {
               </p>
             </div>
           </MotionScrollReveal>
-          
+
+          <VipPriceSwitcher />
           <LivePlansSection showPromo={true} showHeader={false} />
         </div>
       </section>

--- a/src/components/landing/VipPriceSwitcher.tsx
+++ b/src/components/landing/VipPriceSwitcher.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+
+const VipPriceSwitcher = () => {
+  const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
+
+  return (
+    <section className="mb-10">
+      <div className="flex justify-center gap-4 mb-4">
+        <Button
+          variant={billing === 'monthly' ? 'default' : 'outline'}
+          onClick={() => setBilling('monthly')}
+          disabled={billing === 'monthly'}
+        >
+          Monthly
+        </Button>
+        <Button
+          variant={billing === 'annual' ? 'default' : 'outline'}
+          onClick={() => setBilling('annual')}
+          disabled={billing === 'annual'}
+        >
+          Annual
+        </Button>
+      </div>
+      <div className="text-3xl font-bold text-center">
+        <AnimatePresence mode="wait">
+          {billing === 'monthly' ? (
+            <motion.span
+              key="monthly"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.2 }}
+            >
+              $49 / mo
+            </motion.span>
+          ) : (
+            <motion.span
+              key="annual"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.2 }}
+            >
+              $480 / yr
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </div>
+    </section>
+  );
+};
+
+export default VipPriceSwitcher;


### PR DESCRIPTION
## Summary
- add framer-motion based VipPriceSwitcher component
- integrate price switcher into VIP plans section on landing page

## Testing
- `npm test` *(fails: sh: 1: deno: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf31bcfa2c83229674aa7be04fef87