### PR TITLE
Add web manifest and theme color for miniapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,9 @@ miniapp/
 
 # Include mini app static assets for deployment
 # (previously ignored to keep directory empty)
+!supabase/functions/miniapp/
 !supabase/functions/miniapp/static/**
+!supabase/functions/miniapp/manifest.json
 
 # Audit reports
 .audit/

--- a/supabase/functions/miniapp/index.html
+++ b/supabase/functions/miniapp/index.html
@@ -7,6 +7,8 @@
       content="width=device-width,initial-scale=1,viewport-fit=cover"
     />
     <title>Dynamic Capital VIP • Mini App</title>
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#DC2828" />
     <!-- Telegram WebApp SDK -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>

--- a/supabase/functions/miniapp/manifest.json
+++ b/supabase/functions/miniapp/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Dynamic Capital VIP Mini App",
+  "short_name": "Dynamic VIP",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#DC2828"
+}

--- a/supabase/functions/miniapp/static/index.html
+++ b/supabase/functions/miniapp/static/index.html
@@ -7,6 +7,8 @@
       content="width=device-width,initial-scale=1,viewport-fit=cover"
     />
     <title>Dynamic Capital VIP • Mini App</title>
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#DC2828" />
     <!-- Telegram WebApp SDK -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <script type="module" crossorigin src="./assets/index-BcqGMtNb.js"></script>

--- a/supabase/functions/miniapp/static/manifest.json
+++ b/supabase/functions/miniapp/static/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Dynamic Capital VIP Mini App",
+  "short_name": "Dynamic VIP",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#DC2828"
+}


### PR DESCRIPTION
## Summary
- link web manifest and theme color in miniapp HTML
- add PWA manifest file
- allow manifest to be tracked in git

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a02095b88322a4807e114df49a93