### PR TITLE
chore: ignore build output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ dist-ssr
 .next
 *.local
 bun.lockb
-out/
-_static/
+/out/
+/_static/
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- ignore out and _static folders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d77ef5cc83229160e076bbc02122