### PR TITLE
chore: set node version for build

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -21,6 +21,10 @@ version = "0.0.0"
     path = ".next/cache"
 
   [[build.env]]
+    name = "BP_NODE_VERSION"
+    value = "22.*"
+
+  [[build.env]]
     name = "NPM_START_SCRIPT"
     value = "lovable-build.js"
 


### PR DESCRIPTION
## Summary
- pin Node.js buildpack to version 22.x via `BP_NODE_VERSION`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c247b57a348322b293b2b4c26a9c0e