### PR TITLE
fix: guard admin token access in Telegram auth

### DIFF
--- a/src/hooks/useTelegramAuth.tsx
+++ b/src/hooks/useTelegramAuth.tsx
@@ -144,8 +144,13 @@ export function TelegramAuthProvider({ children }: { children: React.ReactNode }
   }, [verifyAndCheckStatus]);
 
   const getAdminAuth = () => {
+    // Skip token checks if storage is unavailable
+    if (typeof window === 'undefined' || !('localStorage' in window)) {
+      return initData ? { initData } : null;
+    }
+
     // Check for stored admin token
-    const token = localStorage.getItem('dc_admin_token');
+    const token = window.localStorage.getItem('dc_admin_token');
     if (token) {
       try {
         const payload = JSON.parse(atob(token.split('.')[1]));
@@ -153,17 +158,17 @@ export function TelegramAuthProvider({ children }: { children: React.ReactNode }
           return { token };
         }
         // Token expired, remove it
-        localStorage.removeItem('dc_admin_token');
+        window.localStorage.removeItem('dc_admin_token');
       } catch {
-        localStorage.removeItem('dc_admin_token');
+        window.localStorage.removeItem('dc_admin_token');
       }
     }
-    
+
     // Use initData if available
     if (initData) {
       return { initData };
     }
-    
+
     return null;
   };
 


### PR DESCRIPTION
## Summary
- guard localStorage usage in `getAdminAuth`

## Testing
- `npm test`
- `npm run lint` *(fails: 'SUPABASE_URL' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68c082e5bfe483228ee3441ca4eff9dd