### PR TITLE
fix: register OpenTelemetry context

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,6 +1,16 @@
+import { registerOTel } from '@vercel/otel';
+
 export async function register() {
-  // Disable Sentry during the production build to avoid React context errors
-  if (process.env.NODE_ENV === 'production') return;
+  // Ensure Next.js' OpenTelemetry context is registered first to avoid null context errors
+  registerOTel();
+
+  // Only enable Sentry when explicitly requested and not during production build
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.ENABLE_SENTRY !== 'true'
+  ) {
+    return;
+  }
 
   try {
     const Sentry =


### PR DESCRIPTION
## Summary
- ensure OpenTelemetry context is registered before initializing Sentry
- gate Sentry initialization behind `ENABLE_SENTRY` to avoid conflicts

## Testing
- `npm test` *(fails: blocks path traversal in _static => Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a0e639dc8322be6e3039f12dceca