### PR TITLE
Fix Supabase typing in admin components

### DIFF
--- a/apps/web/components/admin/AdminDashboard.tsx
+++ b/apps/web/components/admin/AdminDashboard.tsx
@@ -83,17 +83,18 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
       // Check if user is admin via Supabase auth
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
-        const { data: profile } = await supabase
+        const { data: profile, error: profileError } = await supabase
           .from('profiles')
           .select('role')
           .eq('id', user.id)
-          .single();
+          .single<{ role: string | null }>();
 
-        if (!profile) {
+        if (profileError) {
+          console.error('Profile fetch error:', profileError);
           return false;
         }
 
-        return profile.role === 'admin';
+        return profile?.role === 'admin';
       }
       
       return false;

--- a/apps/web/components/admin/SystemStatus.tsx
+++ b/apps/web/components/admin/SystemStatus.tsx
@@ -52,7 +52,11 @@ interface TableInfo {
 
 export const SystemStatus = () => {
   const { supabase } = useSupabase();
-  const supabasePublic = supabase.schema('public');
+  // The default Supabase client already targets the `public` schema,
+  // so we can use it directly without calling `.schema()`, which
+  // avoids a TypeScript type of `never` when strict typings are
+  // enabled.
+  const supabasePublic = supabase;
   const [functions, setFunctions] = useState<FunctionStatus[]>([]);
   const [tables, setTables] = useState<TableInfo[]>([]);
   const [checking, setChecking] = useState(false);

--- a/apps/web/components/ui/enhanced-typography.tsx
+++ b/apps/web/components/ui/enhanced-typography.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React from 'react';
+import * as React from 'react';
+import type { JSX } from 'react';
 import { motion } from 'framer-motion';
 import { cn } from '@/utils';
 
@@ -43,20 +44,18 @@ export const AnimatedHeading: React.FC<AnimatedHeadingProps> = ({
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, delay }}
     >
-      <Component 
-        className={cn(
-          baseClasses[level],
-          gradientClass,
-          glowClass,
-          className
-        )}
-      >
-        {typewriter ? (
-          <TypewriterText text={children as string} />
-        ) : (
-          children
-        )}
-      </Component>
+      {React.createElement(
+        Component,
+        {
+          className: cn(
+            baseClasses[level],
+            gradientClass,
+            glowClass,
+            className
+          )
+        },
+        typewriter ? <TypewriterText text={children as string} /> : children
+      )}
     </motion.div>
   );
 };

--- a/apps/web/context/SupabaseProvider.tsx
+++ b/apps/web/context/SupabaseProvider.tsx
@@ -2,9 +2,10 @@
 
 import { ReactNode, createContext, useContext } from 'react';
 import { useSupabaseClient, useSession } from '@supabase/auth-helpers-react';
+import { SupabaseClient } from '@supabase/supabase-js';
 
 interface SupabaseContextValue {
-  supabase: ReturnType<typeof useSupabaseClient>;
+  supabase: SupabaseClient;
   session: ReturnType<typeof useSession>;
 }
 


### PR DESCRIPTION
## Summary
- handle missing profile roles safely in admin dashboard
- avoid strict schema typing by using default Supabase client
- improve heading component to use React.createElement with explicit JSX typing
- type Supabase context with SupabaseClient

## Testing
- `SITE_URL=http://localhost npm run build` *(fails: Cannot read properties of null (reading 'useContext'))*
- `npm start` *(fails: cannot find module apps/web/.next/standalone/apps/web/server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c4964a95b88322b1ad72a440eda598