### PR TITLE
feat: add go health check service

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ configuration for each component.
 - **Root configuration** – Key files like `package.json`, `tsconfig.json`,
   `eslint.config.js`, and `.env.example` sit at the project root. Keep
   `.env.example` updated when adding new environment variables.
+- **Go service** – simple HTTP server in `go-service/` with a `/healthz` endpoint.
 
 ## Project starters
 
@@ -455,6 +456,27 @@ If tests present:
 
 ```bash
 deno test -A
+```
+
+## Go Service
+
+A minimal Go HTTP server lives in `go-service/` and exposes a `/healthz` endpoint on port `8080`.
+
+### Build and run
+
+```bash
+cd go-service
+go run main.go
+# or build
+go build
+./go-service
+```
+
+### Docker
+
+```bash
+docker build -f docker/go.Dockerfile -t go-service .
+docker run --rm -p 8080:8080 go-service
 ```
 
 ## Smoke checks

--- a/docker/go.Dockerfile
+++ b/docker/go.Dockerfile
@@ -1,0 +1,12 @@
+# Build stage
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go-service/ .
+RUN go build -o service .
+
+# Runtime stage
+FROM alpine:3.20
+WORKDIR /app
+COPY --from=build /src/service ./service
+EXPOSE 8080
+CMD ["./service"]

--- a/go-service/go.mod
+++ b/go-service/go.mod
@@ -1,0 +1,4 @@
+module go-service
+
+go 1.22
+

--- a/go-service/main.go
+++ b/go-service/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	})
+
+	addr := ":8080"
+	fmt.Printf("Listening on %s\n", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add simple Go HTTP service with `/healthz` endpoint
- document building and Docker usage for Go service
- provide Dockerfile for containerized Go builds

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1e8ede5008322bed13c83468890a5