### PR TITLE
docs: add DigitalOcean app logs guide

### DIFF
--- a/docs/DIGITALOCEAN_APP_LOGS.md
+++ b/docs/DIGITALOCEAN_APP_LOGS.md
@@ -1,0 +1,40 @@
+# DigitalOcean App Logs
+
+Guidelines for retrieving build, deploy, runtime, and crash logs for the DigitalOcean App.
+
+## Automation
+
+1. **Install and authenticate `doctl`**
+   - Download and install the DigitalOcean CLI.
+   - Create a personal access token.
+   - Authenticate: `doctl auth init`.
+2. **List apps and get the app ID**
+   - `doctl apps list`
+3. **Fetch logs via CLI**
+   - `doctl apps logs <app-id> <component-name> --type build`
+   - Omit `<component-name>` for all components.
+   - Use `--type run_restarted` for crash logs.
+4. **Retrieve logs via API**
+   - Export token: `export DIGITALOCEAN_TOKEN=...`
+   - Send request:
+     ```bash
+     curl -X GET \
+       -H "Content-Type: application/json" \
+       -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+       "https://api.digitalocean.com/v2/apps/{app_id}/deployments/{deployment_id}/components/{component_name}/logs"
+     ```
+   - Python (PyDo) example:
+     ```python
+     import os
+     from pydo import Client
+
+     client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+     get_resp = client.apps.get_logs(app_id="4f6c71e2", deployment_id="3aa4d20e", component_name="component")
+     ```
+
+## Control Panel
+
+1. **Activity Logs** – Apps → *Your App* → **Activity** shows deployment timeline.
+2. **Deployment Logs** – Activity tab → click a deployment to view Build and Deploy logs.
+3. **Runtime Logs** – **Runtime Logs** tab → select a resource to view live logs.
+4. **Crash Logs** – Access with `doctl apps logs <app-id> --type=run_restarted` (optionally specify a component).


### PR DESCRIPTION
## Summary
- document how to access DigitalOcean App build, deploy, runtime, and crash logs via CLI, API, and control panel

## Testing
- `deno task fmt` *(fails: invalid peer certificate UnknownIssuer)*
- `deno task lint` *(fails: invalid peer certificate UnknownIssuer)*
- `deno task test` *(fails: invalid peer certificate UnknownIssuer)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a671f40c8322b271b6ce4f7a4e23