### PR TITLE
feat: add preview script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "preview": "next start -p 8080",
     "start": "next start",
     "lint": "eslint .",
     "test": "deno test --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org -A --no-check",


### PR DESCRIPTION
## Summary
- add `preview` script to run Next.js production server on port 8080

## Testing
- `npm test`
- `npm run build`
- `curl -I http://localhost:8080/some/route`


------
https://chatgpt.com/codex/tasks/task_e_68c18d91e4e483229ebc27959efca99b