### PR TITLE
fix: redirect root to static index

### DIFF
--- a/server.js
+++ b/server.js
@@ -65,7 +65,7 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (pathname === '/' || pathname === '/index.html') {
-    const location = '/app' + search;
+    const location = '/_static/index.html' + search;
     res.writeHead(302, { Location: location });
     return res.end();
   }

--- a/tests/root-query.test.ts
+++ b/tests/root-query.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "jsr:@std/assert";
 
-Deno.test('redirects root path with query string to /app', async () => {
+Deno.test('redirects root path with query string to /_static/index.html', async () => {
   const command = new Deno.Command('node', {
     args: ['server.js'],
     cwd: new URL('..', import.meta.url).pathname,
@@ -13,7 +13,7 @@ Deno.test('redirects root path with query string to /app', async () => {
       redirect: 'manual',
     });
     assertEquals(res.status, 302);
-    assertEquals(res.headers.get('location'), '/app?foo=bar');
+    assertEquals(res.headers.get('location'), '/_static/index.html?foo=bar');
     await res.arrayBuffer();
   } finally {
     child.kill('SIGTERM');


### PR DESCRIPTION
## Summary
- redirect / requests to `_static/index.html`
- update root path test to expect new redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c511751d788322ae196fd77511170b