### PR TITLE
Add NEXT_PUBLIC_API_URL env variable to docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Base URL for API requests (e.g. https://example.com/api)
+NEXT_PUBLIC_API_URL=
 # Required for email redirects and canonical domain configuration
 # Replace with your production domain, e.g. https://example.com
 SITE_URL=https://urchin-app-macix.ondigitalocean.app

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ time (exposed with Next.js `NEXT_PUBLIC_` prefix so they end up in the browser
 bundle):
 
 ```bash
+NEXT_PUBLIC_API_URL=https://example.com/api
 NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 ```

--- a/docs/env.md
+++ b/docs/env.md
@@ -66,6 +66,7 @@ example value, and where it's referenced in the repository.
 | Key                   | Purpose                                  | Required | Example                   | Used in                           |
 | --------------------- | ---------------------------------------- | -------- | ------------------------- | --------------------------------- |
 | `SITE_URL`            | Base URL for the deployed site; used for redirects and canonical host checks. | Yes      | `https://example.com`     | `next.config.mjs`, `hooks/useAuth.tsx` |
+| `NEXT_PUBLIC_API_URL`  | Base URL for client API requests. | Yes | `https://example.com/api` | `env.ts` |
 | `NODE_EXTRA_CA_CERTS` | Additional CA bundle for outbound HTTPS. | No       | `/etc/ssl/custom.pem`     | `src/utils/http-ca.ts`            |
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |


### PR DESCRIPTION
## Summary
- document `NEXT_PUBLIC_API_URL` env var and add to example config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f0a607f48322a9204c3d1e97c0b2