### PR TITLE
feat: add static site starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ configuration for each component.
 - **Broadcast planner** – standalone service at `broadcast/index.ts`
 - **Queue worker** – standalone service at `queue/index.ts`
 
+## HTML Static Site Starter
+
+A minimal static landing page lives in `static-site/` with `index.html`, `styles.css`, and `scripts.js`.
+Run `npm run build:static` to copy it into the `_static/` directory for deployment.
+Modify the files to suit your needs before running the build.
+
 ## Development Process Overview
 
 | Tool                   | What It Does                                                            | How You Use It                                                                                              |

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "serve:functions": "supabase functions serve --no-verify-jwt",
     "drizzle:generate": "drizzle-kit generate",
     "drizzle:migrate": "drizzle-kit migrate",
-    "sync-env": "deno run -A scripts/sync-env.ts"
+    "sync-env": "deno run -A scripts/sync-env.ts",
+    "build:static": "mkdir -p _static && cp -r static-site _static/"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/static-site/index.html
+++ b/static-site/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Landing Page</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1>Welcome to Dynamic Chatty Bot</h1>
+    <p>Your simple static landing page.</p>
+    <button id="action">Click me</button>
+  </main>
+  <script src="scripts.js"></script>
+</body>
+</html>

--- a/static-site/scripts.js
+++ b/static-site/scripts.js
@@ -1,0 +1,3 @@
+document.getElementById('action')?.addEventListener('click', () => {
+  alert('Static site ready!');
+});

--- a/static-site/styles.css
+++ b/static-site/styles.css
@@ -1,0 +1,12 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 2rem;
+  background-color: #f9f9f9;
+  text-align: center;
+}
+
+main {
+  max-width: 600px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add simple HTML/CSS/JS landing page under `static-site/`
- add `build:static` script to copy static site into `_static`
- document static site usage in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e8ea62b483229f53e8f7e2390f0d