### PR TITLE
docs: clarify static and API setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,35 @@ OCR + crypto TXID). Built with **Lovable Codex** for enhanced development experi
 - Admin commands for maintenance
 - **Lovable Codex Integration** for AI-powered development
 
+## Environment Setup
+
+Create `.env` files for each component and define variables needed in your
+deployment.
+
+### Client-side (`NEXT_PUBLIC_*`)
+
+Variables prefixed with `NEXT_PUBLIC_` are exposed to the browser and can be
+shared between the static landing page and the Next.js API service:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=... 
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+```
+
+Store these in your hosting platform's environment settings or in `.env.local`
+for local development. The static site should have access to the same values at
+build time.
+
+### Server-only secrets
+
+Keep secrets such as `SUPABASE_SERVICE_ROLE_KEY` or `TELEGRAM_BOT_TOKEN` only in
+the environment for the Next.js component. Do **not** prefix them with
+`NEXT_PUBLIC_` or expose them in the static site.
+
+For local work, create a `.env.local` inside `next-app/` and run `npm run dev`
+to load the variables. In production, manage secrets through your platform's
+configuration for each component.
+
 ## Project starters
 
 - **Package scripts** – launch development, build, and production with `npm run dev`, `npm run build`, and `npm run start` in `package.json`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,6 +12,35 @@ full list and usage notes.
 - `TELEGRAM_ADMIN_IDS` (optional)
 - `MINI_APP_URL` or `MINI_APP_SHORT_NAME` (optional)
 
+## API Routing
+
+When deploying a static landing page alongside Next.js API routes, forward
+`/api/*` traffic from the static host to the Next.js service. This keeps both
+components on the same domain and avoids CORS issues.
+
+Example nginx rule:
+
+```nginx
+location /api/ {
+  proxy_pass http://localhost:3000;
+  proxy_set_header Host $host;
+}
+```
+
+Adjust the upstream target for your hosting platform or reverse proxy.
+
+## Performance
+
+Enable caching for assets in the `static` directory and use a CDN when
+possible. Recommended headers:
+
+```
+Cache-Control: public, max-age=31536000, immutable
+```
+
+for hashed assets, and a short `max-age` for `index.html`. Ensure your host
+or CDN honors these headers and caches static content at the edge.
+
 ## Test commands
 
 Run basic checks before deploying:

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -49,9 +49,31 @@ This guide outlines eight high-level steps to run, build, and deploy the Telegra
    - Verify deployed endpoints respond as expected:
    ```bash
    curl -s https://<PROJECT>.functions.supabase.co/miniapp/version
-   curl -s https://<PROJECT>.functions.supabase.co/telegram-bot/version
-   curl -s -X POST https://<PROJECT>.functions.supabase.co/telegram-bot \
-     -H 'x-telegram-bot-api-secret-token: <TELEGRAM_WEBHOOK_SECRET>' \
-     -H 'content-type: application/json' -d '{"test":"ping"}'
+  curl -s https://<PROJECT>.functions.supabase.co/telegram-bot/version
+  curl -s -X POST https://<PROJECT>.functions.supabase.co/telegram-bot \
+    -H 'x-telegram-bot-api-secret-token: <TELEGRAM_WEBHOOK_SECRET>' \
+    -H 'content-type: application/json' -d '{"test":"ping"}'
+  ```
+
+## Local static + API development
+
+When the landing page and API routes are deployed as separate components, you
+can mirror that setup locally:
+
+1. Start the Next.js API service on port 3000:
+
+   ```bash
+   cd next-app
+   npm run dev -- -p 3000
    ```
+
+2. In another terminal, serve the `static` directory and proxy `/api/*` to the
+   Next.js server:
+
+   ```bash
+   npx local-web-server --directory static --port 3001 --proxy /api http://localhost:3000/api
+   ```
+
+Open `http://localhost:3001` and the static page will forward any `/api/*`
+requests to the running Next.js service without CORS issues.
 


### PR DESCRIPTION
## Summary
- document environment variable conventions for static and Next.js components
- outline API routing and caching strategy in deployment docs
- add local static+API development guide

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68c15a0e08a8832292bddda316692aa1