### PR TITLE
fix: restrict access to user_sessions

### DIFF
--- a/supabase/migrations/20250915000100_secure_user_sessions_rls.sql
+++ b/supabase/migrations/20250915000100_secure_user_sessions_rls.sql
@@ -1,0 +1,43 @@
+-- Harden RLS policies for user_sessions to protect sensitive data
+ALTER TABLE public.user_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Remove existing policies to avoid conflicts
+DROP POLICY IF EXISTS "Users view own sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users insert own sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users update own sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users manage their sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Users manage own sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Admins manage all sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Service role full access user_sessions" ON public.user_sessions;
+DROP POLICY IF EXISTS "Deny anonymous access to user_sessions" ON public.user_sessions;
+
+-- Explicitly block anonymous access
+CREATE POLICY "Deny anonymous access to user_sessions"
+ON public.user_sessions
+FOR ALL
+TO anon
+USING (false);
+
+-- Authenticated users may only manage their own sessions
+CREATE POLICY "Users manage own sessions"
+ON public.user_sessions
+FOR ALL
+TO authenticated
+USING (auth.uid() = bot_user_id)
+WITH CHECK (auth.uid() = bot_user_id);
+
+-- Admins can manage all sessions
+CREATE POLICY "Admins manage all sessions"
+ON public.user_sessions
+FOR ALL
+TO authenticated
+USING (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'))
+WITH CHECK (EXISTS (SELECT 1 FROM public.profiles p WHERE p.id = auth.uid() AND p.role = 'admin'));
+
+-- Service role has full access
+CREATE POLICY "Service role full access user_sessions"
+ON public.user_sessions
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);


### PR DESCRIPTION
## Summary
- harden user_sessions RLS to block public reads and limit access to session owners, admins, and service role

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3e5fe00cc83229e293a31355f5540