### PR TITLE
chore: redirect tsbuildinfo to cache

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       ]
     },
     "incremental": true,
+    "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- store TypeScript incremental build info in node cache to avoid stray files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c185309ab48322ad5117300b2fb6e4