### PR TITLE
feat: add framer motion skeletons

### DIFF
--- a/apps/web/components/shared/LivePlansSection.tsx
+++ b/apps/web/components/shared/LivePlansSection.tsx
@@ -5,7 +5,8 @@ import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle, Star, TrendingUp, Users, Crown, Zap, Check, Loader2 } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { CheckCircle, Star, TrendingUp, Users, Crown, Zap, Check } from 'lucide-react';
 import { ThreeDEmoticon, TradingEmoticonSet } from '@/components/ui/three-d-emoticons';
 import { AnimatedHeading, GradientText, CountUp } from '@/components/ui/enhanced-typography';
 import { Interactive3DCard, StaggeredGrid } from '@/components/ui/interactive-cards';
@@ -100,9 +101,12 @@ export const LivePlansSection = ({
   if (loading) {
     return (
       <Card>
-        <CardContent className="flex items-center justify-center py-8">
-          <Loader2 className="w-6 h-6 animate-spin" />
-          <span className="ml-2">Loading plans...</span>
+        <CardContent className="space-y-4 py-8">
+          <div className="flex gap-4">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-40 flex-1" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     );

--- a/apps/web/components/shared/SubscriptionStatusCard.tsx
+++ b/apps/web/components/shared/SubscriptionStatusCard.tsx
@@ -5,7 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MotionCard } from "@/components/ui/motion-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Crown, Calendar, Clock, CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { Crown, Calendar, Clock, CheckCircle, XCircle } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/hooks/useToast";
 import { callEdgeFunction } from "@/config/supabase";
 
@@ -100,9 +101,13 @@ export const SubscriptionStatusCard = ({
   if (loading) {
     return (
       <MotionCard variant="glass" animate={true}>
-        <CardContent className="flex items-center justify-center py-8">
-          <Loader2 className="w-6 h-6 animate-spin" />
-          <span className="ml-2">Loading subscription status...</span>
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-4 w-2/3" />
         </CardContent>
       </MotionCard>
     );

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,15 +1,19 @@
-import { cn } from "@/utils"
+import { cn } from "@/utils";
+import { motion } from "framer-motion";
 
 function Skeleton({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+    <motion.div
+      className={cn("rounded-md bg-muted", className)}
+      initial={{ opacity: 0.6 }}
+      animate={{ opacity: [0.6, 1, 0.6] }}
+      transition={{ duration: 1.5, repeat: Infinity }}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };


### PR DESCRIPTION
## Summary
- use framer motion for animated Skeleton component
- show skeleton placeholders while subscription status loads
- replace plan spinner with skeleton cards during plan fetch

## Testing
- `npm test`
- `npm -w apps/web test`


------
https://chatgpt.com/codex/tasks/task_e_68c4abdb0fe483228b71bf0043d1d096