### PR TITLE
feat: add log level env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=
 # Comma-separated origins allowed for CORS
 ALLOWED_ORIGINS=
+# Optional: control logger verbosity (error, warn, info, log)
+LOG_LEVEL=

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For local work, create a `.env.local` inside `next-app/` and run `npm run dev`
 to load the variables. In production, manage secrets through your platform's
 configuration for each component.
 
+### Logging
+
+Control logger verbosity with the `LOG_LEVEL` environment variable. Supported
+values are `error`, `warn`, `info`, and `log`. It defaults to `log` in
+development and `error` in production.
+
 ## Project Structure
 
 - **Functions** – Edge functions live under `supabase/functions` and any

--- a/docs/env.md
+++ b/docs/env.md
@@ -71,3 +71,4 @@ example value, and where it's referenced in the repository.
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
 | `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS. | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `LOG_LEVEL`           | Controls logger verbosity (`error`, `warn`, `info`, `log`). | No       | `warn`                  | `utils/logger.ts` |

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,5 +1,10 @@
 // Allow running in both Node and Deno environments
-declare const Deno: { env?: { get(name: string): string | undefined } } | undefined;
+declare const Deno:
+  | { env?: { get(name: string): string | undefined } }
+  | undefined;
+declare const process:
+  | { env?: Record<string, string | undefined> }
+  | undefined;
 
 function getEnv(name: string): string | undefined {
   if (typeof process !== 'undefined' && process.env) {
@@ -13,18 +18,33 @@ function getEnv(name: string): string | undefined {
 
 const isDev = getEnv('NODE_ENV') !== 'production';
 
+const levels = ['error', 'warn', 'info', 'log'] as const;
+type Level = (typeof levels)[number];
+
+function getLevel(): Level {
+  const envLevel = getEnv('LOG_LEVEL')?.toLowerCase() as Level | undefined;
+  if (envLevel && levels.includes(envLevel)) return envLevel;
+  return isDev ? 'log' : 'error';
+}
+
+const currentLevel = getLevel();
+
+function shouldLog(level: Level) {
+  return levels.indexOf(level) <= levels.indexOf(currentLevel);
+}
+
 export const logger = {
   log: (...args: unknown[]) => {
-    if (isDev) console.log(...args);
+    if (shouldLog('log')) console.log(...args);
   },
   info: (...args: unknown[]) => {
-    if (isDev) console.info(...args);
+    if (shouldLog('info')) console.info(...args);
   },
   warn: (...args: unknown[]) => {
-    if (isDev) console.warn(...args);
+    if (shouldLog('warn')) console.warn(...args);
   },
   error: (...args: unknown[]) => {
-    if (isDev) console.error(...args);
+    console.error(...args);
   },
 };
 


### PR DESCRIPTION
## Summary
- add LOG_LEVEL environment variable to control logger verbosity
- always emit error logs regardless of environment
- document LOG_LEVEL in docs and env example

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1c9e197c083229f7a4ceaf9aaac0a