### PR TITLE
chore: update dev domain

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -98,14 +98,16 @@ if (nextConfig.output !== 'export') {
       destination: 'https://:host/:path*',
       permanent: true,
     },
-    {
-      source: '/:path*',
-      has: [
-        { type: 'host', value: 'urchin-app-macix.ondigitalocean.app' },
-      ],
-      destination: `https://${CANONICAL_HOST}/:path*`,
-      permanent: true,
-    },
+    ...(process.env.LEGACY_HOST
+      ? [
+          {
+            source: '/:path*',
+            has: [{ type: 'host', value: process.env.LEGACY_HOST }],
+            destination: `https://${CANONICAL_HOST}/:path*`,
+            permanent: true,
+          },
+        ]
+      : []),
   ];
   nextConfig.headers = async () => [
     {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -46,7 +46,7 @@ Run command: node apps/web/.next/standalone/apps/web/server.js
 ```
 
 The `SITE_URL` variable must match your public domain, e.g.
-`https://urchin-app-macix.ondigitalocean.app`.
+`https://app.dynamic.capital`.
 
 ## Deployment logs
 

--- a/project.toml
+++ b/project.toml
@@ -30,7 +30,11 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://urchin-app-macix.ondigitalocean.app"
+    value = "https://app.dynamic.capital"
+
+  [[build.env]]
+    name = "SITE_URL"
+    value = "https://app.dynamic.capital"
 
   [[build.env]]
     name = "NEXT_TELEMETRY_DISABLED"


### PR DESCRIPTION
## Summary
- replace hardcoded ondigitalocean domain with app.dynamic.capital
- allow legacy host redirect via `LEGACY_HOST` env
- update deployment docs with new domain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c440a547c08322b0b229e8b62c3057