### PR TITLE
refactor supabase functions to export handlers

### DIFF
--- a/supabase/functions/active-promos/index.ts
+++ b/supabase/functions/active-promos/index.ts
@@ -62,5 +62,5 @@ export async function handler(req: Request): Promise<Response> {
   }
 }
 
-serve(handler);
 export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/admin-act-on-payment/index.ts
+++ b/supabase/functions/admin-act-on-payment/index.ts
@@ -73,5 +73,5 @@ export async function handler(req: Request): Promise<Response> {
   return ok({ success: true }, corsHeaders);
 }
 
-serve(handler);
 export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/admin-bans/index.ts
+++ b/supabase/functions/admin-bans/index.ts
@@ -3,7 +3,7 @@ import { createClient } from "../_shared/client.ts";
 import { isAdmin, verifyInitDataAndGetUser } from "../_shared/telegram.ts";
 import { ok, bad, unauth, mna } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "admin-bans", ts: new Date().toISOString() });
@@ -54,4 +54,8 @@ serve(async (req) => {
     return ok();
   }
   return bad("Bad Request");
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/admin-check-miniapp/index.ts
+++ b/supabase/functions/admin-check-miniapp/index.ts
@@ -6,7 +6,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -61,4 +61,7 @@ serve(async (req) => {
       }
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/admin-check/index.ts
+++ b/supabase/functions/admin-check/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { ok, bad, unauth, mna } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const corsHeaders = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -60,4 +60,8 @@ serve(async (req) => {
     if (!u || !isAdmin(u.id)) return unauth();
     return ok({ user_id: u.id });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/admin-list-pending/index.ts
+++ b/supabase/functions/admin-list-pending/index.ts
@@ -3,7 +3,7 @@ import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok, bad, unauth, mna, oops } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "admin-list-pending", ts: new Date().toISOString() });
@@ -60,4 +60,8 @@ serve(async (req) => {
   }
 
   return ok({ items: out });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/admin-logs/index.ts
+++ b/supabase/functions/admin-logs/index.ts
@@ -3,7 +3,7 @@ import { createClient } from "../_shared/client.ts";
 import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { ok, bad, unauth, mna, oops } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "admin-logs", ts: new Date().toISOString() });
@@ -34,4 +34,8 @@ serve(async (req) => {
 
   if (error) return oops("Database error", error.message);
   return ok({ items: data });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/admin-review-payment/index.ts
+++ b/supabase/functions/admin-review-payment/index.ts
@@ -25,7 +25,7 @@ async function tgSend(token: string, chatId: string, text: string) {
   }).catch(() => {});
 }
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "admin-review-payment", ts: new Date().toISOString() });
@@ -174,4 +174,8 @@ serve(async (req) => {
   });
 
   return ok({ status: newStatus, subscription_expires_at: expiresAt });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/admin-session/index.ts
+++ b/supabase/functions/admin-session/index.ts
@@ -4,7 +4,7 @@ import { ok, bad, unauth, mna } from "../_shared/http.ts";
 import { envOrSetting } from "../_shared/config.ts";
 import { signHS256 } from "../_shared/jwt.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const corsHeaders = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -69,4 +69,8 @@ serve(async (req) => {
     console.error('Failed to generate admin token:', error);
     return bad("Failed to generate session");
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/ai-faq-assistant/index.ts
+++ b/supabase/functions/ai-faq-assistant/index.ts
@@ -31,7 +31,7 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
@@ -166,4 +166,8 @@ Always end responses with: "💡 Need more help? Contact @DynamicCapital_Support
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/analytics-data/index.ts
+++ b/supabase/functions/analytics-data/index.ts
@@ -12,7 +12,7 @@ const logStep = (step: string, details?: Record<string, unknown>) => {
   console.log(`[ANALYTICS-DATA] ${step}${detailsStr}`);
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -166,4 +166,8 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/bot-status-check/index.ts
+++ b/supabase/functions/bot-status-check/index.ts
@@ -8,7 +8,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -136,4 +136,7 @@ serve(async (req) => {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/broadcast-cron/index.ts
+++ b/supabase/functions/broadcast-cron/index.ts
@@ -4,7 +4,7 @@ import { requireEnv } from "../_shared/env.ts";
 import { functionUrl } from "../_shared/edge.ts";
 import { ok, oops } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "broadcast-cron", ts: new Date().toISOString() });
@@ -37,5 +37,9 @@ serve(async (req) => {
     console.error("broadcast-cron error", err);
     return oops("Failed to dispatch broadcasts", String(err));
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 // <<< DC BLOCK: broadcast-cron-core (end)

--- a/supabase/functions/chatgpt-proxy/index.ts
+++ b/supabase/functions/chatgpt-proxy/index.ts
@@ -5,7 +5,7 @@ import { corsHeaders } from "../_shared/http.ts";
 
 const { OPENAI_API_KEY } = requireEnv(["OPENAI_API_KEY"] as const);
 
-serve(async (req) => {
+export async function handler(req) {
   const origin = req.headers.get("origin");
   const headers = corsHeaders(req);
   if (req.method === "OPTIONS") {
@@ -73,5 +73,9 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 

--- a/supabase/functions/cleanup-old-receipts/index.ts
+++ b/supabase/functions/cleanup-old-receipts/index.ts
@@ -14,7 +14,7 @@ const logStep = (step: string, details?: Record<string, unknown>) => {
   );
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -151,4 +151,8 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/cleanup-old-sessions/index.ts
+++ b/supabase/functions/cleanup-old-sessions/index.ts
@@ -262,7 +262,7 @@ async function resetStuckSessions() {
   }
 }
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -311,4 +311,8 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/cleanup-old-webhook-updates/index.ts
+++ b/supabase/functions/cleanup-old-webhook-updates/index.ts
@@ -7,7 +7,7 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -32,4 +32,8 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/config/index.ts
+++ b/supabase/functions/config/index.ts
@@ -73,7 +73,7 @@ function json(data: unknown, status = 200) {
   });
 }
 
-serve(async (req) => {
+export async function handler(req) {
   let body: Record<string, unknown> = {};
   try {
     body = await req.json();
@@ -112,4 +112,8 @@ serve(async (req) => {
   } catch (e) {
     return json({ error: String(e) }, 500);
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/contact-links/index.ts
+++ b/supabase/functions/contact-links/index.ts
@@ -6,7 +6,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -67,4 +67,7 @@ serve(async (req) => {
       }
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/content-batch/index.ts
+++ b/supabase/functions/content-batch/index.ts
@@ -81,5 +81,5 @@ export async function handler(req: Request): Promise<Response> {
   }
 }
 
-serve(handler);
 export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/crypto-txid/index.ts
+++ b/supabase/functions/crypto-txid/index.ts
@@ -3,7 +3,7 @@ import { verifyInitDataAndGetUser } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
 import { bad, mna, ok, unauth } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method !== "POST") return mna();
 
   let body: { initData?: string; txid?: string; amount?: number; currency?: string };
@@ -54,4 +54,8 @@ serve(async (req) => {
   }
 
   return ok();
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/crypto-webhook/index.ts
+++ b/supabase/functions/crypto-webhook/index.ts
@@ -28,7 +28,7 @@ async function activateSubscription(
   }
 }
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "crypto-webhook", ts: new Date().toISOString() });
@@ -115,4 +115,8 @@ serve(async (req) => {
   }
 
   return ok({ status: isConfirmed ? "completed" : "pending" });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/data-retention-cron/index.ts
+++ b/supabase/functions/data-retention-cron/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "data-retention-cron", ts: new Date().toISOString() });
@@ -40,4 +40,8 @@ serve(async (req) => {
       bans: del3.data?.length || 0,
     },
   });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/debug-bot/index.ts
+++ b/supabase/functions/debug-bot/index.ts
@@ -20,7 +20,7 @@ function getLogger(req: Request) {
   });
 }
 
-serve(async (req) => {
+export async function handler(req) {
   const logger = getLogger(req);
   logger.info("🔧 Debug function called");
   logger.info("Method:", req.method);
@@ -131,4 +131,8 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/github-cleanup/index.ts
+++ b/supabase/functions/github-cleanup/index.ts
@@ -11,7 +11,7 @@ const GITHUB_PAT = Deno.env.get('GITHUB_PAT');
 const GITHUB_REPO = Deno.env.get('GITHUB_REPO'); // format: owner/name
 const DEFAULT_BRANCH = Deno.env.get('GITHUB_DEFAULT_BRANCH') ?? 'main';
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -44,7 +44,11 @@ serve(async (req) => {
     console.error('GitHub cleanup error:', error);
     return oops('Internal server error', message);
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 
 async function performGitHubCleanup(supabase: any) {
   console.log('🧹 Starting GitHub cleanup process...');

--- a/supabase/functions/intent/index.ts
+++ b/supabase/functions/intent/index.ts
@@ -4,7 +4,7 @@ import { ok, bad, unauth, mna, oops, corsHeaders } from "../_shared/http.ts";
 import { getContent } from "../_shared/config.ts";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 
-Deno.serve(async (req) => {
+Deno.export async function handler(req) {
   if (req.method === "OPTIONS") {
     return new Response(null, {
       headers: {
@@ -124,4 +124,8 @@ Deno.serve(async (req) => {
   }
 
   return bad("Unknown intent type");
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/ops-health/index.ts
+++ b/supabase/functions/ops-health/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
 
-serve(async (_req) => {
+export async function handler(_req) {
   const report: Record<string, unknown> = { ok: true, checks: {} };
 
   function checkEnv(name: string, required = true) {
@@ -39,4 +39,8 @@ serve(async (_req) => {
     headers: { "content-type": "application/json" },
     status: code,
   });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/promo-redeem/index.ts
+++ b/supabase/functions/promo-redeem/index.ts
@@ -8,7 +8,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -77,5 +77,9 @@ serve(async (req) => {
       ...corsHeaders 
     } 
   });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 // <<< DC BLOCK: promo-redeem-core (end)

--- a/supabase/functions/receipt-ocr/index.ts
+++ b/supabase/functions/receipt-ocr/index.ts
@@ -54,7 +54,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -130,4 +130,8 @@ serve(async (req) => {
   return new Response(JSON.stringify({ ok: true, ocr: result }), {
     headers: { ...corsHeaders, "content-type": "application/json" },
   });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -10,7 +10,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -122,4 +122,8 @@ serve(async (req) => {
     console.error("Receipt submission error:", error);
     return oops("Internal server error");
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/receipt/index.ts
+++ b/supabase/functions/receipt/index.ts
@@ -3,7 +3,7 @@ import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok, bad, unauth, mna, oops, corsHeaders } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   const approveMatch = url.pathname.match(/\/receipt\/([^/]+)\/(approve|reject)/);
 
@@ -79,4 +79,8 @@ serve(async (req) => {
   }
 
   return mna();
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/receipts/index.ts
+++ b/supabase/functions/receipts/index.ts
@@ -3,7 +3,7 @@ import { verifyInitDataAndGetUser, isAdmin } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok, unauth, mna } from "../_shared/http.ts";
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method !== "GET") return mna();
   const url = new URL(req.url);
   const initData = url.searchParams.get("initData") || "";
@@ -43,4 +43,8 @@ serve(async (req) => {
     created_at: r.created_at,
   }));
   return ok({ items });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/reset-bot/index.ts
+++ b/supabase/functions/reset-bot/index.ts
@@ -8,7 +8,7 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
@@ -124,4 +124,8 @@ serve(async (req) => {
       },
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/rotate-admin-secret/index.ts
+++ b/supabase/functions/rotate-admin-secret/index.ts
@@ -9,7 +9,7 @@ function genHex(n = 24) {
   return Array.from(buf).map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-serve(async (req) => {
+export async function handler(req) {
   try {
     const url = new URL(req.url);
     if (req.method === "GET" && url.pathname.endsWith("/version")) {
@@ -35,5 +35,9 @@ serve(async (req) => {
   } catch (e) {
     return oops("Internal Error", e instanceof Error ? e.message : String(e));
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 

--- a/supabase/functions/rotate-webhook-secret/index.ts
+++ b/supabase/functions/rotate-webhook-secret/index.ts
@@ -17,7 +17,7 @@ async function tg(token: string, method: string, body?: unknown) {
   return await r.json().catch(() => ({}));
 }
 
-serve(async (req) => {
+export async function handler(req) {
   try {
     const urlObj = new URL(req.url);
     if (req.method === "GET" && urlObj.pathname.endsWith("/version")) {
@@ -65,4 +65,8 @@ serve(async (req) => {
   } catch (e) {
     return oops("Internal Error", String(e));
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/setup-lovable-miniapp/index.ts
+++ b/supabase/functions/setup-lovable-miniapp/index.ts
@@ -11,7 +11,7 @@ interface TelegramResponse {
   description?: string;
 }
 
-Deno.serve(async (req) => {
+Deno.export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -149,4 +149,7 @@ Deno.serve(async (req) => {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/setup-miniapp/index.ts
+++ b/supabase/functions/setup-miniapp/index.ts
@@ -11,7 +11,7 @@ interface TelegramResponse {
   description?: string;
 }
 
-Deno.serve(async (req) => {
+Deno.export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -125,4 +125,7 @@ Deno.serve(async (req) => {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/subscription-status/index.ts
+++ b/supabase/functions/subscription-status/index.ts
@@ -6,7 +6,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -78,4 +78,7 @@ serve(async (req) => {
       }
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/subscriptions-cron/index.ts
+++ b/supabase/functions/subscriptions-cron/index.ts
@@ -15,7 +15,7 @@ async function tgSend(token: string, chatId: string, text: string) {
   }).catch(() => {});
 }
 
-serve(async (req) => {
+export async function handler(req) {
   const url = new URL(req.url);
   if (req.method === "GET" && url.pathname.endsWith("/version")) {
     return ok({ name: "subscriptions-cron", ts: new Date().toISOString() });
@@ -104,4 +104,8 @@ serve(async (req) => {
       expired: expired?.length || 0,
     },
   });
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/sync-audit/index.ts
+++ b/supabase/functions/sync-audit/index.ts
@@ -178,7 +178,5 @@ export async function handler(req: Request): Promise<Response> {
   }
 }
 
-Deno.serve(handler);
-
-
-export default handler;
+Deno.export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/system-health/index.ts
+++ b/supabase/functions/system-health/index.ts
@@ -15,7 +15,7 @@ interface SystemHealthCheck {
   last_checked: string;
 }
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -42,7 +42,11 @@ serve(async (req) => {
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 
 async function performHealthCheck(supabase: any): Promise<Response> {
   const healthChecks: SystemHealthCheck[] = [];

--- a/supabase/functions/telegram-bot-sync/index.ts
+++ b/supabase/functions/telegram-bot-sync/index.ts
@@ -13,7 +13,7 @@ interface TelegramBotSyncRequest {
   data?: any;
 }
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -69,7 +69,11 @@ serve(async (req) => {
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 
 async function syncUser(supabase: any, telegram_user_id: string, userData: any) {
   try {

--- a/supabase/functions/telegram-getwebhook/index.ts
+++ b/supabase/functions/telegram-getwebhook/index.ts
@@ -11,7 +11,7 @@ function red(s: string, keep = 4) {
   return s ? s.slice(0, keep) + "...redacted" : "";
 }
 
-serve(async () => {
+export async function handler() {
   const SECRET = await expectedSecret();
   if (!BOT) {
     return new Response(
@@ -36,4 +36,8 @@ serve(async () => {
       },
     },
   );
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/telegram-setwebhook/index.ts
+++ b/supabase/functions/telegram-setwebhook/index.ts
@@ -7,7 +7,7 @@ const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
 const FN = "telegram-webhook";
 const url = BASE ? `${BASE}/functions/v1/${FN}` : "";
 
-serve(async (req) => {
+export async function handler(req) {
   const SECRET = await expectedSecret();
   if (!BOT || !url) {
     return new Response(
@@ -61,4 +61,8 @@ serve(async (req) => {
       },
     },
   );
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+

--- a/supabase/functions/tg-verify-init/index.ts
+++ b/supabase/functions/tg-verify-init/index.ts
@@ -14,7 +14,7 @@ async function signSession(user_id: number, ttlSeconds = 1800) {
   }, secret);
 }
 
-serve(async (req) => {
+export async function handler(req) {
   try {
     const { initData } = await req.json();
     if (!initData) {
@@ -67,6 +67,10 @@ serve(async (req) => {
       status: 500,
     });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 // <<< DC BLOCK: tg-verify-core (end)
 

--- a/supabase/functions/update-telegram-miniapp/index.ts
+++ b/supabase/functions/update-telegram-miniapp/index.ts
@@ -23,7 +23,7 @@ async function callTelegramAPI(botToken: string, method: string, body?: any): Pr
   return await response.json();
 }
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -152,4 +152,7 @@ serve(async (req) => {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/upload-miniapp-html/index.ts
+++ b/supabase/functions/upload-miniapp-html/index.ts
@@ -388,7 +388,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-Deno.serve(async (req) => {
+Deno.export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -432,4 +432,7 @@ Deno.serve(async (req) => {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);

--- a/supabase/functions/vip-sync-enhanced/index.ts
+++ b/supabase/functions/vip-sync-enhanced/index.ts
@@ -9,7 +9,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-serve(async (req) => {
+export async function handler(req) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -49,7 +49,11 @@ serve(async (req) => {
     console.error('VIP Sync error:', error);
     return oops('Internal server error', error.message);
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 
 async function syncVipMembers(supabase: any, botToken: string) {
   console.log('🔄 Starting VIP members sync...');

--- a/supabase/functions/web-app-analytics/index.ts
+++ b/supabase/functions/web-app-analytics/index.ts
@@ -30,7 +30,7 @@ interface AnalyticsEvent {
   utm_campaign?: string;
 }
 
-serve(async (req) => {
+export async function handler(req) {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -59,7 +59,11 @@ serve(async (req) => {
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
-});
+}
+
+export default handler;
+if (import.meta.main) serve(handler);
+
 
 async function trackEvent(
   supabase: SupabaseClient,


### PR DESCRIPTION
## Summary
- refactor supabase edge functions to expose named handler as default export
- ensure `serve` runs only when `import.meta.main` is true for consistent local testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1573e12908322988dcfb76c541266