### PR TITLE
chore: tolerate missing supabase env

### DIFF
--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,11 +1,18 @@
-import { requireEnvVar } from "../src/utils/env.ts";
+import { optionalEnvVar } from "../src/utils/env.ts";
 
-try {
-  requireEnvVar("SUPABASE_URL");
-  requireEnvVar("SUPABASE_ANON_KEY");
+const SUPABASE_URL = optionalEnvVar("SUPABASE_URL");
+const SUPABASE_ANON_KEY = optionalEnvVar("SUPABASE_ANON_KEY");
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.warn(
+    "⚠️  SUPABASE_URL or SUPABASE_ANON_KEY not set. Using placeholder values; some features may be disabled.",
+  );
+  if (!SUPABASE_URL) {
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+  }
+  if (!SUPABASE_ANON_KEY) {
+    process.env.SUPABASE_ANON_KEY = "anon-key-placeholder";
+  }
+} else {
   console.log("✅ Required env vars present");
-} catch (err) {
-  const message = err instanceof Error ? err.message : String(err);
-  console.error(`❌ ${message}`);
-  process.exit(1);
 }

--- a/shared/supabase-client.ts
+++ b/shared/supabase-client.ts
@@ -29,24 +29,20 @@ function getEnvVar(name: string): string | undefined {
   return undefined;
 }
 
-function requireEnvVar(name: string): string {
-  const v = getEnvVar(name);
-  if (!v) throw new Error(`Missing required env: ${name}`);
-  return v;
-}
+const PLACEHOLDER_URL = "https://example.supabase.co";
+const PLACEHOLDER_ANON_KEY = "anon-key-placeholder";
 
-let SUPABASE_URL = "";
-let SUPABASE_ANON_KEY = "";
-let SUPABASE_SERVICE_ROLE_KEY = "";
+let SUPABASE_URL = getEnvVar("SUPABASE_URL") ?? PLACEHOLDER_URL;
+let SUPABASE_ANON_KEY = getEnvVar("SUPABASE_ANON_KEY") ?? PLACEHOLDER_ANON_KEY;
+let SUPABASE_SERVICE_ROLE_KEY = getEnvVar("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 let SUPABASE_ENV_ERROR = "";
 
-try {
-  SUPABASE_URL = requireEnvVar("SUPABASE_URL");
-  SUPABASE_ANON_KEY = requireEnvVar("SUPABASE_ANON_KEY");
-  SUPABASE_SERVICE_ROLE_KEY = getEnvVar("SUPABASE_SERVICE_ROLE_KEY") ?? "";
-} catch (e) {
-  SUPABASE_ENV_ERROR = (e as Error).message;
-  console.error("Configuration error:", SUPABASE_ENV_ERROR);
+if (
+  SUPABASE_URL === PLACEHOLDER_URL ||
+  SUPABASE_ANON_KEY === PLACEHOLDER_ANON_KEY
+) {
+  SUPABASE_ENV_ERROR = "Missing required Supabase env vars";
+  console.warn("Configuration warning:", SUPABASE_ENV_ERROR);
 }
 
 const queryCounts: Record<string, number> = {};
@@ -78,8 +74,8 @@ export function getQueryCounts() {
 }
 
 export function createClient(key: "anon" | "service" = "anon"): any {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    throw new Error("Missing Supabase configuration");
+  if (SUPABASE_ENV_ERROR) {
+    throw new Error(SUPABASE_ENV_ERROR);
   }
   const k = key === "service" && SUPABASE_SERVICE_ROLE_KEY
     ? SUPABASE_SERVICE_ROLE_KEY


### PR DESCRIPTION
## Summary
- warn when SUPABASE env vars are missing and inject placeholders so build can continue
- guard Supabase client creation when placeholders are present

## Testing
- `npm test`
- `node lovable-build.js`

------
https://chatgpt.com/codex/tasks/task_e_68c07ef2b9d08322afc8a339b1c05718