### PR TITLE
Share Supabase types with src integration

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1,0 +1,19 @@
+// Shared Supabase type definitions
+//
+// The Lovable mini-app (src/) and the Next.js app (apps/web/) both rely on the
+// same Supabase project. The generated types already live in
+// `apps/web/types/supabase.ts`; re-export them here so packages that resolve the
+// `@/integrations/supabase` alias from the Vite workspace continue to benefit
+// from the full schema without duplicating files or drifting out of sync.
+
+export type {
+  Database,
+  Json,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+  Enums,
+  CompositeTypes,
+} from "../../../apps/web/types/supabase";
+
+export { Constants } from "../../../apps/web/types/supabase";


### PR DESCRIPTION
## Summary
- add a Supabase types module under `src/integrations` that re-exports the generated schema from the Next.js app
- document why the shared module exists so both workspaces stay in sync without duplicating type files

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c889b9a19083229fc79c58c0a86eed