### PR TITLE
Add receipt upload retries and manual review notifications

### DIFF
--- a/src/components/admin/PaymentReview.tsx
+++ b/src/components/admin/PaymentReview.tsx
@@ -81,13 +81,15 @@ export function PaymentReview() {
   const handlePaymentAction = async (paymentId: string, action: 'approve' | 'reject', notes?: string) => {
     try {
       setProcessing(paymentId);
-      
-      const { data, error } = await callEdgeFunction('ADMIN_ACT_ON_PAYMENT', {
+      const { data: { user } } = await supabase.auth.getUser();
+
+      const { data, error } = await callEdgeFunction('ADMIN_REVIEW_PAYMENT', {
         method: 'POST',
         body: {
           payment_id: paymentId,
-          action,
-          notes
+          decision: action,
+          notes,
+          admin_telegram_id: user?.user_metadata?.telegram_id
         }
       });
 
@@ -95,7 +97,7 @@ export function PaymentReview() {
         throw new Error(error.message);
       }
 
-      if ((data as any)?.ok) {
+      if ((data as any)?.status) {
         toast.success(`Payment ${action}d successfully`);
         fetchPayments();
         setSelectedPayment(null);

--- a/src/components/checkout/ReceiptUpload.tsx
+++ b/src/components/checkout/ReceiptUpload.tsx
@@ -2,16 +2,20 @@ import React from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Upload, Loader2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Upload, Loader2, CheckCircle, AlertCircle } from "lucide-react";
 
 interface ReceiptUploadProps {
   uploadedFile: File | null;
   setUploadedFile: (file: File | null) => void;
   handleFileUpload: () => void;
   uploading: boolean;
+  uploadStatus: 'idle' | 'success' | 'error';
+  handleRetry: () => void;
+  retrying: boolean;
 }
 
-export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({ uploadedFile, setUploadedFile, handleFileUpload, uploading }) => (
+export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({ uploadedFile, setUploadedFile, handleFileUpload, uploading, uploadStatus, handleRetry, retrying }) => (
   <Card>
     <CardHeader>
       <CardTitle className="flex items-center gap-2">
@@ -36,14 +40,43 @@ export const ReceiptUpload: React.FC<ReceiptUploadProps> = ({ uploadedFile, setU
         </div>
       )}
 
-      <Button onClick={handleFileUpload} disabled={!uploadedFile || uploading} className="w-full">
-        {uploading ? (
-          <Loader2 className="h-4 w-4 animate-spin mr-2" />
-        ) : (
-          <Upload className="h-4 w-4 mr-2" />
-        )}
-        {uploading ? "Uploading..." : "Submit Receipt"}
-      </Button>
+      {uploadStatus === 'success' && (
+        <Alert className="border-green-500/20 bg-green-500/10">
+          <CheckCircle className="h-4 w-4 text-green-600" />
+          <AlertDescription className="text-green-600">
+            Receipt uploaded successfully! Your payment is being reviewed.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {uploadStatus === 'error' && (
+        <Alert className="border-dc-brand/20 bg-dc-brand/10">
+          <AlertCircle className="h-4 w-4 text-dc-brand-dark" />
+          <AlertDescription className="text-dc-brand-dark">
+            Upload failed. Please try again.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {uploadStatus === 'error' ? (
+        <Button onClick={handleRetry} disabled={retrying || uploading || !uploadedFile} className="w-full" variant="outline">
+          {retrying ? (
+            <Loader2 className="h-4 w-4 animate-spin mr-2" />
+          ) : (
+            <Upload className="h-4 w-4 mr-2" />
+          )}
+          {retrying ? 'Retrying...' : 'Retry Upload'}
+        </Button>
+      ) : (
+        <Button onClick={handleFileUpload} disabled={!uploadedFile || uploading} className="w-full">
+          {uploading ? (
+            <Loader2 className="h-4 w-4 animate-spin mr-2" />
+          ) : (
+            <Upload className="h-4 w-4 mr-2" />
+          )}
+          {uploading ? "Uploading..." : "Submit Receipt"}
+        </Button>
+      )}
     </CardContent>
   </Card>
 );

--- a/src/components/checkout/WebCheckout.tsx
+++ b/src/components/checkout/WebCheckout.tsx
@@ -45,6 +45,8 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
   const [bankAccounts, setBankAccounts] = useState<BankAccount[]>([]);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [retrying, setRetrying] = useState(false);
   const [isTelegram, setIsTelegram] = useState(false);
   const [telegramInitData, setTelegramInitData] = useState<string | null>(null);
   const [showReceipt, setShowReceipt] = useState(false);
@@ -178,6 +180,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
   const handleFileUpload = async () => {
     if (!uploadedFile || !paymentId) return;
     setUploading(true);
+    setUploadStatus('idle');
     try {
       const uploadRequestBody: any = {
         payment_id: paymentId,
@@ -218,12 +221,21 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
       });
       if (submitError) throw submitError;
       setCurrentStep("pending");
+      setUploadStatus('success');
       toast.success('Receipt uploaded successfully! Your payment is being reviewed.');
     } catch (error: any) {
+      setUploadStatus('error');
       toast.error(error.message || 'Failed to upload receipt');
     } finally {
       setUploading(false);
     }
+  };
+
+  const handleRetryUpload = async () => {
+    if (!uploadedFile) return;
+    setRetrying(true);
+    await handleFileUpload();
+    setRetrying(false);
   };
 
   const calculateFinalPrice = () => {
@@ -340,6 +352,9 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
                 setUploadedFile={setUploadedFile}
                 handleFileUpload={handleFileUpload}
                 uploading={uploading}
+                uploadStatus={uploadStatus}
+                handleRetry={handleRetryUpload}
+                retrying={retrying}
               />
             )}
 

--- a/src/components/receipts/PaymentStatus.tsx
+++ b/src/components/receipts/PaymentStatus.tsx
@@ -76,7 +76,8 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
 
       // Show uploader if payment is pending and no receipt uploaded yet
       const webhookData = data.webhook_data as any;
-      setShowUploader(data.status === 'pending' && !webhookData?.storage_path);
+      const needsResubmit = ['pending_review', 'failed'].includes(data.status);
+      setShowUploader((data.status === 'pending' && !webhookData?.storage_path) || needsResubmit);
     } catch (error: any) {
       toast.error(error.message || 'Failed to fetch payment status');
     } finally {
@@ -93,6 +94,7 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
       case 'completed':
         return <CheckCircle className="h-5 w-5 text-green-500" />;
       case 'pending':
+      case 'pending_review':
         return <Clock className="h-5 w-5 text-yellow-500" />;
       case 'failed':
         return <XCircle className="h-5 w-5 text-dc-brand" />;
@@ -107,6 +109,8 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
         return <Badge className="bg-green-500/10 text-green-600 border-green-500/20">Completed</Badge>;
       case 'pending':
         return <Badge className="bg-yellow-500/10 text-yellow-600 border-yellow-500/20">Pending Review</Badge>;
+      case 'pending_review':
+        return <Badge variant="outline">Manual Review</Badge>;
       case 'failed':
         return <Badge className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/20">Failed</Badge>;
       default:
@@ -197,10 +201,19 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
               <Clock className="h-4 w-4 text-yellow-600" />
               <AlertDescription className="text-yellow-600">
                 <strong>Payment Under Review</strong>
-                {payment.webhook_data?.storage_path 
+                {payment.webhook_data?.storage_path
                   ? ' Your receipt has been uploaded and is being processed.'
                   : ' Please upload your payment receipt to continue.'
                 }
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {payment.status === 'pending_review' && (
+            <Alert className="border-yellow-500/20 bg-yellow-500/10">
+              <Clock className="h-4 w-4 text-yellow-600" />
+              <AlertDescription className="text-yellow-600">
+                <strong>Manual Review Required</strong> Our team will check your payment. You may re-upload your receipt if needed.
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/receipts/ReceiptUploader.tsx
+++ b/src/components/receipts/ReceiptUploader.tsx
@@ -19,6 +19,7 @@ export const ReceiptUploader: React.FC<ReceiptUploaderProps> = ({
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadStatus, setUploadStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [retrying, setRetrying] = useState(false);
 
   const handleFileUpload = async () => {
     if (!uploadedFile || !paymentId) return;
@@ -81,6 +82,13 @@ export const ReceiptUploader: React.FC<ReceiptUploaderProps> = ({
     }
   };
 
+  const handleRetry = async () => {
+    if (!uploadedFile) return;
+    setRetrying(true);
+    await handleFileUpload();
+    setRetrying(false);
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -122,23 +130,39 @@ export const ReceiptUploader: React.FC<ReceiptUploaderProps> = ({
           <Alert className="border-dc-brand/20 bg-dc-brand/10">
             <AlertCircle className="h-4 w-4 text-dc-brand-dark" />
             <AlertDescription className="text-dc-brand-dark">
-              Upload failed. Please try again or contact support.
+              Upload failed. Please try again.
             </AlertDescription>
           </Alert>
         )}
 
-        <Button 
-          onClick={handleFileUpload}
-          disabled={!uploadedFile || uploading}
-          className="w-full"
-        >
-          {uploading ? (
-            <Loader2 className="h-4 w-4 animate-spin mr-2" />
-          ) : (
-            <Upload className="h-4 w-4 mr-2" />
-          )}
-          {uploading ? "Uploading..." : "Submit Receipt"}
-        </Button>
+        {uploadStatus === 'error' ? (
+          <Button
+            variant="outline"
+            onClick={handleRetry}
+            disabled={retrying || uploading || !uploadedFile}
+            className="w-full"
+          >
+            {retrying ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <Upload className="h-4 w-4 mr-2" />
+            )}
+            {retrying ? 'Retrying...' : 'Retry Upload'}
+          </Button>
+        ) : (
+          <Button
+            onClick={handleFileUpload}
+            disabled={!uploadedFile || uploading}
+            className="w-full"
+          >
+            {uploading ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <Upload className="h-4 w-4 mr-2" />
+            )}
+            {uploading ? "Uploading..." : "Submit Receipt"}
+          </Button>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -34,6 +34,7 @@ export const SUPABASE_CONFIG = {
     ADMIN_BANS: 'admin-bans',
     ADMIN_LOGS: 'admin-logs',
     ADMIN_ACT_ON_PAYMENT: 'admin-act-on-payment',
+    ADMIN_REVIEW_PAYMENT: 'admin-review-payment',
     ADMIN_LIST_PENDING: 'admin-list-pending',
     ADMIN_CHECK: 'admin-check',
 

--- a/supabase/functions/payments-auto-review/index.ts
+++ b/supabase/functions/payments-auto-review/index.ts
@@ -143,6 +143,29 @@ export async function handler(req: Request): Promise<Response> {
         results.push({ id: p.id, action: "completed", ok: okr.ok });
         await notify(p.user_id, "✅ Payment confirmed. Thank you!");
       } else {
+        await supa.from("payments").update({ status: "pending_review" }).eq("id", p.id);
+        await supa.from("admin_logs").insert({
+          admin_telegram_id: "system",
+          action_type: "manual_review_required",
+          action_description: `Payment ${p.id} requires manual review (${reason})`,
+          affected_table: "payments",
+          affected_record_id: p.id,
+        });
+
+        const { data: admins } = await supa.from("bot_users").select("telegram_id").eq("is_admin", true);
+        for (const a of admins || []) {
+          if (a.telegram_id && token) {
+            await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                chat_id: a.telegram_id,
+                text: `🚨 Payment ${p.id} requires manual review (${reason})`,
+              }),
+            }).catch(() => {});
+          }
+        }
+
         results.push({
           id: p.id,
           action: ocr ? `held_${reason}` : "waiting_ocr",

--- a/types/telegram-bot.ts
+++ b/types/telegram-bot.ts
@@ -486,6 +486,7 @@ export type DatabaseTable =
 export const PAYMENT_STATUSES = [
   "pending",
   "awaiting_admin",
+  "pending_review",
   "completed",
   "failed",
   "refunded",


### PR DESCRIPTION
## Summary
- add retry button for failed receipt uploads in checkout and status flows
- flag auto-review failures for manual admin review and notify admins
- switch admin payment review UI to `admin-review-payment` endpoint
- allow resubmission of receipts when payments need review or fail

## Testing
- `npm test` *(fails: deno: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bfe561d4908322965aa95c8fd9e6cb