### PR TITLE
feat: add cookie management utilities

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { token } = await req.json();
+  const res = NextResponse.json({ ok: true });
+  if (token) {
+    res.cookies.set('sb:token', token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    });
+  }
+  return res;
+}
+
+export async function DELETE() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set('sb:token', '', {
+    path: '/',
+    maxAge: 0,
+  });
+  return res;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 import './globals.css';
+import { cookies } from 'next/headers';
+import CookieConsent from '@/components/CookieConsent';
 
 export const metadata = {
   title: 'Dynamic Capital VIP',
@@ -7,9 +9,13 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const theme = cookies().get('theme')?.value;
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" className={theme === 'dark' ? 'dark' : ''}>
+      <body>
+        {children}
+        <CookieConsent />
+      </body>
     </html>
   );
 }

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )cookie_consent=([^;]+)/);
+    if (!match) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    document.cookie = `cookie_consent=true; path=/; max-age=${60 * 60 * 24 * 365}`;
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-gray-800 text-white p-4 text-center z-50">
+      <span>We use cookies to enhance your experience.</span>
+      <button onClick={accept} className="ml-2 underline">
+        Accept
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -45,6 +45,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setSession(session);
         setUser(session?.user ?? null);
 
+        if (typeof window !== 'undefined') {
+          if (session?.access_token) {
+            fetch('/api/auth', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token: session.access_token }),
+            });
+          } else {
+            fetch('/api/auth', { method: 'DELETE' });
+          }
+        }
+
         setLoading(false);
       },
     );

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -40,7 +40,8 @@ export function useTheme() {
       }
 
       if (!tg) {
-        const stored = localStorage.getItem('theme') as Theme;
+        const match = document.cookie.match(/(?:^|; )theme=([^;]+)/);
+        const stored = match ? (decodeURIComponent(match[1]) as Theme) : null;
         setTheme(stored || 'system');
       } else {
         setTheme('system');
@@ -113,7 +114,7 @@ export function useTheme() {
       }
     } else if (!tg) {
       try {
-        localStorage.setItem('theme', newTheme);
+        document.cookie = `theme=${newTheme}; path=/; max-age=${60 * 60 * 24 * 365}`;
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Summary
- set and clear Supabase session token cookies through an API route
- persist theme preference and apply on the server
- add basic cookie consent banner

## Testing
- `npm test` *(fails: Relative import path "mime-types" not prefixed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf4025e1c083228bbe7fb4d4959ca0