### PR TITLE
fix: add role typing for profile

### DIFF
--- a/apps/web/components/admin/AdminDashboard.tsx
+++ b/apps/web/components/admin/AdminDashboard.tsx
@@ -87,7 +87,7 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
           .from('profiles')
           .select('role')
           .eq('id', user.id)
-          .single();
+          .single<{ role: string }>();
 
         if (!profile) {
           return false;

--- a/apps/web/context/SupabaseProvider.tsx
+++ b/apps/web/context/SupabaseProvider.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { ReactNode, createContext, useContext } from 'react';
-import { useSupabaseClient, useSession } from '@supabase/auth-helpers-react';
+import { ReactNode, createContext, useContext } from "react";
+import { useSupabaseClient, useSession } from "@supabase/auth-helpers-react";
+import type { Database } from "@/types/supabase";
+
+type SupabaseClientType = ReturnType<typeof useSupabaseClient<Database>>;
 
 interface SupabaseContextValue {
-  supabase: ReturnType<typeof useSupabaseClient>;
+  supabase: SupabaseClientType;
   session: ReturnType<typeof useSession>;
 }
 
@@ -13,7 +16,7 @@ const SupabaseContext = createContext<SupabaseContextValue | undefined>(
 );
 
 export function SupabaseProvider({ children }: { children: ReactNode }) {
-  const supabase = useSupabaseClient();
+  const supabase = useSupabaseClient<Database>();
   const session = useSession();
   return (
     <SupabaseContext.Provider value={{ supabase, session }}>
@@ -25,7 +28,7 @@ export function SupabaseProvider({ children }: { children: ReactNode }) {
 export const useSupabase = () => {
   const context = useContext(SupabaseContext);
   if (!context) {
-    throw new Error('useSupabase must be used within a SupabaseProvider');
+    throw new Error("useSupabase must be used within a SupabaseProvider");
   }
   return context;
 };


### PR DESCRIPTION
## Summary
- ensure Supabase profile query exposes `role`
- type Supabase client context to allow schema access without `never` errors

## Testing
- `npx tsc -p apps/web/tsconfig.json --noEmit`
- `npm test`
- `npm -w apps/web run lint` (fails: 93 problems in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68c48c988be083228d25670f53f55d2a