### PR TITLE
chore: update site url and allowed origins

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -65,7 +65,7 @@ Run command: node apps/web/.next/standalone/apps/web/server.js
 ```
 
 The `SITE_URL` variable must match your public domain, e.g.
-`https://app.dynamic.capital`.
+`https://urchin-app-macix.ondigitalocean.app`.
 
 ## Deployment logs
 

--- a/project.toml
+++ b/project.toml
@@ -30,11 +30,11 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://app.dynamic.capital"
+    value = "https://urchin-app-macix.ondigitalocean.app"
 
   [[build.env]]
     name = "SITE_URL"
-    value = "https://app.dynamic.capital"
+    value = "https://urchin-app-macix.ondigitalocean.app"
 
   [[build.env]]
     name = "NEXT_TELEMETRY_DISABLED"


### PR DESCRIPTION
## Summary
- point SITE_URL and ALLOWED_ORIGINS to the DigitalOcean deployment domain
- document the new SITE_URL example in deployment guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47fffe8e48322a23b010b38267b5e