### PR TITLE
Redirect root to static landing page

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -106,6 +106,11 @@ if (nextConfig.output !== 'export') {
       destination: `https://${CANONICAL_HOST}/:path*`,
       permanent: true,
     },
+    {
+      source: '/',
+      destination: '/_static/',
+      permanent: true,
+    },
   ];
   nextConfig.headers = async () => [
     {


### PR DESCRIPTION
## Summary
- redirect `/` requests to serve the pre-rendered landing page under `/_static/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c41c7d86f08322a4f6717776c06f21