### PR TITLE
docs: add NEXT_PUBLIC_API_URL env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
-NEXT_PUBLIC_SUPABASE_URL=
-NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Base URL for calling the Next.js API
 NEXT_PUBLIC_API_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_SUPABASE_URL=
 # Required for email redirects and canonical domain configuration
 # Replace with your production domain, e.g. https://example.com
 SITE_URL=https://urchin-app-macix.ondigitalocean.app

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ shared between the static landing page and the Next.js API service:
 
 ```
 NEXT_PUBLIC_API_URL=...
-NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+NEXT_PUBLIC_SUPABASE_URL=...
 ```
+
+`NEXT_PUBLIC_API_URL` should point to your deployed API endpoint (e.g., `https://api.example.com`).
 
 Store these in your hosting platform's environment settings or in `.env.local`
 for local development. The static site should have access to the same values at
@@ -296,8 +298,8 @@ bundle):
 
 ```bash
 NEXT_PUBLIC_API_URL=https://<api.example.com>
-NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 ```
 
 Set these in your hosting provider (e.g., Lovable.dev project settings). If


### PR DESCRIPTION
## Summary
- document required NEXT_PUBLIC_API_URL environment variable
- update README to include API URL in setup instructions

## Testing
- `NEXT_PUBLIC_API_URL=http://localhost npm test`
- `NEXT_PUBLIC_API_URL=http://localhost npm run lint`
- `NEXT_PUBLIC_API_URL=http://localhost npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1e6218fd08322a3349c5ba474b5fd