### PR TITLE
docs: add sample Supabase env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 ## Core runtime secrets required by edge functions
-SUPABASE_URL=
-SUPABASE_SERVICE_ROLE_KEY=
+# Base URL of your Supabase project
+SUPABASE_URL=https://your-project.supabase.co
+# Service role key for privileged Supabase access
+SUPABASE_SERVICE_ROLE_KEY=service-role-key
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 # Signs admin JWTs for privileged endpoints
@@ -14,7 +16,7 @@ MINI_APP_URL=
 
 ## Additional Supabase credentials
 # Public anon key for client-side calls
-SUPABASE_ANON_KEY=
+SUPABASE_ANON_KEY=public-anon-key
 SUPABASE_PROJECT_ID=
 SUPABASE_ACCESS_TOKEN=
 SUPABASE_DB_PASSWORD=
@@ -34,8 +36,8 @@ WINDOW_SECONDS=
 AMOUNT_TOLERANCE=
 
 ## Frontend environment variables
-NEXT_PUBLIC_SUPABASE_URL=
-NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=public-anon-key
 TELEGRAM_BOT_USERNAME=
 MINI_APP_SHORT_NAME=
 NEXT_PUBLIC_TELEGRAM_WEBHOOK_SECRET=


### PR DESCRIPTION
## Summary
- add placeholder Supabase URL and keys to `.env.example`

## Testing
- `npm test` *(fails: Failed reading lockfile - unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdd8a98808322bd73b78490883aa0