### PR TITLE
Unify Once UI motion primitives

### DIFF
--- a/apps/landing/README.md
+++ b/apps/landing/README.md
@@ -1,0 +1,45 @@
+# Landing App
+
+The static landing site bundles the lightweight `once-ui.css` and `once-ui.js` assets that power marketing pages without a build step. The JavaScript helper now exposes Framer Motion-inspired reveal utilities that mirror the React experience in the Next.js app.
+
+## Scroll-based reveal helpers
+
+Elements marked with the `data-once-reveal` attribute fade or slide into view when they enter the viewport. The helper observes those nodes with `IntersectionObserver`, adds a preparatory `once-ready` class, and toggles `once-visible` once the element is visible.
+
+```html
+<section class="hero" data-once-reveal="fade-up">
+  <h2>Dynamic Capital</h2>
+  <p>Fast deposits with automated verification.</p>
+</section>
+```
+
+Supported values include:
+
+- `fade-up` (default)
+- `fade-down`
+- `fade-left`
+- `fade-right`
+- `scale`
+- `slide-up`
+- `slide-down`
+- `slide-left`
+- `slide-right`
+
+Add the `data-once-reveal-repeat` attribute when you need the animation to play every time the element scrolls into view.
+
+```html
+<div class="stat" data-once-reveal data-once-reveal-repeat>
+  <strong>3x</strong>
+  Faster approvals
+</div>
+```
+
+## Reduced-motion and hydration support
+
+- Users with `prefers-reduced-motion: reduce` enabled skip the animation; elements become visible immediately.
+- The framework only adds the `once-ready` class when JavaScript is active, so users without scripting continue to see static marketing content.
+- Dynamic content can opt into the reveal helper by calling `window.OnceUI.observeReveals(rootNode)` or `window.OnceUI.refreshReveals()` after injecting markup.
+
+## Smooth scrolling
+
+Anchor links that point to IDs continue to use the existing smooth-scroll helper for in-page navigation. No additional configuration is required.

--- a/apps/landing/public/once-ui/once-ui.css
+++ b/apps/landing/public/once-ui/once-ui.css
@@ -113,3 +113,56 @@ body {
   white-space: nowrap;
   border-width: 0;
 }
+
+/* Reveal animations */
+[data-once-reveal] {
+  transition-property: opacity, transform;
+  transition-duration: 0.4s;
+  transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.once-js [data-once-reveal].once-ready {
+  opacity: 0;
+  transform: translateY(24px);
+}
+
+.once-js [data-once-reveal="fade"].once-ready,
+.once-js [data-once-reveal="fade-up"].once-ready,
+.once-js [data-once-reveal="slide-up"].once-ready,
+.once-js [data-once-reveal="up"].once-ready {
+  transform: translateY(24px);
+}
+
+.once-js [data-once-reveal="fade-down"].once-ready,
+.once-js [data-once-reveal="slide-down"].once-ready,
+.once-js [data-once-reveal="down"].once-ready {
+  transform: translateY(-24px);
+}
+
+.once-js [data-once-reveal="fade-left"].once-ready,
+.once-js [data-once-reveal="slide-left"].once-ready,
+.once-js [data-once-reveal="left"].once-ready {
+  transform: translateX(24px);
+}
+
+.once-js [data-once-reveal="fade-right"].once-ready,
+.once-js [data-once-reveal="slide-right"].once-ready,
+.once-js [data-once-reveal="right"].once-ready {
+  transform: translateX(-24px);
+}
+
+.once-js [data-once-reveal="scale"].once-ready,
+.once-js [data-once-reveal="zoom"].once-ready {
+  transform: scale(0.94);
+}
+
+.once-js [data-once-reveal].once-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .once-js [data-once-reveal] {
+    transition: none;
+  }
+}

--- a/apps/landing/public/once-ui/once-ui.js
+++ b/apps/landing/public/once-ui/once-ui.js
@@ -2,15 +2,15 @@
 
 (function() {
   'use strict';
-  
+
   // Simple smooth scrolling for anchor links
   document.addEventListener('click', function(e) {
     const target = e.target.closest('a[href^="#"]');
     if (!target) return;
-    
+
     const href = target.getAttribute('href');
     if (href === '#') return;
-    
+
     const element = document.querySelector(href);
     if (element) {
       e.preventDefault();
@@ -20,10 +20,104 @@
       });
     }
   });
-  
-  // Add loaded class to body when DOM is ready
-  document.addEventListener('DOMContentLoaded', function() {
+
+  const docEl = document.documentElement;
+  const revealSelector = '[data-once-reveal]';
+  const preparedElements = new WeakSet();
+  const globalOnceUI = (window.OnceUI = window.OnceUI || {});
+
+  const supportsIntersectionObserver = 'IntersectionObserver' in window;
+  const reduceMotionQuery = typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : null;
+
+  const shouldReduceMotion = () => !!(reduceMotionQuery && reduceMotionQuery.matches);
+
+  let observer = supportsIntersectionObserver
+    ? new IntersectionObserver(
+        function(entries) {
+          entries.forEach(function(entry) {
+            const element = entry.target;
+            const repeat = element.hasAttribute('data-once-reveal-repeat');
+            if (entry.isIntersecting) {
+              markVisible(element);
+              if (!repeat && observer) {
+                observer.unobserve(element);
+              }
+            } else if (repeat) {
+              element.classList.remove('once-visible');
+            }
+          });
+        },
+        {
+          threshold: 0.18,
+          rootMargin: '0px 0px -10% 0px'
+        }
+      )
+    : null;
+
+  function markVisible(element) {
+    if (!element.classList.contains('once-visible')) {
+      element.classList.add('once-visible');
+      try {
+        element.dispatchEvent(new CustomEvent('once:reveal'));
+      } catch (_error) {
+        // Older browsers without CustomEvent constructor can skip dispatch
+      }
+    }
+  }
+
+  function prepareElement(element) {
+    if (preparedElements.has(element)) return;
+    preparedElements.add(element);
+    element.classList.add('once-ready');
+  }
+
+  function hydrate(root) {
+    const scope = root && root.nodeType === 1 && root.querySelectorAll ? root : document;
+    const targets = scope.querySelectorAll(revealSelector);
+
+    targets.forEach(function(element) {
+      prepareElement(element);
+      if (shouldReduceMotion() || !observer) {
+        markVisible(element);
+      } else {
+        observer.observe(element);
+      }
+    });
+  }
+
+  function handlePreferenceChange() {
+    if (shouldReduceMotion()) {
+      if (observer) {
+        observer.disconnect();
+      }
+      hydrate();
+    } else {
+      hydrate();
+    }
+  }
+
+  if (reduceMotionQuery) {
+    if (typeof reduceMotionQuery.addEventListener === 'function') {
+      reduceMotionQuery.addEventListener('change', handlePreferenceChange);
+    } else if (typeof reduceMotionQuery.addListener === 'function') {
+      reduceMotionQuery.addListener(handlePreferenceChange);
+    }
+  }
+
+  globalOnceUI.observeReveals = hydrate;
+  globalOnceUI.refreshReveals = hydrate;
+
+  function onReady() {
+    docEl.classList.add('once-js');
     document.body.classList.add('once-loaded');
-  });
-  
+    hydrate();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', onReady, { once: true });
+  } else {
+    onReady();
+  }
 })();

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -10,6 +10,7 @@ import { TelegramAuthProvider } from '@/hooks/useTelegramAuth';
 import { AdminAuthProvider } from '@/hooks/useAdminAuth';
 import { CurrencyProvider } from '@/hooks/useCurrency';
 import { SupabaseProvider } from '@/context/SupabaseProvider';
+import { MotionConfigProvider } from '@/components/ui/motion-config';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [supabaseClient] = useState(() =>
@@ -20,13 +21,15 @@ export default function Providers({ children }: { children: ReactNode }) {
     <SessionContextProvider supabaseClient={supabaseClient}>
       <SupabaseProvider>
         <QueryClientProvider client={queryClient}>
-          <TelegramAuthProvider>
-            <AdminAuthProvider>
-              <AuthProvider>
-                <CurrencyProvider>{children}</CurrencyProvider>
-              </AuthProvider>
-            </AdminAuthProvider>
-          </TelegramAuthProvider>
+          <MotionConfigProvider>
+            <TelegramAuthProvider>
+              <AdminAuthProvider>
+                <AuthProvider>
+                  <CurrencyProvider>{children}</CurrencyProvider>
+                </AuthProvider>
+              </AdminAuthProvider>
+            </TelegramAuthProvider>
+          </MotionConfigProvider>
         </QueryClientProvider>
       </SupabaseProvider>
     </SessionContextProvider>

--- a/apps/web/components/deposit-form.tsx
+++ b/apps/web/components/deposit-form.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { MotionButtonWrapper } from '@/components/ui/motion-theme'
 import { motion } from 'framer-motion'
-import { childVariants } from '@/lib/motion-variants'
+import { onceMotionVariants } from '@/lib/motion-variants'
 
 export default function DepositForm() {
   const [file, setFile] = useState<File | null>(null)
@@ -51,7 +51,7 @@ export default function DepositForm() {
       {status && (
         <motion.p
           className="text-sm text-muted-foreground"
-          variants={childVariants}
+          variants={onceMotionVariants.stackItem}
           initial="hidden"
           animate="visible"
         >

--- a/apps/web/components/once-ui/index.ts
+++ b/apps/web/components/once-ui/index.ts
@@ -1,0 +1,2 @@
+export { OnceButton, type OnceButtonProps } from "./once-button";
+export { OnceContainer, type OnceContainerProps } from "./once-container";

--- a/apps/web/components/once-ui/once-button.tsx
+++ b/apps/web/components/once-ui/once-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+
+import { cn } from "@/utils";
+import { onceMotionVariants } from "@/lib/motion-variants";
+
+type MotionButtonProps = React.ComponentPropsWithoutRef<typeof motion.button>;
+
+export interface OnceButtonProps extends MotionButtonProps {
+  /**
+   * Applies the Once UI button skin. Defaults to the solid primary button.
+   */
+  variant?: "primary" | "outline";
+  /**
+   * Uses the compact padding defined in once-ui.css.
+   */
+  size?: "default" | "small";
+}
+
+const MotionButton = motion.button;
+
+export const OnceButton = React.forwardRef<HTMLButtonElement, OnceButtonProps>(
+  (
+    {
+      variant = "primary",
+      size = "default",
+      className,
+      disabled,
+      children,
+      variants: variantsProp,
+      initial: initialProp,
+      animate: animateProp,
+      whileHover: whileHoverProp,
+      whileTap: whileTapProp,
+      ...rest
+    },
+    ref
+  ) => {
+    const { type: buttonType, ...otherProps } = rest;
+    const motionVariants = variantsProp ?? onceMotionVariants.button;
+    const initialValue = initialProp ?? "initial";
+    const animateValue = animateProp ?? (disabled ? "disabled" : "initial");
+    const hoverValue = disabled ? undefined : whileHoverProp ?? "hover";
+    const tapValue = disabled ? undefined : whileTapProp ?? "tap";
+
+    return (
+      <MotionButton
+        ref={ref}
+        className={cn("once-btn", variant, size === "small" && "small", className)}
+        disabled={disabled}
+        type={buttonType ?? "button"}
+        variants={motionVariants}
+        initial={initialValue}
+        animate={animateValue}
+        whileHover={hoverValue}
+        whileTap={tapValue}
+        {...otherProps}
+      >
+        {children}
+      </MotionButton>
+    );
+  }
+);
+
+OnceButton.displayName = "OnceButton";

--- a/apps/web/components/once-ui/once-container.tsx
+++ b/apps/web/components/once-ui/once-container.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+
+import { cn } from "@/utils";
+import {
+  onceMotionVariants,
+  type OnceRevealVariantKey,
+} from "@/lib/motion-variants";
+
+type MotionDivProps = React.ComponentPropsWithoutRef<typeof motion.div>;
+
+export interface OnceContainerProps extends MotionDivProps {
+  /**
+   * Default animation preset triggered when the container enters the viewport.
+   */
+  variant?: OnceRevealVariantKey | null;
+  /**
+   * Disable the reveal animation while preserving the Once UI layout styles.
+   */
+  animateIn?: boolean;
+  /**
+   * Configure `IntersectionObserver` behaviour. Defaults to a one-time reveal.
+   */
+  once?: boolean;
+  /**
+   * Override the viewport visibility amount used for intersection reveals.
+   */
+  viewportAmount?: number;
+}
+
+const MotionDiv = motion.div;
+
+export const OnceContainer = React.forwardRef<HTMLDivElement, OnceContainerProps>(
+  (
+    {
+      variant = "slideUp",
+      animateIn = true,
+      once = true,
+      viewport,
+      viewportAmount = 0.2,
+      className,
+      children,
+      variants: variantsProp,
+      initial: initialProp,
+      animate: animateProp,
+      whileInView: whileInViewProp,
+      ...rest
+    },
+    ref
+  ) => {
+    const shouldApplyPreset = animateIn && animateProp === undefined;
+    const resolvedVariants =
+      variantsProp ?? (shouldApplyPreset && variant ? onceMotionVariants[variant] : undefined);
+
+    const initialValue =
+      shouldApplyPreset && resolvedVariants ? initialProp ?? "hidden" : initialProp;
+    const whileInViewValue =
+      shouldApplyPreset && resolvedVariants ? whileInViewProp ?? "visible" : whileInViewProp;
+    const resolvedViewport =
+      shouldApplyPreset && resolvedVariants
+        ? viewport ?? { once, amount: viewportAmount }
+        : viewport;
+
+    return (
+      <MotionDiv
+        ref={ref}
+        className={cn("once-container", className)}
+        variants={resolvedVariants}
+        initial={initialValue}
+        animate={animateProp}
+        whileInView={whileInViewValue}
+        viewport={resolvedViewport}
+        {...rest}
+      >
+        {children}
+      </MotionDiv>
+    );
+  }
+);
+
+OnceContainer.displayName = "OnceContainer";

--- a/apps/web/components/telegram/QuickActions.tsx
+++ b/apps/web/components/telegram/QuickActions.tsx
@@ -2,7 +2,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { FileText, Shield, Activity, Users, Bot } from "lucide-react";
 import { motion } from "framer-motion";
-import { parentVariants, childVariants, buttonVariants } from "@/lib/motion-variants";
+import { onceMotionVariants } from "@/lib/motion-variants";
 
 interface QuickActionsProps {
   onRefreshStats?: () => void;
@@ -45,26 +45,26 @@ export const QuickActions = ({ onRefreshStats, onCheckStatus }: QuickActionsProp
 
   return (
     <motion.div
-      variants={parentVariants}
+      variants={onceMotionVariants.stack}
       initial="hidden"
       animate="visible"
     >
       <Card className="p-6 bg-gradient-card border-0 shadow-telegram">
-        <motion.h3 
+        <motion.h3
           className="text-lg font-semibold mb-4 flex items-center gap-2"
-          variants={childVariants}
+          variants={onceMotionVariants.stackItem}
         >
           <Activity className="w-5 h-5 text-telegram" />
           Quick Actions
         </motion.h3>
-        <motion.div 
+        <motion.div
           className="flex flex-wrap gap-3"
-          variants={parentVariants}
+          variants={onceMotionVariants.stack}
         >
           {actions.map((action, index) => (
-            <motion.div key={index} variants={childVariants}>
+            <motion.div key={index} variants={onceMotionVariants.stackItem}>
               <motion.div
-                variants={buttonVariants}
+                variants={onceMotionVariants.button}
                 whileHover="hover"
                 whileTap="tap"
               >

--- a/apps/web/components/ui/enhanced-scroll.tsx
+++ b/apps/web/components/ui/enhanced-scroll.tsx
@@ -5,7 +5,7 @@ import { motion, useScroll, useTransform, useInView, AnimatePresence } from 'fra
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/utils';
-import { cardVariants, staggerContainerVariants, staggerItemVariants } from '@/lib/motion-variants';
+import { onceMotionVariants } from '@/lib/motion-variants';
 
 interface EnhancedScrollProps {
   children: React.ReactNode;
@@ -240,19 +240,19 @@ export function EnhancedScrollContainer({
           className
         )}
         style={{ gap }}
-        variants={stagger ? staggerContainerVariants : undefined}
+        variants={stagger ? onceMotionVariants.staggerContainer : undefined}
         initial={stagger ? "hidden" : undefined}
         animate={stagger ? "visible" : undefined}
       >
         {React.Children.map(children, (child, index) => (
-          <motion.div 
+          <motion.div
             key={index}
             className="snap-center flex-none flex items-stretch"
-            style={{ 
+            style={{
               width: itemWidth,
               minHeight: 'fit-content'
             }}
-            variants={stagger ? staggerItemVariants : cardVariants}
+            variants={stagger ? onceMotionVariants.staggerItem : onceMotionVariants.card}
             whileHover="hover"
             whileTap="tap"
             custom={index}

--- a/apps/web/components/ui/horizontal-snap-scroll.tsx
+++ b/apps/web/components/ui/horizontal-snap-scroll.tsx
@@ -5,7 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/utils';
-import { cardVariants } from '@/lib/motion-variants';
+import { onceMotionVariants } from '@/lib/motion-variants';
 
 interface HorizontalSnapScrollProps {
   children: React.ReactNode;
@@ -186,14 +186,14 @@ export function HorizontalSnapScroll({
         tabIndex={-1}
       >
         {React.Children.map(children, (child, index) => (
-          <motion.div 
+          <motion.div
             key={index}
             className="snap-center flex-none flex items-stretch"
-            style={{ 
+            style={{
               width: itemWidth,
               minHeight: 'fit-content'
             }}
-            variants={cardVariants}
+            variants={onceMotionVariants.card}
             initial="hidden"
             animate="visible"
             whileHover="hover"

--- a/apps/web/lib/motion-variants.ts
+++ b/apps/web/lib/motion-variants.ts
@@ -1,208 +1,337 @@
-// Universal Motion Variants for consistent animations across the app
-import type { Variants } from 'framer-motion';
+import type { Transition, Variants } from "framer-motion";
 
-// === PARENT ORCHESTRATION VARIANTS ===
-// These variants control children through stagger and orchestration
-export const parentVariants: Variants = {
-  hidden: {
-    opacity: 0,
-  },
+type Direction = "up" | "down" | "left" | "right";
+
+type SpringTransition = Transition & { type: "spring" };
+
+const spring = (config: SpringTransition): Transition => config;
+
+export const ONCE_MOTION_SPRINGS = {
+  base: spring({ type: "spring", stiffness: 320, damping: 28, mass: 1 }),
+  soft: spring({ type: "spring", stiffness: 260, damping: 24, mass: 1.05 }),
+  snappy: spring({ type: "spring", stiffness: 400, damping: 25, mass: 0.9 }),
+  modal: spring({ type: "spring", stiffness: 300, damping: 30, mass: 1.05 }),
+} as const;
+
+export const ONCE_MOTION_DURATIONS = {
+  instant: 0.12,
+  quick: 0.2,
+  base: 0.32,
+  slow: 0.48,
+  slower: 0.6,
+} as const;
+
+export const ONCE_MOTION_EASING = {
+  standard: [0.4, 0, 0.2, 1] as const,
+  entrance: [0.16, 1, 0.3, 1] as const,
+  exit: [0.4, 0, 0.6, 1] as const,
+} as const;
+
+export const ONCE_MOTION_STAGGERS = {
+  base: 0.12,
+  dense: 0.06,
+  spacious: 0.2,
+  delay: 0.18,
+} as const;
+
+const fadeIn: Variants = {
+  hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.1,
-      delayChildren: 0.2,
+      duration: ONCE_MOTION_DURATIONS.base,
+      ease: ONCE_MOTION_EASING.entrance,
+    },
+  },
+  exit: {
+    opacity: 0,
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
+const slideUp: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: ONCE_MOTION_SPRINGS.base,
+  },
+  exit: {
+    opacity: 0,
+    y: -24,
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
+const slideDown: Variants = {
+  hidden: { opacity: 0, y: -24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: ONCE_MOTION_SPRINGS.base,
+  },
+  exit: {
+    opacity: 0,
+    y: 24,
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
+const slideLeft: Variants = {
+  hidden: { opacity: 0, x: 24 },
+  visible: {
+    opacity: 1,
+    x: 0,
+    transition: ONCE_MOTION_SPRINGS.base,
+  },
+  exit: {
+    opacity: 0,
+    x: -24,
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
+const slideRight: Variants = {
+  hidden: { opacity: 0, x: -24 },
+  visible: {
+    opacity: 1,
+    x: 0,
+    transition: ONCE_MOTION_SPRINGS.base,
+  },
+  exit: {
+    opacity: 0,
+    x: 24,
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
+const scaleIn: Variants = {
+  hidden: { opacity: 0, scale: 0.94 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: ONCE_MOTION_SPRINGS.soft,
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.94,
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
+const stack: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: ONCE_MOTION_STAGGERS.base,
+      delayChildren: ONCE_MOTION_STAGGERS.delay,
       when: "beforeChildren",
     },
   },
   exit: {
     opacity: 0,
     transition: {
-      staggerChildren: 0.05,
+      staggerChildren: ONCE_MOTION_STAGGERS.dense,
       staggerDirection: -1,
       when: "afterChildren",
     },
   },
 };
 
-// Fast stagger for UI elements
-export const fastParentVariants: Variants = {
+const stackFast: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.05,
-      delayChildren: 0.1,
+      staggerChildren: ONCE_MOTION_STAGGERS.dense,
+      delayChildren: ONCE_MOTION_STAGGERS.base,
+      when: "beforeChildren",
     },
   },
   exit: {
     opacity: 0,
     transition: {
-      staggerChildren: 0.02,
+      staggerChildren: ONCE_MOTION_STAGGERS.dense,
       staggerDirection: -1,
+      when: "afterChildren",
     },
   },
 };
 
-// Slow stagger for hero sections
-export const slowParentVariants: Variants = {
+const stackSlow: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.2,
-      delayChildren: 0.3,
+      staggerChildren: ONCE_MOTION_STAGGERS.spacious,
+      delayChildren: ONCE_MOTION_STAGGERS.spacious,
+      when: "beforeChildren",
     },
   },
   exit: {
     opacity: 0,
     transition: {
-      staggerChildren: 0.1,
+      staggerChildren: ONCE_MOTION_STAGGERS.base,
       staggerDirection: -1,
+      when: "afterChildren",
     },
   },
 };
 
-// === CHILD VARIANTS ===
-// These inherit from parent orchestration
-export const childVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: 20,
-    scale: 0.95,
-  },
+const stackItem: Variants = {
+  hidden: { opacity: 0, y: 20, scale: 0.95 },
   visible: {
     opacity: 1,
     y: 0,
     scale: 1,
-    transition: {
-      type: "spring",
-      stiffness: 320,
-      damping: 28,
-    },
+    transition: ONCE_MOTION_SPRINGS.base,
   },
   exit: {
     opacity: 0,
     y: -20,
     scale: 0.95,
-    transition: {
-      duration: 0.2,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.quick },
   },
 };
 
-// Child variant with custom direction
-export const createChildVariant = (direction: 'up' | 'down' | 'left' | 'right' = 'up', distance = 20): Variants => ({
-  hidden: {
-    opacity: 0,
-    ...(direction === 'up' && { y: distance }),
-    ...(direction === 'down' && { y: -distance }),
-    ...(direction === 'left' && { x: distance }),
-    ...(direction === 'right' && { x: -distance }),
-    scale: 0.95,
-  },
+const stackItemSoft: Variants = {
+  hidden: { opacity: 0, y: 16, scale: 0.97 },
   visible: {
     opacity: 1,
-    x: 0,
+    y: 0,
+    scale: 1,
+    transition: ONCE_MOTION_SPRINGS.soft,
+  },
+  exit: {
+    opacity: 0,
+    y: -16,
+    scale: 0.97,
+    transition: { duration: ONCE_MOTION_DURATIONS.quick },
+  },
+};
+
+const stackItemSlow: Variants = {
+  hidden: { opacity: 0, y: 28, scale: 0.94 },
+  visible: {
+    opacity: 1,
     y: 0,
     scale: 1,
     transition: {
-      type: "spring",
-      stiffness: 320,
-      damping: 28,
+      ...ONCE_MOTION_SPRINGS.base,
+      duration: ONCE_MOTION_DURATIONS.slow,
     },
   },
   exit: {
     opacity: 0,
-    ...(direction === 'up' && { y: -distance }),
-    ...(direction === 'down' && { y: distance }),
-    ...(direction === 'left' && { x: -distance }),
-    ...(direction === 'right' && { x: distance }),
-    scale: 0.95,
-    transition: {
-      duration: 0.2,
-    },
+    y: -28,
+    scale: 0.94,
+    transition: { duration: ONCE_MOTION_DURATIONS.quick },
   },
-});
+};
 
-// Enhanced Card variants with better inheritance
-export const cardVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    scale: 0.95,
-    y: 20,
+const button: Variants = {
+  initial: { scale: 1 },
+  hover: {
+    scale: 1.02,
+    y: -2,
+    transition: ONCE_MOTION_SPRINGS.snappy,
   },
+  tap: {
+    scale: 0.96,
+    transition: { duration: ONCE_MOTION_DURATIONS.instant },
+  },
+  disabled: { opacity: 0.6, scale: 1 },
+};
+
+const primaryButton: Variants = {
+  ...button,
+  hover: {
+    scale: 1.05,
+    y: -3,
+    transition: ONCE_MOTION_SPRINGS.snappy,
+  },
+};
+
+const ghostButton: Variants = {
+  ...button,
+  hover: {
+    scale: 1.02,
+    transition: ONCE_MOTION_SPRINGS.snappy,
+  },
+};
+
+const card: Variants = {
+  hidden: { opacity: 0, scale: 0.95, y: 20 },
   visible: {
     opacity: 1,
     scale: 1,
     y: 0,
-    transition: {
-      type: "spring",
-      stiffness: 320,
-      damping: 28,
-    },
+    transition: ONCE_MOTION_SPRINGS.base,
   },
   hover: {
     scale: 1.02,
     y: -5,
     transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 25,
+      ...ONCE_MOTION_SPRINGS.snappy,
+      stiffness: 420,
     },
   },
   tap: {
     scale: 0.96,
-    transition: {
-      duration: 0.1,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.instant },
   },
   exit: {
     opacity: 0,
     scale: 0.95,
     y: -20,
-    transition: {
-      duration: 0.2,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.quick },
   },
 };
 
-// Interactive card variants
-export const interactiveCardVariants: Variants = {
-  ...cardVariants,
+const interactiveCard: Variants = {
+  ...card,
   hover: {
     scale: 1.03,
     y: -8,
     rotateX: 1,
     transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 25,
+      ...ONCE_MOTION_SPRINGS.snappy,
+      stiffness: 420,
     },
   },
   tap: {
     scale: 0.98,
-    transition: {
-      duration: 0.1,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.instant },
   },
 };
 
-// Page variants
-export const pageVariants: Variants = {
-  initial: {
-    opacity: 0,
-    y: 30,
-    scale: 0.98,
-  },
+const page: Variants = {
+  initial: { opacity: 0, y: 30, scale: 0.98 },
   animate: {
     opacity: 1,
     y: 0,
     scale: 1,
     transition: {
-      type: "spring",
-      stiffness: 300,
-      damping: 30,
+      ...ONCE_MOTION_SPRINGS.soft,
       duration: 0.8,
     },
   },
@@ -210,185 +339,87 @@ export const pageVariants: Variants = {
     opacity: 0,
     y: -30,
     scale: 0.98,
-    transition: {
-      duration: 0.4,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.slow },
   },
 };
 
-// Enhanced Button variants with better micro-interactions
-export const buttonVariants: Variants = {
-  initial: {
-    scale: 1,
-  },
-  hover: {
-    scale: 1.02,
-    y: -2,
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 25,
-    },
-  },
-  tap: {
-    scale: 0.96,
-    transition: {
-      duration: 0.1,
-    },
-  },
-  disabled: {
-    opacity: 0.6,
-    scale: 1,
-  },
-};
-
-// Primary button with enhanced effects
-export const primaryButtonVariants: Variants = {
-  ...buttonVariants,
-  hover: {
-    scale: 1.05,
-    y: -3,
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 25,
-    },
-  },
-};
-
-// Ghost button with subtle effects
-export const ghostButtonVariants: Variants = {
-  ...buttonVariants,
-  hover: {
-    scale: 1.02,
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 25,
-    },
-  },
-};
-
-// Stagger container variants
-export const staggerContainerVariants: Variants = {
-  hidden: {
-    opacity: 0,
-  },
+const staggerContainer: Variants = {
+  hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.1,
-      delayChildren: 0.2,
+      staggerChildren: ONCE_MOTION_STAGGERS.base,
+      delayChildren: ONCE_MOTION_STAGGERS.base,
     },
   },
   exit: {
     opacity: 0,
     transition: {
-      staggerChildren: 0.05,
+      staggerChildren: ONCE_MOTION_STAGGERS.dense,
       staggerDirection: -1,
     },
   },
 };
 
-// Stagger item variants
-export const staggerItemVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    y: 20,
-    scale: 0.95,
-  },
+const staggerItem: Variants = {
+  hidden: { opacity: 0, y: 20, scale: 0.95 },
   visible: {
     opacity: 1,
     y: 0,
     scale: 1,
-    transition: {
-      type: "spring",
-      stiffness: 260,
-      damping: 20,
-    },
+    transition: ONCE_MOTION_SPRINGS.soft,
   },
   exit: {
     opacity: 0,
     y: -20,
     scale: 0.95,
-    transition: {
-      duration: 0.2,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.quick },
   },
 };
 
-// Modal variants
-export const modalVariants: Variants = {
-  hidden: {
-    opacity: 0,
-    scale: 0.8,
-    y: 50,
-  },
+const modal: Variants = {
+  hidden: { opacity: 0, scale: 0.8, y: 50 },
   visible: {
     opacity: 1,
     scale: 1,
     y: 0,
-    transition: {
-      type: "spring",
-      stiffness: 300,
-      damping: 30,
-    },
+    transition: ONCE_MOTION_SPRINGS.modal,
   },
   exit: {
     opacity: 0,
     scale: 0.8,
     y: 50,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.slow },
   },
 };
 
-// Backdrop variants
-export const backdropVariants: Variants = {
-  hidden: {
-    opacity: 0,
-  },
+const backdrop: Variants = {
+  hidden: { opacity: 0 },
   visible: {
     opacity: 1,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
   exit: {
     opacity: 0,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
 };
 
-// Navigation variants
-export const navVariants: Variants = {
-  hidden: {
-    y: -20,
-    opacity: 0,
-  },
+const nav: Variants = {
+  hidden: { y: -20, opacity: 0 },
   visible: {
     y: 0,
     opacity: 1,
-    transition: {
-      type: "spring",
-      stiffness: 300,
-      damping: 30,
-    },
+    transition: ONCE_MOTION_SPRINGS.base,
   },
   exit: {
     y: -20,
     opacity: 0,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
 };
 
-// Floating variants
-export const floatingVariants: Variants = {
+const floating: Variants = {
   floating: {
     y: [-10, 10, -10],
     x: [-5, 5, -5],
@@ -401,8 +432,7 @@ export const floatingVariants: Variants = {
   },
 };
 
-// Pulse variants
-export const pulseVariants: Variants = {
+const pulse: Variants = {
   pulse: {
     scale: [1, 1.05, 1],
     opacity: [1, 0.8, 1],
@@ -414,89 +444,166 @@ export const pulseVariants: Variants = {
   },
 };
 
-// Slide variants
-export const slideVariants: Variants = {
-  slideInFromLeft: {
-    x: -100,
-    opacity: 0,
-  },
-  slideInFromRight: {
-    x: 100,
-    opacity: 0,
-  },
-  slideInFromTop: {
-    y: -100,
-    opacity: 0,
-  },
-  slideInFromBottom: {
-    y: 100,
-    opacity: 0,
-  },
+const slidePresets: Variants = {
+  slideInFromLeft: { x: -100, opacity: 0 },
+  slideInFromRight: { x: 100, opacity: 0 },
+  slideInFromTop: { y: -100, opacity: 0 },
+  slideInFromBottom: { y: 100, opacity: 0 },
   center: {
     x: 0,
     y: 0,
     opacity: 1,
-    transition: {
-      type: "spring",
-      stiffness: 260,
-      damping: 20,
-    },
+    transition: ONCE_MOTION_SPRINGS.soft,
   },
   slideOutToLeft: {
     x: -100,
     opacity: 0,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
   slideOutToRight: {
     x: 100,
     opacity: 0,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
   slideOutToTop: {
     y: -100,
     opacity: 0,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
   slideOutToBottom: {
     y: 100,
     opacity: 0,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.base },
   },
 };
 
-// Tab variants
-export const tabVariants: Variants = {
-  inactive: {
-    scale: 0.95,
-    opacity: 0.7,
-  },
+const tab: Variants = {
+  inactive: { scale: 0.95, opacity: 0.7 },
   active: {
     scale: 1,
     opacity: 1,
-    transition: {
-      type: "spring",
-      stiffness: 300,
-      damping: 25,
-    },
+    transition: ONCE_MOTION_SPRINGS.modal,
   },
   hover: {
     scale: 1.02,
     opacity: 0.9,
-    transition: {
-      duration: 0.2,
-    },
+    transition: { duration: ONCE_MOTION_DURATIONS.quick },
   },
 };
 
+export const onceRevealVariantKeys = [
+  "fadeIn",
+  "slideUp",
+  "slideDown",
+  "slideLeft",
+  "slideRight",
+  "scaleIn",
+] as const;
+
+export type OnceRevealVariantKey = (typeof onceRevealVariantKeys)[number];
+
+export const onceMotionVariants = {
+  fadeIn,
+  slideUp,
+  slideDown,
+  slideLeft,
+  slideRight,
+  scaleIn,
+  stack,
+  stackFast,
+  stackSlow,
+  stackItem,
+  stackItemSoft,
+  stackItemSlow,
+  button,
+  primaryButton,
+  ghostButton,
+  card,
+  interactiveCard,
+  page,
+  staggerContainer,
+  staggerItem,
+  modal,
+  backdrop,
+  nav,
+  floating,
+  pulse,
+  slidePresets,
+  tab,
+} satisfies Record<string, Variants>;
+
+export type OnceMotionVariantKey = keyof typeof onceMotionVariants;
+
+export const parentVariants = stack;
+export const fastParentVariants = stackFast;
+export const slowParentVariants = stackSlow;
+export const childVariants = stackItem;
+
+export const cardVariants = card;
+export const interactiveCardVariants = interactiveCard;
+export const pageVariants = page;
+export const buttonVariants = button;
+export const primaryButtonVariants = primaryButton;
+export const ghostButtonVariants = ghostButton;
+export const staggerContainerVariants = staggerContainer;
+export const staggerItemVariants = staggerItem;
+export const modalVariants = modal;
+export const backdropVariants = backdrop;
+export const navVariants = nav;
+export const floatingVariants = floating;
+export const pulseVariants = pulse;
+export const slideVariants = slidePresets;
+export const tabVariants = tab;
+
+export const createChildVariant = (
+  direction: Direction = "up",
+  distance = 20,
+  springPreset: keyof typeof ONCE_MOTION_SPRINGS = "base"
+): Variants => {
+  const hiddenPosition: Record<Direction, Partial<Record<"x" | "y", number>>> = {
+    up: { y: distance },
+    down: { y: -distance },
+    left: { x: distance },
+    right: { x: -distance },
+  };
+
+  const exitPosition: Record<Direction, Partial<Record<"x" | "y", number>>> = {
+    up: { y: -distance },
+    down: { y: distance },
+    left: { x: -distance },
+    right: { x: distance },
+  };
+
+  return {
+    hidden: {
+      opacity: 0,
+      ...hiddenPosition[direction],
+      scale: 0.95,
+    },
+    visible: {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      scale: 1,
+      transition: ONCE_MOTION_SPRINGS[springPreset],
+    },
+    exit: {
+      opacity: 0,
+      ...exitPosition[direction],
+      scale: 0.95,
+      transition: { duration: ONCE_MOTION_DURATIONS.quick },
+    },
+  };
+};
+
 export default {
+  tokens: {
+    springs: ONCE_MOTION_SPRINGS,
+    durations: ONCE_MOTION_DURATIONS,
+    easing: ONCE_MOTION_EASING,
+    stagger: ONCE_MOTION_STAGGERS,
+  },
+  onceMotionVariants,
   cardVariants,
   pageVariants,
   buttonVariants,

--- a/docs/once-ui-development-checklist.md
+++ b/docs/once-ui-development-checklist.md
@@ -13,10 +13,12 @@ Use this checklist when you scope, build, and verify Dynamic Capital surfaces th
 - [ ] Document any required global styles (body background, typography) or layout constraints (grid, spacing tokens) before coding to avoid ad-hoc overrides.
 - [ ] Plan responsive breakpoints and theme variants (light/dark) using Once UI tokens so components remain consistent across surfaces.
 - [ ] Decide whether custom Once UI components should live alongside existing shared components or in an app-specific folder; create stubs with prop signatures when collaboration is needed.
+- [ ] Ensure the target React surface wraps its root layout with `MotionConfigProvider` so reduced-motion preferences are respected automatically.
 
 ## 2. Frontend Implementation
 ### Layout & Components
 - [ ] Reuse or extend existing layout wrappers (`once-container`, shared page shells) instead of redefining grid and spacing utilities.
+- [ ] Reach for the motion-enabled Once UI primitives (`<OnceContainer>`, `<OnceButton>`) before composing raw `motion.*` elements so animation tokens stay centralized.
 - [ ] Ensure Once UI components accept data via typed props and expose slots/hooks for dynamic states (loading, empty, error) rather than hardcoding copy.
 - [ ] Encapsulate repeated UI into composable components and update Storybook/MDX (if applicable) or inline docs that explain usage constraints.
 
@@ -24,11 +26,13 @@ Use this checklist when you scope, build, and verify Dynamic Capital surfaces th
 - [ ] Apply semantic Once UI classes (`once-btn`, `primary`, `outline`, typography helpers) or Tailwind tokens that map to the same palette; avoid raw hex colors or inline styles except for prototypes.
 - [ ] Confirm interactive states (hover, focus, pressed, disabled) respect accessibility contrast and use the shared transition durations.
 - [ ] Keep custom CSS scoped via module files or `:where` selectors so global Once UI styles remain unmodified.
+- [ ] Use the shared motion tokens exported from `@/lib/motion-variants` (`onceMotionVariants`, `ONCE_MOTION_SPRINGS`, etc.) instead of redefining easing, durations, or stagger timings.
 
 ### Accessibility & Interaction
 - [ ] Provide accessible names, roles, and ARIA attributes for interactive Once UI components (buttons, dialogs, tabs) and ensure keyboard navigation flows match WCAG.
 - [ ] Wire up form validation and error messaging so assistive tech announces issues; include server-error fallback copy.
 - [ ] Test front-end logic with sample data (approved payment, manual review, failure) to confirm state machines render the correct Once UI variants.
+- [ ] Verify both React (`useReducedMotion`) and static (`data-once-reveal`) surfaces honour `prefers-reduced-motion` and still present content when JavaScript is disabled.
 
 ## 3. Backend UI Support
 - [ ] Audit API routes, Supabase RPCs, and Edge Functions that feed the UI to confirm they expose all fields required for Once UI components (labels, icons, status flags, pagination counts).
@@ -42,3 +46,4 @@ Use this checklist when you scope, build, and verify Dynamic Capital surfaces th
 - [ ] Verify hydration/SSR boundaries in Next.js apps (`npm run build && npm run start` locally or preview deploy) and ensure no hydration mismatch warnings occur.
 - [ ] Document schema or API changes in the appropriate `docs/` guide and link the checklist in the PR description with notes on data migrations, feature flags, and manual QA evidence.
 - [ ] Monitor Supabase logs, queue workers, and browser consoles after deployment to catch regressions; plan rollback steps if Once UI components impact protected payment flows.
+- [ ] Smoke test static marketing pages that rely on `once-ui.js` helpers to confirm `window.OnceUI.observeReveals` works for dynamically injected nodes and that content remains visible without JavaScript.


### PR DESCRIPTION
## Summary
- wrap the Next.js provider stack with MotionConfigProvider so Once UI surfaces share reduced-motion settings
- add motion-aware OnceButton and OnceContainer primitives and refactor the motion-variants registry into shared tokens consumed across React components
- enhance once-ui.js/once-ui.css with data attribute reveal helpers, document the workflow in a landing README, and update the Once UI checklist with motion guidance

## Testing
- npm -w apps/web run lint
- npm -w apps/landing run build

------
https://chatgpt.com/codex/tasks/task_e_68c8d206d8e88322a94d2268307d2560