### PR TITLE
Implement private fund pool backend service

### DIFF
--- a/docs/private-fund-pool.md
+++ b/docs/private-fund-pool.md
@@ -1,0 +1,110 @@
+# Private Fund Pool Service
+
+The Private Fund Pool enables share-based USDT investment cycles for Dynamic Capital members. Investors can deposit to join the active cycle, request withdrawals that obey the 7-day notice and 16% reinvestment rule, and participate in monthly settlements where profits are split across payout, reinvestment, and performance fees.
+
+## Database schema
+
+The service introduces the following tables (all in the `public` schema).
+
+| Table | Purpose | Key Columns |
+| --- | --- | --- |
+| `investors` | Links authenticated profiles to pool participation | `profile_id`, `status`, `joined_at` |
+| `fund_cycles` | One row per monthly trading cycle | `cycle_month`, `cycle_year`, `status`, `profit_total_usdt`, `payout_summary` |
+| `investor_deposits` | Ledger of deposits, carryovers, and reinvestments per cycle | `investor_id`, `cycle_id`, `amount_usdt`, `deposit_type`, `tx_hash` |
+| `investor_withdrawals` | Withdrawal requests and approvals | `investor_id`, `cycle_id`, `amount_usdt`, `net_amount_usdt`, `notice_expires_at`, `status` |
+| `investor_shares` | Share percentage and capital base per cycle | `investor_id`, `cycle_id`, `share_percentage`, `contribution_usdt` |
+
+All tables have Row Level Security enabled. Investors (authenticated profiles) can read their own records; admins (profiles with role `admin`) have full access. Edge functions operate with the Supabase service role and manage write operations.
+
+### Cycle workflow
+
+1. Investors submit deposits (`private-pool-deposit`) which create ledger rows and recompute shares for the active cycle.
+2. Withdrawals (`private-pool-withdraw`) create pending requests with a 7-day notice. Admins approve/deny requests; approvals automatically apply the 16% reinvestment rule and recompute shares.
+3. Cycle settlement (`private-pool-settle-cycle`) records the monthly profit split (64% payout, 16% reinvestment, 20% performance fee), closes the current cycle, creates the next cycle, seeds carryover and reinvestment deposits, recomputes shares, and notifies investors.
+
+## Edge function APIs
+
+All endpoints expect authenticated Supabase users. Telegram Mini App sessions can provide `initData` in the request body as an alternative to an `Authorization` header.
+
+### `POST /private-pool-deposit`
+
+Request body:
+
+```json
+{
+  "amount": 150.0,
+  "txHash": "0xabc123...",
+  "notes": "Initial funding"
+}
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "depositId": "uuid",
+  "cycleId": "uuid",
+  "sharePercentage": 42.857143,
+  "contributionUsdt": 150,
+  "totalCycleContribution": 350
+}
+```
+
+### `POST /private-pool-withdraw`
+
+Investor request body:
+
+```json
+{
+  "amount": 50
+}
+```
+
+Response includes the generated withdrawal ID and the notice expiration timestamp. Admin approval uses the same endpoint:
+
+```json
+{
+  "requestId": "uuid",
+  "action": "approve",
+  "adminNotes": "Reviewed"
+}
+```
+
+Approval responses surface the net amount (84% of the requested value), the reinvestment amount (16%), and the updated share distribution.
+
+### `POST /private-pool-settle-cycle`
+
+Admin-only endpoint for month-end settlement.
+
+Request body:
+
+```json
+{
+  "profit": 3000,
+  "notes": "March 2025 cycle"
+}
+```
+
+Response highlights the totals (profit, payouts, reinvestment, performance fees), per-investor payout summary, and the ID/month of the newly created cycle. Investors with linked Telegram IDs receive a notification summarizing their payout, reinvestment, fee, and new share percentage.
+
+## Deployment checklist
+
+1. Apply the migration `supabase/migrations/20250915010000_private_fund_pool.sql` via `supabase db push` or the Supabase dashboard.
+2. Deploy edge functions:
+   ```bash
+   supabase functions deploy private-pool-deposit --no-verify-jwt
+   supabase functions deploy private-pool-withdraw --no-verify-jwt
+   supabase functions deploy private-pool-settle-cycle --no-verify-jwt
+   ```
+3. Provide environment variables for the functions:
+   - `SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `SUPABASE_ANON_KEY` (for auth header validation)
+   - `TELEGRAM_BOT_TOKEN` (optional; enables settlement notifications)
+4. Grant the service role permission to invoke the functions or expose them through your API gateway.
+5. Update operational runbooks to include monthly settlement steps and admin approval procedures for withdrawals.
+
+## Testing
+
+Automated tests cover deposit logic, withdrawal flows (including the admin approval path), and end-to-end settlement behaviour. Run `npm test` to execute the Deno test suite.

--- a/supabase/functions/_shared/private-pool.ts
+++ b/supabase/functions/_shared/private-pool.ts
@@ -1,0 +1,658 @@
+import { createClient, createSupabaseClient, type SupabaseClient } from "./client.ts";
+import { getEnv } from "./env.ts";
+import { verifyInitDataAndGetUser } from "./telegram.ts";
+
+export type UserRole = "user" | "admin";
+export type CycleStatus = "active" | "pending_settlement" | "settled";
+export type DepositType = "external" | "reinvestment" | "carryover" | "adjustment";
+export type WithdrawalStatus = "pending" | "approved" | "denied" | "fulfilled";
+
+export interface Profile {
+  id: string;
+  role: UserRole;
+  telegram_id: string | null;
+  display_name: string | null;
+}
+
+export interface Investor {
+  id: string;
+  profile_id: string;
+  status: string;
+  joined_at: string;
+}
+
+export interface FundCycle {
+  id: string;
+  cycle_month: number;
+  cycle_year: number;
+  status: CycleStatus;
+  profit_total_usdt: number;
+  investor_payout_usdt: number;
+  reinvested_total_usdt: number;
+  performance_fee_usdt: number;
+  payout_summary: unknown;
+  notes: string | null;
+  opened_at: string;
+  closed_at: string | null;
+}
+
+export interface InvestorDeposit {
+  id: string;
+  investor_id: string;
+  cycle_id: string;
+  amount_usdt: number;
+  deposit_type: DepositType;
+  tx_hash: string | null;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface InvestorWithdrawal {
+  id: string;
+  investor_id: string;
+  cycle_id: string;
+  amount_usdt: number;
+  net_amount_usdt: number | null;
+  reinvested_amount_usdt: number | null;
+  status: WithdrawalStatus;
+  requested_at: string;
+  notice_expires_at: string | null;
+  fulfilled_at: string | null;
+  admin_notes: string | null;
+}
+
+export interface InvestorShare {
+  investor_id: string;
+  cycle_id: string;
+  share_percentage: number;
+  contribution_usdt: number;
+  updated_at: string;
+}
+
+export interface InvestorContact {
+  investor_id: string;
+  profile_id: string;
+  telegram_id: string | null;
+  display_name: string | null;
+}
+
+export interface PrivatePoolStore {
+  findProfileById(id: string): Promise<Profile | null>;
+  findProfileByTelegramId(telegramId: string): Promise<Profile | null>;
+  getInvestorByProfileId(profileId: string): Promise<Investor | null>;
+  createInvestor(profileId: string, joinedAt: string): Promise<Investor>;
+  getActiveCycle(): Promise<FundCycle | null>;
+  createCycle(data: {
+    cycle_month: number;
+    cycle_year: number;
+    status?: CycleStatus;
+    opened_at?: string;
+  }): Promise<FundCycle>;
+  closeCycle(
+    cycleId: string,
+    changes: {
+      status: CycleStatus;
+      profit_total_usdt: number;
+      investor_payout_usdt: number;
+      reinvested_total_usdt: number;
+      performance_fee_usdt: number;
+      payout_summary: unknown;
+      closed_at: string;
+      notes?: string | null;
+    },
+  ): Promise<void>;
+  insertDeposit(entry: {
+    investor_id: string;
+    cycle_id: string;
+    amount_usdt: number;
+    deposit_type?: DepositType;
+    tx_hash?: string | null;
+    notes?: string | null;
+    created_at?: string;
+  }): Promise<InvestorDeposit>;
+  listDepositsByCycle(cycleId: string): Promise<InvestorDeposit[]>;
+  listWithdrawalsByCycle(
+    cycleId: string,
+    statuses: WithdrawalStatus[],
+  ): Promise<InvestorWithdrawal[]>;
+  upsertShares(records: InvestorShare[]): Promise<void>;
+  listShares(cycleId: string): Promise<InvestorShare[]>;
+  createWithdrawal(entry: {
+    investor_id: string;
+    cycle_id: string;
+    amount_usdt: number;
+    status?: WithdrawalStatus;
+    net_amount_usdt?: number | null;
+    reinvested_amount_usdt?: number | null;
+    notice_expires_at?: string | null;
+    requested_at?: string;
+    admin_notes?: string | null;
+  }): Promise<InvestorWithdrawal>;
+  updateWithdrawal(
+    id: string,
+    changes: Partial<InvestorWithdrawal>,
+  ): Promise<InvestorWithdrawal | null>;
+  findWithdrawalById(id: string): Promise<InvestorWithdrawal | null>;
+  listInvestorContacts(investorIds: string[]): Promise<InvestorContact[]>;
+}
+
+function asNumber(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "number") return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export class SupabasePrivatePoolStore implements PrivatePoolStore {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async findProfileById(id: string): Promise<Profile | null> {
+    const { data, error } = await this.client
+      .from("profiles")
+      .select("id, role, telegram_id, display_name")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw new Error(`findProfileById failed: ${error.message}`);
+    if (!data) return null;
+    return {
+      id: data.id,
+      role: data.role as UserRole,
+      telegram_id: data.telegram_id ?? null,
+      display_name: data.display_name ?? null,
+    };
+  }
+
+  async findProfileByTelegramId(telegramId: string): Promise<Profile | null> {
+    const { data, error } = await this.client
+      .from("profiles")
+      .select("id, role, telegram_id, display_name")
+      .eq("telegram_id", telegramId)
+      .maybeSingle();
+    if (error) throw new Error(`findProfileByTelegramId failed: ${error.message}`);
+    if (!data) return null;
+    return {
+      id: data.id,
+      role: data.role as UserRole,
+      telegram_id: data.telegram_id ?? null,
+      display_name: data.display_name ?? null,
+    };
+  }
+
+  async getInvestorByProfileId(profileId: string): Promise<Investor | null> {
+    const { data, error } = await this.client
+      .from("investors")
+      .select("id, profile_id, status, joined_at")
+      .eq("profile_id", profileId)
+      .maybeSingle();
+    if (error) throw new Error(`getInvestorByProfileId failed: ${error.message}`);
+    if (!data) return null;
+    return {
+      id: data.id,
+      profile_id: data.profile_id,
+      status: data.status,
+      joined_at: data.joined_at,
+    };
+  }
+
+  async createInvestor(profileId: string, joinedAt: string): Promise<Investor> {
+    const { data, error } = await this.client
+      .from("investors")
+      .insert({ profile_id: profileId, joined_at: joinedAt })
+      .select("id, profile_id, status, joined_at")
+      .single();
+    if (error) throw new Error(`createInvestor failed: ${error.message}`);
+    return {
+      id: data!.id,
+      profile_id: data!.profile_id,
+      status: data!.status,
+      joined_at: data!.joined_at,
+    };
+  }
+
+  async getActiveCycle(): Promise<FundCycle | null> {
+    const { data, error } = await this.client
+      .from("fund_cycles")
+      .select(
+        "id, cycle_month, cycle_year, status, profit_total_usdt, investor_payout_usdt, reinvested_total_usdt, performance_fee_usdt, payout_summary, notes, opened_at, closed_at",
+      )
+      .eq("status", "active")
+      .order("opened_at", { ascending: false })
+      .maybeSingle();
+    if (error) throw new Error(`getActiveCycle failed: ${error.message}`);
+    if (!data) return null;
+    return this.mapFundCycle(data);
+  }
+
+  async createCycle(data: {
+    cycle_month: number;
+    cycle_year: number;
+    status?: CycleStatus;
+    opened_at?: string;
+  }): Promise<FundCycle> {
+    const payload = {
+      cycle_month: data.cycle_month,
+      cycle_year: data.cycle_year,
+      status: data.status ?? "active",
+      opened_at: data.opened_at,
+    };
+    const { data: inserted, error } = await this.client
+      .from("fund_cycles")
+      .insert(payload)
+      .select(
+        "id, cycle_month, cycle_year, status, profit_total_usdt, investor_payout_usdt, reinvested_total_usdt, performance_fee_usdt, payout_summary, notes, opened_at, closed_at",
+      )
+      .single();
+    if (error) throw new Error(`createCycle failed: ${error.message}`);
+    return this.mapFundCycle(inserted!);
+  }
+
+  async closeCycle(
+    cycleId: string,
+    changes: {
+      status: CycleStatus;
+      profit_total_usdt: number;
+      investor_payout_usdt: number;
+      reinvested_total_usdt: number;
+      performance_fee_usdt: number;
+      payout_summary: unknown;
+      closed_at: string;
+      notes?: string | null;
+    },
+  ): Promise<void> {
+    const { error } = await this.client
+      .from("fund_cycles")
+      .update({
+        status: changes.status,
+        profit_total_usdt: changes.profit_total_usdt,
+        investor_payout_usdt: changes.investor_payout_usdt,
+        reinvested_total_usdt: changes.reinvested_total_usdt,
+        performance_fee_usdt: changes.performance_fee_usdt,
+        payout_summary: changes.payout_summary,
+        closed_at: changes.closed_at,
+        updated_at: changes.closed_at,
+        notes: changes.notes ?? null,
+      })
+      .eq("id", cycleId);
+    if (error) throw new Error(`closeCycle failed: ${error.message}`);
+  }
+
+  async insertDeposit(entry: {
+    investor_id: string;
+    cycle_id: string;
+    amount_usdt: number;
+    deposit_type?: DepositType;
+    tx_hash?: string | null;
+    notes?: string | null;
+    created_at?: string;
+  }): Promise<InvestorDeposit> {
+    const { data, error } = await this.client
+      .from("investor_deposits")
+      .insert({
+        investor_id: entry.investor_id,
+        cycle_id: entry.cycle_id,
+        amount_usdt: entry.amount_usdt,
+        deposit_type: entry.deposit_type ?? "external",
+        tx_hash: entry.tx_hash ?? null,
+        notes: entry.notes ?? null,
+        created_at: entry.created_at,
+      })
+      .select("id, investor_id, cycle_id, amount_usdt, deposit_type, tx_hash, notes, created_at")
+      .single();
+    if (error) throw new Error(`insertDeposit failed: ${error.message}`);
+    return this.mapDeposit(data!);
+  }
+
+  async listDepositsByCycle(cycleId: string): Promise<InvestorDeposit[]> {
+    const { data, error } = await this.client
+      .from("investor_deposits")
+      .select("id, investor_id, cycle_id, amount_usdt, deposit_type, tx_hash, notes, created_at")
+      .eq("cycle_id", cycleId);
+    if (error) throw new Error(`listDepositsByCycle failed: ${error.message}`);
+    return (data ?? []).map((row) => this.mapDeposit(row));
+  }
+
+  async listWithdrawalsByCycle(
+    cycleId: string,
+    statuses: WithdrawalStatus[],
+  ): Promise<InvestorWithdrawal[]> {
+    const query = this.client
+      .from("investor_withdrawals")
+      .select(
+        "id, investor_id, cycle_id, amount_usdt, net_amount_usdt, reinvested_amount_usdt, status, requested_at, notice_expires_at, fulfilled_at, admin_notes",
+      )
+      .eq("cycle_id", cycleId);
+    const builder = statuses.length > 0 ? query.in("status", statuses) : query;
+    const { data, error } = await builder;
+    if (error) throw new Error(`listWithdrawalsByCycle failed: ${error.message}`);
+    return (data ?? []).map((row) => this.mapWithdrawal(row));
+  }
+
+  async upsertShares(records: InvestorShare[]): Promise<void> {
+    if (records.length === 0) return;
+    const payload = records.map((r) => ({
+      investor_id: r.investor_id,
+      cycle_id: r.cycle_id,
+      share_percentage: r.share_percentage,
+      contribution_usdt: r.contribution_usdt,
+      updated_at: r.updated_at,
+    }));
+    const { error } = await this.client.from("investor_shares").upsert(payload);
+    if (error) throw new Error(`upsertShares failed: ${error.message}`);
+  }
+
+  async listShares(cycleId: string): Promise<InvestorShare[]> {
+    const { data, error } = await this.client
+      .from("investor_shares")
+      .select("investor_id, cycle_id, share_percentage, contribution_usdt, updated_at")
+      .eq("cycle_id", cycleId);
+    if (error) throw new Error(`listShares failed: ${error.message}`);
+    return (data ?? []).map((row) => ({
+      investor_id: row.investor_id,
+      cycle_id: row.cycle_id,
+      share_percentage: asNumber(row.share_percentage),
+      contribution_usdt: asNumber(row.contribution_usdt),
+      updated_at: row.updated_at,
+    }));
+  }
+
+  async createWithdrawal(entry: {
+    investor_id: string;
+    cycle_id: string;
+    amount_usdt: number;
+    status?: WithdrawalStatus;
+    net_amount_usdt?: number | null;
+    reinvested_amount_usdt?: number | null;
+    notice_expires_at?: string | null;
+    requested_at?: string;
+    admin_notes?: string | null;
+  }): Promise<InvestorWithdrawal> {
+    const { data, error } = await this.client
+      .from("investor_withdrawals")
+      .insert({
+        investor_id: entry.investor_id,
+        cycle_id: entry.cycle_id,
+        amount_usdt: entry.amount_usdt,
+        status: entry.status ?? "pending",
+        net_amount_usdt: entry.net_amount_usdt ?? null,
+        reinvested_amount_usdt: entry.reinvested_amount_usdt ?? null,
+        notice_expires_at: entry.notice_expires_at ?? null,
+        requested_at: entry.requested_at,
+        admin_notes: entry.admin_notes ?? null,
+      })
+      .select(
+        "id, investor_id, cycle_id, amount_usdt, net_amount_usdt, reinvested_amount_usdt, status, requested_at, notice_expires_at, fulfilled_at, admin_notes",
+      )
+      .single();
+    if (error) throw new Error(`createWithdrawal failed: ${error.message}`);
+    return this.mapWithdrawal(data!);
+  }
+
+  async updateWithdrawal(
+    id: string,
+    changes: Partial<InvestorWithdrawal>,
+  ): Promise<InvestorWithdrawal | null> {
+    const payload = { ...changes } as Record<string, unknown>;
+    const { data, error } = await this.client
+      .from("investor_withdrawals")
+      .update(payload)
+      .eq("id", id)
+      .select(
+        "id, investor_id, cycle_id, amount_usdt, net_amount_usdt, reinvested_amount_usdt, status, requested_at, notice_expires_at, fulfilled_at, admin_notes",
+      )
+      .maybeSingle();
+    if (error) throw new Error(`updateWithdrawal failed: ${error.message}`);
+    return data ? this.mapWithdrawal(data) : null;
+  }
+
+  async findWithdrawalById(id: string): Promise<InvestorWithdrawal | null> {
+    const { data, error } = await this.client
+      .from("investor_withdrawals")
+      .select(
+        "id, investor_id, cycle_id, amount_usdt, net_amount_usdt, reinvested_amount_usdt, status, requested_at, notice_expires_at, fulfilled_at, admin_notes",
+      )
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw new Error(`findWithdrawalById failed: ${error.message}`);
+    return data ? this.mapWithdrawal(data) : null;
+  }
+
+  async listInvestorContacts(investorIds: string[]): Promise<InvestorContact[]> {
+    if (investorIds.length === 0) return [];
+    const { data, error } = await this.client
+      .from("investors")
+      .select("id, profile_id, profiles(telegram_id, display_name)")
+      .in("id", investorIds);
+    if (error) throw new Error(`listInvestorContacts failed: ${error.message}`);
+    return (data ?? []).map((row) => ({
+      investor_id: row.id,
+      profile_id: row.profile_id,
+      telegram_id: row.profiles?.telegram_id ?? null,
+      display_name: row.profiles?.display_name ?? null,
+    }));
+  }
+
+  private mapFundCycle(row: any): FundCycle {
+    return {
+      id: row.id,
+      cycle_month: row.cycle_month,
+      cycle_year: row.cycle_year,
+      status: row.status,
+      profit_total_usdt: asNumber(row.profit_total_usdt),
+      investor_payout_usdt: asNumber(row.investor_payout_usdt),
+      reinvested_total_usdt: asNumber(row.reinvested_total_usdt),
+      performance_fee_usdt: asNumber(row.performance_fee_usdt),
+      payout_summary: row.payout_summary,
+      notes: row.notes ?? null,
+      opened_at: row.opened_at,
+      closed_at: row.closed_at ?? null,
+    };
+  }
+
+  private mapDeposit(row: any): InvestorDeposit {
+    return {
+      id: row.id,
+      investor_id: row.investor_id,
+      cycle_id: row.cycle_id,
+      amount_usdt: asNumber(row.amount_usdt),
+      deposit_type: row.deposit_type,
+      tx_hash: row.tx_hash ?? null,
+      notes: row.notes ?? null,
+      created_at: row.created_at,
+    };
+  }
+
+  private mapWithdrawal(row: any): InvestorWithdrawal {
+    return {
+      id: row.id,
+      investor_id: row.investor_id,
+      cycle_id: row.cycle_id,
+      amount_usdt: asNumber(row.amount_usdt),
+      net_amount_usdt: row.net_amount_usdt !== null && row.net_amount_usdt !== undefined
+        ? asNumber(row.net_amount_usdt)
+        : null,
+      reinvested_amount_usdt: row.reinvested_amount_usdt !== null && row.reinvested_amount_usdt !== undefined
+        ? asNumber(row.reinvested_amount_usdt)
+        : null,
+      status: row.status,
+      requested_at: row.requested_at,
+      notice_expires_at: row.notice_expires_at ?? null,
+      fulfilled_at: row.fulfilled_at ?? null,
+      admin_notes: row.admin_notes ?? null,
+    };
+  }
+}
+
+export function createSupabasePoolStore(): SupabasePrivatePoolStore {
+  return new SupabasePrivatePoolStore(createClient("service"));
+}
+
+export function roundCurrency(value: number, decimals = 2): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+export function getCycleMonthYear(date: Date): { cycle_month: number; cycle_year: number } {
+  return { cycle_month: date.getUTCMonth() + 1, cycle_year: date.getUTCFullYear() };
+}
+
+export function getNextCycle(month: number, year: number): { cycle_month: number; cycle_year: number } {
+  if (month === 12) return { cycle_month: 1, cycle_year: year + 1 };
+  return { cycle_month: month + 1, cycle_year: year };
+}
+
+export async function ensureInvestor(
+  store: PrivatePoolStore,
+  profileId: string,
+  now: Date,
+): Promise<Investor> {
+  const existing = await store.getInvestorByProfileId(profileId);
+  if (existing) return existing;
+  return await store.createInvestor(profileId, now.toISOString());
+}
+
+export async function ensureActiveCycle(
+  store: PrivatePoolStore,
+  now: Date,
+): Promise<FundCycle> {
+  const active = await store.getActiveCycle();
+  if (active) return active;
+  const { cycle_month, cycle_year } = getCycleMonthYear(now);
+  return await store.createCycle({ cycle_month, cycle_year, status: "active", opened_at: now.toISOString() });
+}
+
+export interface ShareComputationResult {
+  totalContribution: number;
+  contributions: Map<string, number>;
+  records: InvestorShare[];
+}
+
+export async function recomputeShares(
+  store: PrivatePoolStore,
+  cycleId: string,
+  now: Date,
+): Promise<ShareComputationResult> {
+  const deposits = await store.listDepositsByCycle(cycleId);
+  const contributions = new Map<string, number>();
+  for (const deposit of deposits) {
+    const prev = contributions.get(deposit.investor_id) ?? 0;
+    contributions.set(deposit.investor_id, prev + deposit.amount_usdt);
+  }
+  const withdrawals = await store.listWithdrawalsByCycle(cycleId, ["approved", "fulfilled"]);
+  for (const withdrawal of withdrawals) {
+    const net = withdrawal.net_amount_usdt ?? 0;
+    if (net <= 0) continue;
+    const prev = contributions.get(withdrawal.investor_id) ?? 0;
+    const next = prev - net;
+    contributions.set(withdrawal.investor_id, next > 0 ? next : 0);
+  }
+  const existingShares = await store.listShares(cycleId);
+  const allInvestorIds = new Set<string>([
+    ...contributions.keys(),
+    ...existingShares.map((s) => s.investor_id),
+  ]);
+  const totalContribution = Array.from(contributions.values()).reduce((acc, val) => acc + val, 0);
+  const records: InvestorShare[] = [];
+  for (const investorId of allInvestorIds) {
+    const contribution = contributions.get(investorId) ?? 0;
+    const share = totalContribution > 0 ? (contribution / totalContribution) * 100 : 0;
+    records.push({
+      investor_id: investorId,
+      cycle_id: cycleId,
+      share_percentage: Number(share.toFixed(6)),
+      contribution_usdt: roundCurrency(contribution),
+      updated_at: now.toISOString(),
+    });
+  }
+  if (records.length > 0) await store.upsertShares(records);
+  return { totalContribution: roundCurrency(totalContribution), contributions, records };
+}
+
+export interface AuthContext {
+  profileId: string;
+  telegramId: string | null;
+}
+
+export type ResolveProfileFn = (
+  req: Request,
+  body: unknown,
+  store: PrivatePoolStore,
+) => Promise<AuthContext | null>;
+
+type AuthClient = {
+  auth: {
+    getUser: () => Promise<{
+      data: { user: { id: string; user_metadata?: { telegram_id?: string | null } } | null };
+      error: { message?: string } | null;
+    }>;
+  };
+};
+
+export interface ResolveProfileOptions {
+  getAuthClient?: (authHeader: string) => Promise<AuthClient>;
+  verifyInitData?: (initData: string) => Promise<{ id: number } | null>;
+}
+
+function defaultGetAuthClient(authHeader: string): Promise<AuthClient> {
+  const url = getEnv("SUPABASE_URL");
+  const anon = getEnv("SUPABASE_ANON_KEY");
+  const client = createSupabaseClient(url, anon, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false },
+  });
+  return Promise.resolve(client as unknown as AuthClient);
+}
+
+export function createDefaultResolveProfileFn(
+  options: ResolveProfileOptions = {},
+): ResolveProfileFn {
+  const getAuthClient = options.getAuthClient ?? defaultGetAuthClient;
+  const verifyInitData = options.verifyInitData ?? (async (initData: string) => {
+    const user = await verifyInitDataAndGetUser(initData);
+    return user ? { id: user.id } : null;
+  });
+  return async (req, body, store) => {
+    const authHeader = req.headers.get("Authorization");
+    if (authHeader) {
+      try {
+        const auth = await getAuthClient(authHeader);
+        const { data, error } = await auth.auth.getUser();
+        if (error) throw new Error(error.message ?? "auth.getUser failed");
+        const user = data?.user;
+        if (user) {
+          const profile = await store.findProfileById(user.id);
+          if (profile) {
+            return {
+              profileId: profile.id,
+              telegramId: profile.telegram_id ?? user.user_metadata?.telegram_id ?? null,
+            };
+          }
+        }
+      } catch (err) {
+        console.error("resolveProfile auth error", err);
+      }
+    }
+    const initData =
+      typeof body === "object" && body !== null && "initData" in (body as Record<string, unknown>)
+        ? String((body as Record<string, unknown>).initData ?? "")
+        : null;
+    if (initData) {
+      try {
+        const telegramUser = await verifyInitData(initData);
+        if (telegramUser) {
+          const profile = await store.findProfileByTelegramId(String(telegramUser.id));
+          if (profile) {
+            return { profileId: profile.id, telegramId: profile.telegram_id ?? String(telegramUser.id) };
+          }
+        }
+      } catch (err) {
+        console.error("resolveProfile telegram error", err);
+      }
+    }
+    return null;
+  };
+}
+
+export async function requireAdmin(store: PrivatePoolStore, profileId: string): Promise<boolean> {
+  const profile = await store.findProfileById(profileId);
+  return profile?.role === "admin";
+}

--- a/supabase/functions/_tests/private-pool-deposit.test.ts
+++ b/supabase/functions/_tests/private-pool-deposit.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { createDepositHandler } from "../private-pool-deposit/index.ts";
+import { MockPrivatePoolStore } from "./private_pool_mock.ts";
+
+denoTest("private-pool-deposit records deposit and recalculates shares", async () => {
+  const profileId = "profile-1";
+  const store = new MockPrivatePoolStore({
+    profiles: [
+      { id: profileId, role: "user", telegram_id: "100", display_name: "Alice" },
+    ],
+  });
+  const handler = createDepositHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId, telegramId: "100" }),
+    now: () => new Date("2025-01-01T00:00:00Z"),
+  });
+  const resp = await handler(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: 150 }),
+    headers: { "content-type": "application/json" },
+  }));
+  assertEquals(resp.status, 200);
+  const json = await resp.json();
+  assertEquals(json.ok, true);
+  assertEquals(json.sharePercentage, 100);
+  assertEquals(json.totalCycleContribution, 150);
+  assertEquals(store.deposits.length, 1);
+  const activeCycle = await store.getActiveCycle();
+  if (!activeCycle) throw new Error("active cycle missing");
+  const shares = await store.listShares(activeCycle.id);
+  assertEquals(shares.length, 1);
+  assertEquals(shares[0].share_percentage, 100);
+});
+
+denoTest("private-pool-deposit rejects invalid amount", async () => {
+  const store = new MockPrivatePoolStore({
+    profiles: [
+      { id: "profile-2", role: "user", telegram_id: "200", display_name: "Bob" },
+    ],
+  });
+  const handler = createDepositHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: "profile-2", telegramId: "200" }),
+    now: () => new Date("2025-01-01T00:00:00Z"),
+  });
+  const resp = await handler(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: -10 }),
+    headers: { "content-type": "application/json" },
+  }));
+  assertEquals(resp.status, 400);
+});
+
+function denoTest(name: string, fn: () => Promise<void> | void) {
+  Deno.test(name, fn);
+}

--- a/supabase/functions/_tests/private-pool-settle-cycle.test.ts
+++ b/supabase/functions/_tests/private-pool-settle-cycle.test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { createDepositHandler } from "../private-pool-deposit/index.ts";
+import { createSettleHandler } from "../private-pool-settle-cycle/index.ts";
+import { MockPrivatePoolStore } from "./private_pool_mock.ts";
+
+denoTest("private-pool-settle-cycle splits profit and seeds next cycle", async () => {
+  const adminProfile = "profile-admin";
+  const investorAProfile = "profile-a";
+  const investorBProfile = "profile-b";
+  const store = new MockPrivatePoolStore({
+    profiles: [
+      { id: adminProfile, role: "admin", telegram_id: "300", display_name: "Admin" },
+      { id: investorAProfile, role: "user", telegram_id: "301", display_name: "Investor A" },
+      { id: investorBProfile, role: "user", telegram_id: "302", display_name: "Investor B" },
+    ],
+  });
+  const depositA = createDepositHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: investorAProfile, telegramId: "301" }),
+    now: () => new Date("2025-03-01T00:00:00Z"),
+  });
+  const depositB = createDepositHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: investorBProfile, telegramId: "302" }),
+    now: () => new Date("2025-03-01T00:05:00Z"),
+  });
+  await depositA(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: 200 }),
+    headers: { "content-type": "application/json" },
+  }));
+  await depositB(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: 100 }),
+    headers: { "content-type": "application/json" },
+  }));
+  const notifications: any[] = [];
+  const settle = createSettleHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: adminProfile, telegramId: "300" }),
+    now: () => new Date("2025-03-31T18:00:00Z"),
+    notifyInvestors: async (args) => notifications.push(args),
+  });
+  const resp = await settle(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ profit: 300, notes: "March cycle" }),
+    headers: { "content-type": "application/json" },
+  }));
+  assertEquals(resp.status, 200);
+  const json = await resp.json();
+  assertEquals(json.ok, true);
+  assertEquals(json.totals.profit_total, 300);
+  assertEquals(json.totals.payout_total, 192);
+  assertEquals(json.totals.reinvest_total, 48);
+  assertEquals(json.totals.performance_fee_total, 60);
+  assertEquals(json.payoutSummary.length, 2);
+  const activeCycle = await store.getActiveCycle();
+  if (!activeCycle) throw new Error("new active cycle missing");
+  const previousCycleId = json.cycleId as string;
+  const previousCycle = store.fundCycles.get(previousCycleId);
+  if (!previousCycle) throw new Error("previous cycle not stored");
+  assertEquals(previousCycle.status, "settled");
+  const nextCycleId = json.nextCycle.id as string;
+  assertEquals(activeCycle.id, nextCycleId);
+  const newDeposits = store.deposits.filter((d) => d.cycle_id === nextCycleId);
+  assertEquals(newDeposits.length, 4);
+  const newShares = await store.listShares(nextCycleId);
+  const shareA = newShares.find((s) => store.investors.get(s.investor_id)?.profile_id === investorAProfile);
+  const shareB = newShares.find((s) => store.investors.get(s.investor_id)?.profile_id === investorBProfile);
+  if (!shareA || !shareB) throw new Error("new share entries missing");
+  assertEquals(Math.round(shareA.share_percentage * 100) / 100, 66.67);
+  assertEquals(Math.round(shareB.share_percentage * 100) / 100, 33.33);
+  assertEquals(notifications.length, 1);
+  const note = notifications[0];
+  assertEquals(note.totals.profit_total, 300);
+  assertEquals(note.summary.length, 2);
+  assertEquals(note.notes, "March cycle");
+});
+
+function denoTest(name: string, fn: () => Promise<void> | void) {
+  Deno.test(name, fn);
+}

--- a/supabase/functions/_tests/private-pool-withdraw.test.ts
+++ b/supabase/functions/_tests/private-pool-withdraw.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { createDepositHandler } from "../private-pool-deposit/index.ts";
+import { createWithdrawHandler } from "../private-pool-withdraw/index.ts";
+import { MockPrivatePoolStore } from "./private_pool_mock.ts";
+
+denoTest("private-pool-withdraw enforces notice and admin approval recalculates shares", async () => {
+  const investorProfile = "profile-investor";
+  const investorTwoProfile = "profile-investor-2";
+  const adminProfile = "profile-admin";
+  const store = new MockPrivatePoolStore({
+    profiles: [
+      { id: investorProfile, role: "user", telegram_id: "101", display_name: "Investor A" },
+      { id: investorTwoProfile, role: "user", telegram_id: "102", display_name: "Investor B" },
+      { id: adminProfile, role: "admin", telegram_id: "201", display_name: "Admin" },
+    ],
+  });
+  const depositHandlerA = createDepositHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: investorProfile, telegramId: "101" }),
+    now: () => new Date("2025-02-01T00:00:00Z"),
+  });
+  const depositHandlerB = createDepositHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: investorTwoProfile, telegramId: "102" }),
+    now: () => new Date("2025-02-01T00:05:00Z"),
+  });
+  await depositHandlerA(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: 200 }),
+    headers: { "content-type": "application/json" },
+  }));
+  await depositHandlerB(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: 100 }),
+    headers: { "content-type": "application/json" },
+  }));
+  const withdrawHandlerInvestor = createWithdrawHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: investorProfile, telegramId: "101" }),
+    now: () => new Date("2025-02-10T00:00:00Z"),
+  });
+  const requestResp = await withdrawHandlerInvestor(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ amount: 50 }),
+    headers: { "content-type": "application/json" },
+  }));
+  assertEquals(requestResp.status, 200);
+  const requestJson = await requestResp.json();
+  assertEquals(requestJson.status, "pending");
+  const withdrawalId = requestJson.withdrawalId as string;
+  const pending = await store.findWithdrawalById(withdrawalId);
+  if (!pending) throw new Error("pending withdrawal missing");
+  assertEquals(pending.notice_expires_at !== null, true);
+  const adminHandler = createWithdrawHandler({
+    createStore: () => store,
+    resolveProfile: async () => ({ profileId: adminProfile, telegramId: "201" }),
+    now: () => new Date("2025-02-18T00:00:00Z"),
+  });
+  const approveResp = await adminHandler(new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ requestId: withdrawalId, action: "approve" }),
+    headers: { "content-type": "application/json" },
+  }));
+  assertEquals(approveResp.status, 200);
+  const approveJson = await approveResp.json();
+  assertEquals(approveJson.status, "approved");
+  assertEquals(approveJson.netAmountUsdt, 42);
+  const activeCycle = await store.getActiveCycle();
+  if (!activeCycle) throw new Error("active cycle missing after approval");
+  const shares = await store.listShares(activeCycle.id);
+  const shareA = shares.find((s) => s.investor_id && store.investors.get(s.investor_id)?.profile_id === investorProfile);
+  const shareB = shares.find((s) => s.investor_id && store.investors.get(s.investor_id)?.profile_id === investorTwoProfile);
+  if (!shareA || !shareB) throw new Error("share entries missing");
+  assertEquals(Math.round(shareA.share_percentage * 100) / 100, 61.24);
+  assertEquals(Math.round(shareB.share_percentage * 100) / 100, 38.76);
+});
+
+function denoTest(name: string, fn: () => Promise<void> | void) {
+  Deno.test(name, fn);
+}

--- a/supabase/functions/_tests/private_pool_mock.ts
+++ b/supabase/functions/_tests/private_pool_mock.ts
@@ -1,0 +1,234 @@
+import { roundCurrency, type PrivatePoolStore, type Profile, type Investor, type FundCycle, type InvestorDeposit, type InvestorWithdrawal, type InvestorShare, type InvestorContact, type CycleStatus, type WithdrawalStatus, type DepositType } from "../_shared/private-pool.ts";
+
+export class MockPrivatePoolStore implements PrivatePoolStore {
+  profiles = new Map<string, Profile>();
+  investors = new Map<string, Investor>();
+  fundCycles = new Map<string, FundCycle>();
+  deposits: InvestorDeposit[] = [];
+  withdrawals: InvestorWithdrawal[] = [];
+  shares = new Map<string, InvestorShare>();
+
+  constructor(init?: {
+    profiles?: Profile[];
+    investors?: Investor[];
+    fundCycles?: FundCycle[];
+    deposits?: InvestorDeposit[];
+    withdrawals?: InvestorWithdrawal[];
+    shares?: InvestorShare[];
+  }) {
+    for (const profile of init?.profiles ?? []) this.profiles.set(profile.id, profile);
+    for (const investor of init?.investors ?? []) this.investors.set(investor.id, investor);
+    for (const cycle of init?.fundCycles ?? []) this.fundCycles.set(cycle.id, cycle);
+    this.deposits = [...(init?.deposits ?? [])];
+    this.withdrawals = [...(init?.withdrawals ?? [])];
+    for (const share of init?.shares ?? []) {
+      this.shares.set(this.shareKey(share.cycle_id, share.investor_id), share);
+    }
+  }
+
+  private shareKey(cycleId: string, investorId: string) {
+    return `${cycleId}:${investorId}`;
+  }
+
+  async findProfileById(id: string): Promise<Profile | null> {
+    return this.profiles.get(id) ?? null;
+  }
+
+  async findProfileByTelegramId(telegramId: string): Promise<Profile | null> {
+    for (const profile of this.profiles.values()) {
+      if (profile.telegram_id === telegramId) return profile;
+    }
+    return null;
+  }
+
+  async getInvestorByProfileId(profileId: string): Promise<Investor | null> {
+    for (const investor of this.investors.values()) {
+      if (investor.profile_id === profileId) return investor;
+    }
+    return null;
+  }
+
+  async createInvestor(profileId: string, joinedAt: string): Promise<Investor> {
+    const investor: Investor = {
+      id: crypto.randomUUID(),
+      profile_id: profileId,
+      status: "active",
+      joined_at: joinedAt,
+    };
+    this.investors.set(investor.id, investor);
+    return investor;
+  }
+
+  async getActiveCycle(): Promise<FundCycle | null> {
+    for (const cycle of this.fundCycles.values()) {
+      if (cycle.status === "active") return cycle;
+    }
+    return null;
+  }
+
+  async createCycle(data: {
+    cycle_month: number;
+    cycle_year: number;
+    status?: CycleStatus;
+    opened_at?: string;
+  }): Promise<FundCycle> {
+    const cycle: FundCycle = {
+      id: crypto.randomUUID(),
+      cycle_month: data.cycle_month,
+      cycle_year: data.cycle_year,
+      status: data.status ?? "active",
+      profit_total_usdt: 0,
+      investor_payout_usdt: 0,
+      reinvested_total_usdt: 0,
+      performance_fee_usdt: 0,
+      payout_summary: [],
+      notes: null,
+      opened_at: data.opened_at ?? new Date().toISOString(),
+      closed_at: null,
+    };
+    this.fundCycles.set(cycle.id, cycle);
+    return cycle;
+  }
+
+  async closeCycle(
+    cycleId: string,
+    changes: {
+      status: CycleStatus;
+      profit_total_usdt: number;
+      investor_payout_usdt: number;
+      reinvested_total_usdt: number;
+      performance_fee_usdt: number;
+      payout_summary: unknown;
+      closed_at: string;
+      notes?: string | null;
+    },
+  ): Promise<void> {
+    const cycle = this.fundCycles.get(cycleId);
+    if (!cycle) throw new Error("Cycle not found");
+    cycle.status = changes.status;
+    cycle.profit_total_usdt = changes.profit_total_usdt;
+    cycle.investor_payout_usdt = changes.investor_payout_usdt;
+    cycle.reinvested_total_usdt = changes.reinvested_total_usdt;
+    cycle.performance_fee_usdt = changes.performance_fee_usdt;
+    cycle.payout_summary = changes.payout_summary;
+    cycle.closed_at = changes.closed_at;
+    cycle.notes = changes.notes ?? null;
+  }
+
+  async insertDeposit(entry: {
+    investor_id: string;
+    cycle_id: string;
+    amount_usdt: number;
+    deposit_type?: DepositType;
+    tx_hash?: string | null;
+    notes?: string | null;
+    created_at?: string;
+  }): Promise<InvestorDeposit> {
+    const deposit: InvestorDeposit = {
+      id: crypto.randomUUID(),
+      investor_id: entry.investor_id,
+      cycle_id: entry.cycle_id,
+      amount_usdt: roundCurrency(entry.amount_usdt),
+      deposit_type: entry.deposit_type ?? "external",
+      tx_hash: entry.tx_hash ?? null,
+      notes: entry.notes ?? null,
+      created_at: entry.created_at ?? new Date().toISOString(),
+    };
+    this.deposits.push(deposit);
+    return deposit;
+  }
+
+  async listDepositsByCycle(cycleId: string): Promise<InvestorDeposit[]> {
+    return this.deposits.filter((d) => d.cycle_id === cycleId);
+  }
+
+  async listWithdrawalsByCycle(
+    cycleId: string,
+    statuses: WithdrawalStatus[],
+  ): Promise<InvestorWithdrawal[]> {
+    const allowed = new Set(statuses);
+    return this.withdrawals.filter((w) => w.cycle_id === cycleId && (allowed.size === 0 || allowed.has(w.status)));
+  }
+
+  async upsertShares(records: InvestorShare[]): Promise<void> {
+    for (const record of records) {
+      this.shares.set(this.shareKey(record.cycle_id, record.investor_id), {
+        ...record,
+        share_percentage: record.share_percentage,
+        contribution_usdt: roundCurrency(record.contribution_usdt),
+      });
+    }
+  }
+
+  async listShares(cycleId: string): Promise<InvestorShare[]> {
+    const out: InvestorShare[] = [];
+    for (const record of this.shares.values()) {
+      if (record.cycle_id === cycleId) out.push(record);
+    }
+    return out;
+  }
+
+  async createWithdrawal(entry: {
+    investor_id: string;
+    cycle_id: string;
+    amount_usdt: number;
+    status?: WithdrawalStatus;
+    net_amount_usdt?: number | null;
+    reinvested_amount_usdt?: number | null;
+    notice_expires_at?: string | null;
+    requested_at?: string;
+    admin_notes?: string | null;
+  }): Promise<InvestorWithdrawal> {
+    const withdrawal: InvestorWithdrawal = {
+      id: crypto.randomUUID(),
+      investor_id: entry.investor_id,
+      cycle_id: entry.cycle_id,
+      amount_usdt: roundCurrency(entry.amount_usdt),
+      net_amount_usdt: entry.net_amount_usdt ?? null,
+      reinvested_amount_usdt: entry.reinvested_amount_usdt ?? null,
+      status: entry.status ?? "pending",
+      requested_at: entry.requested_at ?? new Date().toISOString(),
+      notice_expires_at: entry.notice_expires_at ?? null,
+      fulfilled_at: null,
+      admin_notes: entry.admin_notes ?? null,
+    };
+    this.withdrawals.push(withdrawal);
+    return withdrawal;
+  }
+
+  async updateWithdrawal(
+    id: string,
+    changes: Partial<InvestorWithdrawal>,
+  ): Promise<InvestorWithdrawal | null> {
+    const index = this.withdrawals.findIndex((w) => w.id === id);
+    if (index === -1) return null;
+    const current = this.withdrawals[index];
+    const updated: InvestorWithdrawal = {
+      ...current,
+      ...changes,
+    };
+    this.withdrawals[index] = updated;
+    return updated;
+  }
+
+  async findWithdrawalById(id: string): Promise<InvestorWithdrawal | null> {
+    return this.withdrawals.find((w) => w.id === id) ?? null;
+  }
+
+  async listInvestorContacts(investorIds: string[]): Promise<InvestorContact[]> {
+    const out: InvestorContact[] = [];
+    const set = new Set(investorIds);
+    for (const investor of this.investors.values()) {
+      if (!set.has(investor.id)) continue;
+      const profile = this.profiles.get(investor.profile_id);
+      if (!profile) continue;
+      out.push({
+        investor_id: investor.id,
+        profile_id: profile.id,
+        telegram_id: profile.telegram_id ?? null,
+        display_name: profile.display_name ?? null,
+      });
+    }
+    return out;
+  }
+}

--- a/supabase/functions/private-pool-deposit/index.ts
+++ b/supabase/functions/private-pool-deposit/index.ts
@@ -1,0 +1,91 @@
+import { createSupabasePoolStore, ensureActiveCycle, ensureInvestor, recomputeShares, type PrivatePoolStore, type ResolveProfileFn, createDefaultResolveProfileFn, roundCurrency } from "../_shared/private-pool.ts";
+import { ok, bad, unauth, mna, oops, corsHeaders } from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+import { version } from "../_shared/version.ts";
+
+interface DepositBody {
+  amount?: number;
+  txHash?: string;
+  initData?: string;
+  notes?: string;
+}
+
+interface DepositHandlerDeps {
+  createStore: () => PrivatePoolStore;
+  resolveProfile: ResolveProfileFn;
+  now: () => Date;
+}
+
+const defaultDeps: DepositHandlerDeps = {
+  createStore: createSupabasePoolStore,
+  resolveProfile: createDefaultResolveProfileFn(),
+  now: () => new Date(),
+};
+
+function parseBody(raw: unknown): DepositBody {
+  if (typeof raw !== "object" || raw === null) return {};
+  return raw as DepositBody;
+}
+
+export function createDepositHandler(
+  overrides: Partial<DepositHandlerDeps> = {},
+) {
+  const deps: DepositHandlerDeps = { ...defaultDeps, ...overrides };
+  return async function handler(req: Request): Promise<Response> {
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders(req) });
+    }
+    const v = version(req, "private-pool-deposit");
+    if (v) return v;
+    if (req.method !== "POST") return mna();
+    let bodyRaw: unknown;
+    try {
+      bodyRaw = await req.json();
+    } catch {
+      return bad("Bad JSON", undefined, req);
+    }
+    const body = parseBody(bodyRaw);
+    const amount = Number(body.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return bad("Invalid amount", undefined, req);
+    }
+    const store = deps.createStore();
+    const profile = await deps.resolveProfile(req, body, store);
+    if (!profile) {
+      return unauth("Unauthorized", req);
+    }
+    try {
+      const now = deps.now();
+      const investor = await ensureInvestor(store, profile.profileId, now);
+      const cycle = await ensureActiveCycle(store, now);
+      const deposit = await store.insertDeposit({
+        investor_id: investor.id,
+        cycle_id: cycle.id,
+        amount_usdt: roundCurrency(amount),
+        tx_hash: body.txHash ?? null,
+        notes: body.notes ?? null,
+        deposit_type: "external",
+        created_at: now.toISOString(),
+      });
+      const shareResult = await recomputeShares(store, cycle.id, now);
+      const share = shareResult.records.find((r) => r.investor_id === investor.id);
+      return ok({
+        ok: true,
+        depositId: deposit.id,
+        cycleId: cycle.id,
+        sharePercentage: share?.share_percentage ?? 0,
+        contributionUsdt: share?.contribution_usdt ?? roundCurrency(amount),
+        totalCycleContribution: shareResult.totalContribution,
+      }, req);
+    } catch (err) {
+      console.error("private-pool-deposit error", err);
+      return oops("Failed to record deposit", err instanceof Error ? err.message : err, req);
+    }
+  };
+}
+
+export const handler = createDepositHandler();
+
+registerHandler(handler);
+
+export default handler;

--- a/supabase/functions/private-pool-settle-cycle/index.ts
+++ b/supabase/functions/private-pool-settle-cycle/index.ts
@@ -1,0 +1,236 @@
+import { createSupabasePoolStore, recomputeShares, requireAdmin, type PrivatePoolStore, type ResolveProfileFn, createDefaultResolveProfileFn, roundCurrency, getNextCycle, type InvestorShare } from "../_shared/private-pool.ts";
+import { ok, bad, unauth, mna, oops, corsHeaders } from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+import { version } from "../_shared/version.ts";
+import type { InvestorContact, FundCycle } from "../_shared/private-pool.ts";
+
+interface SettleBody {
+  profit?: number;
+  notes?: string;
+  initData?: string;
+}
+
+interface PayoutEntry {
+  investor_id: string;
+  share_percentage: number;
+  contribution_usdt: number;
+  gross_profit_usdt: number;
+  payout_usdt: number;
+  reinvest_usdt: number;
+  performance_fee_usdt: number;
+}
+
+interface SettlementTotals {
+  profit_total: number;
+  payout_total: number;
+  reinvest_total: number;
+  performance_fee_total: number;
+}
+
+interface NotifyArgs {
+  cycle: FundCycle;
+  summary: PayoutEntry[];
+  newShares: InvestorShare[];
+  contacts: InvestorContact[];
+  totals: SettlementTotals;
+  nextCycle: FundCycle;
+  notes?: string | null;
+}
+
+interface SettleHandlerDeps {
+  createStore: () => PrivatePoolStore;
+  resolveProfile: ResolveProfileFn;
+  now: () => Date;
+  notifyInvestors: (args: NotifyArgs) => Promise<void>;
+}
+
+const defaultDeps: SettleHandlerDeps = {
+  createStore: createSupabasePoolStore,
+  resolveProfile: createDefaultResolveProfileFn(),
+  now: () => new Date(),
+  notifyInvestors: defaultNotifyInvestors,
+};
+
+function parseBody(raw: unknown): SettleBody {
+  if (typeof raw !== "object" || raw === null) return {};
+  return raw as SettleBody;
+}
+
+export function createSettleHandler(
+  overrides: Partial<SettleHandlerDeps> = {},
+) {
+  const deps: SettleHandlerDeps = { ...defaultDeps, ...overrides } as SettleHandlerDeps;
+  return async function handler(req: Request): Promise<Response> {
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders(req) });
+    }
+    const v = version(req, "private-pool-settle-cycle");
+    if (v) return v;
+    if (req.method !== "POST") return mna();
+    let bodyRaw: unknown;
+    try {
+      bodyRaw = await req.json();
+    } catch {
+      return bad("Bad JSON", undefined, req);
+    }
+    const body = parseBody(bodyRaw);
+    const store = deps.createStore();
+    const profile = await deps.resolveProfile(req, body, store);
+    if (!profile) {
+      return unauth("Unauthorized", req);
+    }
+    const isAdmin = await requireAdmin(store, profile.profileId);
+    if (!isAdmin) return unauth("Admin access required", req);
+    const now = deps.now();
+    const profit = Number(body.profit);
+    if (!Number.isFinite(profit)) {
+      return bad("Invalid profit amount", undefined, req);
+    }
+    try {
+      const activeCycle = await store.getActiveCycle();
+      if (!activeCycle) {
+        return bad("No active cycle to settle", undefined, req);
+      }
+      const shareData = await recomputeShares(store, activeCycle.id, now);
+      const totalProfit = roundCurrency(profit);
+      const summary: PayoutEntry[] = [];
+      let payoutTotal = 0;
+      let reinvestTotal = 0;
+      let feeTotal = 0;
+      for (const record of shareData.records) {
+        const shareFraction = record.share_percentage / 100;
+        const gross = roundCurrency(totalProfit * shareFraction);
+        const payout = roundCurrency(gross * 0.64);
+        const reinvest = roundCurrency(gross * 0.16);
+        const fee = roundCurrency(gross * 0.20);
+        payoutTotal += payout;
+        reinvestTotal += reinvest;
+        feeTotal += fee;
+        summary.push({
+          investor_id: record.investor_id,
+          share_percentage: record.share_percentage,
+          contribution_usdt: record.contribution_usdt,
+          gross_profit_usdt: gross,
+          payout_usdt: payout,
+          reinvest_usdt: reinvest,
+          performance_fee_usdt: fee,
+        });
+      }
+      await store.closeCycle(activeCycle.id, {
+        status: "settled",
+        profit_total_usdt: totalProfit,
+        investor_payout_usdt: roundCurrency(payoutTotal),
+        reinvested_total_usdt: roundCurrency(reinvestTotal),
+        performance_fee_usdt: roundCurrency(feeTotal),
+        payout_summary: summary,
+        closed_at: now.toISOString(),
+        notes: body.notes ?? null,
+      });
+      const nextMeta = getNextCycle(activeCycle.cycle_month, activeCycle.cycle_year);
+      const nextCycle = await store.createCycle({
+        cycle_month: nextMeta.cycle_month,
+        cycle_year: nextMeta.cycle_year,
+        status: "active",
+        opened_at: now.toISOString(),
+      });
+      for (const entry of summary) {
+        const base = shareData.contributions.get(entry.investor_id) ?? 0;
+        if (base > 0) {
+          await store.insertDeposit({
+            investor_id: entry.investor_id,
+            cycle_id: nextCycle.id,
+            amount_usdt: roundCurrency(base),
+            deposit_type: "carryover",
+            notes: `Carryover from ${activeCycle.cycle_month}/${activeCycle.cycle_year}`,
+            created_at: now.toISOString(),
+          });
+        }
+        if (entry.reinvest_usdt > 0) {
+          await store.insertDeposit({
+            investor_id: entry.investor_id,
+            cycle_id: nextCycle.id,
+            amount_usdt: roundCurrency(entry.reinvest_usdt),
+            deposit_type: "reinvestment",
+            notes: `Reinvestment from ${activeCycle.cycle_month}/${activeCycle.cycle_year} settlement`,
+            created_at: now.toISOString(),
+          });
+        }
+      }
+      const newShares = await recomputeShares(store, nextCycle.id, now);
+      const contacts = await store.listInvestorContacts(summary.map((s) => s.investor_id));
+      const totals: SettlementTotals = {
+        profit_total: totalProfit,
+        payout_total: roundCurrency(payoutTotal),
+        reinvest_total: roundCurrency(reinvestTotal),
+        performance_fee_total: roundCurrency(feeTotal),
+      };
+      await deps.notifyInvestors({
+        cycle: activeCycle,
+        summary,
+        newShares: newShares.records,
+        contacts,
+        totals,
+        nextCycle,
+        notes: body.notes ?? null,
+      });
+      return ok({
+        ok: true,
+        cycleId: activeCycle.id,
+        closedAt: now.toISOString(),
+        totals,
+        payoutSummary: summary,
+        nextCycle: {
+          id: nextCycle.id,
+          cycle_month: nextCycle.cycle_month,
+          cycle_year: nextCycle.cycle_year,
+        },
+        newShareDistribution: newShares.records,
+      }, req);
+    } catch (err) {
+      console.error("private-pool-settle-cycle error", err);
+      return oops("Failed to settle cycle", err instanceof Error ? err.message : err, req);
+    }
+  };
+}
+
+async function defaultNotifyInvestors(args: NotifyArgs): Promise<void> {
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  if (!token) return;
+  const summaryMap = new Map(args.summary.map((s) => [s.investor_id, s] as const));
+  const shareMap = new Map(args.newShares.map((s) => [s.investor_id, s] as const));
+  await Promise.allSettled(
+    args.contacts
+      .filter((contact) => contact.telegram_id)
+      .map(async (contact) => {
+        const entry = summaryMap.get(contact.investor_id);
+        const share = shareMap.get(contact.investor_id);
+        if (!entry || !share) return;
+        const lines = [
+          `Dynamic Capital – Private Fund Pool`,
+          `Cycle ${args.cycle.cycle_month}/${args.cycle.cycle_year} settled.`,
+          `Profit share: ${entry.payout_usdt.toFixed(2)} USDT`,
+          `Reinvested: ${entry.reinvest_usdt.toFixed(2)} USDT`,
+          `Performance fee: ${entry.performance_fee_usdt.toFixed(2)} USDT`,
+          `New share: ${share.share_percentage.toFixed(2)}%`,
+        ];
+        if (args.notes) {
+          lines.push(`Notes: ${args.notes}`);
+        }
+        const body = JSON.stringify({
+          chat_id: contact.telegram_id,
+          text: lines.join("\n"),
+        });
+        await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body,
+        });
+      }),
+  );
+}
+
+export const handler = createSettleHandler();
+
+registerHandler(handler);
+
+export default handler;

--- a/supabase/functions/private-pool-withdraw/index.ts
+++ b/supabase/functions/private-pool-withdraw/index.ts
@@ -1,0 +1,153 @@
+import { createSupabasePoolStore, ensureActiveCycle, ensureInvestor, recomputeShares, requireAdmin, type PrivatePoolStore, type ResolveProfileFn, createDefaultResolveProfileFn, roundCurrency } from "../_shared/private-pool.ts";
+import { ok, bad, unauth, mna, oops, corsHeaders } from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+import { version } from "../_shared/version.ts";
+
+type AdminAction = "approve" | "deny";
+
+interface WithdrawBody {
+  amount?: number;
+  initData?: string;
+  notes?: string;
+  requestId?: string;
+  action?: AdminAction;
+  adminNotes?: string;
+}
+
+interface WithdrawHandlerDeps {
+  createStore: () => PrivatePoolStore;
+  resolveProfile: ResolveProfileFn;
+  now: () => Date;
+}
+
+const defaultDeps: WithdrawHandlerDeps = {
+  createStore: createSupabasePoolStore,
+  resolveProfile: createDefaultResolveProfileFn(),
+  now: () => new Date(),
+};
+
+function parseBody(raw: unknown): WithdrawBody {
+  if (typeof raw !== "object" || raw === null) return {};
+  return raw as WithdrawBody;
+}
+
+function addDays(date: Date, days: number): string {
+  const next = new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+  return next.toISOString();
+}
+
+export function createWithdrawHandler(
+  overrides: Partial<WithdrawHandlerDeps> = {},
+) {
+  const deps: WithdrawHandlerDeps = { ...defaultDeps, ...overrides };
+  return async function handler(req: Request): Promise<Response> {
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders(req) });
+    }
+    const v = version(req, "private-pool-withdraw");
+    if (v) return v;
+    if (req.method !== "POST") return mna();
+    let bodyRaw: unknown;
+    try {
+      bodyRaw = await req.json();
+    } catch {
+      return bad("Bad JSON", undefined, req);
+    }
+    const body = parseBody(bodyRaw);
+    const store = deps.createStore();
+    const profile = await deps.resolveProfile(req, body, store);
+    if (!profile) {
+      return unauth("Unauthorized", req);
+    }
+
+    const now = deps.now();
+
+    try {
+      if (body.action) {
+        if (!body.requestId) {
+          return bad("Missing requestId", undefined, req);
+        }
+        const admin = await requireAdmin(store, profile.profileId);
+        if (!admin) return unauth("Admin access required", req);
+        const withdrawal = await store.findWithdrawalById(body.requestId);
+        if (!withdrawal) {
+          return bad("Withdrawal not found", undefined, req);
+        }
+        if (body.action === "deny") {
+          const updated = await store.updateWithdrawal(withdrawal.id, {
+            status: "denied",
+            admin_notes: body.adminNotes ?? withdrawal.admin_notes ?? null,
+          });
+          return ok({
+            ok: true,
+            status: updated?.status ?? "denied",
+            withdrawalId: withdrawal.id,
+          }, req);
+        }
+        if (withdrawal.status !== "pending") {
+          return bad("Withdrawal already processed", undefined, req);
+        }
+        const netAmount = roundCurrency(withdrawal.amount_usdt * 0.84);
+        const reinvestment = roundCurrency(withdrawal.amount_usdt - netAmount);
+        const updated = await store.updateWithdrawal(withdrawal.id, {
+          status: "approved",
+          fulfilled_at: now.toISOString(),
+          net_amount_usdt: netAmount,
+          reinvested_amount_usdt: reinvestment,
+          admin_notes: body.adminNotes ?? withdrawal.admin_notes ?? null,
+        });
+        const shareResult = await recomputeShares(store, withdrawal.cycle_id, now);
+        const share = shareResult.records.find((r) => r.investor_id === withdrawal.investor_id);
+        return ok({
+          ok: true,
+          status: updated?.status ?? "approved",
+          withdrawalId: withdrawal.id,
+          netAmountUsdt: netAmount,
+          reinvestedAmountUsdt: reinvestment,
+          sharePercentage: share?.share_percentage ?? 0,
+          contributionUsdt: share?.contribution_usdt ?? 0,
+        }, req);
+      }
+
+      const amount = Number(body.amount);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        return bad("Invalid amount", undefined, req);
+      }
+      const investor = await ensureInvestor(store, profile.profileId, now);
+      const cycle = await ensureActiveCycle(store, now);
+      const shareResult = await recomputeShares(store, cycle.id, now);
+      const available = shareResult.contributions.get(investor.id) ?? 0;
+      if (available <= 0) {
+        return bad("No active balance", undefined, req);
+      }
+      if (amount > available) {
+        return bad("Requested amount exceeds available balance", undefined, req);
+      }
+      const withdrawal = await store.createWithdrawal({
+        investor_id: investor.id,
+        cycle_id: cycle.id,
+        amount_usdt: roundCurrency(amount),
+        notice_expires_at: addDays(now, 7),
+        requested_at: now.toISOString(),
+        admin_notes: body.notes ?? null,
+      });
+      return ok({
+        ok: true,
+        withdrawalId: withdrawal.id,
+        status: withdrawal.status,
+        cycleId: cycle.id,
+        noticeExpiresAt: withdrawal.notice_expires_at,
+        availableContribution: roundCurrency(available),
+      }, req);
+    } catch (err) {
+      console.error("private-pool-withdraw error", err);
+      return oops("Failed to process withdrawal", err instanceof Error ? err.message : err, req);
+    }
+  };
+}
+
+export const handler = createWithdrawHandler();
+
+registerHandler(handler);
+
+export default handler;

--- a/supabase/migrations/20250915010000_private_fund_pool.sql
+++ b/supabase/migrations/20250915010000_private_fund_pool.sql
@@ -1,0 +1,202 @@
+-- Private Fund Pool schema
+
+-- Enums for cycle and transaction state
+create type public.fund_cycle_status as enum ('active', 'pending_settlement', 'settled');
+create type public.investor_withdrawal_status as enum ('pending', 'approved', 'denied', 'fulfilled');
+create type public.private_pool_deposit_type as enum ('external', 'reinvestment', 'carryover', 'adjustment');
+
+-- Investors mapped to profiles (auth users)
+create table public.investors (
+  id uuid primary key default gen_random_uuid(),
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  status text not null default 'active',
+  joined_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (profile_id)
+);
+
+-- Monthly fund cycle metadata
+create table public.fund_cycles (
+  id uuid primary key default gen_random_uuid(),
+  cycle_month smallint not null check (cycle_month between 1 and 12),
+  cycle_year integer not null check (cycle_year >= 2020),
+  status public.fund_cycle_status not null default 'active',
+  profit_total_usdt numeric(18,2) not null default 0,
+  investor_payout_usdt numeric(18,2) not null default 0,
+  reinvested_total_usdt numeric(18,2) not null default 0,
+  performance_fee_usdt numeric(18,2) not null default 0,
+  payout_summary jsonb not null default '[]'::jsonb,
+  notes text,
+  opened_at timestamptz not null default now(),
+  closed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (cycle_year, cycle_month)
+);
+
+-- Deposit ledger per investor and cycle
+create table public.investor_deposits (
+  id uuid primary key default gen_random_uuid(),
+  investor_id uuid not null references public.investors(id) on delete cascade,
+  cycle_id uuid not null references public.fund_cycles(id) on delete cascade,
+  amount_usdt numeric(18,2) not null check (amount_usdt > 0),
+  tx_hash text,
+  deposit_type public.private_pool_deposit_type not null default 'external',
+  notes text,
+  created_at timestamptz not null default now()
+);
+
+create unique index investor_deposits_tx_hash_unique on public.investor_deposits (tx_hash) where tx_hash is not null;
+create index investor_deposits_investor_idx on public.investor_deposits (investor_id);
+create index investor_deposits_cycle_idx on public.investor_deposits (cycle_id);
+
+-- Withdrawal requests and settlements
+create table public.investor_withdrawals (
+  id uuid primary key default gen_random_uuid(),
+  investor_id uuid not null references public.investors(id) on delete cascade,
+  cycle_id uuid not null references public.fund_cycles(id) on delete cascade,
+  amount_usdt numeric(18,2) not null check (amount_usdt > 0),
+  net_amount_usdt numeric(18,2),
+  reinvested_amount_usdt numeric(18,2),
+  status public.investor_withdrawal_status not null default 'pending',
+  requested_at timestamptz not null default now(),
+  notice_expires_at timestamptz not null default (now() + interval '7 days'),
+  fulfilled_at timestamptz,
+  admin_notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index investor_withdrawals_investor_idx on public.investor_withdrawals (investor_id);
+create index investor_withdrawals_cycle_idx on public.investor_withdrawals (cycle_id);
+create index investor_withdrawals_status_idx on public.investor_withdrawals (status);
+
+-- Share tracking per cycle
+create table public.investor_shares (
+  id uuid primary key default gen_random_uuid(),
+  investor_id uuid not null references public.investors(id) on delete cascade,
+  cycle_id uuid not null references public.fund_cycles(id) on delete cascade,
+  share_percentage numeric(10,6) not null default 0,
+  contribution_usdt numeric(18,2) not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (investor_id, cycle_id)
+);
+
+create index investor_shares_cycle_idx on public.investor_shares (cycle_id);
+create index investor_shares_investor_idx on public.investor_shares (investor_id);
+
+-- Enable RLS
+alter table public.investors enable row level security;
+alter table public.fund_cycles enable row level security;
+alter table public.investor_deposits enable row level security;
+alter table public.investor_withdrawals enable row level security;
+alter table public.investor_shares enable row level security;
+
+-- Helper to check admin role
+create or replace function public.is_profile_admin(profile_id uuid)
+returns boolean
+language sql
+stable security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.profiles p
+    where p.id = profile_id
+      and p.role = 'admin'
+  );
+$$;
+
+-- Investors policies
+create policy "Investors view own record" on public.investors
+for select to authenticated
+using (profile_id = auth.uid());
+
+create policy "Admins manage investors" on public.investors
+for all to authenticated
+using (public.is_profile_admin(auth.uid()))
+with check (public.is_profile_admin(auth.uid()));
+
+create policy "Service role manages investors" on public.investors
+for all to service_role
+using (true)
+with check (true);
+
+-- Fund cycles policies
+create policy "Authenticated view fund cycles" on public.fund_cycles
+for select to authenticated
+using (true);
+
+create policy "Admins manage fund cycles" on public.fund_cycles
+for all to authenticated
+using (public.is_profile_admin(auth.uid()))
+with check (public.is_profile_admin(auth.uid()));
+
+create policy "Service role manages fund cycles" on public.fund_cycles
+for all to service_role
+using (true)
+with check (true);
+
+-- Investor deposit policies
+create policy "Investors view own deposits" on public.investor_deposits
+for select to authenticated
+using (
+  investor_id in (
+    select inv.id from public.investors inv where inv.profile_id = auth.uid()
+  )
+);
+
+create policy "Admins view deposits" on public.investor_deposits
+for select to authenticated
+using (public.is_profile_admin(auth.uid()));
+
+create policy "Service role manages deposits" on public.investor_deposits
+for all to service_role
+using (true)
+with check (true);
+
+-- Investor withdrawal policies
+create policy "Investors view own withdrawals" on public.investor_withdrawals
+for select to authenticated
+using (
+  investor_id in (
+    select inv.id from public.investors inv where inv.profile_id = auth.uid()
+  )
+);
+
+create policy "Admins manage withdrawals" on public.investor_withdrawals
+for all to authenticated
+using (public.is_profile_admin(auth.uid()))
+with check (public.is_profile_admin(auth.uid()));
+
+create policy "Service role manages withdrawals" on public.investor_withdrawals
+for all to service_role
+using (true)
+with check (true);
+
+-- Investor share policies
+create policy "Investors view own shares" on public.investor_shares
+for select to authenticated
+using (
+  investor_id in (
+    select inv.id from public.investors inv where inv.profile_id = auth.uid()
+  )
+);
+
+create policy "Admins view shares" on public.investor_shares
+for select to authenticated
+using (public.is_profile_admin(auth.uid()));
+
+create policy "Service role manages shares" on public.investor_shares
+for all to service_role
+using (true)
+with check (true);
+
+-- Seed an active cycle if none exists
+insert into public.fund_cycles (cycle_month, cycle_year)
+select extract(month from now())::int, extract(year from now())::int
+where not exists (
+  select 1 from public.fund_cycles where status = 'active'
+);


### PR DESCRIPTION
## Summary
- add schema migration for investors, fund cycles, deposits, withdrawals, and share tracking with RLS policies
- implement private pool deposit, withdraw, and settle edge functions with shared business logic
- document the private fund pool API and cover new flows with Deno tests and mocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8daeb08d08322830667ac0dbbe906