### PR TITLE
Add SPA catchall page for miniapp routing

### DIFF
--- a/supabase/functions/miniapp/static/404.html
+++ b/supabase/functions/miniapp/static/404.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!-- SPA catchall document for client-side routing -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,viewport-fit=cover"
+    />
+    <meta
+      name="description"
+      content="Dynamic Capital VIP Mini App for streamlined deposits, admin tools, and subscription management with a glassmorphism UI."
+    />
+    <link rel="icon" href="/favicon.ico" />
+    <title>Dynamic Capital VIP • Mini App</title>
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#DC2828" />
+    <!-- Telegram WebApp SDK -->
+    <script
+      defer
+      src="https://telegram.org/js/telegram-web-app.js"
+      integrity="sha384-wu6NaNFje/cy2WpzoCYjC6iPCpaj31EaX/jvOdLlueI1ZvziK83GJATi3JJ3gTL+"
+      crossorigin="anonymous"
+    ></script>
+    <script type="module" crossorigin src="./assets/index-BcqGMtNb.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-DGAYLwkG.css">
+  </head>
+  <body>
+    <div id="root">
+      <noscript>This app requires JavaScript to run.</noscript>
+    </div>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- add `404.html` catch-all in miniapp static assets to support SPA routing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c42455a26c83228be9587d05547618