### PR TITLE
test: wait for server readiness

### DIFF
--- a/tests/path-traversal.test.ts
+++ b/tests/path-traversal.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "jsr:@std/assert";
+import { waitForServer } from "./utils/waitForServer.ts";
 
 Deno.test('blocks path traversal in _static', async () => {
   const command = new Deno.Command('node', {
@@ -8,8 +9,7 @@ Deno.test('blocks path traversal in _static', async () => {
   });
   const child = command.spawn();
   try {
-    // Wait briefly for the server to start
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForServer(8123);
     const res = await fetch('http://localhost:8123/_static/../server.js');
     assertEquals(res.status, 404);
     await res.arrayBuffer(); // drain body to avoid leaks

--- a/tests/root-query.test.ts
+++ b/tests/root-query.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "jsr:@std/assert";
+import { waitForServer } from "./utils/waitForServer.ts";
 
 Deno.test('redirects root path with query string to /_static/index.html', async () => {
   const command = new Deno.Command('node', {
@@ -8,7 +9,7 @@ Deno.test('redirects root path with query string to /_static/index.html', async 
   });
   const child = command.spawn();
   try {
-    await new Promise((r) => setTimeout(r, 200));
+    await waitForServer(8124);
     const res = await fetch('http://localhost:8124/?foo=bar', {
       redirect: 'manual',
     });

--- a/tests/utils/waitForServer.ts
+++ b/tests/utils/waitForServer.ts
@@ -1,0 +1,16 @@
+export async function waitForServer(port: number, timeout = 5000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(`http://localhost:${port}/healthz`);
+      if (res.ok) {
+        await res.arrayBuffer();
+        return;
+      }
+    } catch {
+      // server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Server on port ${port} did not start within ${timeout}ms`);
+}


### PR DESCRIPTION
## Summary
- add reusable helper to poll server health endpoint
- update path-traversal and root-query tests to wait for server startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5757b7ca48322baf9b3ee8da38ce7