### PR TITLE
feat: add client directives and enable caching

### DIFF
--- a/components/ui/motion-theme.tsx
+++ b/components/ui/motion-theme.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { motion, AnimatePresence, MotionConfig, useReducedMotion } from 'framer-motion';
 import { cn } from '@/utils';
@@ -98,6 +100,7 @@ interface MotionSectionProps {
     amount?: number;
   };
   variant?: SectionVariant;
+  id?: string;
 }
 
 export const MotionSection: React.FC<MotionSectionProps> = ({
@@ -106,11 +109,13 @@ export const MotionSection: React.FC<MotionSectionProps> = ({
   delay = 0,
   viewport = { once: true, amount: 0.2 },
   variant = "fadeUp",
+  id,
 }) => {
   const isMobile = useIsMobile();
   const selectedVariant = sectionVariants[variant] || sectionVariants.fadeUp;
   return (
     <motion.section
+      id={id}
       className={cn("motion-section", className)}
       variants={selectedVariant}
       initial="hidden"

--- a/components/ui/three-button.tsx
+++ b/components/ui/three-button.tsx
@@ -1,7 +1,9 @@
+"use client";
+
 import React, { useState, useRef } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { Html } from "@react-three/drei";
-import * as THREE from "three";
+import { MathUtils, type Mesh } from "three";
 
 export interface ThreeButtonProps {
   children: React.ReactNode;
@@ -20,17 +22,17 @@ export function ThreeButton({
 }: ThreeButtonProps) {
   const [hovered, setHovered] = useState(false);
   const [active, setActive] = useState(false);
-  const meshRef = useRef<THREE.Mesh>(null);
+  const meshRef = useRef<Mesh>(null);
 
   useFrame((_, delta) => {
     if (!meshRef.current) return;
     const targetScale = active ? 0.95 : hovered ? 1.1 : 1;
     const targetRotX = hovered ? -0.05 : 0;
     const targetRotY = hovered ? 0.05 : 0;
-    const s = THREE.MathUtils.lerp(meshRef.current.scale.x, targetScale, 10 * delta);
+    const s = MathUtils.lerp(meshRef.current.scale.x, targetScale, 10 * delta);
     meshRef.current.scale.set(s, s, s);
-    meshRef.current.rotation.x = THREE.MathUtils.lerp(meshRef.current.rotation.x, targetRotX, 10 * delta);
-    meshRef.current.rotation.y = THREE.MathUtils.lerp(meshRef.current.rotation.y, targetRotY, 10 * delta);
+    meshRef.current.rotation.x = MathUtils.lerp(meshRef.current.rotation.x, targetRotX, 10 * delta);
+    meshRef.current.rotation.y = MathUtils.lerp(meshRef.current.rotation.y, targetRotY, 10 * delta);
   });
 
   return (

--- a/hooks/useTheme.tsx
+++ b/hooks/useTheme.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from 'react';
 import { callEdgeFunction } from '@/config/supabase';
 import { useAuth } from './useAuth';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -63,6 +63,17 @@ const nextConfig = {
       },
     ],
   },
+  webpack: (config, { dev }) => {
+    if (!dev) {
+      config.cache = {
+        type: 'filesystem',
+        buildDependencies: {
+          config: [__filename],
+        },
+      };
+    }
+    return config;
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## Summary
- mark client-side components and hooks with `use client`
- replace wildcard imports in three-button with named `three` exports
- enable filesystem cache in Next.js config

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c209431cdc832295b63e91344c89d6