### PR TITLE
feat: harden OpenAI calls and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ SESSION_JWT_SECRET=
 ALLOWED_ORIGINS=
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
+# API key for OpenAI requests (used by ai-faq-assistant and OCR)
+OPENAI_API_KEY=
+# Optional log level: debug, info, warn, error
+LOG_LEVEL=

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Full list and usage notes: [docs/env.md](docs/env.md).
 - OPENAI_API_KEY _(optional)_
 - OPENAI_ENABLED _(optional)_
 - BENEFICIARY_TABLE _(optional)_
+- LOG_LEVEL _(optional)_
 
 ### Build environment
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -72,3 +72,4 @@ example value, and where it's referenced in the repository.
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
 | `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS. | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `LOG_LEVEL`           | Minimum log level for server logs (`debug`, `info`, `warn`, `error`). | No       | `warn`                    | `utils/logger.ts` |

--- a/tests/ai-faq-assistant.test.ts
+++ b/tests/ai-faq-assistant.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import { equal as assertEquals } from 'node:assert/strict';
+
+const loadHandler = async () => {
+  Deno.env.set('OPENAI_API_KEY', 'test-key');
+  Deno.env.set('SUPABASE_URL', 'https://test.supabase.co');
+  Deno.env.set('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+  Deno.env.set('SUPABASE_ANON_KEY', 'anon-key');
+  await import(`../integrations/supabase/client.ts?test=${Math.random()}`);
+  const mod = await import(`../supabase/functions/ai-faq-assistant/index.ts?test=${Math.random()}`);
+  return mod.default as (req: Request) => Promise<Response>;
+};
+
+test('ai-faq-assistant responds to test ping', async () => {
+  const handler = await loadHandler();
+  const req = new Request('https://example.com', {
+    method: 'POST',
+    body: JSON.stringify({ test: true }),
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+});
+
+test('ai-faq-assistant validates question', async () => {
+  const handler = await loadHandler();
+  const req = new Request('https://example.com', {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+  const res = await handler(req);
+  assertEquals(res.status, 400);
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import { equal as assertEquals } from 'node:assert/strict';
+
+const importFresh = async () => {
+  return await import(`../utils/logger.ts?cachebust=${Math.random()}`);
+};
+
+test('logger.error logs in production', async () => {
+  process.env.NODE_ENV = 'production';
+  delete process.env.LOG_LEVEL;
+  const calls: unknown[][] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => { calls.push(args); };
+  const { logger } = await importFresh();
+  logger.error('boom');
+  console.error = original;
+  assertEquals(calls.length, 1);
+});
+
+test('logger respects LOG_LEVEL', async () => {
+  process.env.NODE_ENV = 'production';
+  process.env.LOG_LEVEL = 'warn';
+  const calls: unknown[][] = [];
+  const originalInfo = console.info;
+  console.info = (...args: unknown[]) => { calls.push(args); };
+  const { logger } = await importFresh();
+  logger.info('hidden');
+  console.info = originalInfo;
+  assertEquals(calls.length, 0);
+});

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -11,20 +11,36 @@ function getEnv(name: string): string | undefined {
   return undefined;
 }
 
-const isDev = getEnv('NODE_ENV') !== 'production';
+const defaultLevel = getEnv('NODE_ENV') !== 'production' ? 'debug' : 'info';
+type Level = 'debug' | 'info' | 'warn' | 'error';
+const levelWeights: Record<Level, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const currentLevel = (getEnv('LOG_LEVEL') as Level | undefined) ?? defaultLevel;
+
+function shouldLog(level: Level): boolean {
+  return levelWeights[level] >= levelWeights[currentLevel];
+}
 
 export const logger = {
+  debug: (...args: unknown[]) => {
+    if (shouldLog('debug')) console.debug(...args);
+  },
   log: (...args: unknown[]) => {
-    if (isDev) console.log(...args);
+    if (shouldLog('info')) console.log(...args);
   },
   info: (...args: unknown[]) => {
-    if (isDev) console.info(...args);
+    if (shouldLog('info')) console.info(...args);
   },
   warn: (...args: unknown[]) => {
-    if (isDev) console.warn(...args);
+    if (shouldLog('warn')) console.warn(...args);
   },
   error: (...args: unknown[]) => {
-    if (isDev) console.error(...args);
+    if (shouldLog('error')) console.error(...args);
   },
 };
 


### PR DESCRIPTION
## Summary
- add fetch timeouts, retries, and default export to ai-faq-assistant
- document OpenAI and logging env vars
- add log level support and production logging tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c21095ebb08322b7512b68841a2e9c