### PR TITLE
Fix supabase typings and stub

### DIFF
--- a/components/shared/EdgeFunctionStatus.tsx
+++ b/components/shared/EdgeFunctionStatus.tsx
@@ -14,7 +14,7 @@ export const EdgeFunctionStatus = () => {
   useEffect(() => {
     const checkStatus = async () => {
       try {
-        const { data, error } = await supabase.functions.invoke<HealthResponse>(
+        const { data, error } = await supabase.functions.invoke(
           "web-app-health",
           { method: "GET" },
         );
@@ -22,7 +22,8 @@ export const EdgeFunctionStatus = () => {
           setStatus("error");
           return;
         }
-        setStatus(data?.overall_status || "degraded");
+        const typedData = data as HealthResponse;
+        setStatus(typedData?.overall_status || "degraded");
       } catch (_err) {
         setStatus("error");
       }

--- a/hooks/useAnalytics.tsx
+++ b/hooks/useAnalytics.tsx
@@ -49,9 +49,12 @@ export const useAnalytics = () => {
       }
 
       // Call analytics edge function
-      const { error } = await supabase.functions.invoke<TrackEventResponse>('web-app-analytics', {
-        body: eventWithContext,
-      });
+      const { error } = await supabase.functions.invoke(
+        'web-app-analytics',
+        {
+          body: eventWithContext,
+        },
+      );
 
       if (error) {
         console.error('Analytics tracking error:', error);

--- a/tests/supabase-client-stub.ts
+++ b/tests/supabase-client-stub.ts
@@ -21,8 +21,24 @@ export function createClient() {
             },
           };
         },
-        insert(_vals: unknown) {
-          return Promise.resolve({ data: null, error: null });
+        insert(vals: any) {
+          const base = Promise.resolve({ data: null, error: null });
+          return {
+            select(_cols?: string) {
+              const selectResp = Promise.resolve({ data: [vals], error: null });
+              return {
+                single() {
+                  return Promise.resolve({ data: vals, error: null });
+                },
+                then: selectResp.then.bind(selectResp),
+                catch: selectResp.catch.bind(selectResp),
+                finally: selectResp.finally.bind(selectResp),
+              };
+            },
+            then: base.then.bind(base),
+            catch: base.catch.bind(base),
+            finally: base.finally.bind(base),
+          };
         },
       };
     },

--- a/types/sentry-nextjs.d.ts
+++ b/types/sentry-nextjs.d.ts
@@ -1,0 +1,1 @@
+declare module '@sentry/nextjs';


### PR DESCRIPTION
## Summary
- avoid generic typings on supabase invoke calls and cast results instead
- enhance test Supabase client stub to support `insert().select().single()` chains
- add Sentry Next.js module stub for type checking

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1ec30ad98832288e5b3dbf12bd5a8