### PR TITLE
chore: remove vite remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ graph TD
 **These areas are safe for UI improvements:**
 
 - **React Components**: All files in `src/components/`
-- **Pages**: All files in `src/pages/`
+- **Pages**: All files in `app/`
 - **Styling**: `src/index.css`, `tailwind.config.ts`
 - **UI Library**: `src/components/ui/`
 - **Hooks**: `src/hooks/` (UI-related only)

--- a/docs/INVENTORY.csv
+++ b/docs/INVENTORY.csv
@@ -2,7 +2,6 @@ path,size_bytes,ext,loc
 .env.example,362,example,16
 tsconfig.json,381,json,19
 .denoignore,123,denoignore,13
-vite.config.ts,471,ts,22
 deno.json,707,json,20
 supabase/functions/test-bot-status/index.ts,2175,ts,74
 supabase/functions/telegram-getwebhook/index.ts,1116,ts,37
@@ -145,7 +144,6 @@ src/utils/config.ts,5173,ts,196
 src/utils/retry.ts,370,ts,14
 src/utils/cache.ts,2050,ts,96
 src/utils/http-ca.ts,212,ts,7
-src/vite-env.d.ts,38,ts,1
 src/pages/RefreshBot.tsx,1666,tsx,61
 src/pages/Auth.tsx,718,tsx,30
 src/pages/Index.tsx,232,tsx,13

--- a/docs/WRAPPERS_INTEGRATION.md
+++ b/docs/WRAPPERS_INTEGRATION.md
@@ -43,7 +43,7 @@ CREATE FOREIGN TABLE s3_files (
 
 ## Application Usage
 
-Wrapper-backed tables can be queried from both the Vite React app and the Telegram bot. Helper functions are provided in `src/integrations/wrappers/queries.ts`:
+Wrapper-backed tables can be queried from both the Next.js app and the Telegram bot. Helper functions are provided in `src/integrations/wrappers/queries.ts`:
 
 ```ts
 import { getRedisSession, getAuth0User, listS3Files } from "@/integrations/wrappers";

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -242,7 +242,7 @@ This integration enhances the development experience by combining the power of A
 **These areas are designed for UI improvements:**
 
 - **React Components**: All files in `src/components/`
-- **Pages & Routing**: `src/pages/` directory
+- **Pages & Routing**: `app/` directory (Next.js App Router)
 - **Styling & Theming**: `src/index.css`, `tailwind.config.ts`
 - **UI Component Library**: `src/components/ui/`
 - **Frontend Hooks**: `src/hooks/` (UI state only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "dynamic-chatty-bot",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite_react_shadcn_ts",
+      "name": "dynamic-chatty-bot",
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "dynamic-chatty-bot",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -72,7 +72,6 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
   const extra = new Set(opts.extraFiles ?? [
     "/favicon.svg",
     "/favicon.ico",
-    "/vite.svg",
     "/site.webmanifest",
     "/robots.txt",
   ]);

--- a/supabase/functions/github-cleanup/index.ts
+++ b/supabase/functions/github-cleanup/index.ts
@@ -148,8 +148,6 @@ async function identifyUnusedFiles(): Promise<string[]> {
     
     // Unused components
     'src/components/welcome/WelcomeMessage.tsx', // If not used in main app
-    'src/pages/NotFound.tsx', // If using a different 404 page
-    'src/pages/RefreshBot.tsx', // If functionality moved
     
     // Redundant scripts
     'scripts/audit/**', // If automated
@@ -192,11 +190,10 @@ async function getCleanupStatus(supabase: any) {
 const RECOMMENDED_STRUCTURE = {
   keep: [
     // Core application files
-    'src/App.tsx',
-    'src/main.tsx',
+    'app/**',
     'src/index.css',
     'tailwind.config.ts',
-    'vite.config.ts',
+    'next.config.mjs',
     'tsconfig.json',
     'package.json',
     
@@ -206,12 +203,9 @@ const RECOMMENDED_STRUCTURE = {
     'src/components/navigation/**', // Navigation
     'src/components/admin/ContactInfo.tsx', // Active admin components
     
-    // Essential pages
-    'src/pages/Index.tsx',
-    'src/pages/Contact.tsx',
-    'src/pages/Plans.tsx',
-    'src/pages/Checkout.tsx',
-    'src/pages/AdminDashboard.tsx',
+    // App router pages
+    'app/page.tsx',
+    'app/**/page.tsx',
     
     // Core hooks and utilities
     'src/hooks/**',
@@ -232,9 +226,6 @@ const RECOMMENDED_STRUCTURE = {
   remove: [
     // Duplicate or old components
     'src/components/admin/BotDebugger.tsx', // If functionality moved
-    'src/pages/BuildMiniApp.tsx', // If not used
-    'src/pages/UploadMiniApp.tsx', // If not used
-    'src/pages/MiniAppDemo.tsx', // If demo not needed
     
     // Development-only files
     'scripts/audit/**',


### PR DESCRIPTION
## Summary
- rename project to `dynamic-chatty-bot`
- update docs and cleanup script for Next.js app router
- drop stale Vite references and icon

## Testing
- `npm test` *(fails: Relative import path "mime-types" not prefixed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3c858f508322b74b9c5956623a87