### PR TITLE
docs: note deploy logs availability

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,6 +48,14 @@ Run command: node apps/web/.next/standalone/apps/web/server.js
 The `SITE_URL` variable must match your public domain, e.g.
 `https://urchin-app-macix.ondigitalocean.app`.
 
+## Deployment logs
+
+The App Platform UI may sometimes display "Deploy logs are not available" after
+a build. Fetch logs using `doctl apps logs <app-id> <component-name> --type build`
+or the [DigitalOcean API](DIGITALOCEAN_APP_LOGS.md#automation) to diagnose
+failed deployments. See [DigitalOcean App Logs](DIGITALOCEAN_APP_LOGS.md) for
+more examples.
+
 ## API Routing
 
 When deploying a static landing page alongside Next.js API routes, forward

--- a/docs/DIGITALOCEAN_APP_LOGS.md
+++ b/docs/DIGITALOCEAN_APP_LOGS.md
@@ -28,9 +28,9 @@ Guidelines for retrieving build, deploy, runtime, and crash logs for the Digital
      import os
      from pydo import Client
 
-     client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
-     get_resp = client.apps.get_logs(app_id="4f6c71e2", deployment_id="3aa4d20e", component_name="component")
-     ```
+    client = Client(token=os.environ.get("DIGITALOCEAN_TOKEN"))
+    get_resp = client.apps.get_logs(app_id="4f6c71e2", deployment_id="3aa4d20e", component_name="component")
+    ```
 
 ## Control Panel
 
@@ -38,3 +38,10 @@ Guidelines for retrieving build, deploy, runtime, and crash logs for the Digital
 2. **Deployment Logs** – Activity tab → click a deployment to view Build and Deploy logs.
 3. **Runtime Logs** – **Runtime Logs** tab → select a resource to view live logs.
 4. **Crash Logs** – Access with `doctl apps logs <app-id> --type=run_restarted` (optionally specify a component).
+
+## Troubleshooting
+
+If the interface shows **Deploy logs are not available**, the logs may not yet
+be generated or have expired. Use the `doctl apps logs <app-id>
+<component-name> --type build` command or the API above to fetch them shortly
+after deployment.


### PR DESCRIPTION
## Summary
- document how to retrieve DigitalOcean deploy logs when the UI says they are unavailable
- link deployment guide to the DigitalOcean logging instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c42ae0e048832291612cdec4691af5