### PR TITLE
Use Deno env helpers and type CORS utils

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { getEnvVar } from './utils/env.ts';
 
 const schema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']),
@@ -9,9 +10,9 @@ const schema = z.object({
 });
 
 export const ENV = schema.parse({
-  NODE_ENV: process.env.NODE_ENV,
-  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN
+  NODE_ENV: getEnvVar('NODE_ENV'),
+  NEXT_PUBLIC_API_URL: getEnvVar('NEXT_PUBLIC_API_URL'),
+  NEXT_PUBLIC_SUPABASE_URL: getEnvVar('NEXT_PUBLIC_SUPABASE_URL'),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
+  NEXT_PUBLIC_SENTRY_DSN: getEnvVar('NEXT_PUBLIC_SENTRY_DSN'),
 });

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -1,13 +1,13 @@
 const rawAllowedOrigins =
-  typeof Deno !== 'undefined'
-    ? Deno.env.get('ALLOWED_ORIGINS')
+  'Deno' in globalThis
+    ? (globalThis as any).Deno.env.get('ALLOWED_ORIGINS')
     : typeof process !== 'undefined'
     ? process.env.ALLOWED_ORIGINS
     : undefined;
 
 const allowedOrigins = (rawAllowedOrigins || '')
   .split(',')
-  .map((o) => o.trim())
+  .map((o: string) => o.trim())
   .filter(Boolean);
 
 export function buildCorsHeaders(origin: string | null) {


### PR DESCRIPTION
## Summary
- refactor env loading to use Deno-aware `getEnvVar` helper instead of Node `process`
- handle allowed origins without Node globals and type CORS mapping

## Testing
- `npm run typecheck`
- `npm test`
- `npx deno check env.ts` *(fails: Failed reading lockfile: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_68c2170036588322a42d266b5e8cc060