### PR TITLE
fix: align NextAuth route exports and Sentry imports

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -17,4 +17,3 @@ const { handlers } = NextAuth({
 
 export const { GET, POST } = handlers;
 
-export default handlers.GET;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,10 +1,7 @@
-import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import nextPWA from 'next-pwa';
 import bundleAnalyzer from '@next/bundle-analyzer';
-
-const require = createRequire(import.meta.url);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -12,7 +9,8 @@ const __dirname = path.dirname(__filename);
 let withSentry = (config) => config;
 if (process.env.ENABLE_SENTRY === 'true') {
   try {
-    ({ withSentryConfig: withSentry } = require('@sentry/nextjs'));
+    const { withSentryConfig } = await import('@sentry/nextjs');
+    withSentry = withSentryConfig;
   } catch {
     console.warn('@sentry/nextjs not installed; skipping Sentry configuration');
   }


### PR DESCRIPTION
## Summary
- remove default export from NextAuth route to satisfy Next.js route expectations
- switch Next.js config to ESM dynamic import for Sentry to avoid instrumentation dependency issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47ac584c88322b7e09f93179e2e9a