### PR TITLE
use service client for storage

### DIFF
--- a/supabase/functions/cleanup-old-receipts/index.ts
+++ b/supabase/functions/cleanup-old-receipts/index.ts
@@ -22,7 +22,7 @@ serve(async (req) => {
   try {
     logStep("Cleanup job started");
 
-    const supabaseClient = createClient();
+    const supabaseClient = createClient("service");
 
     // Calculate date 30 days ago
     const thirtyDaysAgo = new Date();

--- a/supabase/functions/receipt-upload-url/index.ts
+++ b/supabase/functions/receipt-upload-url/index.ts
@@ -78,7 +78,7 @@ export async function handler(req: Request): Promise<Response> {
     return json({ error: "unauthorized" }, 401, corsHeaders);
   }
 
-  const supa = createClient();
+  const supa = createClient("service");
 
   // Generate unique file path
   const timestamp = Date.now();

--- a/supabase/functions/receipt/index.ts
+++ b/supabase/functions/receipt/index.ts
@@ -18,7 +18,7 @@ serve(async (req) => {
     if (!(file instanceof File)) return bad("image required");
     let supa;
     try {
-      supa = createClient();
+      supa = createClient("service");
     } catch (_) {
       supa = null;
     }
@@ -40,7 +40,7 @@ serve(async (req) => {
     if (!u || !isAdmin(u.id)) return unauth();
     let supa;
     try {
-      supa = createClient();
+      supa = createClient("service");
     } catch (_) {
       supa = null;
     }

--- a/supabase/functions/telegram-bot/admin-handlers/common.ts
+++ b/supabase/functions/telegram-bot/admin-handlers/common.ts
@@ -5,7 +5,7 @@ const { TELEGRAM_BOT_TOKEN: BOT_TOKEN } = requireEnv([
   "TELEGRAM_BOT_TOKEN",
 ] as const);
 
-export const supabaseAdmin = createClient();
+export const supabaseAdmin = createClient("service");
 
 let currentMessageId: number | null = null;
 

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -1,7 +1,7 @@
 // Database utility functions for the Telegram bot
 import { createClient } from "../_shared/client.ts";
 
-const supabaseAdmin = createClient();
+const supabaseAdmin = createClient("service");
 
 interface VipPackage {
   id: string;

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -95,7 +95,7 @@ function getSupabase(): SupabaseClient | null {
   if (supabaseAdmin) return supabaseAdmin;
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return null;
   try {
-    supabaseAdmin = createClient();
+    supabaseAdmin = createClient("service");
   } catch (_e) {
     supabaseAdmin = null;
   }


### PR DESCRIPTION
## Summary
- ensure receipt and cleanup edge functions use service-key Supabase client
- switch receipt upload helpers and Telegram bot utilities to service client for storage operations

## Testing
- `npm test` *(fails: deno not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdd924f68832281bd7e6df9cfb3d7