### PR TITLE
fix: add bg-gradient-brand utility

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -28,8 +28,13 @@
 }
 
 @layer utilities {
+  .bg-gradient-brand {
+    background-image: var(--gradient-brand);
+  }
+
   .text-gradient-brand {
-    @apply bg-gradient-brand bg-clip-text text-transparent;
+    @apply bg-clip-text text-transparent;
+    background-image: var(--gradient-brand);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -271,6 +271,10 @@
 }
 
 @layer utilities {
+  .bg-gradient-brand {
+    background-image: var(--gradient-brand);
+  }
+
   /* Text Gradients */
   .text-gradient-primary {
     @apply bg-gradient-to-r from-primary to-dc-accent bg-clip-text text-transparent;


### PR DESCRIPTION
## Summary
- define `bg-gradient-brand` as a custom utility in `globals.css` and root `index.css`
- update `text-gradient-brand` to use the explicit gradient utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c56c8de0a8832283b4d44662a374bd