### PR TITLE
Set production env for web build and start

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "tsx ../../scripts/copy-static.ts",
-    "start": "node .next/standalone/apps/web/server.js",
+    "build": "NODE_ENV=production tsx ../../scripts/copy-static.ts",
+    "start": "NODE_ENV=production node .next/standalone/apps/web/server.js",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check"


### PR DESCRIPTION
## Summary
- enforce `NODE_ENV=production` for web build and start scripts
- avoid skipping production-only steps when running without explicit env

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d1ae6c908322afea955b72ffb4ac