### PR TITLE
refactor: use typed edge function responses

### DIFF
--- a/src/hooks/useAnalytics.tsx
+++ b/src/hooks/useAnalytics.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import type { TrackEventResponse } from '@/types/api';
 
 // Client-only hook: interacts with window, document, and navigator
 
@@ -48,7 +49,7 @@ export const useAnalytics = () => {
       }
 
       // Call analytics edge function
-      const { error } = await supabase.functions.invoke('web-app-analytics', {
+      const { error } = await supabase.functions.invoke<TrackEventResponse>('web-app-analytics', {
         body: eventWithContext,
       });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,20 @@
+export interface VerifyInitDataResponse {
+  ok: boolean;
+}
+
+export interface AdminCheckResponse {
+  ok?: boolean;
+  is_admin?: boolean;
+}
+
+export interface VipStatusResponse {
+  vip?: {
+    is_vip: boolean;
+  };
+}
+
+export interface TrackEventResponse {
+  success?: boolean;
+  event_tracked?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- add shared API response interfaces for edge functions
- use typed responses in telegram auth hook
- type analytics edge function calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c082e9ec688322bd9cc6b56d982e7d