### PR TITLE
refactor: use direct callEdgeFunction in currency hook

### DIFF
--- a/shared/supabase-client.ts
+++ b/shared/supabase-client.ts
@@ -32,9 +32,9 @@ function getEnvVar(name: string): string | undefined {
 const PLACEHOLDER_URL = "https://example.supabase.co";
 const PLACEHOLDER_ANON_KEY = "anon-key-placeholder";
 
-let SUPABASE_URL = getEnvVar("SUPABASE_URL") ?? PLACEHOLDER_URL;
-let SUPABASE_ANON_KEY = getEnvVar("SUPABASE_ANON_KEY") ?? PLACEHOLDER_ANON_KEY;
-let SUPABASE_SERVICE_ROLE_KEY = getEnvVar("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const SUPABASE_URL = getEnvVar("SUPABASE_URL") ?? PLACEHOLDER_URL;
+const SUPABASE_ANON_KEY = getEnvVar("SUPABASE_ANON_KEY") ?? PLACEHOLDER_ANON_KEY;
+const SUPABASE_SERVICE_ROLE_KEY = getEnvVar("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 let SUPABASE_ENV_ERROR = "";
 
 if (

--- a/src/hooks/useCurrency.tsx
+++ b/src/hooks/useCurrency.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { callEdgeFunction } from '@/config/supabase';
 
 // Client-only hook: accesses window and localStorage
 
@@ -62,11 +63,10 @@ export function CurrencyProvider({ children }: CurrencyProviderProps) {
     
     if (!cached || !cacheTime || (Date.now() - parseInt(cacheTime)) >= 3600000) {
       setIsLoading(true);
-      import('@/config/supabase').then(({ callEdgeFunction }) =>
-        callEdgeFunction('CONTENT_BATCH', {
-          method: 'POST',
-          body: { keys: ['usd_mvr_rate'] },
-        })
+      callEdgeFunction('CONTENT_BATCH', {
+        method: 'POST',
+        body: { keys: ['usd_mvr_rate'] },
+      })
         .then(({ data, error }) => {
           if (!error) {
             const rateContent = (data as any)?.contents?.find((c: any) => c.content_key === 'usd_mvr_rate');
@@ -81,8 +81,7 @@ export function CurrencyProvider({ children }: CurrencyProviderProps) {
         .catch(() => {
           // Keep default rate on error
         })
-        .finally(() => setIsLoading(false))
-      );
+        .finally(() => setIsLoading(false));
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- import callEdgeFunction at top of useCurrency
- call Edge Function directly instead of dynamic import
- fix Supabase env variable declarations to const

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c082e824b4832299660cc5223e9cec