### PR TITLE
feat: set default site url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,4 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-public-anon-key
 TELEGRAM_BOT_USERNAME=your-bot-username
 MINI_APP_SHORT_NAME=your-mini-app-short-name
 NEXT_PUBLIC_TELEGRAM_WEBHOOK_SECRET=your-telegram-webhook-secret
+NEXT_PUBLIC_SITE_URL=https://dynamic-capital.lovable.app/

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,10 +7,17 @@ const SUPABASE_ANON_KEY =
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
   "stub-anon-key";
 
+const SITE_URL =
+  process.env.SITE_URL ||
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  "https://dynamic-capital.lovable.app/";
+
 process.env.SUPABASE_URL = SUPABASE_URL;
 process.env.SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
 process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
+process.env.SITE_URL = SITE_URL;
+process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -19,6 +26,8 @@ const nextConfig = {
     SUPABASE_ANON_KEY,
     NEXT_PUBLIC_SUPABASE_URL: SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: SUPABASE_ANON_KEY,
+    SITE_URL,
+    NEXT_PUBLIC_SITE_URL: SITE_URL,
   },
   eslint: {
     ignoreDuringBuilds: true,


### PR DESCRIPTION
## Summary
- add default site URL pointing to dynamic-capital.lovable.app
- expose SITE_URL and NEXT_PUBLIC_SITE_URL to Next.js env

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1472a8e148322a5a3b8fedd2f8545