### PR TITLE
Add Dockerfile for Next.js multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Stage 1: build
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Build application
+COPY . .
+RUN npm run build
+
+# Stage 2: runtime
+FROM node:22-alpine
+WORKDIR /app
+
+# Copy production dependencies and build artifacts
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.env ./
+
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile building the Next.js app and running `npm start`
- include `.env` so runtime picks up environment variables

## Testing
- `npm test`
- `docker build -t dynamic-chatty-bot .` *(fails: Cannot connect to the Docker daemon)*


------
https://chatgpt.com/codex/tasks/task_e_68c15dc9da208322a399a45ab3a2e7d3