### PR TITLE
Relax TLS minimum version for HTTPS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ backed by Supabase.
 
 ## Security Features
 
-- Optional HTTPS server enforces TLS 1.3 when SSL certificates are supplied.
+- Optional HTTPS server enforces TLS 1.2+ (prefers TLS 1.3) when SSL certificates are supplied.
 - HTTP Strict Transport Security (HSTS) headers for all responses.
 - Lightweight per-IP rate limiting to mitigate basic DDoS attacks.
 - Maintains third-party certifications for ISO 27001, SOC 2 Type II, PCI DSS Level 1, HIPAA, GDPR, and the EU–US Data Privacy Framework ([docs/compliance](docs/compliance/README.md)).

--- a/server.js
+++ b/server.js
@@ -167,7 +167,12 @@ let server;
 if (process.env.SSL_KEY_PATH && process.env.SSL_CERT_PATH) {
   const key = readFileSync(process.env.SSL_KEY_PATH);
   const cert = readFileSync(process.env.SSL_CERT_PATH);
-  server = https.createServer({ key, cert, minVersion: 'TLSv1.3', maxVersion: 'TLSv1.3' }, handler);
+  server = https.createServer({
+    key,
+    cert,
+    minVersion: 'TLSv1.2',
+    maxVersion: 'TLSv1.3',
+  }, handler);
   console.log('HTTPS server enabled');
 } else {
   server = http.createServer(handler);


### PR DESCRIPTION
## Summary
- allow the HTTPS server to negotiate TLS 1.2 so clients that do not yet support TLS 1.3 can connect
- keep TLS 1.3 preferred while documenting the broader protocol support in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8d2af75a4832293a2c8ceb54d24a4