### PR TITLE
chore: ignore types directory in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default tseslint.config(
       "**/vendor/**",
       "supabase/functions/**",
       ".next/**",
+      "types/**",
       "scripts/**",
       "next-env.d.ts",
     ],


### PR DESCRIPTION
## Summary
- stop ESLint from linting generated `types` directory to avoid "no-var" errors from Node type definitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c187edf4048322a73043b18fda5025