### PR TITLE
Pin production origin across platform configs

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -1,13 +1,42 @@
 spec:
   name: dynamic-capital
+  region: sgp
+  features:
+    - buildpack-stack=ubuntu-22
+  alerts:
+    - rule: DEPLOYMENT_FAILED
+    - rule: DOMAIN_FAILED
+  domains:
+    - domain: dynamic-capital.ondigitalocean.app
+      type: PRIMARY
+      wildcard: false
+      zone: dynamic-capital.ondigitalocean.app
+  ingress:
+    rules:
+      - component:
+          name: dynamic-capital
+        match:
+          authority:
+            exact: dynamic-capital.ondigitalocean.app
+          path:
+            prefix: /
   envs:
     - key: NODE_ENV
       value: production
+      scope: RUN_AND_BUILD_TIME
+    - key: NEXT_TELEMETRY_DISABLED
+      value: "1"
       scope: RUN_AND_BUILD_TIME
     - key: SITE_URL
       value: https://dynamic-capital.ondigitalocean.app
       scope: RUN_AND_BUILD_TIME
     - key: NEXT_PUBLIC_SITE_URL
+      value: https://dynamic-capital.ondigitalocean.app
+      scope: RUN_AND_BUILD_TIME
+    - key: ALLOWED_ORIGINS
+      value: https://dynamic-capital.ondigitalocean.app
+      scope: RUN_AND_BUILD_TIME
+    - key: MINIAPP_ORIGIN
       value: https://dynamic-capital.ondigitalocean.app
       scope: RUN_AND_BUILD_TIME
     - key: NEXT_PUBLIC_SUPABASE_URL
@@ -27,11 +56,22 @@ spec:
     - key: CDN_SECRET_KEY
       scope: RUN_AND_BUILD_TIME
   services:
-    - name: web
+    - name: dynamic-capital
       source_dir: .
+      github:
+        repo: Dynamic-Capital/Dynamic-Capital
+        branch: main
+        deploy_on_push: true
       environment_slug: node-js
-      build_command: "cd apps/web && npm ci && npm run build"
-      run_command: "cd apps/web && PORT=$PORT npm start"
+      instance_count: 1
+      instance_size_slug: basic-xxs
+      build_command: npm run build
+      run_command: npm run start:web
+      http_port: 8080
+      routes:
+        - path: /
+      health_check:
+        http_path: /
       envs:
         - key: SITE_URL
           value: https://dynamic-capital.ondigitalocean.app
@@ -39,10 +79,6 @@ spec:
         - key: NEXT_PUBLIC_SITE_URL
           value: https://dynamic-capital.ondigitalocean.app
           scope: RUN_AND_BUILD_TIME
-      http_port: 8080
-      instance_count: 1
-      instance_size_slug: basic-xxs
-      routes:
-        - path: /
-      health_check:
-        http_path: /
+        - key: MINIAPP_ORIGIN
+          value: https://dynamic-capital.ondigitalocean.app
+          scope: RUN_AND_BUILD_TIME

--- a/dns/dynamic-capital.ondigitalocean.app.zone
+++ b/dns/dynamic-capital.ondigitalocean.app.zone
@@ -1,0 +1,9 @@
+; DigitalOcean App Platform default domain for Dynamic Capital
+$ORIGIN dynamic-capital.ondigitalocean.app.
+$TTL 1800
+dynamic-capital.ondigitalocean.app. IN SOA ns1.digitalocean.com. hostmaster.dynamic-capital.ondigitalocean.app. 1757878623 10800 3600 604800 1800
+dynamic-capital.ondigitalocean.app. 1800 IN NS ns1.digitalocean.com.
+dynamic-capital.ondigitalocean.app. 1800 IN NS ns2.digitalocean.com.
+dynamic-capital.ondigitalocean.app. 1800 IN NS ns3.digitalocean.com.
+dynamic-capital.ondigitalocean.app. 3600 IN A 162.159.140.98
+dynamic-capital.ondigitalocean.app. 3600 IN A 172.66.0.96

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -8,6 +8,11 @@ This project relies on a Next.js service and Supabase Edge Functions. Use the fo
 - Set `DOMAIN` in your `.env` to the root zone (e.g. `example.com`) for helper scripts and Nginx templates.
 - Update `SITE_URL` and `NEXT_PUBLIC_SITE_URL` to the canonical site URL, and adjust `NEXT_PUBLIC_API_URL` if using an API subdomain.
 - `ALLOWED_ORIGINS` should list the site and API origins so browsers can call the endpoints.
+- The default DigitalOcean domain is tracked in
+  [`dns/dynamic-capital.ondigitalocean.app.zone`](../dns/dynamic-capital.ondigitalocean.app.zone);
+  reapply its NS and A records (162.159.140.98 and 172.66.0.96) if you recreate
+  the domain so Cloudflare keeps proxying both the Next.js UI and the Supabase
+  Edge Functions.
 
 ## Environment variables
 - Copy `.env.example` to `.env.local` and fill in credentials.
@@ -26,6 +31,12 @@ location /api/ {
 
 ## Cloudflare ingress
 Traffic routed through Cloudflare may arrive from public IPs such as `162.159.140.98` or `172.66.0.96`. Set your web app domain's A records to these IPs and let Cloudflare proxy requests to the service running on port `8080`.
+
+## Origin alignment across platforms
+- The DigitalOcean App Platform spec pins the ingress authority to `dynamic-capital.ondigitalocean.app` so load balancers terminate TLS on the canonical host before forwarding traffic to port `8080`.
+- `supabase/config.toml` sets `site_url`, `additional_redirect_urls`, and the Supabase Functions env block to the same origin so Edge Functions and Telegram verification enforce the correct allowlist.
+- `vercel.json` declares the canonical origin as environment defaults and redirects any deployments back to `https://dynamic-capital.ondigitalocean.app` to avoid diverging hosts.
+- `lovable-build.js` and `lovable-dev.js` hydrate `SITE_URL`, `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`, and `MINIAPP_ORIGIN` before running Lovable workflows so previews and builds share the production origin when values are omitted.
 
 ## Outbound connectivity
 Ensure the runtime can reach external services like Supabase over HTTPS (`*.supabase.co`). Adjust firewall or egress rules as needed.

--- a/docs/env.md
+++ b/docs/env.md
@@ -86,4 +86,5 @@ You can confirm access with `doctl spaces list`.
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
 | `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `http://localhost:3000`). | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `MINIAPP_ORIGIN`      | Origins allowed to call Telegram verification and mini-app APIs.              | No (required for production bots) | `https://dynamic-capital.ondigitalocean.app` | `supabase/functions/verify-telegram/index.ts` |
 | `LOG_LEVEL`           | Minimum log level for server logs (`debug`, `info`, `warn`, `error`). | No       | `warn`                    | `utils/logger.ts` |

--- a/lovable-build.js
+++ b/lovable-build.js
@@ -2,7 +2,30 @@
 
 import { execSync } from 'node:child_process';
 
+const PRODUCTION_ORIGIN = 'https://dynamic-capital.ondigitalocean.app';
+const resolvedOrigin =
+  process.env.LOVABLE_ORIGIN ||
+  process.env.SITE_URL ||
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  PRODUCTION_ORIGIN;
+
+for (const key of [
+  'SITE_URL',
+  'NEXT_PUBLIC_SITE_URL',
+  'ALLOWED_ORIGINS',
+  'MINIAPP_ORIGIN',
+]) {
+  if (!process.env[key]) {
+    process.env[key] = resolvedOrigin;
+  }
+}
+
+if (!process.env.LOVABLE_ORIGIN) {
+  process.env.LOVABLE_ORIGIN = resolvedOrigin;
+}
+
 console.log('🔧 Running Lovable build tasks...');
+console.log(`📡 Using origin ${resolvedOrigin} for Lovable build.`);
 
 // Ensure required environment variables are present
 try {

--- a/lovable-dev.js
+++ b/lovable-dev.js
@@ -1,7 +1,30 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process';
 
+const PRODUCTION_ORIGIN = 'https://dynamic-capital.ondigitalocean.app';
+const resolvedOrigin =
+  process.env.LOVABLE_ORIGIN ||
+  process.env.SITE_URL ||
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  PRODUCTION_ORIGIN;
+
+for (const key of [
+  'SITE_URL',
+  'NEXT_PUBLIC_SITE_URL',
+  'ALLOWED_ORIGINS',
+  'MINIAPP_ORIGIN',
+]) {
+  if (!process.env[key]) {
+    process.env[key] = resolvedOrigin;
+  }
+}
+
+if (!process.env.LOVABLE_ORIGIN) {
+  process.env.LOVABLE_ORIGIN = resolvedOrigin;
+}
+
 console.log('🔧 Preparing Lovable dev environment...');
+console.log(`📡 Using origin ${resolvedOrigin} for Lovable dev services.`);
 
 try {
   execSync('npx tsx scripts/check-env.ts', { stdio: 'inherit' });

--- a/project.toml
+++ b/project.toml
@@ -30,11 +30,15 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://162.159.140.98,https://172.66.0.96"
+    value = "https://dynamic-capital.ondigitalocean.app"
 
   [[build.env]]
     name = "SITE_URL"
-    value = "https://162.159.140.98/"
+    value = "https://dynamic-capital.ondigitalocean.app/"
+
+  [[build.env]]
+    name = "MINIAPP_ORIGIN"
+    value = "https://dynamic-capital.ondigitalocean.app"
 
   [[build.env]]
     name = "NEXT_TELEMETRY_DISABLED"

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -18,7 +18,14 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SITE_URL) {
   if (!SITE_URL) {
     process.env.SITE_URL = "http://localhost:8080";
     process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:8080";
+    if (!process.env.MINIAPP_ORIGIN) {
+      process.env.MINIAPP_ORIGIN = "http://localhost:8080";
+    }
   }
 } else {
   console.log("✅ Required env vars present");
+}
+
+if (!process.env.MINIAPP_ORIGIN && process.env.SITE_URL) {
+  process.env.MINIAPP_ORIGIN = process.env.SITE_URL;
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,14 @@
 project_id = "qeejuomcapbdlhnjqjcc"
+
+[global]
+  site_url = "https://dynamic-capital.ondigitalocean.app"
+  additional_redirect_urls = [
+    "https://dynamic-capital.ondigitalocean.app",
+  ]
+
+[functions]
+  [functions.env]
+    SITE_URL = "https://dynamic-capital.ondigitalocean.app"
+    NEXT_PUBLIC_SITE_URL = "https://dynamic-capital.ondigitalocean.app"
+    ALLOWED_ORIGINS = "https://dynamic-capital.ondigitalocean.app"
+    MINIAPP_ORIGIN = "https://dynamic-capital.ondigitalocean.app"

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,18 @@
   "installCommand": "npm install",
   "buildCommand": "npm run build",
   "outputDirectory": "apps/web/.next",
-  "devCommand": "npm run dev"
+  "devCommand": "npm run dev",
+  "env": {
+    "SITE_URL": "https://dynamic-capital.ondigitalocean.app",
+    "NEXT_PUBLIC_SITE_URL": "https://dynamic-capital.ondigitalocean.app",
+    "ALLOWED_ORIGINS": "https://dynamic-capital.ondigitalocean.app",
+    "MINIAPP_ORIGIN": "https://dynamic-capital.ondigitalocean.app"
+  },
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://dynamic-capital.ondigitalocean.app/$1",
+      "permanent": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- pin the DigitalOcean ingress authority and service envs to the production host and expose MINIAPP_ORIGIN
- propagate the canonical origin to Supabase CLI defaults, Vercel deployments, Lovable tooling, and the Paketo buildpack envs
- document the shared origin setup and MINIAPP_ORIGIN requirement across the deployment and networking guides

## Testing
- CI=1 SITE_URL=http://localhost:3000 NEXT_PUBLIC_SITE_URL=http://localhost:3000 ALLOWED_ORIGINS=http://localhost:3000 MINIAPP_ORIGIN=http://localhost:3000 SUPABASE_URL=https://stub.supabase.co NEXT_PUBLIC_SUPABASE_URL=https://stub.supabase.co SUPABASE_ANON_KEY=stub-anon-key-12345 NEXT_PUBLIC_SUPABASE_ANON_KEY=stub-anon-key-12345 npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68c8371a1984832292fe8f8808024942