### PR TITLE
refactor: centralize CORS handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ NEXT_PUBLIC_SITE_URL=https://urchin-app-macix.ondigitalocean.app
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=
-# Comma-separated origins allowed for CORS
+# Comma-separated origins allowed for CORS (e.g. https://example.com,https://another.com)
 ALLOWED_ORIGINS=
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=

--- a/apps/web/app/api/route.ts
+++ b/apps/web/app/api/route.ts
@@ -21,5 +21,6 @@ export const PATCH = methodNotAllowed;
 export const DELETE = methodNotAllowed;
 export const HEAD = methodNotAllowed;
 export function OPTIONS(req: Request) {
-  return new Response(null, { status: 204, headers: corsHeaders(req) });
+  const headers = corsHeaders(req, 'GET');
+  return new Response(null, { status: 204, headers });
 }

--- a/apps/web/utils/http.ts
+++ b/apps/web/utils/http.ts
@@ -14,11 +14,16 @@ const allowedOrigins = (rawAllowedOrigins || '')
   .map((o: string) => o.trim())
   .filter(Boolean);
 
-export function buildCorsHeaders(origin: string | null) {
+if (allowedOrigins.length === 0) {
+  console.warn('[CORS] ALLOWED_ORIGINS is empty; cross-origin requests will be rejected');
+}
+
+export function buildCorsHeaders(origin: string | null, methods?: string) {
   const headers: Record<string, string> = {
-    'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
     'access-control-allow-headers':
       'authorization, x-client-info, apikey, content-type',
+    'access-control-allow-methods':
+      methods || 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
   };
   if (origin && allowedOrigins.includes(origin)) {
     headers['access-control-allow-origin'] = origin;
@@ -26,8 +31,8 @@ export function buildCorsHeaders(origin: string | null) {
   return headers;
 }
 
-export function corsHeaders(req: Request) {
-  return buildCorsHeaders(req.headers.get('origin'));
+export function corsHeaders(req: Request, methods?: string) {
+  return buildCorsHeaders(req.headers.get('origin'), methods);
 }
 
 export function jsonResponse(

--- a/supabase/functions/subscription-status/index.ts
+++ b/supabase/functions/subscription-status/index.ts
@@ -1,14 +1,11 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "../_shared/client.ts";
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeaders } from "../_shared/http.ts";
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+    const headers = corsHeaders(req, 'POST');
+    return new Response(null, { headers });
   }
 
   try {
@@ -16,11 +13,11 @@ serve(async (req) => {
     
     if (!telegram_user_id) {
       return new Response(
-        JSON.stringify({ error: 'telegram_user_id is required' }), 
-        { 
-          status: 400, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-        }
+        JSON.stringify({ error: 'telegram_user_id is required' }),
+        {
+          status: 400,
+          headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+        },
       );
     }
 
@@ -33,11 +30,11 @@ serve(async (req) => {
     if (subscriptionError) {
       console.error('Subscription status error:', subscriptionError);
       return new Response(
-        JSON.stringify({ error: 'Failed to get subscription status' }), 
-        { 
-          status: 500, 
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-        }
+        JSON.stringify({ error: 'Failed to get subscription status' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+        },
       );
     }
 
@@ -62,20 +59,20 @@ serve(async (req) => {
 
     // Return the subscription data directly (not wrapped in another object)
     return new Response(
-      JSON.stringify(subscription), 
-      { 
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-      }
+      JSON.stringify(subscription),
+      {
+        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+      },
     );
 
   } catch (error) {
     console.error('Error in subscription-status:', error);
     return new Response(
-      JSON.stringify({ error: 'Internal server error' }), 
-      { 
-        status: 500, 
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
-      }
+      JSON.stringify({ error: 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+      },
     );
   }
 });

--- a/tests/api/cors.test.ts
+++ b/tests/api/cors.test.ts
@@ -14,3 +14,11 @@ Deno.test('disallowed origin is rejected', () => {
   const headers = corsHeaders(req);
   assert.ok(!('access-control-allow-origin' in headers));
 });
+
+Deno.test('preflight includes allowed methods', () => {
+  const req = new Request('http://localhost', {
+    headers: { origin: 'https://allowed.com' },
+  });
+  const headers = corsHeaders(req, 'GET,POST');
+  assert.equal(headers['access-control-allow-methods'], 'GET,POST');
+});


### PR DESCRIPTION
## Summary
- centralize CORS header generation with optional method configuration
- document `ALLOWED_ORIGINS` and wire it into edge functions and API routes
- add tests covering allowed-origin and allowed-method behaviour

## Testing
- `npm test` *(fails: TypeError: Relative import path "@/utils/env.ts" not prefixed and other module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c38d8e77388322b593bc09792a3c44