### PR TITLE
fix: configure site url and redirects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,10 @@ SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
-SITE_URL=
-NEXT_PUBLIC_SITE_URL=
+# Required for email redirects and canonical domain configuration
+# Replace with your production domain, e.g. https://example.com
+SITE_URL=https://example.com
+NEXT_PUBLIC_SITE_URL=https://example.com
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -72,6 +72,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return process.env.NEXT_PUBLIC_SITE_URL || undefined;
     };
     const redirectUrl = getRedirectUrl();
+    if (!redirectUrl) {
+      console.warn(
+        'NEXT_PUBLIC_SITE_URL is not set; auth emails may contain an invalid redirect URL.'
+      );
+    }
 
     const { error } = await supabase.auth.signUp({
       email,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,10 +7,20 @@ const SUPABASE_ANON_KEY =
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
   "stub-anon-key";
 
+if (
+  process.env.NODE_ENV === "production" &&
+  !process.env.SITE_URL &&
+  !process.env.NEXT_PUBLIC_SITE_URL
+) {
+  throw new Error("SITE_URL environment variable is required in production");
+}
+
 const SITE_URL =
   process.env.SITE_URL ||
   process.env.NEXT_PUBLIC_SITE_URL ||
-  "https://urchin-app-macix.ondigitalocean.app";
+  "http://localhost:3000";
+
+const CANONICAL_HOST = new URL(SITE_URL).hostname;
 
 process.env.SUPABASE_URL = SUPABASE_URL;
 process.env.SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
@@ -39,6 +49,26 @@ const nextConfig = {
         hostname: '**',
       },
     ],
+  },
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        has: [
+          { type: 'header', key: 'x-forwarded-proto', value: 'http' },
+        ],
+        destination: 'https://:host/:path*',
+        permanent: true,
+      },
+      {
+        source: '/:path*',
+        has: [
+          { type: 'host', value: 'urchin-app-macix.ondigitalocean.app' },
+        ],
+        destination: `https://${CANONICAL_HOST}/:path*`,
+        permanent: true,
+      },
+    ];
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary
- require SITE_URL in production and remove hard-coded fallback
- add redirects for HTTP->HTTPS and deprecated domain
- document SITE_URL in `.env.example` and warn if undefined during auth signup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1ac8ebc20832292ae83adbe67cbaa