### PR TITLE
Unify receipt submission flow

### DIFF
--- a/docs/PHASE_3_CHECKOUT.md
+++ b/docs/PHASE_3_CHECKOUT.md
@@ -9,3 +9,36 @@ This phase wires basic payment handling for the Mini App.
 5. **Admin approval** – A later phase will handle verifying receipts and activating plans.
 
 Receipts are stored in a private Supabase Storage bucket and are only uploaded through signed URLs. All sensitive operations (payment creation, signed uploads, linking receipts) happen on Edge functions using the service role key.
+
+## Receipt upload and submission APIs
+
+### `receipt-upload-url`
+
+Generates a signed URL for uploading a receipt file.
+
+- **Endpoint:** `POST /functions/v1/receipt-upload-url`
+- **Body:**
+  - `payment_id` – ID of the pending payment
+  - `filename` – original file name
+  - `content_type` – MIME type
+  - `initData` – Telegram WebApp `initData` (optional when running inside Telegram)
+- **Auth:**
+  - Supabase session via `Authorization` header, or
+  - Telegram `initData` passed in the body
+- **Response:** `{ bucket, file_path, upload_url }`
+
+### `receipt-submit`
+
+Links the uploaded file to the payment after the file is stored.
+
+- **Endpoint:** `POST /functions/v1/receipt-submit`
+- **Body:**
+  - `payment_id` – ID of the payment being confirmed
+  - `file_path` – path returned from `receipt-upload-url`
+  - `bucket` – storage bucket name (optional, defaults to `payment-receipts`)
+  - `initData` – Telegram WebApp `initData` (optional)
+- **Auth:** `Authorization` header or `initData` as above
+- **Success Response:** `{ ok: true, payment_id }`
+
+Both endpoints accept either a Supabase session (web login) or Telegram `initData` to resolve the user submitting the receipt.
+

--- a/src/components/checkout/WebCheckout.tsx
+++ b/src/components/checkout/WebCheckout.tsx
@@ -211,7 +211,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
       const submitRequestBody: any = {
         payment_id: paymentId,
         file_path: uploadData.file_path,
-        storage_bucket: uploadData.bucket
+        bucket: uploadData.bucket
       };
       if (isTelegram && telegramInitData) {
         submitRequestBody.initData = telegramInitData;

--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -1,6 +1,14 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
-import { corsHeaders, ok, bad, unauth, oops } from "../_shared/http.ts";
+import { ok, bad, unauth, oops } from "../_shared/http.ts";
+import { createClient as createSupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getEnv } from "../_shared/env.ts";
+import { verifyInitData } from "../_shared/telegram_init.ts";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
@@ -11,6 +19,25 @@ serve(async (req) => {
     return new Response("Method not allowed", { status: 405, headers: corsHeaders });
   }
 
+  // Attempt to identify user via Supabase session
+  const authHeader = req.headers.get("Authorization");
+  let telegramId: string | null = null;
+  if (authHeader) {
+    try {
+      const supaAuth = createSupabaseClient(
+        getEnv("SUPABASE_URL"),
+        getEnv("SUPABASE_ANON_KEY"),
+        { global: { headers: { Authorization: authHeader } }, auth: { persistSession: false } },
+      );
+      const { data: { user } } = await supaAuth.auth.getUser();
+      if (user) {
+        telegramId = user.user_metadata?.telegram_id || user.id;
+      }
+    } catch (e) {
+      console.warn("Auth check failed", e);
+    }
+  }
+
   let body;
   try {
     body = await req.json();
@@ -18,13 +45,35 @@ serve(async (req) => {
     return bad("Invalid JSON");
   }
 
-  const { telegram_id, payment_id, receipt_url, receipt_file_path } = body;
+  const { payment_id, file_path, bucket, initData, telegram_id } = body;
 
-  if (!telegram_id || !payment_id) {
+  // If no auth, try Telegram initData
+  if (!telegramId && initData) {
+    try {
+      const valid = await verifyInitData(initData);
+      if (valid) {
+        const params = new URLSearchParams(initData);
+        const user = JSON.parse(params.get("user") || "{}");
+        telegramId = String(user.id || "");
+      } else {
+        return unauth("Invalid Telegram initData");
+      }
+    } catch (err) {
+      console.error("Error verifying Telegram initData:", err);
+      return unauth("Telegram verification failed");
+    }
+  }
+
+  // Fallback to explicit telegram_id (e.g., from bot)
+  if (!telegramId && telegram_id) {
+    telegramId = String(telegram_id);
+  }
+
+  if (!payment_id || !file_path) {
     return bad("Missing required fields");
   }
 
-  console.log("Receipt submission:", { telegram_id, payment_id, receipt_url, receipt_file_path });
+  console.log("Receipt submission:", { telegramId, payment_id, file_path, bucket });
 
   const supa = createClient();
 
@@ -35,10 +84,10 @@ serve(async (req) => {
       .update({
         status: "pending",
         webhook_data: {
-          receipt_url,
-          receipt_file_path,
-          submitted_at: new Date().toISOString()
-        }
+          file_path,
+          bucket,
+          submitted_at: new Date().toISOString(),
+        },
       })
       .eq("id", payment_id);
 
@@ -47,17 +96,19 @@ serve(async (req) => {
       return oops("Failed to update payment");
     }
 
-    // Update user subscription if exists
-    const { error: subscriptionError } = await supa
-      .from("user_subscriptions")
-      .update({
-        payment_status: "pending",
-        receipt_file_path
-      })
-      .eq("telegram_user_id", telegram_id);
+    // Update user subscription if we know the user
+    if (telegramId) {
+      const { error: subscriptionError } = await supa
+        .from("user_subscriptions")
+        .update({
+          payment_status: "pending",
+          receipt_file_path: file_path,
+        })
+        .eq("telegram_user_id", telegramId);
 
-    if (subscriptionError) {
-      console.log("Subscription update error (non-critical):", subscriptionError);
+      if (subscriptionError) {
+        console.log("Subscription update error (non-critical):", subscriptionError);
+      }
     }
 
     console.log("Receipt submitted successfully for payment:", payment_id);
@@ -65,9 +116,8 @@ serve(async (req) => {
     return ok({
       success: true,
       message: "Receipt submitted successfully",
-      payment_id
+      payment_id,
     }, corsHeaders);
-
   } catch (error) {
     console.error("Receipt submission error:", error);
     return oops("Internal server error");

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1801,7 +1801,8 @@ export async function startReceiptPipeline(
       body: JSON.stringify({
         telegram_id: String(chatId),
         payment_id: pay.id,
-        storage_path: storagePath,
+        file_path: storagePath,
+        bucket: "payment-receipts",
       }),
     }).then((r) => r.json()).catch(() => null);
     if (!rs?.ok) {


### PR DESCRIPTION
## Summary
- Derive Telegram user from auth headers or initData and accept `file_path` + optional bucket in `receipt-submit`
- Send unified payloads from web receipt uploaders
- Update Telegram bot to call `receipt-submit` with new parameters
- Document receipt upload and submission API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0748f773483229a8484b7896b81ae