### PR TITLE
Fix 404 by copying landing build to Next.js public

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -2,7 +2,7 @@
 "name": "landing",
 "private": true,
 "scripts": {
-"build": "rm -rf ../../_static && mkdir -p ../../_static && cp -r public/* ../../_static/",
+"build": "rm -rf ../../_static && mkdir -p ../../_static && cp -r public/* ../../_static/ && rm -rf ../web/public/_static && mkdir -p ../web/public/_static && cp -r public/* ../web/public/_static/",
 "start": "npx serve ../../_static -l ${PORT:-8080}"
 }
 }


### PR DESCRIPTION
## Summary
- ensure landing build is copied into Next.js public directory so /_static routes resolve

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c820fba083229aed5e459bcf627c