### PR TITLE
Add Certbot HTTPS setup and domain redirect

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,3 +25,16 @@ services:
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - certbot-etc:/etc/letsencrypt
+      - certbot-var:/var/lib/letsencrypt
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - certbot-etc:/etc/letsencrypt
+      - certbot-var:/var/lib/letsencrypt
+    entrypoint: /bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/lib/letsencrypt; sleep 12h & wait $${!}; done;'
+
+volumes:
+  certbot-etc:
+  certbot-var:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,8 +14,26 @@ http {
     }
 
     server {
-        listen 80;
-        listen 443;
+        listen 80 default_server;
+        server_name _;
+
+        location /.well-known/acme-challenge/ {
+            root /var/lib/letsencrypt;
+        }
+
+        location / {
+            return 301 https://dynamiccapital.duckdns.org$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name dynamiccapital.duckdns.org;
+
+        ssl_certificate /etc/letsencrypt/live/dynamiccapital.duckdns.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/dynamiccapital.duckdns.org/privkey.pem;
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
         location / {
             proxy_pass http://app_backend;
@@ -24,5 +42,17 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_next_upstream error timeout http_502 http_503 http_504;
         }
+    }
+
+    server {
+        listen 443 default_server ssl;
+        server_name _;
+
+        ssl_certificate /etc/letsencrypt/live/dynamiccapital.duckdns.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/dynamiccapital.duckdns.org/privkey.pem;
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        return 301 https://dynamiccapital.duckdns.org$request_uri;
     }
 }

--- a/docs/DUCKDNS_NGINX_CERTBOT.md
+++ b/docs/DUCKDNS_NGINX_CERTBOT.md
@@ -83,3 +83,16 @@ These steps install Nginx, enable HTTPS with Certbot, and force all traffic to y
    ```
 
 These steps secure the DuckDNS domain with automatic HTTPS certificates.
+
+## Docker-based setup
+
+This project also ships with a containerized Nginx and Certbot configuration.
+From the repository root, obtain the initial certificate and start the services:
+
+```bash
+scripts/init-letsencrypt.sh
+docker compose up -d nginx certbot
+```
+
+The `certbot` service renews certificates automatically and Nginx forces all
+traffic to `https://dynamiccapital.duckdns.org`.

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Obtain an initial Let's Encrypt certificate for dynamiccapital.duckdns.org
+# Usage: EMAIL=user@example.com ./scripts/init-letsencrypt.sh
+set -euo pipefail
+
+DOMAIN="dynamiccapital.duckdns.org"
+EMAIL="${EMAIL:-admin@dynamiccapital.duckdns.org}"
+WEBROOT_PATH="/var/lib/letsencrypt"
+
+docker compose run --rm certbot certonly \
+  --webroot -w ${WEBROOT_PATH} \
+  --email "${EMAIL}" \
+  --agree-tos \
+  --no-eff-email \
+  -d ${DOMAIN}


### PR DESCRIPTION
## Summary
- Configure nginx to redirect all traffic to https://dynamiccapital.duckdns.org and serve LetsEncrypt certificates
- Add certbot service and shared volumes in docker-compose for automatic renewal
- Provide init-letsencrypt script and document Docker-based HTTPS setup

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c21028c874832290e60b19b70e7a41