### PR TITLE
feat: enhance landing layout and shared styles

### DIFF
--- a/apps/web/components/landing/HeroSection.tsx
+++ b/apps/web/components/landing/HeroSection.tsx
@@ -76,14 +76,6 @@ export default function HeroSection({ onJoinVIP, onLearnMore }: HeroSectionProps
         <div className="absolute bottom-20 right-20 w-80 h-80 bg-[hsl(var(--dc-accent)/0.1)] rounded-full blur-3xl animate-pulse" style={{ animationDelay: '2s' }}></div>
       </div>
 
-      {/* Header with Logo */}
-      <header className="absolute top-0 left-0 w-full flex items-center justify-between p-6 z-20">
-        <BrandLogo size="lg" variant="brand" animated />
-        <Badge className="bg-[hsl(var(--accent-light)/0.2)] text-[hsl(var(--accent-light))] border-[hsl(var(--accent-light)/0.3)]">
-          {content.badge}
-        </Badge>
-      </header>
-
       {/* Animated Background Text */}
       <motion.svg
         className="absolute top-0 left-1/2 -translate-x-1/2 w-[120%] h-[120%] pointer-events-none opacity-20"
@@ -104,13 +96,19 @@ export default function HeroSection({ onJoinVIP, onLearnMore }: HeroSectionProps
       {/* Hero Content */}
       <div className="relative z-10 max-w-5xl px-6">
         <MotionFadeIn>
+          <div className="mb-10 flex flex-col items-center">
+            <BrandLogo size="lg" variant="brand" animated />
+            <Badge className="mt-4 bg-[hsl(var(--accent-light)/0.2)] text-[hsl(var(--accent-light))] border-[hsl(var(--accent-light)/0.3)]">
+              {content.badge}
+            </Badge>
+          </div>
           <div className="mb-6">
             <Badge className="mb-4 bg-[hsl(var(--accent-gold)/0.2)] text-[hsl(var(--accent-gold))] border-[hsl(var(--accent-gold)/0.3)] text-lg px-6 py-2">
               <Sparkles className="w-5 h-5 mr-2" />
               {content.badgeHighlight}
             </Badge>
           </div>
-          
+
           <h1 className="text-5xl md:text-7xl font-black text-gradient-brand mb-6">
             {content.title}
           </h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import HeroSection from '../apps/web/components/landing/HeroSection';
-import FeatureGrid from '../apps/web/components/landing/FeatureGrid';
-import VipPriceSwitcher from '../apps/web/components/landing/VipPriceSwitcher';
-import { LivePlansSection } from '../apps/web/components/shared/LivePlansSection';
-import TestimonialsSection from '../apps/web/components/landing/TestimonialsSection';
-import IntegrationSection from '../apps/web/components/landing/IntegrationSection';
-import CTASection from '../apps/web/components/landing/CTASection';
-import { ChatAssistantWidget } from '../apps/web/components/shared/ChatAssistantWidget';
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
+import HeroSection from '@/components/landing/HeroSection';
+import FeatureGrid from '@/components/landing/FeatureGrid';
+import VipPriceSwitcher from '@/components/landing/VipPriceSwitcher';
+import { LivePlansSection } from '@/components/shared/LivePlansSection';
+import TestimonialsSection from '@/components/landing/TestimonialsSection';
+import IntegrationSection from '@/components/landing/IntegrationSection';
+import CTASection from '@/components/landing/CTASection';
+import { ChatAssistantWidget } from '@/components/shared/ChatAssistantWidget';
 
 function App() {
   const handleJoinVIP = () => {
@@ -44,35 +46,38 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-brand">
-      <HeroSection onJoinVIP={handleJoinVIP} onLearnMore={handleLearnMore} />
+    <div className="min-h-screen flex flex-col bg-gradient-brand">
+      <Header />
+      <main className="flex-1">
+        <HeroSection onJoinVIP={handleJoinVIP} onLearnMore={handleLearnMore} />
 
-      <VipPriceSwitcher />
+        <VipPriceSwitcher />
 
-      <div id="features">
-        <FeatureGrid />
-      </div>
+        <div id="features">
+          <FeatureGrid />
+        </div>
 
-      <LivePlansSection
-        showPromo
-        onPlanSelect={handleSelectPlan}
-        onBankPayment={handleBankPayment}
-        onCryptoPayment={handleCryptoPayment}
-      />
+        <LivePlansSection
+          showPromo
+          onPlanSelect={handleSelectPlan}
+          onBankPayment={handleBankPayment}
+          onCryptoPayment={handleCryptoPayment}
+        />
 
-      <TestimonialsSection />
+        <TestimonialsSection />
 
-      <IntegrationSection
-        onOpenTelegram={handleOpenTelegram}
-        onViewAccount={handleViewAccount}
-        onContactSupport={handleContactSupport}
-      />
+        <IntegrationSection
+          onOpenTelegram={handleOpenTelegram}
+          onViewAccount={handleViewAccount}
+          onContactSupport={handleContactSupport}
+        />
 
-      <CTASection
-        onJoinNow={handleJoinVIP}
-        onOpenTelegram={handleOpenTelegram}
-      />
-
+        <CTASection
+          onJoinNow={handleJoinVIP}
+          onOpenTelegram={handleOpenTelegram}
+        />
+      </main>
+      <Footer />
       <ChatAssistantWidget />
     </div>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'apps/web')
+    }
+  },
   server: {
     port: 8080
   },


### PR DESCRIPTION
## Summary
- add global header and footer to landing page and reorganize sections
- refactor hero section to show shared branding within content
- support `@` path alias for shared components in Vite

## Testing
- `npm test`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68c56e187e448322a7636f388dbc0597