### PR TITLE
Handle import.meta.env in env helper

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -8,6 +8,12 @@ export function getEnvVar(name: string): string | undefined {
     const nextKey = `NEXT_PUBLIC_${name}`;
     if (process.env[nextKey]) return process.env[nextKey];
   }
+  if (typeof import.meta !== "undefined" && import.meta.env) {
+    const env: Record<string, string | undefined> = (import.meta as any).env;
+    if (env[name]) return env[name];
+    const nextKey = `NEXT_PUBLIC_${name}`;
+    if (env[nextKey]) return env[nextKey];
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- support reading environment variables from import.meta.env for browser builds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a1d451088322b9d8f75e1dd630f8