### PR TITLE
feat: update hero section with branding

### DIFF
--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -1,20 +1,28 @@
 "use client";
 
 import { motion } from "framer-motion";
+import BrandLogo from "@/components/BrandLogo";
 
 export default function HeroSection() {
   return (
     <section className="relative flex flex-col items-center justify-center h-screen bg-black text-center overflow-hidden">
+      {/* Header with Logo */}
+      <header className="absolute top-0 left-0 w-full flex items-center justify-between p-6 z-20 text-white">
+        <BrandLogo size="lg" variant="brand" />
+        <span className="text-sm uppercase tracking-widest">Branding Guideline</span>
+      </header>
+
       {/* Curved Text Ticker */}
       <motion.svg
         className="absolute top-0 left-1/2 -translate-x-1/2 w-[120%] h-[120%] pointer-events-none"
         viewBox="0 0 1000 500"
         initial={{ x: 0 }}
         animate={{ x: ["0%", "-50%"] }}
-        transition={{ repeat: Infinity, duration: 20, ease: "linear" }}
+        transition={{ repeat: Infinity, repeatType: "loop", duration: 30, ease: "linear" }}
+        style={{ willChange: "transform" }}
       >
         <path id="curve" d="M 0,300 Q 500,100 1000,300" fill="transparent" />
-        <text fill="#f13d00" fontSize="36" fontWeight="bold" letterSpacing="2px">
+        <text fill="#f13d00" fontSize="56" fontWeight="bold" letterSpacing="2px">
           <textPath href="#curve" startOffset="0%">
             ALL YOU NEED IS THE PROJECT ARCHIVE — ALL YOU NEED IS THE PROJECT ARCHIVE —
           </textPath>


### PR DESCRIPTION
## Summary
- add branded header with logo to hero section
- optimize curved ticker animation and enlarge text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4c9ae658c8322a05077dd0a39603a