### PR TITLE
Use Next.js export output

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,7 +47,7 @@ process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  output: 'export',
   env: {
     SUPABASE_URL,
     SUPABASE_ANON_KEY,


### PR DESCRIPTION
## Summary
- configure Next.js to produce a static export output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c276e0dd04832283e9ac4e285e8ee6