### PR TITLE
Add user dashboard, deposit form, and theme settings page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { supabase } from '@/integrations/supabase/client'
+
+type BotUser = {
+  id: string
+  username: string | null
+  full_name?: string | null
+}
+
+export default function DashboardPage() {
+  const [user, setUser] = useState<BotUser | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      const authUser = session?.user
+      if (authUser) {
+        const { data } = await supabase
+          .from('bot_users')
+          .select('*')
+          .eq('id', authUser.id)
+          .single()
+        if (data) {
+          setUser(data as BotUser)
+        }
+      }
+    }
+    load()
+  }, [])
+
+  return (
+    <main className="container py-xl">
+      <h1 className="text-3xl font-bold mb-lg">
+        {user ? `Welcome, ${user.username || user.full_name || 'User'}!` : 'Welcome!'}
+      </h1>
+      <div className="flex gap-base">
+        <Link
+          href="/deposit"
+          className="px-base py-sm bg-primary text-primary-foreground rounded-md"
+        >
+          Deposit
+        </Link>
+        <Link
+          href="/settings"
+          className="px-base py-sm bg-secondary text-secondary-foreground rounded-md"
+        >
+          Settings
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/app/deposit/page.tsx
+++ b/app/deposit/page.tsx
@@ -1,0 +1,10 @@
+import DepositForm from "@/components/deposit-form"
+
+export default function DepositPage() {
+  return (
+    <main className="container py-xl">
+      <h1 className="text-3xl font-bold mb-lg">Deposit</h1>
+      <DepositForm />
+    </main>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useState, FormEvent, ChangeEvent } from 'react'
+
+const themes = ['light', 'dark', 'glass'] as const
+
+type Theme = (typeof themes)[number]
+
+export default function SettingsPage() {
+  const [theme, setTheme] = useState<Theme>('light')
+  const [status, setStatus] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/functions/v1/theme-save')
+        if (res.ok) {
+          const data = await res.json()
+          if (data.theme) {
+            setTheme(data.theme as Theme)
+            applyTheme(data.theme)
+          }
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    load()
+  }, [])
+
+  const applyTheme = (t: Theme) => {
+    document.documentElement.className = t
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value as Theme
+    setTheme(val)
+    applyTheme(val)
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      const res = await fetch('/functions/v1/theme-save', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ theme }),
+      })
+      if (!res.ok) {
+        throw new Error(await res.text())
+      }
+      setStatus('Preference saved.')
+    } catch (err: any) {
+      setStatus(`Error: ${err.message}`)
+    }
+  }
+
+  return (
+    <main className="container py-xl">
+      <h1 className="text-3xl font-bold mb-lg">Settings</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-lg">
+        <div className="flex flex-col gap-sm">
+          {themes.map((t) => (
+            <label key={t} className="flex items-center gap-sm">
+              <input
+                type="radio"
+                name="theme"
+                value={t}
+                checked={theme === t}
+                onChange={handleChange}
+              />
+              <span className="capitalize">{t}</span>
+            </label>
+          ))}
+        </div>
+        <button
+          type="submit"
+          className="self-start bg-primary text-primary-foreground px-base py-sm rounded-md"
+        >
+          Save
+        </button>
+        {status && <p className="text-sm text-muted-foreground">{status}</p>}
+      </form>
+    </main>
+  )
+}

--- a/src/components/deposit-form.tsx
+++ b/src/components/deposit-form.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState, FormEvent, ChangeEvent } from 'react'
+
+export default function DepositForm() {
+  const [file, setFile] = useState<File | null>(null)
+  const [status, setStatus] = useState<string | null>(null)
+
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0]
+    setFile(f ?? null)
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!file) {
+      setStatus('Please select an image receipt.')
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('file', file)
+
+    setStatus('Uploading...')
+    try {
+      const res = await fetch('/functions/v1/telegram-bot', {
+        method: 'POST',
+        body: formData,
+      })
+      if (!res.ok) {
+        throw new Error(await res.text())
+      }
+      setStatus('Deposit submitted successfully.')
+      setFile(null)
+    } catch (err: any) {
+      setStatus(`Error: ${err.message}`)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-base">
+      <input
+        type="file"
+        accept="image/*"
+        onChange={handleFile}
+        className="border border-input rounded-md p-sm bg-background text-foreground"
+      />
+      <button
+        type="submit"
+        className="bg-primary text-primary-foreground px-base py-sm rounded-md"
+      >
+        Submit
+      </button>
+      {status && <p className="text-sm text-muted-foreground">{status}</p>}
+    </form>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Add dashboard page that greets authenticated users and links to deposit and settings
- Implement deposit form component and deposit page for uploading receipt images
- Provide settings page for choosing theme preference persisted via edge function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c092f29928832285c28738340c4f5e