### PR TITLE
feat: add configurable timeout to config fetch

### DIFF
--- a/broadcast/index.ts
+++ b/broadcast/index.ts
@@ -24,7 +24,16 @@ function sleep(ms: number) {
 }
 
 export async function planBroadcast(opts: PlanBroadcastOptions) {
-  if (!(await configClient.getFlag("broadcasts_enabled"))) {
+  let enabled: boolean;
+  try {
+    enabled = await configClient.getFlag("broadcasts_enabled");
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("timed out")) {
+      throw new Error("Config request timed out while checking broadcasts_enabled");
+    }
+    throw err;
+  }
+  if (!enabled) {
     throw new Error("Broadcasts disabled");
   }
   const { segment, text, media, chunkSize = 25, pauseMs = 500 } = opts;


### PR DESCRIPTION
## Summary
- add configurable AbortController-based timeout to config client
- surface timeout errors to callers with clear message
- handle timeout failure when planning broadcasts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c157428d248322bc0bde8b57ae401b