### PR TITLE
fix: export valid auth handler

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -2,19 +2,19 @@ import NextAuth from "next-auth";
 import { SupabaseAdapter } from "@auth/supabase-adapter";
 import GitHub from "next-auth/providers/github";
 
-const handler = NextAuth({
+const { handlers } = NextAuth({
   adapter: SupabaseAdapter({
     url: process.env.SUPABASE_URL || "https://stub.supabase.co",
     secret: process.env.SUPABASE_SERVICE_ROLE_KEY || "stub-service-role-key",
   }),
   providers: [
     GitHub({
-      clientId: process.env.GITHUB_ID || "", 
+      clientId: process.env.GITHUB_ID || "",
       clientSecret: process.env.GITHUB_SECRET || "",
     }),
   ],
 });
 
-export { handler as GET, handler as POST };
+export const { GET, POST } = handlers;
 
-export default handler;
+export default handlers.GET;


### PR DESCRIPTION
## Summary
- export NextAuth handlers for GET and POST
- provide default handler for Next.js

## Testing
- `npm test`
- `npm -w apps/web run lint` *(fails: Expected an assignment or function call and instead saw an expression)*
- `npm -w apps/web exec eslint app/api/auth/[...nextauth]/route.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c474af14f88322851e0777bec6d007