### PR TITLE
Add Telegram API guard rails and mini-app link tests

### DIFF
--- a/supabase/functions/telegram-bot/helpers/escape.ts
+++ b/supabase/functions/telegram-bot/helpers/escape.ts
@@ -1,0 +1,10 @@
+export function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+  return text.replace(/[&<>"']/g, (ch) => map[ch]);
+}

--- a/tests/escape-html.test.ts
+++ b/tests/escape-html.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import { equal as assertEquals } from 'node:assert/strict';
+
+const supaState: any = { tables: {} };
+(globalThis as any).__SUPA_MOCK__ = supaState;
+
+function setEnv() {
+  process.env.SUPABASE_URL = 'http://local';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc';
+  process.env.SUPABASE_ANON_KEY = 'anon';
+  process.env.TELEGRAM_BOT_TOKEN = 'tok';
+}
+
+function cleanup() {
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.SUPABASE_ANON_KEY;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  supaState.tables = {};
+}
+
+test('sendMessage escapes HTML characters', async () => {
+  setEnv();
+  const payloads: any[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input: Request | string, init?: RequestInit) => {
+    payloads.push(JSON.parse(String(init?.body)));
+    return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+  };
+  try {
+    const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+    await mod.sendMessage(1, '<script>alert(1)</script>');
+    assertEquals(payloads[0].text, '&lt;script&gt;alert(1)&lt;/script&gt;');
+  } finally {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  }
+});

--- a/tests/get-supabase.test.ts
+++ b/tests/get-supabase.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import { throws } from 'node:assert/strict';
+
+const supaState: any = { tables: {} };
+(globalThis as any).__SUPA_MOCK__ = supaState;
+
+function setEnv() {
+  process.env.SUPABASE_URL = 'http://local';
+  process.env.SUPABASE_ANON_KEY = 'anon';
+  process.env.TELEGRAM_BOT_TOKEN = 'tok';
+  // Intentionally omit SUPABASE_SERVICE_ROLE_KEY
+}
+
+function cleanup() {
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_ANON_KEY;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  supaState.tables = {};
+}
+
+test('getSupabase throws when credentials missing', async () => {
+  setEnv();
+  const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+  throws(() => mod.getSupabase(), /Missing Supabase credentials/);
+  cleanup();
+});

--- a/tests/miniapp-link.test.ts
+++ b/tests/miniapp-link.test.ts
@@ -1,0 +1,131 @@
+import test from 'node:test';
+import { equal as assertEquals, ok as assert } from 'node:assert/strict';
+
+const supaState: any = { tables: {} };
+(globalThis as any).__SUPA_MOCK__ = supaState;
+
+function setEnv(extra: Record<string, string> = {}) {
+  process.env.SUPABASE_URL = 'http://local';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'svc';
+  process.env.SUPABASE_ANON_KEY = 'anon';
+  process.env.TELEGRAM_WEBHOOK_SECRET = 'secret';
+  Object.assign(process.env, extra);
+}
+
+function cleanup() {
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.SUPABASE_ANON_KEY;
+  delete process.env.TELEGRAM_WEBHOOK_SECRET;
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.MINI_APP_URL;
+  delete process.env.MINI_APP_SHORT_NAME;
+  delete process.env.TELEGRAM_BOT_USERNAME;
+  supaState.tables = {};
+}
+
+test('sendMiniAppLink returns URL when enabled with direct URL', async () => {
+  setEnv({ TELEGRAM_BOT_TOKEN: 'tok', MINI_APP_URL: 'https://ma/' });
+  supaState.tables = {
+    kv_config: [{ key: 'features:published', value: { data: { mini_app_enabled: true } } }],
+  };
+  const calls: Array<{ body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith('https://api.telegram.org')) {
+      calls.push({ body: init?.body ? String(init.body) : '' });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  };
+  try {
+    const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+    const url = await mod.sendMiniAppLink(1);
+    assertEquals(url, 'https://ma/');
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(payload.reply_markup.inline_keyboard[0][0].web_app.url, 'https://ma/');
+  } finally {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  }
+});
+
+test('sendMiniAppLink returns deep link when short name configured', async () => {
+  setEnv({ TELEGRAM_BOT_TOKEN: 'tok', MINI_APP_SHORT_NAME: 'short', TELEGRAM_BOT_USERNAME: 'mybot' });
+  supaState.tables = {
+    kv_config: [{ key: 'features:published', value: { data: { mini_app_enabled: true } } }],
+  };
+  const calls: Array<{ body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith('https://api.telegram.org')) {
+      calls.push({ body: init?.body ? String(init.body) : '' });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  };
+  try {
+    const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+    const url = await mod.sendMiniAppLink(1);
+    assertEquals(url, 'https://t.me/mybot/short');
+    const payload = JSON.parse(calls[0].body);
+    assertEquals(payload.reply_markup.inline_keyboard[0][0].url, 'https://t.me/mybot/short');
+  } finally {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  }
+});
+
+test('sendMiniAppLink disabled', async () => {
+  setEnv({ TELEGRAM_BOT_TOKEN: 'tok' });
+  supaState.tables = {
+    kv_config: [{ key: 'features:published', value: { data: { mini_app_enabled: false } } }],
+  };
+  const calls: Array<{ body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith('https://api.telegram.org')) {
+      calls.push({ body: init?.body ? String(init.body) : '' });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  };
+  try {
+    const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+    const url = await mod.sendMiniAppLink(1);
+    assertEquals(url, null);
+    assert(calls.length > 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  }
+});
+
+test('sendMiniAppLink with missing token', async () => {
+  setEnv();
+  supaState.tables = {
+    kv_config: [{ key: 'features:published', value: { data: { mini_app_enabled: true } } }],
+  };
+  const calls: Array<{ body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith('https://api.telegram.org')) {
+      calls.push({ body: init?.body ? String(init.body) : '' });
+      return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  };
+  try {
+    const mod = await import(`../supabase/functions/telegram-bot/index.ts?${Math.random()}`);
+    const url = await mod.sendMiniAppLink(1);
+    assertEquals(url, null);
+    assertEquals(calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary
- wrap Telegram API calls with timeout and status checks
- escape HTML in Telegram messages
- throw when Supabase credentials are missing
- test mini-app link helpers and HTML escaping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a78566288322b2d8861c3c0e3e1f