### PR TITLE
fix: import motion for FeatureGrid

### DIFF
--- a/apps/web/components/landing/FeatureGrid.tsx
+++ b/apps/web/components/landing/FeatureGrid.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { MotionHoverCard, MotionStagger, MotionScrollReveal } from "@/components/ui/motion-components";
 import { TrendingUp, Shield, Users } from "lucide-react";
 import { callEdgeFunction } from "@/config/supabase";
+import { motion } from "framer-motion";
 
 const FeatureGrid = () => {
   const defaultContent = {


### PR DESCRIPTION
## Summary
- import `motion` from framer-motion in FeatureGrid to fix missing reference

## Testing
- `npm run start`
- `CI=1 npm run build`
- `CI=1 npm run export`
- `npm run output`
- `CI=1 npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_68c6febf32d48322ba7438b8db390017