### PR TITLE
fix: export valid auth handler

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -2,14 +2,14 @@ import NextAuth from "next-auth";
 import { SupabaseAdapter } from "@auth/supabase-adapter";
 import GitHub from "next-auth/providers/github";
 
-const handler = NextAuth({
+const { auth: handler } = NextAuth({
   adapter: SupabaseAdapter({
     url: process.env.SUPABASE_URL || "https://stub.supabase.co",
     secret: process.env.SUPABASE_SERVICE_ROLE_KEY || "stub-service-role-key",
   }),
   providers: [
     GitHub({
-      clientId: process.env.GITHUB_ID || "", 
+      clientId: process.env.GITHUB_ID || "",
       clientSecret: process.env.GITHUB_SECRET || "",
     }),
   ],


### PR DESCRIPTION
## Summary
- fix NextAuth auth route to export handler function for GET and POST

## Testing
- `npm test`
- `npm -w apps/web run lint` *(fails: Expected an assignment or function call and instead saw an expression)*
- `npm -w apps/web exec eslint app/api/auth/[...nextauth]/route.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c474af14f88322851e0777bec6d007