### PR TITLE
Fix allowed origin env detection for Deno compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,17 +299,18 @@ Full list and usage notes: [docs/env.md](docs/env.md).
 
 Both the dashboard and the Telegram MiniApp require these variables at build
 time (exposed with Next.js `NEXT_PUBLIC_` prefix so they end up in the browser
-bundle):
+bundle). `NEXT_PUBLIC_API_URL` is optional and defaults to `/api` if omitted:
 
 ```bash
-NEXT_PUBLIC_API_URL=https://example.com/api
 NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+# NEXT_PUBLIC_API_URL=https://example.com/api
 ```
 
-Set these in your hosting provider (e.g., Lovable.dev project settings). If
+Set the required Supabase values in your hosting provider (e.g., Lovable.dev project settings). If
 either value is missing, the app will render a configuration error screen
-instead of loading. The client also accepts `SUPABASE_URL`/`SUPABASE_ANON_KEY`
+instead of loading. You can optionally set `NEXT_PUBLIC_API_URL` to point at a custom API; otherwise the client uses
+the relative `/api` path. The client also accepts `SUPABASE_URL`/`SUPABASE_ANON_KEY`
 as fallbacks if the `NEXT_PUBLIC_` values are not provided.
 
 Values are set in Supabase function secrets, GitHub Environments, or Lovable

--- a/docs/env.md
+++ b/docs/env.md
@@ -66,7 +66,7 @@ example value, and where it's referenced in the repository.
 | Key                   | Purpose                                  | Required | Example                   | Used in                           |
 | --------------------- | ---------------------------------------- | -------- | ------------------------- | --------------------------------- |
 | `SITE_URL`            | Base URL for the deployed site; used for redirects and canonical host checks. | Yes      | `https://example.com`     | `next.config.mjs`, `hooks/useAuth.tsx` |
-| `NEXT_PUBLIC_API_URL`  | Base URL for client API requests. | Yes | `https://example.com/api` | `env.ts` |
+| `NEXT_PUBLIC_API_URL`  | Base URL for client API requests (defaults to same-origin `/api`). | No | `https://example.com/api` | `env.ts` |
 | `NODE_EXTRA_CA_CERTS` | Additional CA bundle for outbound HTTPS. | No       | `/etc/ssl/custom.pem`     | `src/utils/http-ca.ts`            |
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |

--- a/env.ts
+++ b/env.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
-import { getEnvVar } from './utils/env.ts';
+import { getEnvVar, optionalEnvVar } from './utils/env.ts';
 
 const schema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']),
-  NEXT_PUBLIC_API_URL: z.string().url(),
+  NEXT_PUBLIC_API_URL: z.string().url().optional(),
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string().min(10),
   NEXT_PUBLIC_SENTRY_DSN: z.string().optional()
@@ -11,7 +11,7 @@ const schema = z.object({
 
 export const ENV = schema.parse({
   NODE_ENV: getEnvVar('NODE_ENV'),
-  NEXT_PUBLIC_API_URL: getEnvVar('NEXT_PUBLIC_API_URL'),
+  NEXT_PUBLIC_API_URL: optionalEnvVar('NEXT_PUBLIC_API_URL'),
   NEXT_PUBLIC_SUPABASE_URL: getEnvVar('NEXT_PUBLIC_SUPABASE_URL'),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
   NEXT_PUBLIC_SENTRY_DSN: getEnvVar('NEXT_PUBLIC_SENTRY_DSN'),

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -1,9 +1,13 @@
+// Access Node's process via globalThis to avoid TypeScript errors when `process`
+// is not defined (e.g. in Deno environments)
+const nodeProcess = (globalThis as any).process as
+  | { env?: Record<string, string | undefined> }
+  | undefined;
+
 const rawAllowedOrigins =
   'Deno' in globalThis
     ? (globalThis as any).Deno.env.get('ALLOWED_ORIGINS')
-    : typeof process !== 'undefined'
-    ? process.env.ALLOWED_ORIGINS
-    : undefined;
+    : nodeProcess?.env?.ALLOWED_ORIGINS;
 
 const allowedOrigins = (rawAllowedOrigins || '')
   .split(',')


### PR DESCRIPTION
## Summary
- guard `process` usage in `utils/http` so API routes work in Deno environments
- allow builds without `NEXT_PUBLIC_API_URL` by making it optional and documenting the default `/api`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c21a1b55c88322b0e28cae5ba7c1f1