### PR TITLE
chore: configure SITE_URL for deployment

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -34,7 +34,7 @@ version = "0.0.0"
 
   [[build.env]]
     name = "SITE_URL"
-    value = "https://urchin-app-macix.ondigitalocean.app"
+    value = "https://dynamic-capital.lovable.app/"
 
   [[build.env]]
     name = "NEXT_TELEMETRY_DISABLED"


### PR DESCRIPTION
## Summary
- configure SITE_URL env var for Lovable deployment

## Testing
- `node --check apps/web/next.config.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70da4d70c83228f170dc2b637e7e0