### PR TITLE
feat(web): add static export script

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -51,7 +51,7 @@ process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  output: process.env.NEXT_OUTPUT || 'standalone',
   env: {
     SUPABASE_URL,
     SUPABASE_ANON_KEY,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "tsx ../../scripts/copy-static.ts",
     "start": "node .next/standalone/apps/web/server.js",
+    "export": "NEXT_OUTPUT=export next build",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check"


### PR DESCRIPTION
## Summary
- add `export` script to web workspace to produce static export via `next build`
- make Next.js config respect `NEXT_OUTPUT` env to allow static exports

## Testing
- `npm -w apps/web run export -- --help`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4210236488322829ca6b9b3201979