### PR TITLE
fix: add stub module for @sentry/nextjs

### DIFF
--- a/types/sentry-nextjs.d.ts
+++ b/types/sentry-nextjs.d.ts
@@ -1,1 +1,6 @@
-declare module '@sentry/nextjs';
+declare module '@sentry/nextjs' {
+  export interface InitOptions {
+    [key: string]: unknown;
+  }
+  export function init(options?: InitOptions): void;
+}


### PR DESCRIPTION
## Summary
- add a lightweight declaration for `@sentry/nextjs` so TypeScript recognizes Sentry's `init` API

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c1f505a1708322b6cb473ee67490d1