### PR TITLE
feat: improve price formatter

### DIFF
--- a/tests/format-price.test.ts
+++ b/tests/format-price.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import { equal as assertEquals } from 'node:assert/strict';
+
+import { formatPrice } from '../utils/format-price.ts';
+
+test('formatPrice defaults to whole currency units', () => {
+  assertEquals(formatPrice(1234.56, 'USD'), '$1,235');
+});
+
+test('formatPrice supports custom locale and fraction digits', () => {
+  const result = formatPrice(1234.56, 'USD', 'en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  assertEquals(result, '$1,234.56');
+});

--- a/utils/format-price.ts
+++ b/utils/format-price.ts
@@ -1,0 +1,23 @@
+/**
+ * Format a numeric amount as a currency string.
+ *
+ * @param amount - The numeric value to format.
+ * @param currency - ISO 4217 currency code. Defaults to "USD".
+ * @param locale - BCP 47 locale string. Defaults to "en-US".
+ * @param options - Additional {@link Intl.NumberFormat} options. By default
+ *                  the result is rounded to the nearest whole currency unit.
+ */
+export function formatPrice(
+  amount: number,
+  currency: string = "USD",
+  locale: string = "en-US",
+  options: Intl.NumberFormatOptions = {},
+) {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+    ...options,
+  }).format(amount);
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -5,11 +5,4 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatPrice(amount: number, currency: string = "USD") {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
-}
+export { formatPrice } from "./format-price.ts";


### PR DESCRIPTION
## Summary
- factor out `formatPrice` into its own module
- allow optional locale and Intl options for price formatting
- add tests covering default and custom formatting behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1435d5d9c8322b8c57e7051dd98dd