### PR TITLE
feat: add api service for runtime logs

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -35,3 +35,7 @@ spec:
       http_port: 8080
       routes:
         - path: /
+    - name: api
+      source_dir: .
+      environment_slug: node-js
+      run_command: "node server.js"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+import http from 'node:http';
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  console.log(`${req.method} ${req.url}`);
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('API service running\n');
+});
+
+server.listen(port, () => {
+  console.log(`API service listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add simple Node API server for runtime logging
- configure app spec to deploy API service

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c42c6f5324832281364e1e12333406