### PR TITLE
Fix static asset output directory for deployment

### DIFF
--- a/scripts/copy-static.ts
+++ b/scripts/copy-static.ts
@@ -10,11 +10,12 @@ if (!copyOnly) {
 }
 
 const root = process.cwd();
+const projectRoot = join(root, '..', '..');
 const nextStatic = join(root, '.next', 'static');
 const nextServerApp = join(root, '.next', 'server', 'app');
-// Copy build output to a project-level `_static` directory so the site can be
+// Copy build output to a repository-level `_static` directory so the site can be
 // served as a regular static site (e.g. on DigitalOcean).
-const destRoot = join(root, '_static');
+const destRoot = join(projectRoot, '_static');
 
 async function copyAssets() {
   // Remove existing destination


### PR DESCRIPTION
## Summary
- ensure copy-static script outputs static assets to repository-level `_static`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3eef532e083229e70009ca8e55247