### PR TITLE
Add static 404 page for unmatched routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ node_modules/
 out/
 dist/
 dist-ssr/
-_static/
+_static/*
+!_static/404.html
 
 # Logs
 logs

--- a/_static/404.html
+++ b/_static/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Page Not Found</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; padding: 4rem; }
+    h1 { font-size: 2rem; margin-bottom: 1rem; }
+    a { color: #007bff; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <h1>Page Not Found</h1>
+  <p>The page you're looking for doesn't exist.</p>
+  <p><a href="/">Return to the homepage</a></p>
+</body>
+</html>

--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -140,5 +140,11 @@ export async function serveStatic(req: Request, opts: StaticOpts): Promise<Respo
 
   // Unknown path → 404
   console.log(`[static] Path not found: ${url.pathname}`);
+  const notFound = await readFileFrom(opts.rootDir, "404.html");
+  if (notFound) {
+    const h = new Headers(notFound.headers);
+    for (const [k, v] of Object.entries(sec)) h.set(k, v);
+    return new Response(notFound.body, { headers: h, status: 404 });
+  }
   return nf("Not Found");
 }


### PR DESCRIPTION
## Summary
- serve a custom `_static/404.html` page when routes are not found
- keep `_static/404.html` under version control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3f78d1a208322812b670b10c50413