### PR TITLE
fix: correct Supabase insert types

### DIFF
--- a/apps/web/components/admin/AdminDataManager.tsx
+++ b/apps/web/components/admin/AdminDataManager.tsx
@@ -122,12 +122,10 @@ export const AdminDataManager = () => {
 
       const { error } = await supabase
         .from("kv_config")
-        .insert([
-          {
-            key: kvConfigForm.key,
-            value: parsedValue
-          } as TablesInsert<"kv_config">
-        ]);
+        .insert<TablesInsert<"kv_config">>({
+          key: kvConfigForm.key,
+          value: parsedValue
+        });
 
       if (error) throw error;
 
@@ -145,14 +143,12 @@ export const AdminDataManager = () => {
     try {
       const { error } = await supabase
         .from("abuse_bans")
-        .insert([
-          {
-            telegram_id: abuseBanForm.telegram_id,
-            reason: abuseBanForm.reason || null,
-            expires_at: abuseBanForm.expires_at || null,
-            created_by: abuseBanForm.created_by || null
-          } as TablesInsert<"abuse_bans">
-        ]);
+        .insert<TablesInsert<"abuse_bans">>({
+          telegram_id: abuseBanForm.telegram_id,
+          reason: abuseBanForm.reason || null,
+          expires_at: abuseBanForm.expires_at || null,
+          created_by: abuseBanForm.created_by || null
+        });
 
       if (error) throw error;
 

--- a/apps/web/integrations/supabase/client.ts
+++ b/apps/web/integrations/supabase/client.ts
@@ -1,5 +1,8 @@
 // Supabase client and helpers
-import { createClient as createBrowserClient } from '@supabase/supabase-js';
+import {
+  createClient as createBrowserClient,
+  type SupabaseClient as SupabaseJsClient,
+} from '@supabase/supabase-js';
 import { getEnvVar } from '@/utils/env.ts';
 import type { Database } from './types.ts';
 
@@ -42,7 +45,7 @@ const loggingFetch: typeof fetch = async (input, init) => {
   return res;
 };
 
-export type SupabaseClient = ReturnType<typeof createBrowserClient>;
+export type SupabaseClient = SupabaseJsClient<Database>;
 
 export function createClient(role: 'anon' | 'service' = 'anon'): SupabaseClient {
   const key =
@@ -56,7 +59,7 @@ export function createClient(role: 'anon' | 'service' = 'anon'): SupabaseClient 
         : SUPABASE_ENV_ERROR || 'Missing Supabase anon key',
     );
   }
-  return createBrowserClient(SUPABASE_URL, key, {
+  return createBrowserClient<Database>(SUPABASE_URL, key, {
     global: { fetch: loggingFetch },
   });
 }


### PR DESCRIPTION
## Summary
- ensure AdminDataManager insert calls use typed schema
- type Supabase client with Database for proper generics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3c2074cd883229fec9da3cbc21398