### PR TITLE
Improve Telegram init verification and webhook maintenance

### DIFF
--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-nocheck
 import { createClient } from "./client.ts";
 
 // In-memory fallback map when kv_config table is unavailable

--- a/supabase/functions/_shared/telegram_init.ts
+++ b/supabase/functions/_shared/telegram_init.ts
@@ -17,11 +17,11 @@ async function importKey(token: string) {
   );
 }
 
-export async function verifyTelegramInitData(
+export async function verifyInitData(
   initData: string,
   windowSec = 900,
   token = getEnv("TELEGRAM_BOT_TOKEN"),
-) {
+): Promise<boolean> {
   if (!initData) return false;
   const key = await importKey(token);
   const params = new URLSearchParams(initData);
@@ -39,3 +39,6 @@ export async function verifyTelegramInitData(
   const age = Math.floor(Date.now() / 1000) - auth;
   return !(windowSec > 0 && (isNaN(auth) || age > windowSec));
 }
+
+// Backwards compatibility export
+export { verifyInitData as verifyTelegramInitData };

--- a/supabase/functions/checkout-init/index.ts
+++ b/supabase/functions/checkout-init/index.ts
@@ -4,7 +4,7 @@ import { getEnv } from "../_shared/env.ts";
 import { bad, mna, ok, oops, json } from "../_shared/http.ts";
 import { createClient as createSupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { version } from "../_shared/version.ts";
-import { verifyTelegramInitData } from "../_shared/telegram_verification.ts";
+import { verifyInitData } from "../_shared/telegram_init.ts";
 import { getContent } from "../_shared/config.ts";
 
 const corsHeaders = {
@@ -69,7 +69,7 @@ export async function handler(req: Request): Promise<Response> {
   // If no auth header, try Telegram initData verification
   if (!telegramId && body.initData) {
     try {
-      const valid = await verifyTelegramInitData(body.initData);
+      const valid = await verifyInitData(body.initData);
       if (valid) {
         const params = new URLSearchParams(body.initData);
         const user = JSON.parse(params.get("user") || "{}");

--- a/supabase/functions/cleanup-old-webhook-updates/index.ts
+++ b/supabase/functions/cleanup-old-webhook-updates/index.ts
@@ -1,0 +1,35 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "../_shared/client.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+  try {
+    const supabase = createClient("service");
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const { error, count } = await supabase
+      .from("webhook_updates")
+      .delete({ count: "exact" })
+      .lt("created_at", cutoff);
+    if (error) throw error;
+    return new Response(
+      JSON.stringify({ success: true, deleted: count ?? 0 }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ success: false, error: String(err) }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+});

--- a/supabase/functions/receipt-upload-url/index.ts
+++ b/supabase/functions/receipt-upload-url/index.ts
@@ -4,7 +4,7 @@ import { getEnv } from "../_shared/env.ts";
 import { bad, mna, ok, oops, json } from "../_shared/http.ts";
 import { version } from "../_shared/version.ts";
 import { createClient as createSupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { verifyTelegramInitData } from "../_shared/telegram_verification.ts";
+import { verifyInitData } from "../_shared/telegram_init.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -56,7 +56,7 @@ export async function handler(req: Request): Promise<Response> {
   // If no auth header, try Telegram initData verification
   if (!telegramId && body.initData) {
     try {
-      const valid = await verifyTelegramInitData(body.initData);
+      const valid = await verifyInitData(body.initData);
       if (valid) {
         const params = new URLSearchParams(body.initData);
         const user = JSON.parse(params.get("user") || "{}");

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -45,11 +45,21 @@ async function sendMessage(
     return;
   }
   try {
-    await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, text, ...extra }),
-    });
+    const resp = await fetch(
+      `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text, ...extra }),
+      },
+    );
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      baseLogger.error("sendMessage failed", {
+        status: resp.status,
+        body,
+      });
+    }
   } catch (err) {
     baseLogger.error("sendMessage error", err);
   }

--- a/supabase/functions/verify-initdata/index.ts
+++ b/supabase/functions/verify-initdata/index.ts
@@ -1,50 +1,11 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { bad, ok } from "../_shared/http.ts";
-import { getEnv } from "../_shared/env.ts";
-
-function toHex(buf: ArrayBuffer) {
-  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-async function importKey(token: string) {
-  const e = new TextEncoder();
-  const s = await crypto.subtle.digest("SHA-256", e.encode(token));
-  return crypto.subtle.importKey(
-    "raw",
-    s,
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-}
-
-export async function verifyFromRaw(
-  initData: string,
-  windowSec = 900,
-  token = getEnv("TELEGRAM_BOT_TOKEN"),
-) {
-  if (!initData) return false;
-  const key = await importKey(token);
-  const params = new URLSearchParams(initData);
-  const hash = params.get("hash") || "";
-  params.delete("hash");
-  const dcs = Array.from(params.entries()).map(([k, v]) => `${k}=${v}`).sort()
-    .join("\n");
-  const sig = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(dcs),
-  );
-  if (toHex(sig) !== hash) return false;
-  const auth = Number(params.get("auth_date") || "0");
-  const age = Math.floor(Date.now() / 1000) - auth;
-  return !(windowSec > 0 && (isNaN(auth) || age > windowSec));
-}
+import { verifyInitData } from "../_shared/telegram_init.ts";
 
 export async function handler(req: Request): Promise<Response> {
   if (req.method !== "POST") return bad("Use POST");
   const { initData } = await req.json().catch(() => ({}));
-  const passed = await verifyFromRaw(initData || "");
+  const passed = await verifyInitData(initData || "");
   return ok({ ok: passed });
 }
 


### PR DESCRIPTION
## Summary
- centralize Telegram initData HMAC validation and reuse in edge functions
- enforce auth_date freshness when issuing sessions
- log Telegram sendMessage failures and add webhook update cleanup cron

## Testing
- `deno check --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org supabase/functions/tg-verify-init/index.ts`
- `deno check --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org supabase/functions/telegram-webhook/index.ts`
- `deno check --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org supabase/functions/verify-initdata/index.ts`
- `deno check --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org supabase/functions/cleanup-old-webhook-updates/index.ts`
- `deno check --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org supabase/functions/_shared/config.ts`
- `npm test` *(fails: start command includes Mini App button when env present, start command includes Mini App button when env missing, telegram-bot rejects requests without secret, telegram-bot accepts valid secret, telegram-bot /version endpoint, telegram_init_ttl_test.ts, verify_initdata_test.ts, callback edits message instead of sending new one, resolveTargets accepts array, resolveTargets accepts object with userIds, main-menu.test.ts, miniapp-edge-host-routing.test.ts, sendMiniAppOrBotOptions uses nav:plans callback)*

------
https://chatgpt.com/codex/tasks/task_e_68bf530b04e08322b5c2ea359874ddca