### PR TITLE
feat: cache next build in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,8 +425,11 @@ on images.
 1. **Build the image**
 
    ```bash
-   docker build -f docker/Dockerfile -t dynamic-chatty-bot .
+   DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t dynamic-chatty-bot .
    ```
+
+   BuildKit enables caching of Next.js build artifacts. For non-Docker CI,
+   cache the `apps/web/.next/cache` directory between runs to speed up builds.
 
 2. **Run the container**
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 # Stage 1: build
 FROM node:22-alpine AS builder
 WORKDIR /app
@@ -8,7 +9,7 @@ RUN npm ci
 
 # Build application
 COPY . .
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 RUN npm prune --omit=dev
 
 # Stage 2: runtime


### PR DESCRIPTION
## Summary
- enable BuildKit caching for Next.js builds in Docker
- document DOCKER_BUILDKIT and caching .next in non-Docker CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c440f1458883228dc757d66a3a97f7