### PR TITLE
Add fallback content to miniapp index pages

### DIFF
--- a/supabase/functions/miniapp/index.html
+++ b/supabase/functions/miniapp/index.html
@@ -11,7 +11,9 @@
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <noscript>This app requires JavaScript to run.</noscript>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/supabase/functions/miniapp/static/index.html
+++ b/supabase/functions/miniapp/static/index.html
@@ -13,7 +13,9 @@
     <link rel="stylesheet" crossorigin href="./assets/index-DGAYLwkG.css">
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <noscript>This app requires JavaScript to run.</noscript>
+    </div>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- provide non-JS fallback messages in miniapp root containers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0a016491c8322a5fd1bd598785e99