### PR TITLE
Ensure static output and configure CORS

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -32,5 +32,8 @@ spec:
           scope: RUN_TIME
         - key: SUPABASE_SERVICE_ROLE_KEY
           scope: RUN_TIME
+        - key: ALLOWED_ORIGINS
+          value: https://example.com
+          scope: RUN_AND_BUILD_TIME
       routes:
         - path: /app

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && npm run copy-static",
     "start": "next start -p ${PORT:-8080}",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "npm -w apps/landing run build && npm -w apps/web run build && npm -w apps/web run copy-static",
+    "build": "npm -w apps/landing run build && npm -w apps/web run build",
     "build:landing": "npm -w apps/landing run build",
     "build:web": "npm -w apps/web run build",
     "build:miniapp": "bash scripts/build-miniapp.sh",


### PR DESCRIPTION
## Summary
- generate `_static` during web build
- document ALLOWED_ORIGINS for deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e552fe408322baa767f3baed5ba3