### PR TITLE
Fix build scripts and miniapp entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "name": "dynamic-chatty-bot",
   "private": true,
-  "workspaces": ["apps/*"],
-  "engines": { "node": ">=22.0.0 <23.0.0" },
+  "workspaces": [
+    "apps/*"
+  ],
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
   "type": "module",
   "scripts": {
     "build": "npm -w apps/landing run build && npm -w apps/web run build",
     "build:landing": "npm -w apps/landing run build",
     "build:web": "npm -w apps/web run build",
+    "build:miniapp": "bash scripts/build-miniapp.sh",
     "start:web": "npm -w apps/web run start",
     "test": "node scripts/check-static-homepage.js && deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check"
   }

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,4 +1,5 @@
-import { optionalEnvVar } from "../utils/env.ts";
+// Reuse the env helper from the web app to avoid maintaining a separate copy
+import { optionalEnvVar } from "../apps/web/utils/env.ts";
 
 const SUPABASE_URL = optionalEnvVar("SUPABASE_URL");
 const SUPABASE_ANON_KEY = optionalEnvVar("SUPABASE_ANON_KEY");

--- a/supabase/functions/miniapp/index.html
+++ b/supabase/functions/miniapp/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Miniapp</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- reuse web env helper in `scripts/check-env.ts`
- add root `build:miniapp` script for Vite miniapp
- provide `supabase/functions/miniapp/index.html` so Vite build resolves entry

## Testing
- `npx tsx scripts/check-env.ts`
- `npm -w apps/web run build`
- `npm run build:miniapp`


------
https://chatgpt.com/codex/tasks/task_e_68c3902eed608322b6e2309f0979968e