### PR TITLE
fix: guard profile before role check in admin dashboard

### DIFF
--- a/apps/web/components/admin/AdminDashboard.tsx
+++ b/apps/web/components/admin/AdminDashboard.tsx
@@ -88,8 +88,12 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
           .select('role')
           .eq('id', user.id)
           .single();
-        
-        return profile?.role === 'admin';
+
+        if (!profile) {
+          return false;
+        }
+
+        return profile.role === 'admin';
       }
       
       return false;


### PR DESCRIPTION
## Summary
- ensure profile data is checked for null before accessing role in AdminDashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48b22b05c83229150cd16f76809c9