### PR TITLE
chore: align build scripts with next

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "drizzle-kit migrate",
     "sync-env": "deno run -A scripts/sync-env.ts",
-    "build:dev": "vite build --mode development"
+    "build:dev": "next build"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## Summary
- ensure Next.js scripts for dev, build, start
- map `build:dev` to `next build` to avoid errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0fe4181ac832284fc460e1d3fcced