### PR TITLE
docs: add task for Next.js build caching

### DIFF
--- a/docs/NEXTJS_BUILD_CACHE_TASK.md
+++ b/docs/NEXTJS_BUILD_CACHE_TASK.md
@@ -1,0 +1,20 @@
+# Enable Next.js Build Caching
+
+## Summary
+A recent Next.js build produced the warning `⚠ No build cache found. Please configure build caching for faster rebuilds.` Implement caching for the `apps/web` Next.js application so repeated builds run faster and the warning disappears.
+
+## Acceptance Criteria
+- CI and local builds persist the `apps/web/.next/cache` directory between runs.
+- GitHub Actions use `actions/cache` or an equivalent approach with a cache key based on the lockfile hash.
+- Documentation or configuration updates clearly describe the caching strategy.
+
+## Notes
+- Example GitHub Actions snippet:
+  ```yaml
+  - uses: actions/cache@v3
+    with:
+      path: apps/web/.next/cache
+      key: ${{ runner.os }}-nextjs-${{ hashFiles('apps/web/package-lock.json') }}
+  ```
+- Docker builds can mount or copy `.next/cache` from a previous layer or shared volume.
+- Set `NEXT_CACHE_DIR` if a custom cache location is required.


### PR DESCRIPTION
## Summary
- add documentation task to enable build caching for apps/web Next.js app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c47ee8b39c8322a8b998be08e7d2c1