### PR TITLE
chore: update env URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,18 @@
-SUPABASE_URL=
+SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
-NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 CDN_BUCKET=
 CDN_REGION=
 CDN_ACCESS_KEY=
 CDN_SECRET_KEY=
 # Base URL for API requests (defaults to http://localhost:3000/api in development)
-NEXT_PUBLIC_API_URL=http://localhost:3000/api
+NEXT_PUBLIC_API_URL=https://urchin-app-macix.ondigitalocean.app/api
 # Required for email redirects and canonical domain configuration
 # Defaults to localhost for local development; replace with your deployed domain in staging or production
-SITE_URL=http://localhost:3000
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
+SITE_URL=https://urchin-app-macix.ondigitalocean.app
+NEXT_PUBLIC_SITE_URL=https://urchin-app-macix.ondigitalocean.app
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,5 @@
-SITE_URL=
-NEXT_PUBLIC_SUPABASE_URL=
+SITE_URL=https://urchin-app-macix.ondigitalocean.app
+NEXT_PUBLIC_API_URL=https://urchin-app-macix.ondigitalocean.app/api
+NEXT_PUBLIC_SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=


### PR DESCRIPTION
## Summary
- correct site and API base URLs in env examples

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4b74a9e5c83229a744dd84f3ca9c6