### PR TITLE
Serve signal index from static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist/
 dist-ssr/
 _static/*
 !_static/404.html
+!_static/index.html
 
 # Logs
 logs

--- a/_static/index.html
+++ b/_static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Signal</title>
+</head>
+<body>
+  Signal index served from _static.
+</body>
+</html>

--- a/apps/web/app/signal/route.ts
+++ b/apps/web/app/signal/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export async function GET() {
+  const filePath = join(process.cwd(), '_static', 'index.html');
+  const html = readFileSync(filePath, 'utf8');
+  return new NextResponse(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- track and add _static/index.html
- expose /signal route that serves static index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c416bd9380832298fcdfa50b4995bf