### PR TITLE
Add friendly Codex CLI logging

### DIFF
--- a/lovable-build.js
+++ b/lovable-build.js
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 
 import { execSync } from 'node:child_process';
+import {
+  banner,
+  celebrate,
+  divider,
+  info,
+  note,
+  step,
+  success,
+  warn,
+  error as logError,
+} from './scripts/utils/friendly-logger.js';
 
 const PRODUCTION_ORIGIN = 'https://dynamic-capital.ondigitalocean.app';
 const resolvedOrigin =
@@ -9,6 +20,13 @@ const resolvedOrigin =
   process.env.NEXT_PUBLIC_SITE_URL ||
   PRODUCTION_ORIGIN;
 
+banner(
+  'Codex CLI · Friendly Build Mode',
+  'Running Lovable build tasks with cheerful updates.',
+);
+info(`Resolved origin preference: ${resolvedOrigin}`);
+
+const defaultedKeys = [];
 for (const key of [
   'SITE_URL',
   'NEXT_PUBLIC_SITE_URL',
@@ -17,39 +35,78 @@ for (const key of [
 ]) {
   if (!process.env[key]) {
     process.env[key] = resolvedOrigin;
+    defaultedKeys.push(key);
   }
+}
+
+if (defaultedKeys.length > 0) {
+  warn('Origin variables were missing. Applying the resolved origin to keep builds consistent.', {
+    details: defaultedKeys.map((key) => `${key} → ${resolvedOrigin}`),
+  });
+} else {
+  success('All origin-related environment variables are ready to go.');
 }
 
 if (!process.env.LOVABLE_ORIGIN) {
   process.env.LOVABLE_ORIGIN = resolvedOrigin;
+  note(`LOVABLE_ORIGIN defaulted to ${resolvedOrigin} so previews match the build.`);
+} else {
+  info(`LOVABLE_ORIGIN already configured as ${process.env.LOVABLE_ORIGIN}.`);
 }
 
-console.log('🔧 Running Lovable build tasks...');
-console.log(`📡 Using origin ${resolvedOrigin} for Lovable build.`);
+const supabaseFallbacks = [];
+if (!process.env.SUPABASE_URL) {
+  process.env.SUPABASE_URL = 'https://stub.supabase.co';
+  supabaseFallbacks.push('SUPABASE_URL → https://stub.supabase.co');
+}
+if (!process.env.SUPABASE_ANON_KEY) {
+  process.env.SUPABASE_ANON_KEY = 'stub-anon-key';
+  supabaseFallbacks.push('SUPABASE_ANON_KEY → stub-anon-key');
+}
 
-// Ensure required environment variables are present
+if (supabaseFallbacks.length > 0) {
+  note('Supabase credentials are not configured; placeholder values will be used for local build helpers.', {
+    details: supabaseFallbacks,
+  });
+}
+
+divider();
+step('Ensuring required environment variables are present...');
 try {
   execSync('npx tsx scripts/check-env.ts', { stdio: 'inherit' });
+  success('Environment check passed.');
 } catch (error) {
-  console.error('❌ Environment check failed:', error.message);
+  logError('Environment check failed. Fix the issues above before building.', {
+    details: error?.message ? [error.message] : undefined,
+  });
   process.exit(1);
 }
 
 const tasks = [
   { cmd: 'npm run build', label: 'Next.js build' },
-  { cmd: 'npm run build:miniapp', label: 'Miniapp build' }
+  { cmd: 'npm run build:miniapp', label: 'Miniapp build' },
 ];
 
+divider();
 let exitCode = 0;
 for (const { cmd, label } of tasks) {
-  console.log(`\n🔨 ${label}...`);
+  step(`${label} in progress...`);
   try {
     execSync(cmd, { stdio: 'inherit' });
-    console.log(`✅ ${label} completed successfully!`);
+    success(`${label} completed successfully!`);
   } catch (error) {
-    console.error(`❌ ${label} failed:`, error.message);
+    logError(`${label} failed. Check the output above for details.`, {
+      details: error?.message ? [error.message] : undefined,
+    });
     exitCode = 1;
   }
+  divider();
+}
+
+if (exitCode === 0) {
+  celebrate('All Codex CLI build tasks finished with a smile!');
+} else {
+  warn('Some build tasks did not finish successfully. Review the logs above.');
 }
 
 process.exitCode = exitCode;

--- a/lovable-dev.js
+++ b/lovable-dev.js
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process';
+import {
+  banner,
+  celebrate,
+  divider,
+  info,
+  note,
+  step,
+  success,
+  warn,
+  error as logError,
+} from './scripts/utils/friendly-logger.js';
 
 const PRODUCTION_ORIGIN = 'https://dynamic-capital.ondigitalocean.app';
 const resolvedOrigin =
@@ -8,6 +19,13 @@ const resolvedOrigin =
   process.env.NEXT_PUBLIC_SITE_URL ||
   PRODUCTION_ORIGIN;
 
+banner(
+  'Codex CLI · Friendly Dev Mode',
+  'Configuring the Lovable workspace with emoji-powered feedback.',
+);
+info(`Resolved origin preference: ${resolvedOrigin}`);
+
+const defaultedKeys = [];
 for (const key of [
   'SITE_URL',
   'NEXT_PUBLIC_SITE_URL',
@@ -16,33 +34,80 @@ for (const key of [
 ]) {
   if (!process.env[key]) {
     process.env[key] = resolvedOrigin;
+    defaultedKeys.push(key);
   }
+}
+
+if (defaultedKeys.length > 0) {
+  warn('Origin variables were missing. Filling them with the resolved origin so previews stay happy.', {
+    details: defaultedKeys.map((key) => `${key} → ${resolvedOrigin}`),
+  });
+} else {
+  success('All origin-related environment variables were already set. Nice!');
 }
 
 if (!process.env.LOVABLE_ORIGIN) {
   process.env.LOVABLE_ORIGIN = resolvedOrigin;
+  note(`LOVABLE_ORIGIN defaulted to ${resolvedOrigin} for local previews.`);
+} else {
+  info(`LOVABLE_ORIGIN already configured as ${process.env.LOVABLE_ORIGIN}.`);
 }
 
-console.log('🔧 Preparing Lovable dev environment...');
-console.log(`📡 Using origin ${resolvedOrigin} for Lovable dev services.`);
+const supabaseFallbacks = [];
+if (!process.env.SUPABASE_URL) {
+  process.env.SUPABASE_URL = 'https://stub.supabase.co';
+  supabaseFallbacks.push('SUPABASE_URL → https://stub.supabase.co');
+}
+if (!process.env.SUPABASE_ANON_KEY) {
+  process.env.SUPABASE_ANON_KEY = 'stub-anon-key';
+  supabaseFallbacks.push('SUPABASE_ANON_KEY → stub-anon-key');
+}
+
+if (supabaseFallbacks.length > 0) {
+  warn(
+    'Supabase credentials were not found. Using placeholder values; database-powered features may be limited.',
+    { details: supabaseFallbacks },
+  );
+}
+
+divider();
+step('Running friendly preflight checks...');
 
 try {
+  info('Validating required environment variables...');
   execSync('npx tsx scripts/check-env.ts', { stdio: 'inherit' });
-  try {
-    const deno = execSync('bash scripts/deno_bin.sh').toString().trim();
-    execSync(`${deno} run -A scripts/check-supabase-connectivity.ts`, { stdio: 'inherit' });
-  } catch (err) {
-    console.warn('⚠️  Supabase connectivity check failed (continuing):', err.message);
+  success('Environment bootstrap complete.');
+
+  if (supabaseFallbacks.length === 0) {
+    try {
+      info('Checking Supabase connectivity just in case...');
+      const deno = execSync('bash scripts/deno_bin.sh').toString().trim();
+      execSync(`${deno} run -A scripts/check-supabase-connectivity.ts`, {
+        stdio: 'inherit',
+      });
+      success('Supabase connectivity looks good.');
+    } catch (err) {
+      warn('Supabase connectivity check failed (continuing).', {
+        details: err?.message ? [err.message] : undefined,
+      });
+    }
+  } else {
+    note('Skipping Supabase connectivity check while placeholder credentials are in use.');
   }
 } catch (error) {
-  console.error('❌ Preflight checks failed:', error.message);
+  logError('Preflight checks failed. Please resolve the issue above.', {
+    details: error?.message ? [error.message] : undefined,
+  });
   process.exit(1);
 }
 
 if (process.env.CI === '1') {
-  console.log('CI environment detected; skipping dev server start.');
+  warn('CI environment detected; skipping dev server start to keep pipelines tidy.');
   process.exit(0);
 }
 
-console.log('\n🚀 Starting Next.js dev server...');
+divider();
+step('Starting the Next.js dev server with extra cheer...');
+note('Tip: Watch for build output below. Press Ctrl+C when you are done.');
+celebrate('Happy coding! The server logs will stream next.');
 execSync('npm run dev', { stdio: 'inherit' });

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,31 +1,48 @@
 // Reuse the env helper from the web app to avoid maintaining a separate copy
 import { optionalEnvVar } from "../apps/web/utils/env.ts";
+import { celebrate, info, success, warn } from "./utils/friendly-logger.js";
 
 const SUPABASE_URL = optionalEnvVar("SUPABASE_URL");
 const SUPABASE_ANON_KEY = optionalEnvVar("SUPABASE_ANON_KEY");
 const SITE_URL = optionalEnvVar("SITE_URL");
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SITE_URL) {
-  console.warn(
-    "⚠️  SUPABASE_URL, SUPABASE_ANON_KEY or SITE_URL not set. Using placeholder values; some features may be disabled.",
+const placeholders: string[] = [];
+
+if (!SUPABASE_URL) {
+  process.env.SUPABASE_URL = "https://stub.supabase.co";
+  placeholders.push("SUPABASE_URL → https://stub.supabase.co");
+}
+if (!SUPABASE_ANON_KEY) {
+  process.env.SUPABASE_ANON_KEY = "stub-anon-key";
+  placeholders.push("SUPABASE_ANON_KEY → stub-anon-key");
+}
+if (!SITE_URL) {
+  const fallbackOrigin = "http://localhost:8080";
+  process.env.SITE_URL = fallbackOrigin;
+  process.env.NEXT_PUBLIC_SITE_URL = fallbackOrigin;
+  placeholders.push(
+    "SITE_URL & NEXT_PUBLIC_SITE_URL → http://localhost:8080",
   );
-  if (!SUPABASE_URL) {
-    process.env.SUPABASE_URL = "https://stub.supabase.co";
+  if (!process.env.MINIAPP_ORIGIN) {
+    process.env.MINIAPP_ORIGIN = fallbackOrigin;
+    placeholders.push("MINIAPP_ORIGIN → http://localhost:8080");
   }
-  if (!SUPABASE_ANON_KEY) {
-    process.env.SUPABASE_ANON_KEY = "stub-anon-key";
-  }
-  if (!SITE_URL) {
-    process.env.SITE_URL = "http://localhost:8080";
-    process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:8080";
-    if (!process.env.MINIAPP_ORIGIN) {
-      process.env.MINIAPP_ORIGIN = "http://localhost:8080";
-    }
-  }
+}
+
+if (placeholders.length > 0) {
+  warn(
+    "Some environment variables were missing. Friendly placeholders were added so the Codex CLI keeps humming.",
+    { details: placeholders },
+  );
 } else {
-  console.log("✅ Required env vars present");
+  success("All required environment variables are already set. 🌟");
 }
 
 if (!process.env.MINIAPP_ORIGIN && process.env.SITE_URL) {
   process.env.MINIAPP_ORIGIN = process.env.SITE_URL;
+  info(`MINIAPP_ORIGIN defaulted to ${process.env.MINIAPP_ORIGIN} to match SITE_URL.`);
+} else if (process.env.MINIAPP_ORIGIN) {
+  info(`MINIAPP_ORIGIN is set to ${process.env.MINIAPP_ORIGIN}.`);
 }
+
+celebrate("Codex CLI environment bootstrap complete. Happy building!");

--- a/scripts/utils/friendly-logger.js
+++ b/scripts/utils/friendly-logger.js
@@ -1,0 +1,76 @@
+const DEFAULT_DIVIDER_LENGTH = 48;
+
+function toLines(value) {
+  if (value === undefined || value === null) return [];
+  const array = Array.isArray(value) ? value : [value];
+  return array
+    .flatMap((item) => String(item).split('\n'))
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+}
+
+function output(emoji, message, options = {}) {
+  const { details, indent = '   ', stream = console.log, bullet = '•' } = options;
+  const messageLines = toLines(message);
+  if (messageLines.length === 0) {
+    stream(`${emoji}`);
+    return;
+  }
+
+  const [firstLine, ...rest] = messageLines;
+  const formatted = [`${emoji} ${firstLine}`];
+  for (const line of rest) {
+    formatted.push(`${indent}${line}`);
+  }
+
+  for (const detail of toLines(details)) {
+    formatted.push(`${indent}${bullet} ${detail}`);
+  }
+
+  stream(formatted.join('\n'));
+}
+
+export function banner(title, subtitle) {
+  const lines = [title, subtitle].filter(Boolean).map((line) => line.length);
+  const length = Math.max(DEFAULT_DIVIDER_LENGTH, ...lines.map((len) => len + 6));
+  const border = '═'.repeat(length);
+
+  console.log(`\n${border}`);
+  console.log(`✨ ${title}`);
+  if (subtitle) {
+    console.log(`   ${subtitle}`);
+  }
+  console.log(`${border}\n`);
+}
+
+export function divider(length = DEFAULT_DIVIDER_LENGTH) {
+  console.log('─'.repeat(length));
+}
+
+export function step(message, options) {
+  output('🚀', message, options);
+}
+
+export function info(message, options) {
+  output('💡', message, options);
+}
+
+export function success(message, options) {
+  output('🎉', message, options);
+}
+
+export function warn(message, options = {}) {
+  output('⚠️', message, { ...options, stream: console.warn });
+}
+
+export function error(message, options = {}) {
+  output('❌', message, { ...options, stream: console.error });
+}
+
+export function note(message, options) {
+  output('📝', message, options);
+}
+
+export function celebrate(message, options) {
+  output('🥳', message, options);
+}


### PR DESCRIPTION
## Summary
- add a reusable friendly logger with emoji helpers for Codex CLI scripts
- refresh lovable build/dev entrypoints to use cheerful messaging and clearer preflight handling
- upgrade the environment bootstrap script to report placeholders and success with friendlier tone

## Testing
- `CI=1 node lovable-dev.js`
- `npx tsx scripts/check-env.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c878cdbcc88322a62b97d543d7bcb7