### PR TITLE
chore: target node 20 for builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: build
-FROM node:22-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 
 # Install dependencies
@@ -12,7 +12,7 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 # Stage 2: runtime
-FROM node:22-alpine
+FROM node:20-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -6,7 +6,7 @@ This guide outlines eight high-level steps to run, build, and deploy the Telegra
    - Telegram bot for deposit workflows with optional Mini App for richer interactions.
 
 2. **Set up prerequisites**
-   - Install Node.js \u2265 22, Deno, and the Supabase CLI.
+   - Install Node.js \u2265 20, Deno, and the Supabase CLI.
 
 3. **Prepare environment variables**
    - Copy `.env.example` to `.env.local` and populate values:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "apps/*"
   ],
   "engines": {
-    "node": ">=22.0.0 <23.0.0"
+    "node": ">=20.0.0 <23.0.0"
   },
   "type": "module",
   "scripts": {

--- a/project.toml
+++ b/project.toml
@@ -22,7 +22,7 @@ version = "0.0.0"
 
   [[build.env]]
     name = "BP_NODE_VERSION"
-    value = "22.*"
+    value = "20.*"
 
   [[build.env]]
     name = "NPM_START_SCRIPT"


### PR DESCRIPTION
## Summary
- use Node.js 20 in buildpack and Dockerfile
- loosen `package.json` engine to support Node 20+
- update docs to reflect Node 20 requirement

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3f264a62883229acbde7b9e54a1f0