### PR TITLE
Document admin secret and add auto-review version test

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -14,6 +14,7 @@ below.
 | SUPABASE_DB_PASSWORD      | ✅                           | ✅                               | ✅                          |
 | TELEGRAM_BOT_TOKEN        | ✅                           | ✅                               | ❌                          |
 | TELEGRAM_WEBHOOK_SECRET   | ✅                           | ✅                               | ❌                          |
+| ADMIN_API_SECRET          | ✅                           | ✅                               | ❌                          |
 | BENEFICIARY_TABLE         | ✅                           | ✅                               | ❌                          |
 | OPENAI_API_KEY            | ✅                           | ✅                               | ❌                          |
 | OPENAI_ENABLED            | ✅                           | ✅                               | ❌                          |

--- a/supabase/functions/_tests/payments-auto-review-version.test.ts
+++ b/supabase/functions/_tests/payments-auto-review-version.test.ts
@@ -1,0 +1,10 @@
+import { assertEquals, assert } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import handler from "../payments-auto-review/index.ts";
+
+Deno.test("payments-auto-review exposes version", async () => {
+  const res = await handler(new Request("https://example.com/version", { method: "GET" }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.name, "payments-auto-review");
+  assert(typeof body.ts === "string" && body.ts.length > 0);
+});


### PR DESCRIPTION
## Summary
- document `ADMIN_API_SECRET` in configuration table
- add a unit test ensuring `payments-auto-review` exposes its version endpoint

## Testing
- `~/.deno/bin/deno test supabase/functions/_tests/payments-auto-review-version.test.ts --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org -A --no-check`

------
https://chatgpt.com/codex/tasks/task_e_68bfd92271f483229472eb41e1f80baf