### PR TITLE
Add CORS headers to static server

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,6 +45,16 @@ async function streamFile(res, filePath, status = 200) {
 }
 
 const server = http.createServer(async (req, res) => {
+  // Enable CORS for all requests
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    return res.end();
+  }
+
   const url = req.url || '/';
   console.log(`${req.method} ${url}`);
 


### PR DESCRIPTION
## Summary
- enable CORS for all requests in server.js
- handle preflight `OPTIONS` requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48262e4048322a52ba9a01741dceb