### PR TITLE
Centralize CORS handling across API routes

### DIFF
--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,12 +1,13 @@
 import { jsonResponse, methodNotAllowed } from '../../../lib/httpResponse';
+import { corsHeaders } from '../../../lib/cors';
 
 interface HelloResponse {
   message: string;
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   const body: HelloResponse = { message: 'Hello from the API' };
-  return jsonResponse(body);
+  return jsonResponse(body, {}, req);
 }
 
 export const POST = methodNotAllowed;
@@ -14,4 +15,6 @@ export const PUT = methodNotAllowed;
 export const PATCH = methodNotAllowed;
 export const DELETE = methodNotAllowed;
 export const HEAD = methodNotAllowed;
-export const OPTIONS = methodNotAllowed;
+export function OPTIONS(req: Request) {
+  return new Response(null, { status: 204, headers: corsHeaders(req) });
+}

--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -1,12 +1,13 @@
 import { jsonResponse, methodNotAllowed } from '../../lib/httpResponse';
+import { corsHeaders } from '../../lib/cors';
 
 interface ApiResponse {
   message: string;
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   const body: ApiResponse = { message: 'API is running' };
-  return jsonResponse(body);
+  return jsonResponse(body, {}, req);
 }
 
 export const POST = methodNotAllowed;
@@ -14,4 +15,6 @@ export const PUT = methodNotAllowed;
 export const PATCH = methodNotAllowed;
 export const DELETE = methodNotAllowed;
 export const HEAD = methodNotAllowed;
-export const OPTIONS = methodNotAllowed;
+export function OPTIONS(req: Request) {
+  return new Response(null, { status: 204, headers: corsHeaders(req) });
+}

--- a/lib/cors.ts
+++ b/lib/cors.ts
@@ -1,0 +1,19 @@
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+export function buildCorsHeaders(origin: string | null) {
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  };
+  if (origin && allowedOrigins.includes(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+  }
+  return headers;
+}
+
+export function corsHeaders(req: Request) {
+  return buildCorsHeaders(req.headers.get('origin'));
+}

--- a/lib/httpResponse.ts
+++ b/lib/httpResponse.ts
@@ -1,14 +1,19 @@
 // Lightweight helpers for constructing HTTP responses
-export function jsonResponse(data: unknown, init: ResponseInit = {}) {
-  return new Response(JSON.stringify(data), {
-    ...init,
-    headers: {
-      'content-type': 'application/json',
-      ...(init.headers || {}),
-    },
-  });
+import { corsHeaders } from './cors';
+
+export function jsonResponse(
+  data: unknown,
+  init: ResponseInit = {},
+  req?: Request,
+) {
+  const headers = {
+    'content-type': 'application/json',
+    ...(init.headers || {}),
+    ...(req ? corsHeaders(req) : {}),
+  };
+  return new Response(JSON.stringify(data), { ...init, headers });
 }
 
-export function methodNotAllowed() {
-  return jsonResponse({ error: 'Method Not Allowed' }, { status: 405 });
+export function methodNotAllowed(req?: Request) {
+  return jsonResponse({ error: 'Method Not Allowed' }, { status: 405 }, req);
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '')
-  .split(',')
-  .map((o) => o.trim())
-  .filter(Boolean);
-
-function buildCorsHeaders(origin: string | null) {
-  const headers: Record<string, string> = {
-    'Access-Control-Allow-Methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  };
-  if (origin && allowedOrigins.includes(origin)) {
-    headers['Access-Control-Allow-Origin'] = origin;
-  }
-  return headers;
-}
+import { buildCorsHeaders } from './lib/cors';
 
 export function middleware(req: NextRequest) {
   const origin = req.headers.get('origin');


### PR DESCRIPTION
## Summary
- add shared CORS utilities for building headers
- use shared helper in middleware and API routes
- include CORS headers in JSON responses and preflight handlers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e4a06d9483229c1d02fdd29dac96