### PR TITLE
Enable strict mode and add 404 handler

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,13 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center">
+      <h1 className="mb-2 text-4xl font-bold">404 - Page Not Found</h1>
+      <p className="text-lg text-muted-foreground">
+        The page you're looking for does not exist.
+      </p>
+      <a href="/" className="mt-4 text-blue-500 underline">
+        Return home
+      </a>
+    </div>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -42,11 +42,13 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  reactStrictMode: true,
   images: {
     remotePatterns: [
       {
         protocol: 'https',
         hostname: '**',
+        pathname: '/**',
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "next start -H 0.0.0.0 -p ${PORT:-8080}",
     "preview:miniapp": "cd supabase/functions/miniapp && npm run preview",
     "start": "next start -H 0.0.0.0 -p ${PORT:-8080}",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors=deno.land,cdn.skypack.dev,registry.npmjs.org -A --no-check",
     "postbuild": "tsx scripts/copy-static.ts --copy-only",


### PR DESCRIPTION
## Summary
- enable React strict mode and allow remote image patterns
- add dedicated 404 page to avoid blank screens
- introduce `typecheck` script for TypeScript validation

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1b6531f108322886e0d4e67bd526b