### PR TITLE
fix: redirect root to deployed site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ NEXT_PUBLIC_API_URL=https://urchin-app-macix.ondigitalocean.app/
 # Required for email redirects and canonical domain configuration
 # Defaults to localhost for local development; replace with your deployed domain in staging or production
 SITE_URL=https://urchin-app-macix.ondigitalocean.app/
-NEXT_PUBLIC_SITE_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=https://urchin-app-macix.ondigitalocean.app/
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 </head>
 <body>
     <script>
-        // Redirect to the static landing site
-        window.location.href = '/_static/index.html';
+        // Redirect to the deployed site
+        window.location.href = 'https://urchin-app-macix.ondigitalocean.app/';
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect root index.html to deployed site
- set SITE_URL and API URLs in env example to deployment domain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4d73af00c8322a0f58bf62d6c96e9