### PR TITLE
Enhance stacked card effect and expand landing services

### DIFF
--- a/_static/index.html
+++ b/_static/index.html
@@ -11,6 +11,14 @@
     <h1>Welcome to Dynamic Chatty Bot</h1>
     <p>Your simple static landing page.</p>
     <button id="action">Click me</button>
+    <section id="services">
+      <h2>Our Services</h2>
+      <ul class="service-list">
+        <li>⚡ Trading Signals</li>
+        <li>📊 Market Analysis</li>
+        <li>🛡️ Risk Management</li>
+      </ul>
+    </section>
   </main>
   <script src="scripts.js"></script>
 </body>

--- a/apps/landing/public/index.html
+++ b/apps/landing/public/index.html
@@ -11,6 +11,14 @@
     <h1>Welcome to Dynamic Chatty Bot</h1>
     <p>Your simple static landing page.</p>
     <button id="action">Click me</button>
+    <section id="services">
+      <h2>Our Services</h2>
+      <ul class="service-list">
+        <li>⚡ Trading Signals</li>
+        <li>📊 Market Analysis</li>
+        <li>🛡️ Risk Management</li>
+      </ul>
+    </section>
   </main>
   <script src="scripts.js"></script>
 </body>

--- a/apps/landing/public/styles.css
+++ b/apps/landing/public/styles.css
@@ -10,3 +10,22 @@ main {
   max-width: 600px;
   margin: 0 auto;
 }
+
+#services {
+  margin-top: 2rem;
+}
+
+.service-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.service-list li {
+  background: #fff;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/apps/web/components/ui/stack-card.tsx
+++ b/apps/web/components/ui/stack-card.tsx
@@ -34,6 +34,8 @@ export function StackCard({
 
   const rotateX = useTransform(mouseY, [-300, 300], [15, -15]);
   const rotateY = useTransform(mouseX, [-300, 300], [-15, 15]);
+  const bgRotateX = useTransform(rotateX, (v) => v / 2);
+  const bgRotateY = useTransform(rotateY, (v) => v / 2);
 
   const handleMouseMove = (e: React.MouseEvent) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -46,6 +48,7 @@ export function StackCard({
   return (
     <div
       className={cn("relative", className)}
+      style={{ perspective: 1000 }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onMouseMove={handleMouseMove}
@@ -55,6 +58,11 @@ export function StackCard({
         <motion.div
           key={index}
           className="absolute inset-0"
+          style={{
+            rotateX: rotateOnHover ? bgRotateX : 0,
+            rotateY: rotateOnHover ? bgRotateY : 0,
+            transformStyle: "preserve-3d",
+          }}
           initial={{
             x: -(stackOffset * (stackSize - index - 1)),
             y: -(stackOffset * (stackSize - index - 1)),
@@ -94,6 +102,7 @@ export function StackCard({
         style={{
           rotateX: rotateOnHover ? rotateX : 0,
           rotateY: rotateOnHover ? rotateY : 0,
+          transformStyle: "preserve-3d",
         }}
         animate={{
           scale: isHovered && scaleOnHover ? 1.05 : 1,


### PR DESCRIPTION
## Summary
- add perspective and parallax rotation to stacked card component for smoother 3D interaction
- expand static landing page with a simple services section listing key offerings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a38a7a5483228dacefbcbda5109d