### PR TITLE
feat: add landing redirect and build config

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Capital VIP</title>
+</head>
+<body>
+    <script>
+        // Redirect to your DigitalOcean app
+        window.location.href = 'https://urchin-app-macix.ondigitalocean.app';
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:landing": "npm -w apps/landing run build",
     "build:web": "npm -w apps/web run build",
     "build:miniapp": "bash scripts/build-miniapp.sh",
+    "build:dev": "vite build --mode development",
     "start:web": "npm -w apps/web run start",
     "dev": "npm -w apps/web run dev",
     "debug": "NODE_OPTIONS='--inspect' npm run dev",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: './index.html'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add root index.html redirecting to DigitalOcean app
- configure Vite build with React plugin
- add build:dev script to run Vite in development mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3bf77d3ec8322a1aabd38c2f5c4c9