### PR TITLE
Handle optional OpenTelemetry registration

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,9 +1,13 @@
-import { registerOTel } from '@vercel/otel';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 
 export async function register() {
   // Ensure Next.js' OpenTelemetry context is registered first to avoid null context errors
-  registerOTel();
+  try {
+    const { registerOTel } = await import('@vercel/otel');
+    registerOTel();
+  } catch {
+    // Optional dependency not installed; continue without OpenTelemetry registration
+  }
   // Register OpenTelemetry instrumentations to avoid dynamic import warnings
   registerInstrumentations({ instrumentations: [] });
 


### PR DESCRIPTION
## Summary
- Avoid build-time module errors by dynamically importing `@vercel/otel`
- Gracefully skip OpenTelemetry setup when the module is absent

## Testing
- `npm -w apps/web run build`
- `npm -w apps/web run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a7f9a3d48322919dc8541fb1f94f