### PR TITLE
chore: use Next.js ESLint recommended config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,19 +8,21 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   { ignores: ["dist", "tests/**", "**/vendor/**"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      nextPlugin.flatConfig.recommended,
+    ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      "@next/next": nextPlugin,
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
     },
     rules: {
-      ...nextPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": "off",
       "@typescript-eslint/no-unused-vars": "off",


### PR DESCRIPTION
## Summary
- extend ESLint with Next.js recommended rules
- drop manual spread of Next.js plugin rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bffffda3488322bb12113d25d28c07