### PR TITLE
feat: centralize CORS handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ SESSION_JWT_SECRET=your-session-jwt-secret
 USDT_TRC20_ADDRESS=your-usdt-trc20-address
 # Must keep trailing slash
 MINI_APP_URL=https://your-mini-app-url/
+ALLOWED_ORIGINS=http://localhost:3000
 
 ## Additional Supabase credentials
 # Public anon key for client-side calls

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ PII; rate limits enabled.
 
 Full list and usage notes: [docs/env.md](docs/env.md).
 
+- The `ALLOWED_ORIGINS` variable controls which domains may call the API and edge functions.
 - Copy `.env.example` to `.env.local` and replace the placeholder values with
   real secrets for your environment. This file is ignored by Git so each
   contributor maintains their own local configuration.

--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,65 +1,15 @@
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
-  .split(",")
-  .map((o) => o.trim())
-  .filter(Boolean);
-
-function buildCorsHeaders(origin: string | null) {
-  const baseHeaders = {
-    "Access-Control-Allow-Methods": "GET,OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
-  } as Record<string, string>;
-  if (origin && allowedOrigins.includes(origin)) {
-    baseHeaders["Access-Control-Allow-Origin"] = origin;
-  }
-  return baseHeaders;
-}
-
 interface HelloResponse {
   message: string;
 }
 
-interface ErrorResponse {
-  error: string;
+export async function GET() {
+  const body: HelloResponse = { message: 'Hello from the API' };
+  return new Response(JSON.stringify(body));
 }
 
-export async function GET(request: Request) {
-  const origin = request.headers.get("origin");
-  if (origin && !allowedOrigins.includes(origin)) {
-    const body: ErrorResponse = { error: "Origin not allowed" };
-    return new Response(JSON.stringify(body), { status: 403 });
-  }
-  try {
-    const body: HelloResponse = { message: "Hello from the API" };
-    return new Response(JSON.stringify(body), {
-      headers: buildCorsHeaders(origin),
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    const body: ErrorResponse = { error: message };
-    return new Response(JSON.stringify(body), {
-      status: 500,
-      headers: buildCorsHeaders(origin),
-    });
-  }
-}
-
-export async function OPTIONS(request: Request) {
-  const origin = request.headers.get("origin");
-  if (origin && !allowedOrigins.includes(origin)) {
-    return new Response(JSON.stringify({}), { status: 403 });
-  }
-  return new Response(JSON.stringify({}), {
-    headers: buildCorsHeaders(origin),
-  });
-}
-
-function methodNotAllowed(request: Request) {
-  const origin = request.headers.get("origin");
-  const body: ErrorResponse = { error: "Method Not Allowed" };
-  return new Response(JSON.stringify(body), {
-    status: 405,
-    headers: buildCorsHeaders(origin),
-  });
+function methodNotAllowed() {
+  const body = { error: 'Method Not Allowed' };
+  return new Response(JSON.stringify(body), { status: 405 });
 }
 
 export const POST = methodNotAllowed;

--- a/docs/env.md
+++ b/docs/env.md
@@ -69,3 +69,4 @@ example value, and where it's referenced in the repository.
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
+| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS. | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+function buildCorsHeaders(origin: string | null) {
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  };
+  if (origin && allowedOrigins.includes(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+  }
+  return headers;
+}
+
+export function middleware(req: NextRequest) {
+  const origin = req.headers.get('origin');
+  const headers = buildCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    if (origin && !headers['Access-Control-Allow-Origin']) {
+      return new NextResponse(null, { status: 403 });
+    }
+    return new NextResponse(null, { status: 204, headers });
+  }
+
+  if (origin && !headers['Access-Control-Allow-Origin']) {
+    return new NextResponse('Origin not allowed', { status: 403 });
+  }
+
+  const res = NextResponse.next();
+  Object.entries(headers).forEach(([k, v]) => res.headers.set(k, v));
+  return res;
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -65,3 +65,7 @@ const nextConfig = {
 };
 
 export default nextConfig;
+
+export const config = {
+  matcher: ['/api/:path*'],
+};

--- a/tests/api/cors.test.ts
+++ b/tests/api/cors.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+
+Deno.env.set('ALLOWED_ORIGINS', 'https://allowed.com');
+const { corsHeaders } = await import('../../supabase/functions/_shared/http.ts');
+
+Deno.test('allowed origin receives CORS header', () => {
+  const req = new Request('http://localhost', { headers: { origin: 'https://allowed.com' } });
+  const headers = corsHeaders(req);
+  assert.equal(headers['access-control-allow-origin'], 'https://allowed.com');
+});
+
+Deno.test('disallowed origin is rejected', () => {
+  const req = new Request('http://localhost', { headers: { origin: 'https://denied.com' } });
+  const headers = corsHeaders(req);
+  assert.ok(!('access-control-allow-origin' in headers));
+});

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,3 +1,6 @@
+// Allow running in both Node and Deno environments
+declare const Deno: { env?: { get(name: string): string | undefined } } | undefined;
+
 function getEnv(name: string): string | undefined {
   if (typeof process !== 'undefined' && process.env) {
     return process.env[name];


### PR DESCRIPTION
## Summary
- add ALLOWED_ORIGINS env variable and docs
- centralize API route CORS via middleware
- share CORS headers for Supabase functions and add tests

## Testing
- `npm test`
- `npm run build`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68c13a3ced648322bb0accbf4b31b971