### PR TITLE
fix: configure prod URLs and build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ CDN_REGION=
 CDN_ACCESS_KEY=
 CDN_SECRET_KEY=
 # Base URL for API requests (defaults to http://localhost:3000/api in development)
-NEXT_PUBLIC_API_URL=https://urchin-app-macix.ondigitalocean.app/
+NEXT_PUBLIC_API_URL=https://urchin-app-macix.ondigitalocean.app/api
 # Required for email redirects and canonical domain configuration
 # Defaults to localhost for local development; replace with your deployed domain in staging or production
 SITE_URL=https://urchin-app-macix.ondigitalocean.app/
@@ -18,7 +18,7 @@ TELEGRAM_WEBHOOK_SECRET=
 SESSION_JWT_SECRET=
 # Comma-separated origins allowed for CORS (e.g. https://example.com,https://another.com)
 # Defaults to http://localhost:3000 for local development
-ALLOWED_ORIGINS=http://localhost:3000
+ALLOWED_ORIGINS=https://urchin-app-macix.ondigitalocean.app
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
 # PostHog analytics

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "NODE_ENV=production tsx ../../scripts/copy-static.ts",
+    "build": "NODE_ENV=production next build && NODE_ENV=production tsx ../../scripts/copy-static.ts --copy-only",
     "start": "NODE_ENV=production node .next/standalone/apps/web/server.js",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 </head>
 <body>
     <script>
-        // Redirect to the deployed site
-        window.location.href = 'https://urchin-app-macix.ondigitalocean.app/';
+        // Redirect to the Next.js app
+        window.location.href = '/app';
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point client to `/api` endpoint and set CORS to deployed domain
- build Next.js app before copying static assets
- redirect root to `/app` for environment agnostic landing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e4cde52883228fb26690c009e0a2