### PR TITLE
fix: defer sentry init and improve cors default

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
     "@react-three/drei": "^10.7.5",
     "@react-three/fiber": "^9.0.0",
     "@sentry/nextjs": "^8.55.0",
+    "@opentelemetry/instrumentation": "^0.57.2",
     "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.57.2",

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,6 +1,13 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});
+if (process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN) {
+  (async () => {
+    try {
+      const Sentry = await import('@sentry/nextjs');
+      Sentry.init({
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN,
+        tracesSampleRate: 1.0,
+      });
+    } catch {
+      // Sentry SDK not available; skip initialization
+    }
+  })();
+}

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,6 +1,13 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});
+if (process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  (async () => {
+    try {
+      const Sentry = await import('@sentry/nextjs');
+      Sentry.init({
+        dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+        tracesSampleRate: 1.0,
+      });
+    } catch {
+      // Sentry SDK not available; skip initialization
+    }
+  })();
+}

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,6 +1,13 @@
-import * as Sentry from '@sentry/nextjs';
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});
+if (process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  (async () => {
+    try {
+      const Sentry = await import('@sentry/nextjs');
+      Sentry.init({
+        dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+        tracesSampleRate: 1.0,
+      });
+    } catch {
+      // Sentry SDK not available; skip initialization
+    }
+  })();
+}

--- a/apps/web/utils/http.ts
+++ b/apps/web/utils/http.ts
@@ -9,15 +9,17 @@ const rawAllowedOrigins =
     ? (globalThis as any).Deno.env.get('ALLOWED_ORIGINS')
     : nodeProcess?.env?.ALLOWED_ORIGINS;
 
-const defaultOrigin = 'http://localhost:3000';
+const defaultOrigin = nodeProcess?.env?.SITE_URL || 'http://localhost:3000';
 
 let allowedOrigins: string[];
 
 if (rawAllowedOrigins === undefined) {
-  console.warn(
-    `[CORS] ALLOWED_ORIGINS is missing; defaulting to ${defaultOrigin}`,
-  );
   allowedOrigins = [defaultOrigin];
+  if (!nodeProcess?.env?.SITE_URL) {
+    console.warn(
+      `[CORS] ALLOWED_ORIGINS is missing; defaulting to ${defaultOrigin}`,
+    );
+  }
 } else if (rawAllowedOrigins.trim() === '') {
   // Empty string means allow all origins
   allowedOrigins = ['*'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^3.9.0",
+        "@opentelemetry/instrumentation": "^0.57.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/tests/api/cors-missing.test.ts
+++ b/tests/api/cors-missing.test.ts
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict';
 
-Deno.test('missing ALLOWED_ORIGINS defaults to localhost', async () => {
+Deno.test('missing ALLOWED_ORIGINS defaults to site URL', async () => {
   Deno.env.delete('ALLOWED_ORIGINS');
   const { corsHeaders } = await import(
     `../../apps/web/utils/http.ts?missing=${Math.random()}`,
   );
+  const origin = Deno.env.get('SITE_URL') ?? 'http://localhost:3000';
   const req = new Request('http://localhost', {
-    headers: { origin: 'http://localhost:3000' },
+    headers: { origin },
   });
   const headers = corsHeaders(req);
-  assert.equal(headers['access-control-allow-origin'], 'http://localhost:3000');
+  assert.equal(headers['access-control-allow-origin'], origin);
 });


### PR DESCRIPTION
## Summary
- load Sentry dynamically so React context is only accessed on client at runtime
- default CORS origins to SITE_URL and quiet warning when ALLOWED_ORIGINS is missing
- add opentelemetry instrumentation dependency and adjust CORS test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c486eb21b883228c2f3f1ada71db83