### PR TITLE
feat: provide default supabase env

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,25 @@
+const SUPABASE_URL =
+  process.env.SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  "https://stub.supabase.co";
+const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  "stub-anon-key";
+
+process.env.SUPABASE_URL = SUPABASE_URL;
+process.env.SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
+process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  env: {
+    SUPABASE_URL,
+    SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_SUPABASE_URL: SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: SUPABASE_ANON_KEY,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -8,10 +8,10 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
     "⚠️  SUPABASE_URL or SUPABASE_ANON_KEY not set. Using placeholder values; some features may be disabled.",
   );
   if (!SUPABASE_URL) {
-    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_URL = "https://stub.supabase.co";
   }
   if (!SUPABASE_ANON_KEY) {
-    process.env.SUPABASE_ANON_KEY = "anon-key-placeholder";
+    process.env.SUPABASE_ANON_KEY = "stub-anon-key";
   }
 } else {
   console.log("✅ Required env vars present");


### PR DESCRIPTION
## Summary
- default Supabase URL and anon key in Next config so the app boots even without env vars
- align check-env script with stub Supabase values

## Testing
- `npm test`
- `npm run lint`
- `CI=1 npm run build`
- `npm run start -- -p 8080`


------
https://chatgpt.com/codex/tasks/task_e_68c12cba68a0832298f0ea1ab11054d7