### PR TITLE
chore: allow remote imports in Deno checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ All Deno tasks live in `deno.json` and can be run via `deno task <name>`.
 Type check:
 
 ```bash
-deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
+deno check --allow-import supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
 ```
 
 If tests present:

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "check": "NODE_TLS_REJECT_UNAUTHORIZED=0 deno check --no-npm --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org,cdn.skypack.dev,lib.deno.dev,jsr.io supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
+    "check": "NODE_TLS_REJECT_UNAUTHORIZED=0 deno check --allow-import=deno.land,registry.npmjs.org,cdn.skypack.dev,lib.deno.dev,jsr.io --no-npm --unsafely-ignore-certificate-errors=deno.land,registry.npmjs.org,cdn.skypack.dev,lib.deno.dev,jsr.io supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
     "serve": "supabase functions serve",
     "fmt": "bash -lc '$(bash scripts/deno_bin.sh) fmt --check .'",
     "fmt:write": "bash -lc '$(bash scripts/deno_bin.sh) fmt .'",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -69,7 +69,7 @@ or CDN honors these headers and caches static content at the edge.
 Run basic checks before deploying:
 
 ```bash
-deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
+deno check --allow-import supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
 deno test -A
 node scripts/assert-miniapp-bundle.mjs
 ```

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -33,7 +33,7 @@ This guide outlines eight high-level steps to run, build, and deploy the Telegra
 6. **Quality checks**
    - Type-check and test the codebase:
    ```bash
-   deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
+   deno check --allow-import supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
    deno test -A
    ```
 

--- a/docs/REPO_SUMMARY.md
+++ b/docs/REPO_SUMMARY.md
@@ -167,7 +167,7 @@ tests/
   - Expand coverage around Supabase client utilities
 
 ## 8) Deno Tasks
-- check → deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
+- check → deno check --allow-import supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts
 - serve → supabase functions serve
 - fmt → bash -lc '$(bash scripts/deno_bin.sh) fmt --check .'
 - fmt:write → bash -lc '$(bash scripts/deno_bin.sh) fmt .'

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -146,7 +146,7 @@ crash).
   `supabase start` → `supabase functions serve telegram-bot --no-verify-jwt` →\
   `curl -X POST "http://127.0.0.1:54321/functions/v1/telegram-bot" -H "content-type: application/json" -H "X-Telegram-Bot-Api-Secret-Token: $TELEGRAM_WEBHOOK_SECRET" -d '{"test":"ping"}'`
 - **Typecheck:**
-  `deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts`
+  `deno check --allow-import supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts`
 - **Post-deploy smoke:** invoke ping; check `getWebhookInfo` shows the correct
   URL and low pending updates.
 

--- a/scripts/predeploy.js
+++ b/scripts/predeploy.js
@@ -7,7 +7,7 @@ function run(cmd) {
 }
 
 const commands = [
-  "DENO_TLS_CA_STORE=system deno check supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
+  "DENO_TLS_CA_STORE=system deno check --allow-import=deno.land,registry.npmjs.org,cdn.skypack.dev,lib.deno.dev,jsr.io supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts",
   "npm test",
   "node scripts/assert-miniapp-bundle.mjs"
 ];


### PR DESCRIPTION
## Summary
- allow `deno check` to import remote modules
- document new `--allow-import` requirement across docs

## Testing
- `DENO_TLS_CA_STORE=system npx deno check --allow-import=deno.land,registry.npmjs.org,cdn.skypack.dev,lib.deno.dev,jsr.io supabase/functions/telegram-bot/*.ts supabase/functions/telegram-bot/**/*.ts`
- `npm test`
- `node scripts/assert-miniapp-bundle.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c2403faed88322b1ba9d2692f7e792