### PR TITLE
Fix locale layout async params to satisfy Next.js

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,8 +2,14 @@ import { NextIntlClientProvider } from 'next-intl';
 import { ReactNode } from 'react';
 import messages from './messages';
 
-export default function LocaleLayout({ children, params }: { children: ReactNode; params: { locale: string } }) {
-  const locale = params.locale;
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const localeMessages = (messages as Record<string, any>)[locale] || messages.en;
   return (
     <NextIntlClientProvider locale={locale} messages={localeMessages}>


### PR DESCRIPTION
## Summary
- refactor locale layout to accept async params for Next.js compatibility

## Testing
- `npm test`
- `npm run predeploy`
- `npx next build` *(fails: React Context is unavailable in Server Components)*
- `npm run start` *(fails: missing `.next` build output)*

------
https://chatgpt.com/codex/tasks/task_e_68c2361af8f88322a864d7f532b05f35