### PR TITLE
Add repository inventory overview

### DIFF
--- a/docs/REPO_INVENTORY.md
+++ b/docs/REPO_INVENTORY.md
@@ -1,0 +1,62 @@
+# Dynamic Capital Repository Inventory
+
+_Last updated: 2025-09-15 (UTC)._ 
+
+## 1. Product snapshot
+
+- Telegram-first deposit automation with optional Mini App plus a static marketing site, all backed by Supabase for data storage and automation flows.【F:README.md†L1-L39】
+- Two deployable front ends ship from this repo: a static landing page under `apps/landing` and a dynamic Next.js dashboard/mini app under `apps/web`. The static build is published into `_static/` for serving without runtime secrets.【F:README.md†L10-L57】【F:README.md†L96-L117】
+
+## 2. Application surfaces
+
+### Web & Mini App delivery
+- **`apps/landing/`** – Lightweight marketing site with its own `public/` assets and package manifest used to generate the `_static/` deployment bundle.【F:README.md†L44-L117】【76ebf3†L1-L2】
+- **`apps/web/`** – Main Next.js application powering the Telegram Mini App and dashboard with feature-specific folders for routes (`app/`), UI (`components/`), hooks, and configuration (`next.config.mjs`, `tailwind.config.ts`, etc.).【F:README.md†L16-L39】【e9cdd9†L1-L6】
+- **`_static/` + `server.js`** – Prebuilt landing assets are served by the hardened Node static server at the project root, which enforces caching, CORS, security headers, and a `/healthz` check.【F:README.md†L96-L117】【304716†L1-L112】
+- **`Procfile`** – Declares the production start command for the standalone Next.js server so PaaS platforms can boot the app.【1512da†L1-L2】
+
+### Background and CLI services
+- **`broadcast/index.ts`** – Standalone broadcast planner referenced in the project overview for scheduling outbound messaging jobs.【4bcdf6†L1-L2】【6cb097†L1-L2】
+- **`queue/index.ts`** – Lightweight worker harness for queued tasks that complement the Telegram workflows.【a55bc1†L1-L2】【416f4d†L1-L2】
+- **`go-service/`** – Minimal Go HTTP service (with `main.go` and `go.mod`) that exposes a `/healthz` endpoint for infrastructure probes.【F:README.md†L58-L65】【bf9fee†L1-L2】
+
+## 3. Supabase platform & data layer
+
+- **`supabase/functions/`** – Large catalog of Deno Edge Functions covering Telegram bot logic, mini-app operations, admin tooling, payments, analytics, and health checks. Shared helpers live in `_shared/` alongside feature-specific directories such as `telegram-bot`, `miniapp`, `admin-*`, and `analytics-*` families.【b6622b†L1-L86】【ffcaaf†L1-L10】
+- **`supabase/migrations/`** – Sequential SQL migrations that manage tables, policies, indexes, and seed data for the Supabase/Postgres backend (dozens of files spanning bot content, payments, promotions, subscriptions, and auditing).【7456a1†L1-L20】
+- **`supabase/config.toml` & `supabase/functions/_tests/`** – Supabase CLI configuration and targeted Deno tests (`miniapp-health`, `start-command`, `webhook-secret`) that validate deployed functions.【a5daed†L1-L2】【9b6ab9†L1-L2】
+- **`db/`** – Local TypeScript client and schema references (`client.ts`, `schema.ts`) for interacting with the database outside of Supabase Edge Functions.【ddbcb5†L1-L2】
+
+## 4. Supporting infrastructure & configuration
+
+- **`docker/`** – Container assets including app and Go service Dockerfiles, compose file, Nginx config, and health check script for running the stack in controlled environments.【b095f5†L1-L2】
+- **`dns/`** – DNS zone export (`dynamic-capital.ondigitalocean.app.zone`) used to reproduce external records.【a93f31†L1-L2】
+- **`external/dynamic_codex/`** – Separate Lovable Codex project (Vite app, Supabase integration, telemetry README) maintained alongside the main bot for experiments and trading automation tie-ins.【c79fa4†L1-L7】【b8f4df†L1-L56】
+- **`lovable-build.js` / `lovable-dev.js`** – Helper scripts that bootstrap environment variables and orchestrate combined Next.js + miniapp builds when running on Lovable’s deployment platform.【e53642†L1-L36】
+
+## 5. Tooling, documentation & testing
+
+- **`scripts/`** – Operational CLI scripts for building miniapp bundles, setting Telegram webhooks, syncing environments, performing audits, and running verification suites (`verify/`, `cleanup/`, `ops/`, etc.).【13847a†L1-L8】
+- **`docs/`** – Extensive knowledge base with deployment guides, checklists, networking notes, Supabase audits, and workflow documentation; includes machine-generated `INVENTORY.csv` for line-of-code and size tracking.【e6c7f6†L1-L32】【648e45†L1-L120】
+- **`tests/`** – Vitest/Jest-style suites validating API routes, miniapp options, Telegram flows, payments policies, and utility helpers, plus stubs for Supabase and Telegram integrations.【fd35fe†L1-L12】
+
+## 6. Quick directory reference
+
+| Path | Purpose / Highlights |
+| --- | --- |
+| `apps/landing/` | Static marketing site that feeds the `_static/` deployment bundle.【F:README.md†L44-L117】【76ebf3†L1-L2】 |
+| `apps/web/` | Next.js mini app + dashboard with rich component, hook, and config subfolders.【F:README.md†L16-L39】【e9cdd9†L1-L6】 |
+| `_static/` & `server.js` | Built landing assets served through the hardened Node static server with security headers and health checks.【F:README.md†L96-L117】【304716†L1-L112】 |
+| `broadcast/index.ts` | Broadcast planner entry point for scheduled outbound messaging.【4bcdf6†L1-L2】【6cb097†L1-L2】 |
+| `queue/index.ts` | Worker harness for queued Telegram operations.【a55bc1†L1-L2】【416f4d†L1-L2】 |
+| `supabase/functions/` | Comprehensive suite of Deno Edge Functions plus shared helpers for bot, admin, analytics, and miniapp tasks.【b6622b†L1-L86】【ffcaaf†L1-L10】 |
+| `supabase/migrations/` | Database schema, policy, index, and seed migrations for Supabase/Postgres.【7456a1†L1-L20】 |
+| `scripts/` | Automation scripts for builds, deployments, audits, and environment checks.【13847a†L1-L8】 |
+| `docs/` | Repository documentation, checklists, and inventories for onboarding and audits.【e6c7f6†L1-L32】【648e45†L1-L120】 |
+| `tests/` | Automated test suites and stubs covering APIs, miniapp flows, and Telegram integrations.【fd35fe†L1-L12】 |
+| `docker/` | Containerization and reverse proxy assets (Dockerfiles, Compose, Nginx, health checks).【b095f5†L1-L2】 |
+| `go-service/` | Auxiliary Go health service exposing `/healthz`.【bf9fee†L1-L2】 |
+| `dns/` | Exported DNS zone records.【a93f31†L1-L2】 |
+| `external/dynamic_codex/` | Lovable Codex companion project with its own app and Supabase wiring.【c79fa4†L1-L7】【b8f4df†L1-L56】 |
+| `db/` | TypeScript database client/schema utilities.【ddbcb5†L1-L2】 |
+| `Procfile` | Platform startup definition pointing at the Next.js standalone server build.【1512da†L1-L2】 |


### PR DESCRIPTION
## Summary
- add a dedicated repository inventory guide for quick navigation of the codebase
- document major applications, supabase functions, infrastructure assets, and tooling directories with citations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8766545a08322b00c52644b012f4d