### PR TITLE
Handle null-like env vars in util functions

### DIFF
--- a/tests/utils-config-env.test.ts
+++ b/tests/utils-config-env.test.ts
@@ -13,3 +13,16 @@ test('utils/config requires Supabase env vars', async () => {
   if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl; else delete process.env.SUPABASE_URL;
   if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey; else delete process.env.SUPABASE_ANON_KEY;
 });
+
+test('utils/config rejects null-like env values', async () => {
+  const prevUrl = process.env.SUPABASE_URL;
+  const prevKey = process.env.SUPABASE_ANON_KEY;
+  process.env.SUPABASE_URL = 'null';
+  process.env.SUPABASE_ANON_KEY = 'undefined';
+  await rejects(
+    import(`../utils/config.ts?${Date.now()}`),
+    /Missing required env: SUPABASE_URL/,
+  );
+  if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl; else delete process.env.SUPABASE_URL;
+  if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey; else delete process.env.SUPABASE_ANON_KEY;
+});

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -4,13 +4,24 @@ declare const process:
   | undefined;
 declare const Deno: { env: { get(key: string): string | undefined } } | undefined;
 
+function sanitize(v: string | undefined): string | undefined {
+  if (!v) return undefined;
+  const val = v.trim();
+  if (val === "" || val.toLowerCase() === "undefined" || val.toLowerCase() === "null") {
+    return undefined;
+  }
+  return val;
+}
+
 function readEnv(key: string): string | undefined {
-  if (typeof process !== "undefined" && process.env?.[key]) {
-    return process.env[key];
+  if (typeof process !== "undefined" && process.env) {
+    const v = sanitize(process.env[key]);
+    if (v !== undefined) return v;
   }
   if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
     try {
-      return Deno.env.get(key) ?? undefined;
+      const v = sanitize(Deno.env.get(key) ?? undefined);
+      if (v !== undefined) return v;
     } catch {
       // ignore permission errors
     }


### PR DESCRIPTION
## Summary
- sanitize environment variable reads across Node/Deno helpers to treat empty, `undefined`, or `null` strings as missing
- apply the same sanitation in Supabase shared env utilities
- extend tests to cover null-like env values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c269a21bbc8322b32f7b40380644b2