### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+supabase/functions/node_modules
+npm-debug.log
+.git
+.env
+dist
+build
+tmp
+.vscode
+.vercel
+.turbo
+coverage
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- add root `.dockerignore` to trim Docker build context

## Testing
- `npm test`
- `docker build -f Dockerfile.temp .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68c15dcbff008322a827e9aae902cd54