### PR TITLE
refactor: harden auth flows

### DIFF
--- a/src/context/SupabaseProvider.tsx
+++ b/src/context/SupabaseProvider.tsx
@@ -13,12 +13,14 @@ export const SupabaseProvider = ({ children }: { children: React.ReactNode }) =>
   const [session, setSession] = useState<Session | null>(null);
 
   useEffect(() => {
-    // Load initial session
-    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setSession(session);
+      },
+    );
 
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-    });
+    // After the listener is ready, load the current session
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
 
     return () => {
       listener.subscription.unsubscribe();

--- a/src/hooks/useAdminAuth.tsx
+++ b/src/hooks/useAdminAuth.tsx
@@ -15,21 +15,27 @@ export function AdminAuthProvider({ children }: { children: React.ReactNode }) {
   const [isAdmin, setIsAdmin] = useState(false);
   const [isVip, setIsVip] = useState(false);
   const [loading, setLoading] = useState(true);
+  const isBrowser = typeof window !== 'undefined';
 
   useEffect(() => {
+    if (!isBrowser) {
+      setLoading(false);
+      return;
+    }
+
     // Check for existing admin status in localStorage or session
     const storedAdminStatus = localStorage.getItem('isAdmin');
     const storedVipStatus = localStorage.getItem('isVip');
-    
+
     if (storedAdminStatus) {
       setIsAdmin(JSON.parse(storedAdminStatus));
     }
     if (storedVipStatus) {
       setIsVip(JSON.parse(storedVipStatus));
     }
-    
+
     setLoading(false);
-  }, []);
+  }, [isBrowser]);
 
   const checkAdminStatus = async (telegramUserId?: string): Promise<boolean> => {
     if (!telegramUserId) return false;
@@ -41,7 +47,9 @@ export function AdminAuthProvider({ children }: { children: React.ReactNode }) {
 
       if (!adminError && adminData !== null) {
         setIsAdmin(adminData);
-        localStorage.setItem('isAdmin', JSON.stringify(adminData));
+        if (isBrowser) {
+          localStorage.setItem('isAdmin', JSON.stringify(adminData));
+        }
         return adminData;
       }
 
@@ -58,9 +66,11 @@ export function AdminAuthProvider({ children }: { children: React.ReactNode }) {
         
         setIsAdmin(adminStatus);
         setIsVip(vipStatus);
-        localStorage.setItem('isAdmin', JSON.stringify(adminStatus));
-        localStorage.setItem('isVip', JSON.stringify(vipStatus));
-        
+        if (isBrowser) {
+          localStorage.setItem('isAdmin', JSON.stringify(adminStatus));
+          localStorage.setItem('isVip', JSON.stringify(vipStatus));
+        }
+
         return adminStatus;
       }
 
@@ -92,8 +102,10 @@ export function AdminAuthProvider({ children }: { children: React.ReactNode }) {
       if (!error && data) {
         setIsAdmin(data.is_admin || false);
         setIsVip(data.is_vip || false);
-        localStorage.setItem('isAdmin', JSON.stringify(data.is_admin || false));
-        localStorage.setItem('isVip', JSON.stringify(data.is_vip || false));
+        if (isBrowser) {
+          localStorage.setItem('isAdmin', JSON.stringify(data.is_admin || false));
+          localStorage.setItem('isVip', JSON.stringify(data.is_vip || false));
+        }
         return true;
       }
 

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -30,8 +30,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const { data: profile } = useQuery({
     queryKey: ['profile', user?.id],
-    queryFn: () => getProfile(user!.id),
-    enabled: !!user,
+    queryFn: () => user ? getProfile(user.id) : Promise.resolve(null),
+    enabled: !!user?.id,
   });
 
   useEffect(() => {
@@ -65,7 +65,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     firstName?: string,
     lastName?: string,
   ) => {
-    const redirectUrl = `${globalThis.location.origin}/`;
+    const getRedirectUrl = () => {
+      if (typeof window !== 'undefined') {
+        return `${window.location.origin}/`;
+      }
+      return process.env.NEXT_PUBLIC_SITE_URL || undefined;
+    };
+    const redirectUrl = getRedirectUrl();
 
     const { error } = await supabase.auth.signUp({
       email,

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,11 +2,12 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-// Import the supabase client like this:
-// import { supabase } from "@/integrations/supabase/client";
+if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
+  throw new Error('Missing Supabase environment variables');
+}
 
 // When building in a non-browser environment (e.g. during SSR or in tests),
 // `localStorage` will not be defined. Guard access so bundling doesn't crash.

--- a/supabase/functions/verify-telegram/index.ts
+++ b/supabase/functions/verify-telegram/index.ts
@@ -105,7 +105,7 @@ async function verifyInitData(initData: string) {
   return { ok: true, user } as const;
 }
 
-Deno.serve(async (req) => {
+export default async function handler(req: Request) {
   const origin = req.headers.get("Origin");
   if (origin && !allowList.has(origin)) {
     return json({ ok: false, error: "Forbidden" }, 403);
@@ -138,4 +138,8 @@ Deno.serve(async (req) => {
     console.error("verify-telegram error", err);
     return withCors(oops("SERVER_ERROR", String(err)), origin);
   }
-});
+}
+
+if (import.meta.main) {
+  Deno.serve(handler);
+}


### PR DESCRIPTION
## Summary
- register Supabase auth listener before fetching initial session
- avoid profile lookup for null users and use env-safe redirect
- safeguard admin auth localStorage usage
- export verify-telegram handler and serve conditionally
- source Supabase client credentials from environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c06df15008832294dc47202435a373