### PR TITLE
feat: restore dynamic capital branding

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -27,6 +27,12 @@
   .typography-6xl { @apply text-6xl; }
 }
 
+@layer utilities {
+  .text-gradient-brand {
+    @apply bg-gradient-brand bg-clip-text text-transparent;
+  }
+}
+
 /* === UNIVERSAL FRAMER MOTION THEME === */
 :root {
   /* Enhanced Motion Design Tokens - Red Theme */
@@ -36,23 +42,23 @@
   --card-foreground: 224 71.4% 4.1%;
   --popover: 0 0% 100%;
   --popover-foreground: 224 71.4% 4.1%;
-  --primary: 0 72% 51%;
-  --primary-foreground: 0 0% 98%;
+  --primary: 14 100% 57%;
+  --primary-foreground: 0 0% 100%;
   --secondary: 0 68% 95%;
   --secondary-foreground: 0 45% 20%;
   --muted: 0 5% 96%;
   --muted-foreground: 0 5% 45%;
   --elevated: 0 72% 10%;
-  --accent: 0 85% 65%;
-  --accent-foreground: 0 0% 98%;
+  --accent: 340 75% 55%;
+  --accent-foreground: 0 0% 100%;
   --destructive: 0 72% 51%;
   --destructive-foreground: 0 0% 98%;
   --border: 0 10% 89%;
   --input: 0 10% 89%;
-  --ring: 0 72% 51%;
+  --ring: 14 100% 57%;
   --radius: 0.5rem;
-  --chart-1: 0 72% 51%;
-  --chart-2: 14 100% 57%;
+  --chart-1: 14 100% 57%;
+  --chart-2: 200 100% 50%;
   --chart-3: 28 87% 67%;
   --chart-4: 340 82% 62%;
   --chart-5: 320 65% 55%;
@@ -66,11 +72,11 @@
   --motion-ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Dynamic Capital Red Brand Colors */
-  --dc-brand: 0 72% 51%;
-  --dc-brand-light: 0 85% 65%;
-  --dc-brand-dark: 0 65% 40%;
-  --dc-secondary: 0 85% 65%;
-  --dc-accent: 0 90% 60%;
+  --dc-brand: 14 100% 57%;
+  --dc-brand-light: 14 100% 67%;
+  --dc-brand-dark: 14 100% 47%;
+  --dc-secondary: 200 100% 50%;
+  --dc-accent: 340 75% 55%;
 
   /* Motion-Enhanced Red Gradients */
   --gradient-motion-primary: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--dc-brand-light)) 50%, hsl(var(--dc-accent)) 100%);
@@ -106,20 +112,20 @@
   --card-foreground: 0 5% 98%;
   --popover: 0 8% 8%;
   --popover-foreground: 0 5% 98%;
-  --primary: 0 72% 51%;
-  --primary-foreground: 0 5% 10%;
+  --primary: 14 100% 57%;
+  --primary-foreground: 0 0% 100%;
   --secondary: 0 10% 15%;
   --secondary-foreground: 0 5% 98%;
   --muted: 0 10% 15%;
   --muted-foreground: 0 5% 65%;
   --elevated: 0 5% 95%;
-  --accent: 0 85% 65%;
-  --accent-foreground: 0 5% 10%;
+  --accent: 340 75% 55%;
+  --accent-foreground: 0 0% 100%;
   --destructive: 0 65% 45%;
   --destructive-foreground: 0 5% 98%;
   --border: 0 15% 18%;
   --input: 0 15% 18%;
-  --ring: 0 85% 65%;
+  --ring: 14 100% 57%;
 
   /* Dark mode motion effects */
   --glass-motion-bg: hsl(var(--dc-brand) / 0.15);

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -44,8 +44,8 @@ export default function HomePage() {
     window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
   };
 
-  return (
-    <div className="min-h-screen bg-background">
+    return (
+      <div className="min-h-screen bg-gradient-brand">
       <HeroSection onJoinVIP={handleJoinVIP} onLearnMore={handleLearnMore} />
       
       <div id="features">

--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -111,10 +111,8 @@ export default function HeroSection({ onJoinVIP, onLearnMore }: HeroSectionProps
             </Badge>
           </div>
           
-          <h1 className="text-5xl md:text-7xl font-black text-foreground mb-6">
-            <span className="bg-gradient-to-r from-foreground via-primary to-[hsl(var(--dc-accent))] bg-clip-text text-transparent">
-              {content.title}
-            </span>
+          <h1 className="text-5xl md:text-7xl font-black text-gradient-brand mb-6">
+            {content.title}
           </h1>
 
           <p className="text-xl md:text-2xl text-muted-foreground mb-8 leading-relaxed max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- align global color tokens with Dynamic Capital palette
- add `text-gradient-brand` utility and apply to hero title
- use `bg-gradient-brand` on landing page container

## Testing
- `npm -w apps/web run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5698230208322952ef9a76b66a068