### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[{*.md,*.mdx}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- add .editorconfig to enforce consistent formatting and whitespace rules across editors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b5fb87c08322938289656ea24037