### PR TITLE
Serve index for root path queries

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,20 +55,20 @@ const server = http.createServer(async (req, res) => {
     return res.end();
   }
 
-  const url = req.url || '/';
-  console.log(`${req.method} ${url}`);
+  const { pathname } = new URL(req.url || '/', 'http://localhost');
+  console.log(`${req.method} ${pathname}`);
 
-  if (url === '/healthz') {
+  if (pathname === '/healthz') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });
     return res.end('ok');
   }
 
-  if (url === '/' || url === '/index.html') {
+  if (pathname === '/' || pathname === '/index.html') {
     return await streamFile(res, join(root, 'index.html'));
   }
 
-  if (url.startsWith('/_static/')) {
-    const normalizedUrl = normalize(url);
+  if (pathname.startsWith('/_static/')) {
+    const normalizedUrl = normalize(pathname);
     const filePath = join(root, normalizedUrl.slice(1));
     if (!filePath.startsWith(staticRoot)) {
       res.writeHead(404, { 'Content-Type': 'text/plain' });

--- a/tests/root-query.test.ts
+++ b/tests/root-query.test.ts
@@ -1,0 +1,19 @@
+import { assertEquals } from "jsr:@std/assert";
+
+Deno.test('serves index.html for root path with query string', async () => {
+  const command = new Deno.Command('node', {
+    args: ['server.js'],
+    cwd: new URL('..', import.meta.url).pathname,
+    env: { ...Deno.env.toObject(), PORT: '8124' }
+  });
+  const child = command.spawn();
+  try {
+    await new Promise((r) => setTimeout(r, 200));
+    const res = await fetch('http://localhost:8124/?foo=bar');
+    assertEquals(res.status, 200);
+    await res.arrayBuffer();
+  } finally {
+    child.kill('SIGTERM');
+    await child.status;
+  }
+});


### PR DESCRIPTION
## Summary
- fix server to ignore query strings when routing
- add test confirming root with query returns index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c4c90a608322859b49364a663ebd