### PR TITLE
chore: suppress Sentry bundling warnings

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -20,10 +20,18 @@ export async function register() {
   }
 
   try {
+    // Use a dynamic import that is ignored by webpack so that Sentry's
+    // optional peer dependencies (which contain dynamic `require` calls)
+    // are not bundled during compilation. This suppresses "Critical
+    // dependency" warnings emitted by webpack when building the app.
     const Sentry =
       typeof window === 'undefined'
-        ? await import('@sentry/nextjs')
-        : await import('@sentry/browser');
+        ? await import(
+            /* webpackIgnore: true */ '@sentry/nextjs'
+          )
+        : await import(
+            /* webpackIgnore: true */ '@sentry/browser'
+          );
     Sentry.init({
       dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
       tracesSampleRate: 1.0,


### PR DESCRIPTION
## Summary
- avoid bundling Sentry SDK modules so webpack no longer emits critical dependency warnings during build

## Testing
- `npm -w apps/web run build`
- `grep -i 'critical dependency' -n /tmp/build.log`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c508244b8883229d411102803883bd