### PR TITLE
chore: configure SITE_URL for production

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -33,11 +33,11 @@ services:
       - key: SITE_URL
         scope: RUN_AND_BUILD_TIME
         type: GENERAL
-        value: ${SITE_URL}
+        value: https://urchin-app-macix.ondigitalocean.app
       - key: NEXT_PUBLIC_SITE_URL
         scope: RUN_AND_BUILD_TIME
         type: GENERAL
-        value: ${NEXT_PUBLIC_SITE_URL}
+        value: https://urchin-app-macix.ondigitalocean.app
       - key: TELEGRAM_BOT_TOKEN
         scope: RUN_TIME
         type: SECRET

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # Required for email redirects and canonical domain configuration
 # Replace with your production domain, e.g. https://example.com
-SITE_URL=https://example.com
-NEXT_PUBLIC_SITE_URL=https://example.com
+SITE_URL=https://urchin-app-macix.ondigitalocean.app
+NEXT_PUBLIC_SITE_URL=https://urchin-app-macix.ondigitalocean.app
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=


### PR DESCRIPTION
## Summary
- set SITE_URL and NEXT_PUBLIC_SITE_URL to production domain
- document canonical domain in example env file

## Testing
- `npm test`
- `doctl apps list` *(fails: access token is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c1baf83694832290eb2bcfa73ec4eb