### PR TITLE
Organize project checklists

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Modify the files to suit your needs before running the build.
 ## Maintenance & Automation
 
 - Regenerate the documentation inventory after touching edge functions or environment variables with `npm run docs:summary`. The script updates `docs/REPO_SUMMARY.md` so reviewers can confirm every handler exposes a default export and spot any new `Deno.env.get` usage.
+- Review the [Checklist Directory](docs/CHECKLISTS.md) to find the right project, launch, or integration checklist and see which ones have automation keys (`npm run checklists`).
 - Keep `docs/env.md` in sync when introducing deployment settings such as `FUNCTIONS_BASE_URL` or log drain credentials (`LOGTAIL_SOURCE_TOKEN`, `LOGTAIL_URL`). Pair updates with the summary script so both docs reference the same keys.
 - When rotating the Telegram webhook secret, run `deno run -A scripts/set-webhook.ts` (or `deno task set:webhook`) after deploying the updated function to re-register the webhook with BotFather.
 

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -1,0 +1,51 @@
+# Checklist Directory
+
+Dynamic Capital relies on curated checklists to keep workstreams aligned across documentation, code, and deployments. This directory groups the major lists by theme so you can quickly find the right guide and see whether automation is available.
+
+## How to use automation
+
+Run the helper to explore or execute automation-aware checklists:
+
+```bash
+npm run checklists -- --list
+npm run checklists -- --checklist <key> [--include-optional]
+```
+
+Each key maps to a sequence defined in [`scripts/run-checklists.js`](../scripts/run-checklists.js). The helper reads the tables below, resolves the referenced tasks, and runs the associated commands.
+
+## Quick reference
+
+| Checklist | Primary focus | Typical use | Automation key |
+| --- | --- | --- | --- |
+| [`Dynamic Capital Checklist`](./dynamic-capital-checklist.md) | Aggregated repo status and cross-checks | Kick off large initiatives or review overall progress | `dynamic-capital` |
+| [`Coding Efficiency Checklist`](./coding-efficiency-checklist.md) | Day-to-day development hygiene | Scope and deliver individual features or maintenance updates | `coding-efficiency` |
+| [`Once UI Development Checklist`](./once-ui-development-checklist.md) | Frontend/back-end surfaces using Once UI | Build or refactor any Once UI-powered surface (landing, dashboard, mini app shell) | `once-ui` |
+| [`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md) | Environment variables and outbound link audits | Confirm production configuration before toggling features | `variables-and-links` |
+| [`Go Live Checklist`](./GO_LIVE_CHECKLIST.md) | Manual production readiness smoke tests | Validate Telegram webhook flows before launch | `go-live` |
+| [`Launch Checklist`](./LAUNCH_CHECKLIST.md) | Secrets and keeper setup | Harden Supabase edge functions ahead of launch | — |
+| [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md) | Well-architected review for hosted frontends | Audit Vercel deployments for operational readiness | — |
+| [`Automated Trading System Build Checklist`](./automated-trading-checklist.md) | TradingView → Vercel → Supabase → MetaTrader 5 pipeline | Stand up or extend the automated trading stack | — |
+| [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md) | Merging Dynamic Codex into this monorepo | Track integration status across frontend, backend, and tooling | — |
+
+## Project delivery
+
+### Aggregate & iteration checklists
+- **[`Dynamic Capital Checklist`](./dynamic-capital-checklist.md)** – the umbrella tracker that collects repo-level action items and links to every specialized list. Use it for weekly reviews or when coordinating cross-functional workstreams.
+- **[`Coding Efficiency Checklist`](./coding-efficiency-checklist.md)** – a reusable template for feature branches. Copy it into issues or PRs to make sure implementation, testing, and documentation steps land together.
+
+### UI & shared tooling
+- **[`Once UI Development Checklist`](./once-ui-development-checklist.md)** – ensures surfaces built on the Once UI design system follow linting, testing, and build expectations. Includes optional automation for production builds and mini app packaging.
+
+## Launch & production hardening
+- **[`Go Live Checklist`](./GO_LIVE_CHECKLIST.md)** – quick Telegram webhook and Mini App validation steps. Use alongside the `go-live` automation key for repeatable smoke tests.
+- **[`Launch Checklist`](./LAUNCH_CHECKLIST.md)** – enumerates Supabase secrets and keeper tasks required before exposing the bot to end users.
+- **[`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md)** – covers outbound URLs, hostnames, and environment variable drift. Pair it with the automation key `variables-and-links` to run scripted audits.
+- **[`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)** – applies the Vercel Well-Architected review to the hosted frontend. Ideal before handoffs or compliance reviews.
+
+## Specialized projects & integrations
+- **[`Automated Trading System Build Checklist`](./automated-trading-checklist.md)** – sequences the deliverables for the TradingView → Supabase → MetaTrader 5 automation project, from Pine Script alerts to VPS hardening.
+- **[`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)** – documents the remaining work to fold Dynamic Codex into this repository without regressing existing tooling.
+
+## Keep documentation in sync
+
+Update checklists when processes change and reference supporting docs such as [`docs/env.md`](./env.md), [`docs/SETUP_SUMMARY.md`](./SETUP_SUMMARY.md), or service-specific runbooks. When automation is added for a new workflow, record the key and linked tasks here so contributors can discover it quickly.

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -2,14 +2,23 @@
 
 This tracker documents the outstanding work required across the Dynamic Capital project. Check items off as they are completed.
 
-### Automation helper
+> [!TIP] Use the [Checklist Directory](./CHECKLISTS.md) to see how this tracker relates to other project-specific lists and automation keys.
 
-Run `npm run checklists -- --list` to see automation-friendly tasks mapped to this document and related checklists. When you
-need to execute the scripted steps for a section, call the helper with the relevant key, for example `npm run checklists --
---checklist dynamic-capital`. Optional items (long-running builds or smoke tests) are skipped by default; include them with
-`--include-optional`. You can also target individual tasks with `--only <task-id>` or exclude steps with `--skip <task-id>`.
+## Quick navigation
+
+- [Automation helper](#automation-helper)
+- [Repo-Level Action Items](#repo-level-action-items)
+- [Setup Follow-Ups](#setup-follow-ups)
+- [Development & Delivery Guides](#development--delivery-guides)
+- [Launch & Production Readiness](#launch--production-readiness)
+- [Specialized Projects](#specialized-projects)
+
+## Automation helper
+
+Run `npm run checklists -- --list` to see automation-friendly tasks mapped to this document and related checklists. When you need to execute the scripted steps for a section, call the helper with the relevant key—for example `npm run checklists -- --checklist dynamic-capital`. Optional items (long-running builds or smoke tests) are skipped by default; include them with `--include-optional`. You can also target individual tasks with `--only <task-id>` or exclude steps with `--skip <task-id>`. The same helper powers the automation keys highlighted in the [Checklist Directory](./CHECKLISTS.md).
 
 ## Repo-Level Action Items
+
 - [x] Add default exports to all Edge Functions.
 - [x] Build out integration tests for payment and webhook flows.
 - [x] Document expected environment variables and values.
@@ -19,130 +28,31 @@ need to execute the scripted steps for a section, call the helper with the relev
 - [x] Expand the README with setup guidance.
 
 ## Setup Follow-Ups
+
 - [ ] Complete the Supabase CLI workflow (`npx supabase login && supabase link && supabase db push`).
 - [ ] Refresh or open the pending PR ensuring CI checks pass.
 - [ ] Enable auto-merge with the required branch protections.
 - [ ] Run the production sanity test (`/start`, `/plans`, approve test payment) to confirm `current_vip.is_vip`.
 
-## Coding Efficiency Checklist
-### Alignment
-- [ ] Confirm acceptance criteria.
-- [ ] Identify impacted packages and services.
-- [ ] Research existing patterns.
-- [ ] Log questions and risks.
+## Development & Delivery Guides
 
-### Orientation
-- [ ] Review the README.
-- [ ] Review the development workflow.
-- [ ] Review architecture guides.
-- [ ] Draft an implementation plan.
+Use these references to plan individual features and keep day-to-day work aligned with the repo’s tooling standards.
 
-### Environment Preparation
-- [ ] Copy `.env`.
-- [ ] Run `npm run sync-env`.
-- [ ] Start local dependencies.
-- [ ] Run the Lovable dev server.
-- [ ] Start relevant watchers.
+- **[Coding Efficiency Checklist](./coding-efficiency-checklist.md)** – Day-to-day iteration steps covering discovery, environment preparation, implementation, QA, and documentation. Pair with the `coding-efficiency` automation key for scripted verification.
+- **[Once UI Development Checklist](./once-ui-development-checklist.md)** – Frontend and backend guardrails for surfaces built on the Once UI design system. Includes optional automation (`once-ui`) for workspace builds, linting, and mini app packaging.
 
-### Implementation Planning
-- [ ] Reuse shared utilities.
-- [ ] List needed tests.
-- [ ] Gather fixtures.
-- [ ] Decide on configuration, migration, or flag changes.
+## Launch & Production Readiness
 
-### Shared Tooling Practices
-- [ ] Use standard development and build scripts.
-- [ ] Rely on landing-page tooling.
-- [ ] Run monorepo builds.
-- [ ] Consult code-structure and domain runbooks.
+Confirm the deployment posture before exposing new entry points or changes to end users.
 
-### Configuration Hygiene
-- [ ] Cross-check configuration documentation.
-- [ ] Update `docs/env.md` and the variables checklist.
-- [ ] Rerun `npm run sync-env`.
+- **[Go Live Checklist](./GO_LIVE_CHECKLIST.md)** – Manual Telegram webhook and Mini App validation steps. Use the `go-live` automation key to bundle repeatable smoke tests.
+- **[Launch Checklist](./LAUNCH_CHECKLIST.md)** – Supabase secret inventories and keeper scheduling required ahead of production launches.
+- **[Variables and Links Checklist](./VARIABLES_AND_LINKS_CHECKLIST.md)** – Environment variable, hostname, and URL verification. The `variables-and-links` automation key runs the scripted audits that complement the manual review.
+- **[Vercel Production Checklist](./VERCEL_PRODUCTION_CHECKLIST.md)** – Applies the Vercel Well-Architected pillars to hosted frontends so operations, reliability, and cost expectations stay aligned.
 
-### Quality Safeguards
-- [ ] Update tests.
-- [ ] Run fix-and-check scripts.
-- [ ] Execute `npm run verify`.
-- [ ] Hit Supabase endpoints after changes.
-- [ ] Capture manual QA evidence.
+## Specialized Projects
 
-### Documentation and Handoff
-- [ ] Update documentation.
-- [ ] Capture UI artifacts.
-- [ ] Summarize PR decisions with verification output and references.
-- [ ] Rebase, open PR, and monitor CI.
-- [ ] Close out services and branches post-merge.
+Track larger initiatives that span multiple teams or subsystems and copy the detailed checklists into project docs for visibility.
 
-## Automated Trading System Build Checklist
-### TradingView Signal Groundwork
-- [ ] Finalize Pine Script logic.
-- [ ] Add alert payloads.
-- [ ] Upgrade plan.
-- [ ] Create alerts.
-- [ ] Set webhook URL.
-- [ ] Secure secrets.
-
-### Vercel Webhook Receiver
-- [ ] Scaffold the project.
-- [ ] Implement validation.
-- [ ] Parse payloads.
-- [ ] Map to Supabase inserts.
-- [ ] Handle duplicates.
-- [ ] Add logging.
-- [ ] Configure environment variables.
-- [ ] Deploy to production.
-
-### Supabase Backend
-- [ ] Design the schema.
-- [ ] Apply migrations.
-- [ ] Enable Realtime.
-- [ ] Configure policies.
-- [ ] Test inserts.
-- [ ] Document API usage.
-
-### MT5 Expert Advisor
-- [ ] Set up the development environment.
-- [ ] Watch for signals.
-- [ ] Parse signals.
-- [ ] Implement execution and risk controls.
-- [ ] Write back results.
-- [ ] Add error handling.
-- [ ] Backtest and forward-test with Supabase data.
-
-### Hosting and Infrastructure
-- [ ] Provision a VPS.
-- [ ] Harden the server.
-- [ ] Install MT5 and deploy the EA.
-- [ ] Configure monitoring and auto-restart.
-- [ ] Monitor system metrics and logs.
-
-### GitHub and CI/CD Setup
-- [ ] Organize repository artifacts.
-- [ ] Configure CI.
-- [ ] Add deployment workflows.
-- [ ] Establish branch protections and secret management.
-- [ ] Document contribution guidelines.
-
-### End-to-End Validation
-- [ ] Dry-run TradingView → Supabase → MT5.
-- [ ] Verify execution logging.
-- [ ] Set up alerting.
-- [ ] Review latency.
-- [ ] Schedule performance audits.
-
-## Go-Live Checklist
-- [ ] Verify the webhook.
-- [ ] Validate bank approval and manual review paths.
-- [x] Ensure duplicate receipts are blocked.
-- [ ] Confirm crypto confirmation handling.
-- [ ] Test admin commands.
-
-## Variables and Links Checklist
-- [ ] Confirm required secrets and production values.
-- [ ] Validate bot handles.
-- [ ] Remove placeholders.
-- [ ] Ensure `MINI_APP_URL` and other links point to production.
-- [ ] Run edge host and linkage audits.
-- [ ] Double-check Mini App external links.
+- **[Automated Trading System Build Checklist](./automated-trading-checklist.md)** – Sequences the TradingView → Vercel → Supabase → MetaTrader 5 automation effort, from alert payloads to VPS hardening and monitoring.
+- **[Dynamic Codex Integration Checklist](./dynamic_codex_integration_checklist.md)** – Captures the remaining work to fold Dynamic Codex into this monorepo without breaking existing tooling or deployments.


### PR DESCRIPTION
## Summary
- add a dedicated documentation hub that groups major project, launch, and integration checklists with their automation keys
- streamline the Dynamic Capital aggregate checklist so it links to the specialized guides instead of duplicating their content
- surface the checklist directory from the README so contributors can locate the right workflow quickly

## Testing
- npm run checklists -- --list

------
https://chatgpt.com/codex/tasks/task_e_68c8e0366c508322bbaea14a9e405925