### PR TITLE
feat: export default handler in edge functions

### DIFF
--- a/supabase/functions/active-promos/index.ts
+++ b/supabase/functions/active-promos/index.ts
@@ -63,3 +63,4 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+export default handler;

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -74,3 +74,4 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+export default handler;

--- a/supabase/functions/analytics-collector/index.ts
+++ b/supabase/functions/analytics-collector/index.ts
@@ -91,3 +91,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/broadcast-dispatch/index.ts
+++ b/supabase/functions/broadcast-dispatch/index.ts
@@ -85,3 +85,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/checkout-init/index.ts
+++ b/supabase/functions/checkout-init/index.ts
@@ -163,3 +163,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/content-batch/index.ts
+++ b/supabase/functions/content-batch/index.ts
@@ -82,3 +82,4 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+export default handler;

--- a/supabase/functions/funnel-track/index.ts
+++ b/supabase/functions/funnel-track/index.ts
@@ -36,3 +36,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/keep-alive/index.ts
+++ b/supabase/functions/keep-alive/index.ts
@@ -82,3 +82,5 @@ addEventListener("beforeunload", () => {
   stopKeepAlive();
   baseLogger.info("Keep-alive service stopped");
 });
+
+export default handler;

--- a/supabase/functions/miniapp-deposit/index.ts
+++ b/supabase/functions/miniapp-deposit/index.ts
@@ -19,3 +19,5 @@ export async function handler(req: Request): Promise<Response> {
 if (import.meta.main) {
   Deno.serve(handler);
 }
+
+export default handler;

--- a/supabase/functions/miniapp-smoke/index.ts
+++ b/supabase/functions/miniapp-smoke/index.ts
@@ -90,3 +90,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -35,7 +35,7 @@ function num(x: unknown) {
   return isFinite(n) ? n : null;
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   try {
     const url = new URL(req.url);
     if (req.method === "GET" && url.pathname.endsWith("/version")) {
@@ -159,4 +159,8 @@ serve(async (req) => {
   } catch (e) {
     return oops("Internal Error", String(e));
   }
-});
+}
+
+if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/plans/index.ts
+++ b/supabase/functions/plans/index.ts
@@ -53,3 +53,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/promo-validate/index.ts
+++ b/supabase/functions/promo-validate/index.ts
@@ -131,3 +131,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/receipt-upload-url/index.ts
+++ b/supabase/functions/receipt-upload-url/index.ts
@@ -101,3 +101,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/referral-link/index.ts
+++ b/supabase/functions/referral-link/index.ts
@@ -24,3 +24,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/setup-telegram-webhook/index.ts
+++ b/supabase/functions/setup-telegram-webhook/index.ts
@@ -98,3 +98,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/setup-webhook-helper/index.ts
+++ b/supabase/functions/setup-webhook-helper/index.ts
@@ -74,3 +74,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/setup-webhook/index.ts
+++ b/supabase/functions/setup-webhook/index.ts
@@ -102,3 +102,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -180,3 +180,5 @@ export async function handler(req: Request): Promise<Response> {
 
 Deno.serve(handler);
 
+
+export default handler;

--- a/supabase/functions/telegram-webhook-keeper/index.ts
+++ b/supabase/functions/telegram-webhook-keeper/index.ts
@@ -114,3 +114,5 @@ export async function handler(req: Request): Promise<Response> {
 if (import.meta.main) {
   Deno.serve(handler);
 }
+
+export default handler;

--- a/supabase/functions/theme-get/index.ts
+++ b/supabase/functions/theme-get/index.ts
@@ -12,7 +12,7 @@ function parseToken(bearer: string | undefined) {
   }
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   const uid = parseToken(req.headers.get("authorization") || "");
   if (!uid) {
     return new Response(JSON.stringify({ ok: false, error: "unauthorized" }), {
@@ -24,5 +24,9 @@ serve(async (req) => {
   return new Response(JSON.stringify({ mode }), {
     headers: { "content-type": "application/json" },
   });
-});
+}
+
+if (import.meta.main) serve(handler);
+
+export default handler;
 // <<< DC BLOCK: theme-get-core (end)

--- a/supabase/functions/theme-save/index.ts
+++ b/supabase/functions/theme-save/index.ts
@@ -12,7 +12,7 @@ function parseToken(bearer: string | undefined) {
   }
 }
 
-serve(async (req) => {
+export async function handler(req: Request): Promise<Response> {
   const uid = parseToken(req.headers.get("authorization") || "");
   if (!uid) {
     return new Response(JSON.stringify({ ok: false, error: "unauthorized" }), {
@@ -59,5 +59,9 @@ serve(async (req) => {
       status: 500,
     });
   }
-});
+}
+
+if (import.meta.main) serve(handler);
+
+export default handler;
 // <<< DC BLOCK: theme-save-core (end)

--- a/supabase/functions/trade-helper/index.ts
+++ b/supabase/functions/trade-helper/index.ts
@@ -120,3 +120,5 @@ Remember to keep this educational and include proper risk disclaimers.`;
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;

--- a/supabase/functions/verify-initdata/index.ts
+++ b/supabase/functions/verify-initdata/index.ts
@@ -49,3 +49,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 serve(handler);
+
+export default handler;

--- a/supabase/functions/web-app-health/index.ts
+++ b/supabase/functions/web-app-health/index.ts
@@ -154,3 +154,4 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+export default handler;


### PR DESCRIPTION
## Summary
- expose explicit handler and default export for theme save and get functions
- wrap payments-auto-review logic in exported handler
- add default handler exports across edge functions including trade-helper and others

## Testing
- `npm test` *(fails: start command includes Mini App button when env present; start command includes Mini App button when env missing; telegram-bot rejects requests without secret; telegram-bot accepts valid secret; telegram-bot /version endpoint; callback edits message instead of sending new one; resolveTargets accepts array; resolveTargets accepts object with userIds; ./tests/main-menu.test.ts (uncaught error); ./tests/miniapp-edge-host-routing.test.ts (uncaught error); sendMiniAppOrBotOptions uses nav:plans callback)*


------
https://chatgpt.com/codex/tasks/task_e_68bf5270e5d48322a56285046d615de9