### PR TITLE
fix: prevent locale page client usage causing prerender error

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,2 +1,1 @@
-"use client";
 export { default } from '../page';


### PR DESCRIPTION
## Summary
- remove client directive from `[locale]/page.tsx` so redirect executes in server context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4a4c32350832292b68341366ba0af