### PR TITLE
refactor: add typings for receipt uploads

### DIFF
--- a/components/billing/PromoCodeInput.tsx
+++ b/components/billing/PromoCodeInput.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import logger from "@/utils/logger";
 import { Sparkles, Tag, Percent, DollarSign, Loader2, Check, X } from "lucide-react";
+import type { TelegramWindow } from "@/types/telegram-webapp";
 
 interface PromoCodeInputProps {
   planId: string;
@@ -44,7 +45,10 @@ const PromoCodeInput = ({ planId, onApplied }: PromoCodeInputProps) => {
       const apiPlanId = uuidRegex.test(planId) ? planId : "6e07f718-606e-489d-9626-2a5fa3e84eec";
       
       // Try using Telegram data first, fall back to demo user
-      const telegramId = (window as any).Telegram?.WebApp?.initDataUnsafe?.user?.id?.toString() || "123456789";
+      const telegramId =
+        (typeof window !== "undefined"
+          ? (window as TelegramWindow).Telegram?.WebApp?.initDataUnsafe?.user?.id?.toString()
+          : undefined) || "123456789";
       
       const { data, error } = await supabase.functions.invoke("promo-validate", {
         body: {

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -13,6 +13,7 @@ import { TextLoader } from "@/components/ui/text-loader";
 import { MotionFadeIn, MotionStagger, MotionCounter } from "@/components/ui/motion-components";
 import { ResponsiveMotion } from "@/components/ui/responsive-motion";
 import { MorphingText } from "@/components/ui/animated-text";
+import type { TelegramWindow } from "@/types/telegram-webapp";
 
 interface HeroSectionProps { onOpenTelegram: () => void; }
 
@@ -176,9 +177,10 @@ const HeroSection = ({ onOpenTelegram }: HeroSectionProps) => {
                   icon={<Crown className={`${isMobile ? 'w-4 h-4' : 'w-5 h-5'}`} />}
                   onClick={() => {
                     return new Promise((resolve) => {
+                      const tg = typeof window !== "undefined" ? (window as TelegramWindow).Telegram?.WebApp : undefined;
                       const isInTelegram = Boolean(
-                        (window as any).Telegram?.WebApp?.initData ||
-                        (window as any).Telegram?.WebApp?.initDataUnsafe ||
+                        tg?.initData ||
+                        tg?.initDataUnsafe ||
                         window.location.search.includes("tgWebAppPlatform") ||
                         navigator.userAgent.includes("TelegramWebApp")
                       );

--- a/components/receipts/PaymentStatus.tsx
+++ b/components/receipts/PaymentStatus.tsx
@@ -78,8 +78,9 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
       const webhookData = data.webhook_data as any;
       const needsResubmit = ['pending_review', 'failed'].includes(data.status);
       setShowUploader((data.status === 'pending' && !webhookData?.storage_path) || needsResubmit);
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to fetch payment status');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch payment status';
+      toast.error(message);
     } finally {
       setLoading(false);
     }

--- a/components/shared/ChatAssistantWidget.tsx
+++ b/components/shared/ChatAssistantWidget.tsx
@@ -120,7 +120,7 @@ Here are some quick answers to common questions:
       } else {
         throw new Error("No answer received");
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to get AI answer:", error);
       appendMessages({
         role: "assistant",

--- a/supabase/functions/miniapp/src/pages/Contact.tsx
+++ b/supabase/functions/miniapp/src/pages/Contact.tsx
@@ -4,6 +4,7 @@ import { Badge } from "../components/ui/badge";
 import PrimaryButton from "../components/PrimaryButton";
 import { useApi } from "../hooks/useApi";
 import Toast from "../components/Toast";
+import type { TelegramWindow } from "../../../../types/telegram-webapp";
 
 interface ContactLink {
   id: string;
@@ -48,7 +49,7 @@ export default function Contact() {
 
   const handleContactClick = (url: string, platform: string) => {
     try {
-      const tg = (window as any).Telegram?.WebApp;
+      const tg = typeof window !== 'undefined' ? (window as TelegramWindow).Telegram?.WebApp : undefined;
       if (tg) {
         tg.openLink(url);
       } else {

--- a/types/receipts.ts
+++ b/types/receipts.ts
@@ -1,0 +1,17 @@
+export interface ReceiptUploadBody {
+  payment_id: string;
+  filename: string;
+  content_type: string;
+  initData?: string;
+}
+
+export interface ReceiptSubmitBody {
+  payment_id: string;
+  file_path: string;
+  bucket: string;
+  initData?: string;
+}
+
+export interface ApiError {
+  message: string;
+}

--- a/types/telegram-webapp.ts
+++ b/types/telegram-webapp.ts
@@ -1,0 +1,15 @@
+export interface TelegramWebApp {
+  initData?: string;
+  initDataUnsafe?: {
+    user?: {
+      id?: number;
+    };
+  };
+  colorScheme?: 'light' | 'dark';
+}
+
+export interface TelegramWindow extends Window {
+  Telegram?: {
+    WebApp?: TelegramWebApp;
+  };
+}


### PR DESCRIPTION
## Summary
- add Telegram WebApp and receipt payload interfaces
- use typed window helpers across receipt upload and related components
- tighten error handling and unknown typing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1573fc91c8322b8a6c33c4aab4ace