### PR TITLE
chore: sync deno fallback version

### DIFF
--- a/scripts/deno_bin.sh
+++ b/scripts/deno_bin.sh
@@ -5,5 +5,9 @@ if command -v deno >/dev/null 2>&1; then
   echo "deno"
   exit 0
 fi
-# Fallback via npm distribution of Deno.
-echo "npx -y @deno/cli@1.46.3 deno"
+
+# Fallback via npm distribution of Deno using the same major version
+# as the "deno" dependency in package.json.
+DENO_VERSION=$(jq -r '.devDependencies.deno' package.json)
+DENO_MAJOR=$(echo "$DENO_VERSION" | sed -E 's/^[^0-9]*([0-9]+).*/\1/')
+echo "npx -y @deno/cli@${DENO_MAJOR} deno"


### PR DESCRIPTION
## Summary
- make `scripts/deno_bin.sh` use the same major Deno version as the dev dependency

## Testing
- `npm test`
- `npm run lint -- scripts/deno_bin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1d6069b7483228de40afacab8ee58