### PR TITLE
Notify users on payment review and receipt OCR

### DIFF
--- a/scripts/setup-db-webhooks.ts
+++ b/scripts/setup-db-webhooks.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env
+/**
+ * Registers database webhooks so Supabase can trigger edge functions when
+ * payments or receipts change.
+ *
+ * Required env vars:
+ *   SUPABASE_PROJECT_ID   - Project reference, e.g. abcdefghijklmnop
+ *   SUPABASE_ACCESS_TOKEN - Personal access token with project write access
+ *
+ * Optional env vars:
+ *   FUNCTIONS_BASE_URL    - Override functions base URL
+ */
+
+const project = Deno.env.get("SUPABASE_PROJECT_ID");
+const accessToken = Deno.env.get("SUPABASE_ACCESS_TOKEN");
+if (!project) throw new Error("SUPABASE_PROJECT_ID missing");
+if (!accessToken) throw new Error("SUPABASE_ACCESS_TOKEN missing");
+
+const funcBase = Deno.env.get("FUNCTIONS_BASE_URL") ?? `https://${project}.functions.supabase.co`;
+
+const hooks = [
+  {
+    name: "payments-auto-review",
+    table: "payments",
+    events: ["INSERT"],
+    url: `${funcBase}/payments-auto-review`,
+  },
+  {
+    name: "receipt-ocr",
+    table: "receipts",
+    events: ["INSERT", "UPDATE"],
+    url: `${funcBase}/receipt-ocr`,
+  },
+];
+
+for (const h of hooks) {
+  const body = {
+    name: h.name,
+    table: h.table,
+    schema: "public",
+    events: h.events,
+    url: h.url,
+    enabled: true,
+  };
+  const resp = await fetch(
+    `https://api.supabase.com/v1/projects/${project}/database/webhooks`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  const txt = await resp.text();
+  console.log(h.name, resp.status, txt);
+}


### PR DESCRIPTION
## Summary
- Send Telegram status messages during payment auto-review, including OCR queueing, approval, and manual review paths
- Notify users when receipt OCR completes with amount and confidence details
- Add script to register database webhooks for payments and receipts

## Testing
- `npm test` *(fails: sh: 1: deno: not found)*
- `npx -y @deno/cli deno test --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev -A --no-check` *(fails: npm ERR! 404 '@deno/cli@*' is not in this registry)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4eec91348322869af80c4de761f1