### PR TITLE
fix: read env vars from import meta

### DIFF
--- a/shared/supabase-client.ts
+++ b/shared/supabase-client.ts
@@ -2,14 +2,25 @@ import { createClient as createSupabaseClient, type SupabaseClient as SBClient }
 import type { Database } from "../types/supabase.ts";
 
 function getEnvVar(name: string): string | undefined {
+  const prefixes = ["", "NEXT_PUBLIC_", "VITE_", "REACT_APP_"];
   if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
-    const v = Deno.env.get(name);
-    if (v) return v;
+    for (const p of prefixes) {
+      const v = Deno.env.get(`${p}${name}`);
+      if (v) return v;
+    }
   }
   if (typeof process !== "undefined" && typeof process.env !== "undefined") {
-    if (process.env[name]) return process.env[name];
-    const nextKey = `NEXT_PUBLIC_${name}`;
-    if (process.env[nextKey]) return process.env[nextKey];
+    for (const p of prefixes) {
+      const v = process.env[`${p}${name}`];
+      if (v) return v;
+    }
+  }
+  if (typeof import.meta !== "undefined" && (import.meta as any).env) {
+    const env = (import.meta as any).env as Record<string, string | undefined>;
+    for (const p of prefixes) {
+      const v = env[`${p}${name}`];
+      if (v) return v;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- support env vars from `import.meta.env` including Vite and React prefixes
- expand prefix lookup to `NEXT_PUBLIC_`, `VITE_`, and `REACT_APP_` across all runtime sources

## Testing
- `npm test` *(fails: 39 passed, 11 failed)*
- `deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev -A --no-check tests/missing-env-screen.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf48cb0cd883229b2a1ef9d1e52fa6