### PR TITLE
chore: bind server to all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ on images.
 2. **Run the container**
 
    ```bash
-   docker run -p 3000:3000 --env-file .env.local dynamic-chatty-bot
+   docker run -p 8080:8080 --env-file .env.local dynamic-chatty-bot
    # or start via Compose with three app replicas
    docker compose up --scale app=3
    ```
@@ -392,7 +392,7 @@ on images.
    ```
 
 6. **Troubleshooting**
-   - If ports like `3000` or `54321` are taken, adjust `-p` mappings or stop the
+   - If ports like `8080` or `54321` are taken, adjust `-p` mappings or stop the
      conflicting service.
    - Ensure required environment variables are present; missing values may cause
      runtime errors.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,5 +29,5 @@ RUN chown -R app:app /app
 
 USER app
 
-EXPOSE 3000
+EXPOSE 8080
 CMD ["npm", "start"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       NODE_ENV: production
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -5,7 +5,7 @@ set -eu
 for c in $(docker compose ps -q app); do
   name=$(docker inspect -f '{{.Name}}' "$c" | sed 's#^/##')
   addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$c")
-  if curl -fs "http://$addr:3000/" >/dev/null; then
+  if curl -fs "http://$addr:8080/" >/dev/null; then
     echo "$name healthy"
   else
     echo "$name UNHEALTHY" >&2

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -8,9 +8,9 @@ events {
 http {
     upstream app_backend {
         # Docker DNS round-robins to each replica when scaled
-        server app:3000 max_fails=3 fail_timeout=30s;
-        server app:3000 max_fails=3 fail_timeout=30s;
-        server app:3000 max_fails=3 fail_timeout=30s;
+        server app:8080 max_fails=3 fail_timeout=30s;
+        server app:8080 max_fails=3 fail_timeout=30s;
+        server app:8080 max_fails=3 fail_timeout=30s;
     }
 
     server {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -44,7 +44,7 @@ Example nginx rule:
 
 ```nginx
 location /api/ {
-  proxy_pass http://localhost:3000;
+  proxy_pass http://localhost:8080;
   proxy_set_header Host $host;
 }
 ```

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -7,18 +7,18 @@ This project relies on a Next.js service and Supabase Edge Functions. Use the fo
 - `ALLOWED_ORIGINS` defines a comma-separated list of domains allowed to call the API and edge functions.
 
 ## Exposing the app
-- Run the app in Docker (or similar) and map the container's port `3000` to your host.
+- Run the app in Docker (or similar) and map the container's port `8080` to your host.
 - If you host a static site separately, forward `/api/*` requests to the Next.js service. Example Nginx rule:
 
 ```nginx
 location /api/ {
-  proxy_pass http://localhost:3000;
+  proxy_pass http://localhost:8080;
   proxy_set_header Host $host;
 }
 ```
 
 ## Cloudflare ingress
-Traffic routed through Cloudflare may arrive from public IPs such as `162.159.140.98` or `172.66.0.96`. Point your DNS to Cloudflare and let it proxy requests to the service running on port `3000`.
+Traffic routed through Cloudflare may arrive from public IPs such as `162.159.140.98` or `172.66.0.96`. Point your DNS to Cloudflare and let it proxy requests to the service running on port `8080`.
 
 ## Outbound connectivity
 Ensure the runtime can reach external services like Supabase over HTTPS (`*.supabase.co`). Adjust firewall or egress rules as needed.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,7 +18,7 @@ if (
 const SITE_URL =
   process.env.SITE_URL ||
   process.env.NEXT_PUBLIC_SITE_URL ||
-  "http://localhost:3000";
+    "http://localhost:8080";
 
 const CANONICAL_HOST = new URL(SITE_URL).hostname;
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "preview": "next start -p 8080",
+    "preview": "next start -H 0.0.0.0 -p ${PORT:-8080}",
     "preview:miniapp": "cd supabase/functions/miniapp && npm run preview",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0 -p ${PORT:-8080}",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org -A --no-check",
     "postbuild": "tsx scripts/copy-static.ts --copy-only",


### PR DESCRIPTION
## Summary
- ensure Next.js server binds to 0.0.0.0 on port 8080
- update Docker and docs to match new port

## Testing
- `npx deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org --no-lock`
- `npx deno test -A --no-check --no-lock --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org` (failed: Module not found "file:///workspace/Dynamic-Chatty-Bot/lib/http")
- `node scripts/assert-miniapp-bundle.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c1b1ac4dc88322b12f54f33eedf581