### PR TITLE
feat: add root API route

### DIFF
--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,0 +1,18 @@
+interface ApiResponse {
+  message: string;
+}
+
+export async function GET() {
+  const body: ApiResponse = { message: 'API is running' };
+  return new Response(JSON.stringify(body));
+}
+
+function methodNotAllowed() {
+  const body = { error: 'Method Not Allowed' };
+  return new Response(JSON.stringify(body), { status: 405 });
+}
+
+export const POST = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const DELETE = methodNotAllowed;

--- a/tests/api/root.test.ts
+++ b/tests/api/root.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+
+async function run() {
+  const { GET } = await import('../../app/api/route.ts')
+  const res = await GET(new Request('http://localhost'))
+  assert.equal(res.status, 200)
+  const data = await res.json()
+  assert.deepEqual(data, { message: 'API is running' })
+}
+
+if (typeof Deno !== 'undefined') {
+  Deno.test('GET /api returns status', run)
+} else {
+  const { default: test } = await import('node:test')
+  test('GET /api returns status', run)
+}


### PR DESCRIPTION
## Summary
- add GET `/api` route that returns a simple running message
- respond 405 to unsupported HTTP methods
- test root API endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c14ed8e8e8832294ed9e6b8bb26f84