### PR TITLE
Use Deno script for edge smoke check

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy:edge": "npx supabase functions deploy miniapp telegram-bot receipt-submit receipt-ocr crypto-webhook admin-act-on-payment --project-ref qeejuomcapbdlhnjqjcc",
     "edge:deploy:core": "npx supabase functions deploy telegram-bot miniapp --project-ref qeejuomcapbdlhnjqjcc",
     "edge:deploy:ops": "npx supabase functions deploy payments-auto-review data-retention-cron broadcast-cron subscriptions-cron rotate-webhook-secret --project-ref qeejuomcapbdlhnjqjcc",
-    "edge:smoke": "node scripts/smoke.js",
+    "edge:smoke": "deno run -A scripts/smoke-miniapp.ts",
     "serve:functions": "supabase functions serve --no-verify-jwt",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
## Summary
- use existing Deno smoke test script for `edge:smoke`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1d5f065b08322966ecf23232e494e