### PR TITLE
refactor: memoize edge function hook

### DIFF
--- a/src/hooks/useEdgeFunction.ts
+++ b/src/hooks/useEdgeFunction.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useSupabase } from '@/context/SupabaseProvider';
 import { callEdgeFunction, SUPABASE_CONFIG } from "@/config/supabase";
 
@@ -12,12 +13,12 @@ type CallOptions = {
 export function useEdgeFunction() {
   const { session } = useSupabase();
 
-  return async function edgeFunction<T>(
-    name: FunctionName,
-    options: CallOptions = {},
-  ) {
-    const token = session?.access_token;
-    return callEdgeFunction<T>(name, { ...options, token });
-  };
+  return useCallback(
+    async <T,>(name: FunctionName, options: CallOptions = {}) => {
+      const token = session?.access_token;
+      return callEdgeFunction<T>(name, { ...options, token });
+    },
+    [session?.access_token],
+  );
 }
 


### PR DESCRIPTION
## Summary
- memoize edge function handler with `useCallback`
- change handler only when `session?.access_token` changes

## Testing
- `npm test`
- `npm run lint` *(fails: 'SUPABASE_URL' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68c082e6aa9883228afcb20d640edca7