### PR TITLE
chore: add SITE_URL env to app spec

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -32,6 +32,13 @@ spec:
       environment_slug: node-js
       build_command: "cd apps/web && npm ci && npm run build"
       run_command: "cd apps/web && PORT=$PORT npm start"
+      envs:
+        - key: SITE_URL
+          value: https://dynamic-capital.ondigitalocean.app
+          scope: RUN_AND_BUILD_TIME
+        - key: NEXT_PUBLIC_SITE_URL
+          value: https://dynamic-capital.ondigitalocean.app
+          scope: RUN_AND_BUILD_TIME
       http_port: 8080
       instance_count: 1
       instance_size_slug: basic-xxs


### PR DESCRIPTION
## Summary
- define SITE_URL and NEXT_PUBLIC_SITE_URL for the web service in the DigitalOcean app spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c832afaecc83228f77a42517376322