### PR TITLE
fix: mark client components for Next.js build

### DIFF
--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -4,10 +4,10 @@ import Link from "next/link";
 import BrandLogo from "@/components/BrandLogo";
 import { MotionStagger } from "@/components/ui/motion-components";
 import { motion } from "framer-motion";
-import { useSession, signIn, signOut } from "next-auth/react";
+import { useAuth } from "@/hooks/useAuth";
 
 const Navbar = () => {
-  const { data: session } = useSession();
+  const { user, signOut } = useAuth();
   return (
     <nav className="glass-motion-nav border-b border-border">
       <div className="container mx-auto flex items-center justify-between p-4">
@@ -26,10 +26,10 @@ const Navbar = () => {
               <Link href="#settings" className="hover:text-primary">Settings</Link>
             </motion.div>
           </MotionStagger>
-          {session ? (
+          {user ? (
             <button onClick={() => signOut()} className="hover:text-primary">Logout</button>
           ) : (
-            <button onClick={() => signIn()} className="hover:text-primary">Login</button>
+            <Link href="/login" className="hover:text-primary">Login</Link>
           )}
         </div>
       </div>

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { cn } from "@/utils";
 

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 
 import { cn } from "@/utils";

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 

--- a/context/SupabaseProvider.tsx
+++ b/context/SupabaseProvider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';


### PR DESCRIPTION
## Summary
- replace NextAuth usage in `Navbar` with internal auth context
- mark Supabase context provider and common UI components as client components

## Testing
- `npm test`
- `npm run build` *(fails: TypeError: Cannot read properties of null (reading 'useContext'))*


------
https://chatgpt.com/codex/tasks/task_e_68c285f04c588322aa1e3338aecb4892