### PR TITLE
test: isolate Supabase env vars in missing-env test

### DIFF
--- a/tests/missing-env-screen.test.ts
+++ b/tests/missing-env-screen.test.ts
@@ -2,8 +2,12 @@ import test from 'node:test';
 import { ok as assert } from 'node:assert/strict';
 
 test('missing Supabase env vars sets error flag', async () => {
+  const prevUrl = process.env.SUPABASE_URL;
+  const prevKey = process.env.SUPABASE_ANON_KEY;
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_ANON_KEY;
   const mod = await import(`../config/supabase.ts?${Date.now()}`);
   assert(mod.SUPABASE_ENV_ERROR);
+  if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl;
+  if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey;
 });


### PR DESCRIPTION
## Summary
- ensure `missing-env-screen.test.ts` restores Supabase env vars after manipulating them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26df3bfbc8322a3c5d140c575c7fa