### PR TITLE
fix: reload supabase config for env var tests

### DIFF
--- a/config/supabase.ts
+++ b/config/supabase.ts
@@ -1,5 +1,16 @@
 import { optionalEnvVar } from "../utils/env.ts";
-import { SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_ENV_ERROR } from "../integrations/supabase/client.ts";
+
+// Re-import the Supabase client on each load so tests that manipulate
+// environment variables get a fresh view of the configuration. This avoids
+// module cache issues where earlier imports lock in env vars before tests
+// delete them.
+const {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  SUPABASE_ENV_ERROR,
+} = await import(
+  `../integrations/supabase/client.ts?${Date.now()}`
+);
 
 const PROJECT_ID = SUPABASE_URL.match(/^https:\/\/([a-z0-9]+)\.supabase\.co/)
   ? RegExp.$1


### PR DESCRIPTION
## Summary
- ensure Supabase config reloads client to reflect environment changes during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c26c6cfc408322b1318994a013220a