### PR TITLE
feat: add health check endpoint

### DIFF
--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,0 +1,12 @@
+import { jsonResponse, methodNotAllowed } from '../lib/httpResponse';
+
+export async function GET() {
+  return jsonResponse({ status: 'ok' });
+}
+
+export const POST = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const DELETE = methodNotAllowed;
+export const HEAD = methodNotAllowed;
+export const OPTIONS = methodNotAllowed;


### PR DESCRIPTION
## Summary
- add a simple `/health` endpoint that returns status ok

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1be80076c8322a4f17fc2d82c4b88