### PR TITLE
chore: add site url env to app spec

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -31,7 +31,7 @@ services:
         type: GENERAL
         value: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
       - key: SITE_URL
-        scope: RUN_TIME
+        scope: RUN_AND_BUILD_TIME
         type: GENERAL
         value: ${SITE_URL}
       - key: NEXT_PUBLIC_SITE_URL


### PR DESCRIPTION
## Summary
- include SITE_URL env var for build and runtime in DigitalOcean App spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7e8dc208322a16bb87a24cc5aad