### PR TITLE
chore: automate static asset uploads

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -1,0 +1,28 @@
+name: Upload Static Assets
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build landing
+        run: npm run build:landing
+      - name: Upload assets
+        env:
+          CDN_BUCKET: ${{ secrets.CDN_BUCKET }}
+          CDN_ACCESS_KEY: ${{ secrets.CDN_ACCESS_KEY }}
+          CDN_SECRET_KEY: ${{ secrets.CDN_SECRET_KEY }}
+          CDN_REGION: ${{ secrets.CDN_REGION }}
+          CDN_ENDPOINT: ${{ secrets.CDN_ENDPOINT }}
+        run: npm run upload-assets

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ A minimal static landing page lives in `apps/landing/public/` with `index.html`,
 Run `npm run build:landing` to copy these files into the `_static/` directory for deployment. The root `server.js` serves the `_static` directory and returns `404.html` for unknown routes.
 Modify the files to suit your needs before running the build.
 
+## Asset Deployment
+
+- Run `npm run upload-assets` to push the generated `_static` directory to the configured CDN.
+- A GitHub Actions workflow (`upload-assets.yml`) builds `apps/landing` and uploads assets on pushes to `main`. It expects `CDN_BUCKET`, `CDN_ACCESS_KEY`, `CDN_SECRET_KEY`, and optional `CDN_REGION`/`CDN_ENDPOINT` secrets.
+- During development, `npm run upload-assets:watch` monitors `_static` and uploads changes automatically.
+
 ## Development Process Overview
 
 | Tool                   | What It Does                                                            | How You Use It                                                                                              |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.600.0",
+        "chokidar-cli": "^3.0.0",
         "mime-types": "^2.1.35",
         "supabase": "^2.40.7"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "debug": "NODE_OPTIONS='--inspect' npm run dev",
     "preview": "npm run dev",
     "upload-assets": "node scripts/upload-assets.js",
+    "upload-assets:watch": "chokidar '_static/**/*' -c 'npm run upload-assets'",
     "test": "node scripts/check-static-homepage.js && deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check",
     "verify": "bash scripts/verify/verify_all.sh",
     "export": "npm run build",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.600.0",
+    "chokidar-cli": "^3.0.0",
     "mime-types": "^2.1.35",
     "supabase": "^2.40.7"
   },

--- a/scripts/upload-assets.js
+++ b/scripts/upload-assets.js
@@ -9,7 +9,7 @@ const region = process.env.CDN_REGION || "nyc3";
 const endpoint = process.env.CDN_ENDPOINT || `https://${region}.digitaloceanspaces.com`;
 const accessKeyId = process.env.CDN_ACCESS_KEY;
 const secretAccessKey = process.env.CDN_SECRET_KEY;
-const distDir = process.argv[2] || "apps/landing/dist";
+const distDir = process.argv[2] || "_static";
 
 if (!bucket || !accessKeyId || !secretAccessKey) {
   console.error("Missing CDN configuration (CDN_BUCKET, CDN_ACCESS_KEY, CDN_SECRET_KEY).");


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and upload static assets on pushes to main
- watch `_static` locally and upload changes automatically
- document asset upload pipeline in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59be4f3248322935e33efccb5bf84