### PR TITLE
feat: serve sitemap.xml and robots.txt

### DIFF
--- a/apps/web/config/supabase.ts
+++ b/apps/web/config/supabase.ts
@@ -1,5 +1,4 @@
 import { getEnvVar } from "@/utils/env.ts";
-export { SUPABASE_ENV_ERROR } from "@/integrations/supabase/client.ts";
 
 const SUPABASE_URL = getEnvVar("NEXT_PUBLIC_SUPABASE_URL", ["SUPABASE_URL"]) ??
   "";

--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -9,7 +9,7 @@ export type StaticOpts = {
   rootDir: URL; // e.g., new URL("../miniapp/static/", import.meta.url)
   spaRoots?: string[]; // paths that should serve index.html
   security?: Record<string, string>;
-  extraFiles?: string[]; // e.g., ["/favicon.svg", "/site.webmanifest"]
+  extraFiles?: string[]; // e.g., ["/favicon.svg", "/site.webmanifest", "/sitemap.xml"]
 };
 export const DEFAULT_SECURITY = {
   "referrer-policy": "strict-origin-when-cross-origin",
@@ -75,6 +75,7 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
     "/favicon.ico",
     "/site.webmanifest",
     "/robots.txt",
+    "/sitemap.xml",
   ]);
 
   // HEAD allowed on SPA roots

--- a/supabase/functions/_tests/static_extra_files_test.ts
+++ b/supabase/functions/_tests/static_extra_files_test.ts
@@ -1,0 +1,18 @@
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/testing/asserts.ts";
+import { serveStatic, StaticOpts } from "../_shared/static.ts";
+
+Deno.test("serve robots.txt and sitemap.xml with correct content-type", async () => {
+  const rootDir = new URL("../miniapp/static/", import.meta.url);
+  const opts: StaticOpts = {
+    rootDir,
+    extraFiles: ["/robots.txt", "/sitemap.xml"],
+  };
+
+  const robots = await serveStatic(new Request("https://example.com/robots.txt"), opts);
+  assertEquals(robots.status, 200);
+  assert(robots.headers.get("content-type")?.startsWith("text/plain"));
+
+  const sitemap = await serveStatic(new Request("https://example.com/sitemap.xml"), opts);
+  assertEquals(sitemap.status, 200);
+  assertEquals(sitemap.headers.get("content-type"), "application/xml");
+});

--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -298,7 +298,13 @@ export async function handler(req: Request): Promise<Response> {
         rootDir: new URL("./static/", import.meta.url),
         spaRoots: ["/"],
         security: ENHANCED_SECURITY_HEADERS,
-        extraFiles: ["/favicon.ico", "/favicon.svg", "/vite.svg", "/robots.txt"]
+        extraFiles: [
+          "/favicon.ico",
+          "/favicon.svg",
+          "/vite.svg",
+          "/robots.txt",
+          "/sitemap.xml",
+        ]
       };
 
       // Try static serving first (normalize /miniapp prefix if present)

--- a/supabase/functions/miniapp/static/robots.txt
+++ b/supabase/functions/miniapp/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://mini.dynamic.capital/miniapp/sitemap.xml

--- a/supabase/functions/miniapp/static/sitemap.xml
+++ b/supabase/functions/miniapp/static/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mini.dynamic.capital/</loc>
+  </url>
+  <url>
+    <loc>https://mini.dynamic.capital/miniapp/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- serve `sitemap.xml` via shared static helper and miniapp
- add static `robots.txt` and `sitemap.xml` assets
- test static files and fix duplicate Supabase env export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a492a6e88322a303a3f7ce17e7bc