### PR TITLE
chore: ignore build output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist-ssr
 .next
 *.local
 bun.lockb
+out/
+_static/
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- keep `out/` and `_static/` build artifacts out of version control

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18124c6388322838b827086da58d5