### PR TITLE
fix: wrap navbar with providers

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import './globals.css';
 import '../env';
 import Footer from '@/components/layout/Footer';
+import Navbar from '@/components/layout/Navbar';
 import Providers from './providers';
 import DefaultSeo from '@/components/DefaultSeo';
 
@@ -24,7 +25,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <Providers>
           <DefaultSeo />
-          {/* Navbar removed to avoid build-time hook issues */}
+          <Navbar />
           <main>{children}</main>
           <Footer />
         </Providers>


### PR DESCRIPTION
## Summary
- reintroduce the Navbar component inside the Providers wrapper
- ensure top-level layout imports Navbar so it receives context

## Testing
- `npm test`
- `npm -w apps/web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4a9f0ed708322854864e0f51dc92e