### PR TITLE
Restrict access to VIP channel links

### DIFF
--- a/supabase/migrations/20250911000000_restrict_plan_channels_access.sql
+++ b/supabase/migrations/20250911000000_restrict_plan_channels_access.sql
@@ -1,0 +1,18 @@
+-- Restrict plan channel access to subscribed users
+-- 1) Drop public read policy if exists
+DROP POLICY IF EXISTS "Public can view plan channels" ON public.plan_channels;
+
+-- 2) Only allow authenticated users with active subscription to view
+CREATE POLICY "Subscribed users can view plan channels"
+  ON public.plan_channels
+  FOR SELECT
+  TO authenticated
+  USING (
+    is_active = true AND
+    EXISTS (
+      SELECT 1 FROM public.user_subscriptions us
+      WHERE us.bot_user_id = auth.uid()
+        AND us.plan_id = plan_channels.plan_id
+        AND us.is_active = true
+    )
+  );


### PR DESCRIPTION
## Summary
- drop public read access on `plan_channels`
- allow only authenticated users with an active subscription to select channel links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e63866b4832281a84c30cf9b6f38