### PR TITLE
fix: configure DO build and runtime for Next.js app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+web: node apps/web/.next/standalone/apps/web/server.js

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "tsx ../../scripts/copy-static.ts",
-    "start": "next start -p ${PORT:-8080}",
+    "start": "node .next/standalone/apps/web/server.js",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,6 +19,7 @@ Include your database connection string or anon key as needed:
 
 - `SUPABASE_ANON_KEY`
 - `DATABASE_URL` (connection string)
+- `SITE_URL` (base URL of your deployment)
 
 ## Connectivity validation
 
@@ -34,6 +35,18 @@ If either command fails, DigitalOcean may be blocking outbound traffic. Ensure
 egress rules permit HTTPS requests to `*.supabase.co` and increase timeouts if
 requests are dropped under load. Add retries with exponential backoff in your
 pipeline or contact Supabase support if connectivity issues persist.
+
+## DigitalOcean build and run commands
+
+Configure the App Platform component to run the project build before serving the app:
+
+```
+Build command: npm run build
+Run command: node apps/web/.next/standalone/apps/web/server.js
+```
+
+The `SITE_URL` variable must match your public domain, e.g.
+`https://urchin-app-macix.ondigitalocean.app`.
 
 ## API Routing
 

--- a/project.toml
+++ b/project.toml
@@ -25,7 +25,7 @@ version = "0.0.0"
     value = "22.*"
 
   [[build.env]]
-    name = "NPM_START_SCRIPT"
+    name = "BP_NODE_RUN_SCRIPTS"
     value = "lovable-build.js"
 
   [[build.env]]
@@ -38,4 +38,4 @@ version = "0.0.0"
 
 [[processes]]
 type = "web"
-command = "npm start"
+command = "node apps/web/.next/standalone/apps/web/server.js"


### PR DESCRIPTION
## Summary
- run Next.js standalone server directly instead of `next start`
- document DigitalOcean build and runtime commands, including `SITE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4028caec08322bc5286407a11076e