### PR TITLE
chore: export static assets to root-level directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ configuration for each component.
 ## HTML Static Site Starter
 
 A minimal static landing page lives in `static-site/` with `index.html`, `styles.css`, and `scripts.js`.
-Run `npm run build:static` to copy it into the `_static/` directory for deployment.
+Run `npm run build:static` to copy it into the `/_static/` directory for deployment.
 Modify the files to suit your needs before running the build.
 
 ## Development Process Overview

--- a/scripts/copy-static.ts
+++ b/scripts/copy-static.ts
@@ -12,9 +12,9 @@ if (!copyOnly) {
 const root = process.cwd();
 const nextStatic = join(root, '.next', 'static');
 const nextServerApp = join(root, '.next', 'server', 'app');
-// Copy build output to a root-level `_static` directory so the site can be
+// Copy build output to a root-level `/_static` directory so the site can be
 // served as a regular static site (e.g. on DigitalOcean).
-const destRoot = join(root, '_static');
+const destRoot = join('/', '_static');
 
 async function copyAssets() {
   // Remove existing destination

--- a/scripts/generate-static.mjs
+++ b/scripts/generate-static.mjs
@@ -3,7 +3,8 @@ import { join } from 'node:path';
 
 const root = process.cwd();
 const outDir = join(root, 'out');
-const staticDir = join(root, '_static');
+// Output to a root-level directory so deployment tooling can pick it up
+const staticDir = join('/', '_static');
 
 async function copyOut() {
   await rm(staticDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- copy Next.js export to root `/_static` directory so deployment tooling can access it
- clarify static build instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3dc67170c8322b284958489a8ce19