### PR TITLE
Fix redirect to static landing page

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,5 +3,5 @@ import { redirect } from 'next/navigation';
 export const dynamic = 'force-dynamic';
 
 export default function HomePage() {
-  redirect('/_static/');
+  redirect('/_static/index.html');
 }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <body>
     <script>
         // Redirect to the static landing site
-        window.location.href = '/_static/';
+        window.location.href = '/_static/index.html';
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect root index.html to the explicit static landing page
- update Next.js home page to redirect to `/ _static/index.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4baf8b04883228c6c12182f3299d4