### PR TITLE
refactor: export tg-verify-init handler

### DIFF
--- a/supabase/functions/tg-verify-init/index.ts
+++ b/supabase/functions/tg-verify-init/index.ts
@@ -14,7 +14,7 @@ async function signSession(user_id: number, ttlSeconds = 1800) {
   }, secret);
 }
 
-serve(async (req) => {
+async function handler(req: Request): Promise<Response> {
   try {
     const { initData } = await req.json();
     if (!initData) {
@@ -67,6 +67,10 @@ serve(async (req) => {
       status: 500,
     });
   }
-});
+}
+
+if (import.meta.main) serve(handler);
+
+export default handler;
 // <<< DC BLOCK: tg-verify-core (end)
 

--- a/tests/tg-verify-init.test.ts
+++ b/tests/tg-verify-init.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import { equal as assertEquals, ok as assert, match as assertMatch } from 'node:assert/strict';
+
+async function makeInitData(user: Record<string, unknown>, token: string) {
+  const enc = new TextEncoder();
+  const secretKey = await crypto.subtle.digest('SHA-256', enc.encode(token));
+  const key = await crypto.subtle.importKey('raw', secretKey, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const params = new URLSearchParams({
+    user: JSON.stringify(user),
+    auth_date: String(Math.floor(Date.now() / 1000)),
+    query_id: 'TEST',
+  });
+  const dcs = Array.from(params.entries()).map(([k, v]) => `${k}=${v}`).sort().join('\n');
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(dcs));
+  const hash = [...new Uint8Array(sig)].map(b => b.toString(16).padStart(2, '0')).join('');
+  params.set('hash', hash);
+  return params.toString();
+}
+
+test('tg-verify-init returns session token for valid initData', async () => {
+  Deno.env.set('TELEGRAM_BOT_TOKEN', 'token');
+  Deno.env.set('SESSION_JWT_SECRET', 'secret');
+  try {
+    const initData = await makeInitData({ id: 1, username: 'alice' }, 'token');
+    const { default: handler } = await import('../supabase/functions/tg-verify-init/index.ts');
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ initData }),
+    });
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+    const data = await res.json();
+    assert(data.ok);
+    assertEquals(data.user_id, 1);
+    assertEquals(data.username, 'alice');
+    assertMatch(data.session_token, /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/);
+  } finally {
+    Deno.env.delete('TELEGRAM_BOT_TOKEN');
+    Deno.env.delete('SESSION_JWT_SECRET');
+  }
+});


### PR DESCRIPTION
## Summary
- refactor tg-verify-init to expose handler and only serve when run directly
- add test covering handler for valid initData

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1c9dd07508322bee4a9e619b7ff61