### PR TITLE
chore: add build all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:landing": "npm -w apps/landing run build",
     "build:web": "npm -w apps/web run build",
     "build:miniapp": "bash scripts/build-miniapp.sh",
+    "build:all": "npm run build:landing && npm run build:web && npm run build:miniapp",
     "build:dev": "vite build --mode development",
     "start": "npm -w apps/web run start",
     "start:web": "npm -w apps/web run start",


### PR DESCRIPTION
## Summary
- add build:all script to run landing, web, and miniapp builds sequentially

## Testing
- `npm run build:all` (fails: terminated after Next.js build warnings)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5063d13fc8322b8a96358176b1ace