### PR TITLE
Clarify nginx redirect and LetsEncrypt init instructions

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,10 @@
 worker_processes auto;
 
+# Nginx configuration for dynamiccapital.duckdns.org
+# - Redirects all HTTP traffic to HTTPS
+# - Serves Let's Encrypt certificates from /etc/letsencrypt
+# - Proxies requests to the internal app service
+
 # Basic event configuration
 events {
     worker_connections 1024;
@@ -13,6 +18,7 @@ http {
         server app:8080 max_fails=3 fail_timeout=30s;
     }
 
+    # Catch-all HTTP server: serve ACME challenges and redirect everything else to HTTPS
     server {
         listen 80 default_server;
         server_name _;
@@ -26,6 +32,7 @@ http {
         }
     }
 
+    # Primary HTTPS server for dynamiccapital.duckdns.org
     server {
         listen 443 ssl;
         server_name dynamiccapital.duckdns.org;
@@ -44,6 +51,7 @@ http {
         }
     }
 
+    # Fallback HTTPS server: redirect unknown hosts to the canonical domain
     server {
         listen 443 default_server ssl;
         server_name _;

--- a/docs/DUCKDNS_NGINX_CERTBOT.md
+++ b/docs/DUCKDNS_NGINX_CERTBOT.md
@@ -90,7 +90,7 @@ This project also ships with a containerized Nginx and Certbot configuration.
 From the repository root, obtain the initial certificate and start the services:
 
 ```bash
-scripts/init-letsencrypt.sh
+EMAIL=you@example.com scripts/init-letsencrypt.sh
 docker compose up -d nginx certbot
 ```
 


### PR DESCRIPTION
## Summary
- document using an email when bootstrapping LetsEncrypt certs
- add explanatory comments to nginx config that redirects everything to https://dynamiccapital.duckdns.org

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2121f900c83229fabbd3c401d580b