### PR TITLE
docs: default env to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,12 @@ CDN_BUCKET=
 CDN_REGION=
 CDN_ACCESS_KEY=
 CDN_SECRET_KEY=
-# Base URL for API requests (e.g. https://example.com/api)
-NEXT_PUBLIC_API_URL=
+# Base URL for API requests (defaults to http://localhost:3000/api in development)
+NEXT_PUBLIC_API_URL=http://localhost:3000/api
 # Required for email redirects and canonical domain configuration
-# Replace with your production domain, e.g. https://example.com
-SITE_URL=https://urchin-app-macix.ondigitalocean.app
-NEXT_PUBLIC_SITE_URL=https://urchin-app-macix.ondigitalocean.app
+# Defaults to localhost for local development; replace with your deployed domain in staging or production
+SITE_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ backed by Supabase.
 
 ## Environment Setup
 
+Copy `.env.example` to `.env.local` and adjust values for your environment:
+
+```bash
+cp .env.example .env.local
+```
+
+The example defaults `SITE_URL` and `NEXT_PUBLIC_SITE_URL` to
+`http://localhost:3000` so the app works locally out of the box. Replace these
+with your deployed domain when staging or going to production.
+
 Create `.env` files for each component and define variables needed in your
 deployment.
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -75,8 +75,8 @@ example value, and where it's referenced in the repository.
 
 | Key                   | Purpose                                  | Required | Example                   | Used in                           |
 | --------------------- | ---------------------------------------- | -------- | ------------------------- | --------------------------------- |
-| `SITE_URL`            | Base URL for the deployed site; used for redirects and canonical host checks. | Yes      | `https://example.com`     | `next.config.mjs`, `hooks/useAuth.tsx` |
-| `NEXT_PUBLIC_API_URL`  | Base URL for client API requests (defaults to same-origin `/api`). | No | `https://example.com/api` | `env.ts` |
+| `SITE_URL`            | Base URL for the deployed site; used for redirects and canonical host checks. | Yes      | `http://localhost:3000` | `next.config.mjs`, `hooks/useAuth.tsx` |
+| `NEXT_PUBLIC_API_URL`  | Base URL for client API requests (defaults to same-origin `/api`). | No | `http://localhost:3000/api` | `env.ts` |
 | `NODE_EXTRA_CA_CERTS` | Additional CA bundle for outbound HTTPS. | No       | `/etc/ssl/custom.pem`     | `src/utils/http-ca.ts`            |
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |


### PR DESCRIPTION
## Summary
- default SITE_URL and NEXT_PUBLIC_SITE_URL to http://localhost:3000 for local development
- document copying `.env.example` to `.env.local`
- reflect localhost defaults in environment variable reference

## Testing
- `npm run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c430bb40b48322a030a842f597d2fb