### PR TITLE
Handle missing ALLOWED_ORIGINS for CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=
 # Comma-separated origins allowed for CORS (e.g. https://example.com,https://another.com)
+# Leave blank to allow all origins
 ALLOWED_ORIGINS=
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ PII; rate limits enabled.
 Full list and usage notes: [docs/env.md](docs/env.md).
 
 - The `ALLOWED_ORIGINS` variable controls which domains may call the API and
-  edge functions.
+  edge functions. If unset, all origins are allowed.
 - See [docs/NETWORKING.md](docs/NETWORKING.md) for port mappings, reverse proxy
   tips, and Cloudflare ingress IPs.
 - Copy `.env.example` to `.env.local` and replace the placeholder values with

--- a/apps/web/utils/http.ts
+++ b/apps/web/utils/http.ts
@@ -9,14 +9,21 @@ const rawAllowedOrigins =
     ? (globalThis as any).Deno.env.get('ALLOWED_ORIGINS')
     : nodeProcess?.env?.ALLOWED_ORIGINS;
 
-let allowedOrigins = (rawAllowedOrigins || '')
-  .split(',')
-  .map((o: string) => o.trim())
-  .filter(Boolean);
+let allowedOrigins: string[];
 
-if (allowedOrigins.length === 0) {
-  console.warn('[CORS] ALLOWED_ORIGINS is empty; allowing all origins');
+if (rawAllowedOrigins === undefined) {
+  console.warn('[CORS] ALLOWED_ORIGINS is missing; allowing all origins');
   allowedOrigins = ['*'];
+} else {
+  allowedOrigins = rawAllowedOrigins
+    .split(',')
+    .map((o: string) => o.trim())
+    .filter(Boolean);
+
+  if (allowedOrigins.length === 0) {
+    console.warn('[CORS] ALLOWED_ORIGINS is empty; allowing all origins');
+    allowedOrigins = ['*'];
+  }
 }
 
 export function buildCorsHeaders(origin: string | null, methods?: string) {

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -4,7 +4,7 @@ This project relies on a Next.js service and Supabase Edge Functions. Use the fo
 
 ## Environment variables
 - Copy `.env.example` to `.env.local` and fill in credentials.
-- `ALLOWED_ORIGINS` defines a comma-separated list of domains allowed to call the API and edge functions.
+- `ALLOWED_ORIGINS` defines a comma-separated list of domains allowed to call the API and edge functions. If unset, all origins are permitted.
 
 ## Exposing the app
 - Run the app in Docker (or similar) and map the container's port `8080` to your host.

--- a/docs/env.md
+++ b/docs/env.md
@@ -81,5 +81,5 @@ example value, and where it's referenced in the repository.
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
-| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS. | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (leave blank to allow all). | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
 | `LOG_LEVEL`           | Minimum log level for server logs (`debug`, `info`, `warn`, `error`). | No       | `warn`                    | `utils/logger.ts` |

--- a/tests/api/cors-missing.test.ts
+++ b/tests/api/cors-missing.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+
+Deno.test('missing ALLOWED_ORIGINS allows wildcard origin', async () => {
+  Deno.env.delete('ALLOWED_ORIGINS');
+  const { corsHeaders } = await import(`../../apps/web/utils/http.ts?missing=${Math.random()}`);
+  const req = new Request('http://localhost', { headers: { origin: 'https://any.com' } });
+  const headers = corsHeaders(req);
+  assert.equal(headers['access-control-allow-origin'], '*');
+});


### PR DESCRIPTION
## Summary
- log a clearer warning when ALLOWED_ORIGINS env var is missing and allow all origins by default
- document the default behavior of ALLOWED_ORIGINS in env docs, README and networking guide
- add a test ensuring missing ALLOWED_ORIGINS falls back to wildcard CORS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c409b3d8b083229c9943806f19e1fb