### PR TITLE
fix: remove root redirect causing 404

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -106,11 +106,6 @@ if (nextConfig.output !== 'export') {
       destination: `https://${CANONICAL_HOST}/:path*`,
       permanent: true,
     },
-    {
-      source: '/',
-      destination: '/_static/',
-      permanent: true,
-    },
   ];
   nextConfig.headers = async () => [
     {


### PR DESCRIPTION
## Summary
- remove redirect from `/` to `/_static/` so root path serves Next.js home page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c42deb9b5483228bb93e1769208b8f