### PR TITLE
Add default export and expand Supabase env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ Full list and usage notes: [docs/env.md](docs/env.md).
   real secrets for your environment. This file is ignored by Git so each
   contributor maintains their own local configuration.
 
+- If `SUPABASE_URL` (or `NEXT_PUBLIC_SUPABASE_URL`) is missing at runtime, the app
+  will render a **Configuration Error: Missing required env: SUPABASE_URL** screen.
+  During local development you can run `node scripts/check-env.ts` to populate safe
+  placeholder values and avoid crashes.
+
 - SUPABASE_URL
 - SUPABASE_ANON_KEY
 - SUPABASE_SERVICE_ROLE_KEY

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -7,12 +7,16 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.warn(
     "⚠️  SUPABASE_URL or SUPABASE_ANON_KEY not set. Using placeholder values; some features may be disabled.",
   );
-  if (!SUPABASE_URL) {
-    process.env.SUPABASE_URL = "https://stub.supabase.co";
-  }
-  if (!SUPABASE_ANON_KEY) {
-    process.env.SUPABASE_ANON_KEY = "stub-anon-key";
-  }
-} else {
+}
+
+const url = SUPABASE_URL || "https://stub.supabase.co";
+const key = SUPABASE_ANON_KEY || "stub-anon-key";
+
+process.env.SUPABASE_URL = url;
+process.env.NEXT_PUBLIC_SUPABASE_URL = url;
+process.env.SUPABASE_ANON_KEY = key;
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = key;
+
+if (SUPABASE_URL && SUPABASE_ANON_KEY) {
   console.log("✅ Required env vars present");
 }

--- a/supabase/functions/auth/telegram-init/index.ts
+++ b/supabase/functions/auth/telegram-init/index.ts
@@ -92,3 +92,5 @@ export async function handler(req: Request): Promise<Response> {
 }
 
 if (import.meta.main) serve(handler);
+
+export default handler;


### PR DESCRIPTION
## Summary
- export `handler` as default in auth/telegram-init function
- expand `check-env.ts` to set NEXT_PUBLIC Supabase vars with placeholders
- document missing `SUPABASE_URL` configuration and `check-env` helper in README

## Testing
- `npm test`
- `npx tsx scripts/check-env.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c14ef7f8d88322baf3b95acedb8228