### PR TITLE
feat: deploy landing as DO web service

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,14 +1,14 @@
 spec:
   name: dynamic-capital
-  static_sites:
+  services:
     - name: landing
       source_dir: apps/landing
+      environment_slug: node-js
       build_command: "npm ci && npm run build && npm --prefix ../.. run upload-assets"
-      output_dir: "dist"
+      run_command: "npm run start"
+      http_port: 8080
       routes:
         - path: /
-      index_document: index.html
-      catchall_document: index.html
       envs:
         - key: CDN_BUCKET
           scope: RUN_AND_BUILD_TIME
@@ -18,7 +18,6 @@ spec:
           scope: RUN_AND_BUILD_TIME
         - key: CDN_SECRET_KEY
           scope: RUN_AND_BUILD_TIME
-  services:
     - name: web
       source_dir: apps/web
       environment_slug: node-js


### PR DESCRIPTION
## Summary
- convert DigitalOcean app spec for `landing` from static site to web service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3eb01fc3083229a1ffdd6c8eed14f