### PR TITLE
Enhance Codex diagnostics and Supabase fallbacks

### DIFF
--- a/external/dynamic_codex/src/App.tsx
+++ b/external/dynamic_codex/src/App.tsx
@@ -1,17 +1,44 @@
 import { MessagesDashboard } from './components/MessagesDashboard';
 import { BotStatus } from './components/BotStatus';
+import { WebhookConfigurator } from './components/WebhookConfigurator';
+import { WebhookTester } from './components/WebhookTester';
+import { TelegramTester } from './components/TelegramTester';
+import { BotSetup } from './components/BotSetup';
 import { ThemeProvider } from './components/theme-provider';
 import { Toaster } from './components/ui/sonner';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
 
 function App() {
   return (
     <ThemeProvider defaultTheme="system" storageKey="telegram-bot-theme">
       <div className="min-h-screen bg-background">
         <div className="container mx-auto py-6 px-4 max-w-4xl">
-          <div className="space-y-6">
-            <BotStatus />
-            <MessagesDashboard />
-          </div>
+          <Tabs defaultValue="dashboard" className="space-y-6">
+            <TabsList className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+              <TabsTrigger value="webhook">Webhook Tools</TabsTrigger>
+              <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
+              <TabsTrigger value="setup">Setup</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="dashboard" className="space-y-6">
+              <BotStatus />
+              <MessagesDashboard />
+            </TabsContent>
+
+            <TabsContent value="webhook" className="space-y-6">
+              <WebhookConfigurator />
+              <WebhookTester />
+            </TabsContent>
+
+            <TabsContent value="diagnostics">
+              <TelegramTester />
+            </TabsContent>
+
+            <TabsContent value="setup">
+              <BotSetup />
+            </TabsContent>
+          </Tabs>
         </div>
       </div>
       <Toaster />

--- a/external/dynamic_codex/src/components/WebhookConfigurator.tsx
+++ b/external/dynamic_codex/src/components/WebhookConfigurator.tsx
@@ -18,6 +18,7 @@ import {
   Database
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { supabaseUrl as envSupabaseUrl } from '../lib/supabase';
 
 export function WebhookConfigurator() {
   const [webhookUrl, setWebhookUrl] = useState('');
@@ -27,19 +28,18 @@ export function WebhookConfigurator() {
   const [isCheckingWebhook, setIsCheckingWebhook] = useState(false);
 
   const botToken = '8423362395:AAGVVE-Fy6NPMWTQ77nDDKYZUYXh7Z2eIhc';
-  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-  
+  const hasSupabaseConfig = Boolean(envSupabaseUrl);
   // Generate the webhook URL
-  const generatedWebhookUrl = supabaseUrl 
-    ? `${supabaseUrl}/functions/v1/telegram-webhook`
+  const generatedWebhookUrl = envSupabaseUrl
+    ? `${envSupabaseUrl}/functions/v1/telegram-webhook`
     : 'https://YOUR_PROJECT.supabase.co/functions/v1/telegram-webhook';
 
   useEffect(() => {
-    if (supabaseUrl) {
+    if (envSupabaseUrl) {
       setWebhookUrl(generatedWebhookUrl);
     }
     checkCurrentWebhook();
-  }, [supabaseUrl]);
+  }, [generatedWebhookUrl]);
 
   const copyToClipboard = (text: string, label: string) => {
     navigator.clipboard.writeText(text);
@@ -147,7 +147,9 @@ export function WebhookConfigurator() {
       <div className="flex items-center gap-2">
         <Webhook className="h-6 w-6" />
         <h2 className="text-2xl font-bold">Webhook Configuration</h2>
-        <Badge variant="secondary">Setup Required</Badge>
+        <Badge variant={hasSupabaseConfig ? 'default' : 'secondary'}>
+          {hasSupabaseConfig ? 'Ready' : 'Setup Required'}
+        </Badge>
       </div>
 
       {/* Current Webhook Status */}
@@ -204,6 +206,15 @@ export function WebhookConfigurator() {
                   <div className="mt-1 text-sm">{currentWebhookInfo.ip_address || 'Not available'}</div>
                 </div>
               </div>
+
+              {!hasSupabaseConfig && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    Add <code>VITE_SUPABASE_URL</code> to generate a webhook endpoint automatically.
+                  </AlertDescription>
+                </Alert>
+              )}
 
               {currentWebhookInfo.last_error_date && (
                 <Alert variant="destructive">

--- a/external/dynamic_codex/src/lib/supabase.ts
+++ b/external/dynamic_codex/src/lib/supabase.ts
@@ -1,27 +1,68 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const envSupabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const envSupabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-// Create a mock client if environment variables are missing
-let supabase: SupabaseClient;
+export const supabaseUrl = envSupabaseUrl;
+export const supabaseAnonKey = envSupabaseAnonKey;
+export const isSupabaseConfigured = Boolean(envSupabaseUrl && envSupabaseAnonKey);
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.warn('Missing Supabase environment variables. Using mock client.');
-  supabase = {
-    from: () => ({
-      select: () => Promise.resolve({ data: [], error: null, count: 0 }),
-      insert: () => Promise.resolve({ data: [], error: null }),
-    }),
-    channel: () => ({
-      on: () => ({ subscribe: () => {} }),
-      subscribe: () => {},
-      unsubscribe: () => {},
-    }),
-  } as unknown as SupabaseClient;
-} else {
-  supabase = createClient(supabaseUrl, supabaseAnonKey);
+type MockQueryResult<T = unknown> = {
+  data: T[];
+  error: null;
+  count?: number;
+};
+
+type MockQueryBuilder<T> = PromiseLike<MockQueryResult<T>> & {
+  select: (...args: unknown[]) => MockQueryBuilder<T>;
+  order: (...args: unknown[]) => MockQueryBuilder<T>;
+  limit: (...args: unknown[]) => Promise<MockQueryResult<T>>;
+  range: (...args: unknown[]) => MockQueryBuilder<T>;
+  eq: (...args: unknown[]) => MockQueryBuilder<T>;
+  insert: (...args: unknown[]) => Promise<MockQueryResult<T>>;
+  catch: Promise<MockQueryResult<T>>['catch'];
+  finally: Promise<MockQueryResult<T>>['finally'];
+};
+
+function createMockQueryBuilder<T>(result: MockQueryResult<T>): MockQueryBuilder<T> {
+  const resolved = Promise.resolve(result);
+  const builder: Partial<MockQueryBuilder<T>> = {};
+
+  builder.select = () => builder as MockQueryBuilder<T>;
+  builder.order = () => builder as MockQueryBuilder<T>;
+  builder.range = () => builder as MockQueryBuilder<T>;
+  builder.eq = () => builder as MockQueryBuilder<T>;
+  builder.limit = () => resolved;
+  builder.insert = () => resolved;
+  builder.then = resolved.then.bind(resolved);
+  builder.catch = resolved.catch.bind(resolved);
+  builder.finally = resolved.finally.bind(resolved);
+
+  return builder as MockQueryBuilder<T>;
 }
+
+function createMockSupabaseClient(): SupabaseClient {
+  console.warn('Missing Supabase environment variables. Using mock client.');
+
+  return {
+    from: () => createMockQueryBuilder({ data: [], error: null, count: 0 }),
+    channel: () => {
+      const channel = {
+        on: () => channel,
+        subscribe: (callback?: (status: string) => void) => {
+          callback?.('SUBSCRIBED');
+          return channel;
+        },
+        unsubscribe: () => undefined,
+      };
+      return channel;
+    },
+  } as unknown as SupabaseClient;
+}
+
+const supabase: SupabaseClient = isSupabaseConfigured
+  ? createClient(envSupabaseUrl!, envSupabaseAnonKey!)
+  : createMockSupabaseClient();
 
 export { supabase };
 


### PR DESCRIPTION
## Summary
- add a tabbed layout so the Codex dashboard surfaces webhook, diagnostics, and setup tools alongside the core bot view
- harden Supabase-dependent widgets with explicit configuration checks, graceful fallbacks, and a richer local mock client
- expand the Telegram/Webhook testers and configurator with clearer status messaging and skip logic when Supabase is unavailable

## Testing
- npm --prefix external/dynamic_codex run lint

------
https://chatgpt.com/codex/tasks/task_e_68c899b72cb083228e86f2d7dac640de