### PR TITLE
chore: add vite development build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "serve:functions": "supabase functions serve --no-verify-jwt",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "drizzle-kit migrate",
-    "sync-env": "deno run -A scripts/sync-env.ts"
+    "sync-env": "deno run -A scripts/sync-env.ts",
+    "build:dev": "vite build --mode development"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## Summary
- add vite `build:dev` script for development builds

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0fae8876c832291471b69f5dd4c35