### PR TITLE
fix static build directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ configuration for each component.
 ## HTML Static Site Starter
 
 A minimal static landing page lives in `static-site/` with `index.html`, `styles.css`, and `scripts.js`.
-Run `npm run build:static` to copy it into the `/_static/` directory for deployment.
+Run `npm run build:static` to copy it into the `_static/` directory for deployment.
 Modify the files to suit your needs before running the build.
 
 ## Development Process Overview

--- a/scripts/copy-static.ts
+++ b/scripts/copy-static.ts
@@ -12,9 +12,9 @@ if (!copyOnly) {
 const root = process.cwd();
 const nextStatic = join(root, '.next', 'static');
 const nextServerApp = join(root, '.next', 'server', 'app');
-// Copy build output to a root-level `/_static` directory so the site can be
+// Copy build output to a project-level `_static` directory so the site can be
 // served as a regular static site (e.g. on DigitalOcean).
-const destRoot = join('/', '_static');
+const destRoot = join(root, '_static');
 
 async function copyAssets() {
   // Remove existing destination

--- a/scripts/generate-static.mjs
+++ b/scripts/generate-static.mjs
@@ -3,8 +3,8 @@ import { join } from 'node:path';
 
 const root = process.cwd();
 const outDir = join(root, 'out');
-// Output to a root-level directory so deployment tooling can pick it up
-const staticDir = join('/', '_static');
+// Output to a project-level directory so deployment tooling can pick it up
+const staticDir = join(root, '_static');
 
 async function copyOut() {
   await rm(staticDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- write static assets to a project-level `_static` directory to avoid permission errors
- update build script references and README documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e0c48ecc8322bccd98cb24d819c7