### PR TITLE
Redirect root to static landing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ experience.
 
 The project is split into two deployables:
 
-- A **static landing page** served at `/` from `apps/landing`.
+- A **static landing page** served at `/_static` from `apps/landing`.
 - A **dynamic Next.js dashboard** served at `/app` from `apps/web`.
 
 Static content never touches runtime secrets, while the dashboard handles

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 </head>
 <body>
     <script>
-        // Redirect to the Next.js dashboard
-        window.location.href = 'https://urchin-app-macix.ondigitalocean.app/app';
+        // Redirect to the static landing site
+        window.location.href = '/_static/';
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect root index to the static landing site
- document static landing page path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c417d876748322b2f904bd05d2fd74