### PR TITLE
Configure HTTP route helpers

### DIFF
--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,18 +1,17 @@
+import { jsonResponse, methodNotAllowed } from '../../../lib/http.ts';
+
 interface HelloResponse {
   message: string;
 }
 
 export async function GET() {
   const body: HelloResponse = { message: 'Hello from the API' };
-  return new Response(JSON.stringify(body));
-}
-
-function methodNotAllowed() {
-  const body = { error: 'Method Not Allowed' };
-  return new Response(JSON.stringify(body), { status: 405 });
+  return jsonResponse(body);
 }
 
 export const POST = methodNotAllowed;
 export const PUT = methodNotAllowed;
 export const PATCH = methodNotAllowed;
 export const DELETE = methodNotAllowed;
+export const HEAD = methodNotAllowed;
+export const OPTIONS = methodNotAllowed;

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,18 +1,17 @@
+import { jsonResponse, methodNotAllowed } from '../../lib/http.ts';
+
 interface ApiResponse {
   message: string;
 }
 
 export async function GET() {
   const body: ApiResponse = { message: 'API is running' };
-  return new Response(JSON.stringify(body));
-}
-
-function methodNotAllowed() {
-  const body = { error: 'Method Not Allowed' };
-  return new Response(JSON.stringify(body), { status: 405 });
+  return jsonResponse(body);
 }
 
 export const POST = methodNotAllowed;
 export const PUT = methodNotAllowed;
 export const PATCH = methodNotAllowed;
 export const DELETE = methodNotAllowed;
+export const HEAD = methodNotAllowed;
+export const OPTIONS = methodNotAllowed;

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,13 @@
+export function jsonResponse(data: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+}
+
+export function methodNotAllowed() {
+  return jsonResponse({ error: 'Method Not Allowed' }, { status: 405 });
+}


### PR DESCRIPTION
## Summary
- centralize JSON response and 405 handling in a new `lib/http` helper
- wire API route handlers to use shared helpers and explicitly block unsupported methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1a6e36b888322a17e8f80557e1845