### PR TITLE
feat: add Supabase connectivity check

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,6 +19,21 @@ Include your database connection string or anon key as needed:
 - `SUPABASE_ANON_KEY`
 - `DATABASE_URL` (connection string)
 
+## Connectivity validation
+
+Verify the app can reach Supabase before deploying or scaling out. Run a simple
+ping and the scripted check locally or as a predeploy step:
+
+```bash
+curl -i "$SUPABASE_URL"
+deno run -A scripts/check-supabase-connectivity.ts
+```
+
+If either command fails, DigitalOcean may be blocking outbound traffic. Ensure
+egress rules permit HTTPS requests to `*.supabase.co` and increase timeouts if
+requests are dropped under load. Add retries with exponential backoff in your
+pipeline or contact Supabase support if connectivity issues persist.
+
 ## API Routing
 
 When deploying a static landing page alongside Next.js API routes, forward

--- a/scripts/check-supabase-connectivity.ts
+++ b/scripts/check-supabase-connectivity.ts
@@ -1,0 +1,33 @@
+// scripts/check-supabase-connectivity.ts
+/**
+ * Fails if the Supabase REST endpoint is unreachable or returns a non-2xx status.
+ *
+ * Usage:
+ *   deno run -A scripts/check-supabase-connectivity.ts
+ */
+import { requireEnvVar } from "../utils/env.ts";
+
+const SUPABASE_URL = requireEnvVar("SUPABASE_URL");
+const SUPABASE_ANON_KEY = requireEnvVar("SUPABASE_ANON_KEY");
+
+try {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/`, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+  });
+
+  if (!res.ok) {
+    console.error(
+      `\u274c  Supabase connectivity check failed: ${res.status} ${res.statusText}`,
+    );
+    Deno.exit(1);
+  }
+
+  console.log("\u2705 Supabase REST endpoint reachable");
+  Deno.exit(0);
+} catch (err) {
+  console.error("\u274c  Supabase connectivity error:", err?.message ?? err);
+  Deno.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to verify Supabase REST endpoint connectivity
- document DigitalOcean ↔ Supabase connectivity validation steps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a7c0ab7083229facf0f21137ce41