### PR TITLE
chore: update SITE_URL for DigitalOcean deployment

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -10,7 +10,10 @@ spec:
     - key: CDN_SECRET_KEY
       scope: RUN_AND_BUILD_TIME
     - key: SITE_URL
-      value: https://urchin-app-macix.ondigitalocean.app
+      value: https://dynamic-capital.ondigitalocean.app
+      scope: RUN_AND_BUILD_TIME
+    - key: NEXT_PUBLIC_SITE_URL
+      value: https://dynamic-capital.ondigitalocean.app
       scope: RUN_AND_BUILD_TIME
     - key: NEXT_PUBLIC_SUPABASE_URL
       scope: RUN_AND_BUILD_TIME


### PR DESCRIPTION
## Summary
- update DigitalOcean app spec with `dynamic-capital.ondigitalocean.app`
- expose `NEXT_PUBLIC_SITE_URL`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7130c4dbc832284dbe01890027d07