### PR TITLE
feat: allow multiple env prefixes for supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 
 Set these in your hosting provider (e.g., Lovable.dev project settings). If either
 value is missing, the app will render a configuration error screen instead of
-loading.
+loading. The client also accepts `SUPABASE_URL`/`SUPABASE_ANON_KEY` (and their
+`VITE_`/`REACT_APP_` variants) as fallbacks if the `NEXT_PUBLIC_` values are not
+provided.
 
 Values are set in Supabase function secrets, GitHub Environments, or Lovable Codex
 project settings. Do not commit them.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,16 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  process.env.REACT_APP_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  process.env.REACT_APP_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
   throw new Error('Missing Supabase environment variables');


### PR DESCRIPTION
## Summary
- support SUPABASE_URL and other common prefixes when creating Supabase client
- document supported env var fallbacks

## Testing
- `npm test`
- `npm run build`
- `npx -y supabase functions deploy telegram-bot --project-ref qeejuomcapbdlhnjqjcc` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68c07b72e4ac83229f9c545f70bce33d