### PR TITLE
chore: add base reset and typography classes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,29 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+  * {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+@layer components {
+  .typography-xs { @apply text-xs; }
+  .typography-sm { @apply text-sm; }
+  .typography-base { @apply text-base; }
+  .typography-lg { @apply text-lg; }
+  .typography-xl { @apply text-xl; }
+  .typography-2xl { @apply text-2xl; }
+  .typography-3xl { @apply text-3xl; }
+  .typography-4xl { @apply text-4xl; }
+  .typography-5xl { @apply text-5xl; }
+  .typography-6xl { @apply text-6xl; }
+}
+
 /* === UNIVERSAL FRAMER MOTION THEME === */
 :root {
   /* Enhanced Motion Design Tokens - Red Theme */


### PR DESCRIPTION
## Summary
- apply global box-sizing and margin/padding reset
- add reusable typography scale classes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c3b86290832292a9f635ea76b6cd