### PR TITLE
Include SITE_URL in environment configuration

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -65,6 +65,7 @@ example value, and where it's referenced in the repository.
 
 | Key                   | Purpose                                  | Required | Example                   | Used in                           |
 | --------------------- | ---------------------------------------- | -------- | ------------------------- | --------------------------------- |
+| `SITE_URL`            | Base URL for the deployed site; used for redirects and canonical host checks. | Yes      | `https://example.com`     | `next.config.mjs`, `hooks/useAuth.tsx` |
 | `NODE_EXTRA_CA_CERTS` | Additional CA bundle for outbound HTTPS. | No       | `/etc/ssl/custom.pem`     | `src/utils/http-ca.ts`            |
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -2,16 +2,21 @@ import { optionalEnvVar } from "../utils/env.ts";
 
 const SUPABASE_URL = optionalEnvVar("SUPABASE_URL");
 const SUPABASE_ANON_KEY = optionalEnvVar("SUPABASE_ANON_KEY");
+const SITE_URL = optionalEnvVar("SITE_URL");
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SITE_URL) {
   console.warn(
-    "⚠️  SUPABASE_URL or SUPABASE_ANON_KEY not set. Using placeholder values; some features may be disabled.",
+    "⚠️  SUPABASE_URL, SUPABASE_ANON_KEY or SITE_URL not set. Using placeholder values; some features may be disabled.",
   );
   if (!SUPABASE_URL) {
     process.env.SUPABASE_URL = "https://stub.supabase.co";
   }
   if (!SUPABASE_ANON_KEY) {
     process.env.SUPABASE_ANON_KEY = "stub-anon-key";
+  }
+  if (!SITE_URL) {
+    process.env.SITE_URL = "http://localhost:8080";
+    process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:8080";
   }
 } else {
   console.log("✅ Required env vars present");


### PR DESCRIPTION
## Summary
- document SITE_URL as required for the web app
- check for SITE_URL in env preflight script and set fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b9d4bb488322b2cc4b110a2037a4