### PR TITLE
Add checklist bulk processing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Modify the files to suit your needs before running the build.
 ## Maintenance & Automation
 
 - Regenerate the documentation inventory after touching edge functions or environment variables with `npm run docs:summary`. The script updates `docs/REPO_SUMMARY.md` so reviewers can confirm every handler exposes a default export and spot any new `Deno.env.get` usage.
+- Review the [Checklist Directory](docs/CHECKLISTS.md) to find the right project, launch, or integration checklist and see which ones have automation keys (`npm run checklists`).
 - Keep `docs/env.md` in sync when introducing deployment settings such as `FUNCTIONS_BASE_URL` or log drain credentials (`LOGTAIL_SOURCE_TOKEN`, `LOGTAIL_URL`). Pair updates with the summary script so both docs reference the same keys.
 - When rotating the Telegram webhook secret, run `deno run -A scripts/set-webhook.ts` (or `deno task set:webhook`) after deploying the updated function to re-register the webhook with BotFather.
 

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -1,0 +1,62 @@
+# Checklist Directory
+
+Dynamic Capital relies on curated checklists to keep workstreams aligned across documentation, code, and deployments. This directory groups the major lists by theme so you can quickly find the right guide and see whether automation is available.
+
+## How to use automation
+
+Run the helper to explore or execute automation-aware checklists:
+
+```bash
+npm run checklists -- --list
+npm run checklists -- --checklist <key> [--include-optional]
+```
+
+Each key maps to a sequence defined in [`scripts/run-checklists.js`](../scripts/run-checklists.js). The helper reads the tables below, resolves the referenced tasks, and runs the associated commands.
+
+### Bulk process checklists
+
+Use the bulk processor to audit checklist progress or export open items:
+
+```bash
+npm run checklists:process
+npm run checklists:process -- --state all --format json --output tmp/checklists.json
+```
+
+The script scans Markdown files whose names include `checklist`, groups items by section, and supports `text`, `markdown`, or `json` output so you can review status in bulk or feed another tool.
+
+## Quick reference
+
+| Checklist | Primary focus | Typical use | Automation key |
+| --- | --- | --- | --- |
+| [`Dynamic Capital Checklist`](./dynamic-capital-checklist.md) | Aggregated repo status and cross-checks | Kick off large initiatives or review overall progress | `dynamic-capital` |
+| [`Coding Efficiency Checklist`](./coding-efficiency-checklist.md) | Day-to-day development hygiene | Scope and deliver individual features or maintenance updates | `coding-efficiency` |
+| [`Once UI Development Checklist`](./once-ui-development-checklist.md) | Frontend/back-end surfaces using Once UI | Build or refactor any Once UI-powered surface (landing, dashboard, mini app shell) | `once-ui` |
+| [`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md) | Environment variables and outbound link audits | Confirm production configuration before toggling features | `variables-and-links` |
+| [`Go Live Checklist`](./GO_LIVE_CHECKLIST.md) | Manual production readiness smoke tests | Validate Telegram webhook flows before launch | `go-live` |
+| [`Launch Checklist`](./LAUNCH_CHECKLIST.md) | Secrets and keeper setup | Harden Supabase edge functions ahead of launch | — |
+| [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md) | Well-architected review for hosted frontends | Audit Vercel deployments for operational readiness | — |
+| [`Automated Trading System Build Checklist`](./automated-trading-checklist.md) | TradingView → Vercel → Supabase → MetaTrader 5 pipeline | Stand up or extend the automated trading stack | — |
+| [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md) | Merging Dynamic Codex into this monorepo | Track integration status across frontend, backend, and tooling | — |
+
+## Project delivery
+
+### Aggregate & iteration checklists
+- **[`Dynamic Capital Checklist`](./dynamic-capital-checklist.md)** – the umbrella tracker that collects repo-level action items and links to every specialized list. Use it for weekly reviews or when coordinating cross-functional workstreams.
+- **[`Coding Efficiency Checklist`](./coding-efficiency-checklist.md)** – a reusable template for feature branches. Copy it into issues or PRs to make sure implementation, testing, and documentation steps land together.
+
+### UI & shared tooling
+- **[`Once UI Development Checklist`](./once-ui-development-checklist.md)** – ensures surfaces built on the Once UI design system follow linting, testing, and build expectations. Includes optional automation for production builds and mini app packaging.
+
+## Launch & production hardening
+- **[`Go Live Checklist`](./GO_LIVE_CHECKLIST.md)** – quick Telegram webhook and Mini App validation steps. Use alongside the `go-live` automation key for repeatable smoke tests.
+- **[`Launch Checklist`](./LAUNCH_CHECKLIST.md)** – enumerates Supabase secrets and keeper tasks required before exposing the bot to end users.
+- **[`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md)** – covers outbound URLs, hostnames, and environment variable drift. Pair it with the automation key `variables-and-links` to run scripted audits.
+- **[`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)** – applies the Vercel Well-Architected review to the hosted frontend. Ideal before handoffs or compliance reviews.
+
+## Specialized projects & integrations
+- **[`Automated Trading System Build Checklist`](./automated-trading-checklist.md)** – sequences the deliverables for the TradingView → Supabase → MetaTrader 5 automation project, from Pine Script alerts to VPS hardening.
+- **[`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)** – documents the remaining work to fold Dynamic Codex into this repository without regressing existing tooling.
+
+## Keep documentation in sync
+
+Update checklists when processes change and reference supporting docs such as [`docs/env.md`](./env.md), [`docs/SETUP_SUMMARY.md`](./SETUP_SUMMARY.md), or service-specific runbooks. When automation is added for a new workflow, record the key and linked tasks here so contributors can discover it quickly.

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -2,14 +2,23 @@
 
 This tracker documents the outstanding work required across the Dynamic Capital project. Check items off as they are completed.
 
-### Automation helper
+> [!TIP] Use the [Checklist Directory](./CHECKLISTS.md) to see how this tracker relates to other project-specific lists and automation keys.
 
-Run `npm run checklists -- --list` to see automation-friendly tasks mapped to this document and related checklists. When you
-need to execute the scripted steps for a section, call the helper with the relevant key, for example `npm run checklists --
---checklist dynamic-capital`. Optional items (long-running builds or smoke tests) are skipped by default; include them with
-`--include-optional`. You can also target individual tasks with `--only <task-id>` or exclude steps with `--skip <task-id>`.
+## Quick navigation
+
+- [Automation helper](#automation-helper)
+- [Repo-Level Action Items](#repo-level-action-items)
+- [Setup Follow-Ups](#setup-follow-ups)
+- [Development & Delivery Guides](#development--delivery-guides)
+- [Launch & Production Readiness](#launch--production-readiness)
+- [Specialized Projects](#specialized-projects)
+
+## Automation helper
+
+Run `npm run checklists -- --list` to see automation-friendly tasks mapped to this document and related checklists. When you need to execute the scripted steps for a section, call the helper with the relevant key—for example `npm run checklists -- --checklist dynamic-capital`. Optional items (long-running builds or smoke tests) are skipped by default; include them with `--include-optional`. You can also target individual tasks with `--only <task-id>` or exclude steps with `--skip <task-id>`. The same helper powers the automation keys highlighted in the [Checklist Directory](./CHECKLISTS.md).
 
 ## Repo-Level Action Items
+
 - [x] Add default exports to all Edge Functions.
 - [x] Build out integration tests for payment and webhook flows.
 - [x] Document expected environment variables and values.
@@ -19,130 +28,31 @@ need to execute the scripted steps for a section, call the helper with the relev
 - [x] Expand the README with setup guidance.
 
 ## Setup Follow-Ups
+
 - [ ] Complete the Supabase CLI workflow (`npx supabase login && supabase link && supabase db push`).
 - [ ] Refresh or open the pending PR ensuring CI checks pass.
 - [ ] Enable auto-merge with the required branch protections.
 - [ ] Run the production sanity test (`/start`, `/plans`, approve test payment) to confirm `current_vip.is_vip`.
 
-## Coding Efficiency Checklist
-### Alignment
-- [ ] Confirm acceptance criteria.
-- [ ] Identify impacted packages and services.
-- [ ] Research existing patterns.
-- [ ] Log questions and risks.
+## Development & Delivery Guides
 
-### Orientation
-- [ ] Review the README.
-- [ ] Review the development workflow.
-- [ ] Review architecture guides.
-- [ ] Draft an implementation plan.
+Use these references to plan individual features and keep day-to-day work aligned with the repo’s tooling standards.
 
-### Environment Preparation
-- [ ] Copy `.env`.
-- [ ] Run `npm run sync-env`.
-- [ ] Start local dependencies.
-- [ ] Run the Lovable dev server.
-- [ ] Start relevant watchers.
+- **[Coding Efficiency Checklist](./coding-efficiency-checklist.md)** – Day-to-day iteration steps covering discovery, environment preparation, implementation, QA, and documentation. Pair with the `coding-efficiency` automation key for scripted verification.
+- **[Once UI Development Checklist](./once-ui-development-checklist.md)** – Frontend and backend guardrails for surfaces built on the Once UI design system. Includes optional automation (`once-ui`) for workspace builds, linting, and mini app packaging.
 
-### Implementation Planning
-- [ ] Reuse shared utilities.
-- [ ] List needed tests.
-- [ ] Gather fixtures.
-- [ ] Decide on configuration, migration, or flag changes.
+## Launch & Production Readiness
 
-### Shared Tooling Practices
-- [ ] Use standard development and build scripts.
-- [ ] Rely on landing-page tooling.
-- [ ] Run monorepo builds.
-- [ ] Consult code-structure and domain runbooks.
+Confirm the deployment posture before exposing new entry points or changes to end users.
 
-### Configuration Hygiene
-- [ ] Cross-check configuration documentation.
-- [ ] Update `docs/env.md` and the variables checklist.
-- [ ] Rerun `npm run sync-env`.
+- **[Go Live Checklist](./GO_LIVE_CHECKLIST.md)** – Manual Telegram webhook and Mini App validation steps. Use the `go-live` automation key to bundle repeatable smoke tests.
+- **[Launch Checklist](./LAUNCH_CHECKLIST.md)** – Supabase secret inventories and keeper scheduling required ahead of production launches.
+- **[Variables and Links Checklist](./VARIABLES_AND_LINKS_CHECKLIST.md)** – Environment variable, hostname, and URL verification. The `variables-and-links` automation key runs the scripted audits that complement the manual review.
+- **[Vercel Production Checklist](./VERCEL_PRODUCTION_CHECKLIST.md)** – Applies the Vercel Well-Architected pillars to hosted frontends so operations, reliability, and cost expectations stay aligned.
 
-### Quality Safeguards
-- [ ] Update tests.
-- [ ] Run fix-and-check scripts.
-- [ ] Execute `npm run verify`.
-- [ ] Hit Supabase endpoints after changes.
-- [ ] Capture manual QA evidence.
+## Specialized Projects
 
-### Documentation and Handoff
-- [ ] Update documentation.
-- [ ] Capture UI artifacts.
-- [ ] Summarize PR decisions with verification output and references.
-- [ ] Rebase, open PR, and monitor CI.
-- [ ] Close out services and branches post-merge.
+Track larger initiatives that span multiple teams or subsystems and copy the detailed checklists into project docs for visibility.
 
-## Automated Trading System Build Checklist
-### TradingView Signal Groundwork
-- [ ] Finalize Pine Script logic.
-- [ ] Add alert payloads.
-- [ ] Upgrade plan.
-- [ ] Create alerts.
-- [ ] Set webhook URL.
-- [ ] Secure secrets.
-
-### Vercel Webhook Receiver
-- [ ] Scaffold the project.
-- [ ] Implement validation.
-- [ ] Parse payloads.
-- [ ] Map to Supabase inserts.
-- [ ] Handle duplicates.
-- [ ] Add logging.
-- [ ] Configure environment variables.
-- [ ] Deploy to production.
-
-### Supabase Backend
-- [ ] Design the schema.
-- [ ] Apply migrations.
-- [ ] Enable Realtime.
-- [ ] Configure policies.
-- [ ] Test inserts.
-- [ ] Document API usage.
-
-### MT5 Expert Advisor
-- [ ] Set up the development environment.
-- [ ] Watch for signals.
-- [ ] Parse signals.
-- [ ] Implement execution and risk controls.
-- [ ] Write back results.
-- [ ] Add error handling.
-- [ ] Backtest and forward-test with Supabase data.
-
-### Hosting and Infrastructure
-- [ ] Provision a VPS.
-- [ ] Harden the server.
-- [ ] Install MT5 and deploy the EA.
-- [ ] Configure monitoring and auto-restart.
-- [ ] Monitor system metrics and logs.
-
-### GitHub and CI/CD Setup
-- [ ] Organize repository artifacts.
-- [ ] Configure CI.
-- [ ] Add deployment workflows.
-- [ ] Establish branch protections and secret management.
-- [ ] Document contribution guidelines.
-
-### End-to-End Validation
-- [ ] Dry-run TradingView → Supabase → MT5.
-- [ ] Verify execution logging.
-- [ ] Set up alerting.
-- [ ] Review latency.
-- [ ] Schedule performance audits.
-
-## Go-Live Checklist
-- [ ] Verify the webhook.
-- [ ] Validate bank approval and manual review paths.
-- [x] Ensure duplicate receipts are blocked.
-- [ ] Confirm crypto confirmation handling.
-- [ ] Test admin commands.
-
-## Variables and Links Checklist
-- [ ] Confirm required secrets and production values.
-- [ ] Validate bot handles.
-- [ ] Remove placeholders.
-- [ ] Ensure `MINI_APP_URL` and other links point to production.
-- [ ] Run edge host and linkage audits.
-- [ ] Double-check Mini App external links.
+- **[Automated Trading System Build Checklist](./automated-trading-checklist.md)** – Sequences the TradingView → Vercel → Supabase → MetaTrader 5 automation effort, from alert payloads to VPS hardening and monitoring.
+- **[Dynamic Codex Integration Checklist](./dynamic_codex_integration_checklist.md)** – Captures the remaining work to fold Dynamic Codex into this monorepo without breaking existing tooling or deployments.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "verify": "bash scripts/verify/verify_all.sh",
     "sync-env": "deno run -A scripts/sync-env.ts",
     "checklists": "node scripts/run-checklists.js",
+    "checklists:process": "deno run -A scripts/process-checklists.ts",
     "export": "npm run build",
     "output": "npm -w apps/web run copy-static",
     "supabase:start": "supabase start",

--- a/scripts/process-checklists.ts
+++ b/scripts/process-checklists.ts
@@ -1,0 +1,452 @@
+#!/usr/bin/env -S deno run -A
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface Options {
+  directories: string[];
+  match: string;
+  format: "text" | "markdown" | "json";
+  state: "open" | "done" | "all";
+  output?: string;
+  includeEmpty: boolean;
+  absolute: boolean;
+  help: boolean;
+}
+
+interface ChecklistItem {
+  text: string;
+  state: "open" | "done";
+  line: number;
+  section: string | null;
+}
+
+interface ChecklistReport {
+  absolutePath: string;
+  relativePath: string;
+  summary: {
+    total: number;
+    open: number;
+    done: number;
+  };
+  filteredItems: ChecklistItem[];
+  sections: { name: string; items: ChecklistItem[] }[];
+}
+
+const HELP_TEXT = `Bulk process repository checklists.
+
+Usage: deno run -A scripts/process-checklists.ts [options] [paths]
+
+Options:
+  -d, --dir <path>         Directory to scan (may be repeated). Defaults to docs/.
+  -m, --match <pattern>    File name filter (substring or * wildcard). Default: *checklist*.
+  -f, --format <type>      Output format: text, markdown, json. Default: text.
+  -s, --state <state>      Filter by state: open, done, all. Default: open.
+  -o, --output <path>      Write results to the given file instead of stdout.
+      --absolute           Show absolute paths instead of relative paths.
+      --include-empty      Include checklists with no matching items.
+  -h, --help               Show this help message.
+
+Any additional positional arguments are treated as directories to scan.
+`;
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = {
+    directories: [],
+    match: "*checklist*",
+    format: "text",
+    state: "open",
+    includeEmpty: false,
+    absolute: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--dir":
+      case "-d": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --dir");
+        }
+        i += 1;
+        options.directories.push(value);
+        break;
+      }
+      case "--match":
+      case "-m": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --match");
+        }
+        i += 1;
+        options.match = value;
+        break;
+      }
+      case "--format":
+      case "-f": {
+        const value = argv[i + 1]?.toLowerCase();
+        if (!value) {
+          throw new Error("Missing value for --format");
+        }
+        i += 1;
+        if (value !== "text" && value !== "markdown" && value !== "json") {
+          throw new Error("Unsupported format. Use text, markdown, or json.");
+        }
+        options.format = value as Options["format"];
+        break;
+      }
+      case "--state":
+      case "-s": {
+        const value = argv[i + 1]?.toLowerCase();
+        if (!value) {
+          throw new Error("Missing value for --state");
+        }
+        i += 1;
+        if (value !== "open" && value !== "done" && value !== "all") {
+          throw new Error("Unsupported state. Use open, done, or all.");
+        }
+        options.state = value as Options["state"];
+        break;
+      }
+      case "--output":
+      case "-o": {
+        const value = argv[i + 1];
+        if (!value) {
+          throw new Error("Missing value for --output");
+        }
+        i += 1;
+        options.output = value;
+        break;
+      }
+      case "--absolute": {
+        options.absolute = true;
+        break;
+      }
+      case "--include-empty": {
+        options.includeEmpty = true;
+        break;
+      }
+      case "--help":
+      case "-h": {
+        options.help = true;
+        break;
+      }
+      default: {
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        options.directories.push(arg);
+      }
+    }
+  }
+
+  if (options.directories.length === 0) {
+    options.directories.push("docs");
+  }
+
+  return options;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildMatcher(pattern: string): (name: string) => boolean {
+  if (!pattern || pattern === "*") {
+    return () => true;
+  }
+  if (!pattern.includes("*")) {
+    const needle = pattern.toLowerCase();
+    return (name) => name.toLowerCase().includes(needle);
+  }
+  const regex = new RegExp(
+    `^${pattern.split("*").map(escapeRegExp).join(".*")}$`,
+    "i",
+  );
+  return (name) => regex.test(name);
+}
+
+async function collectFiles(
+  paths: string[],
+  matcher: (name: string) => boolean,
+): Promise<string[]> {
+  const files: string[] = [];
+  const ignored = new Set([
+    ".git",
+    "node_modules",
+    ".next",
+    "dist",
+    "build",
+    "_static",
+    "supabase/.branches",
+  ]);
+
+  const seen = new Set<string>();
+
+  async function walkDir(current: string) {
+    for await (const entry of Deno.readDir(current)) {
+      if (ignored.has(entry.name)) continue;
+      const nextPath = join(current, entry.name);
+      if (entry.isDirectory) {
+        if ([...ignored].some((skip) => nextPath.includes(skip))) continue;
+        await walkDir(nextPath);
+      } else if (entry.isFile) {
+        const name = entry.name;
+        if (!name.toLowerCase().endsWith(".md")) continue;
+        if (!matcher(name)) continue;
+        if (!seen.has(nextPath)) {
+          seen.add(nextPath);
+          files.push(nextPath);
+        }
+      }
+    }
+  }
+
+  for (const pathItem of paths) {
+    const absolute = join(repoRoot, pathItem);
+    try {
+      const stat = await Deno.stat(absolute);
+      if (stat.isDirectory) {
+        await walkDir(absolute);
+      } else if (stat.isFile) {
+        const name = absolute.split("/").pop() ?? absolute;
+        if (
+          name.toLowerCase().endsWith(".md") && matcher(name) &&
+          !seen.has(absolute)
+        ) {
+          seen.add(absolute);
+          files.push(absolute);
+        }
+      }
+    } catch (error) {
+      console.error(`Warning: unable to read ${pathItem}: ${error.message}`);
+    }
+  }
+
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+function parseChecklist(text: string): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+  const lines = text.split(/\r?\n/);
+  let currentSection: string | null = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index];
+    const headingMatch = raw.match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (headingMatch) {
+      currentSection = headingMatch[2].trim();
+      continue;
+    }
+    const checkboxMatch = raw.match(/^\s*[-*]\s+\[( |x|X)\]\s+(.*)$/);
+    if (checkboxMatch) {
+      const state = checkboxMatch[1].toLowerCase() === "x" ? "done" : "open";
+      const textValue = checkboxMatch[2].trim();
+      items.push({
+        text: textValue,
+        state,
+        line: index + 1,
+        section: currentSection,
+      });
+    }
+  }
+  return items;
+}
+
+function filterItems(
+  items: ChecklistItem[],
+  state: Options["state"],
+): ChecklistItem[] {
+  switch (state) {
+    case "open":
+      return items.filter((item) => item.state === "open");
+    case "done":
+      return items.filter((item) => item.state === "done");
+    default:
+      return items.slice();
+  }
+}
+
+function groupBySection(
+  items: ChecklistItem[],
+): { name: string; items: ChecklistItem[] }[] {
+  const order: string[] = [];
+  const map = new Map<string, ChecklistItem[]>();
+  for (const item of items) {
+    const key = item.section ?? "General";
+    if (!map.has(key)) {
+      map.set(key, []);
+      order.push(key);
+    }
+    map.get(key)!.push(item);
+  }
+  return order.map((name) => ({ name, items: map.get(name)! }));
+}
+
+async function generateReport(options: Options): Promise<ChecklistReport[]> {
+  const matcher = buildMatcher(options.match);
+  const files = await collectFiles(options.directories, matcher);
+  const reports: ChecklistReport[] = [];
+
+  for (const file of files) {
+    const text = await Deno.readTextFile(file);
+    const items = parseChecklist(text);
+    const filtered = filterItems(items, options.state);
+    if (filtered.length === 0 && !options.includeEmpty) {
+      continue;
+    }
+    const openCount = items.filter((item) => item.state === "open").length;
+    const doneCount = items.filter((item) => item.state === "done").length;
+    reports.push({
+      absolutePath: file,
+      relativePath: relative(repoRoot, file),
+      summary: {
+        total: items.length,
+        open: openCount,
+        done: doneCount,
+      },
+      filteredItems: filtered,
+      sections: groupBySection(filtered),
+    });
+  }
+
+  return reports;
+}
+
+function renderText(reports: ChecklistReport[], options: Options): string {
+  const lines: string[] = [];
+  lines.push(
+    `Checklist bulk processing summary (${reports.length} file${
+      reports.length === 1 ? "" : "s"
+    })`,
+  );
+  lines.push(`State filter: ${options.state}`);
+  lines.push("");
+  if (reports.length === 0) {
+    lines.push("No checklist items matched the provided filters.");
+    return lines.join("\n");
+  }
+
+  for (const report of reports) {
+    const label = options.absolute ? report.absolutePath : report.relativePath;
+    lines.push(label);
+    lines.push(
+      `  Total: ${report.summary.total} (open: ${report.summary.open}, done: ${report.summary.done})`,
+    );
+    if (report.filteredItems.length === 0) {
+      lines.push("  (no items matched the current state filter)");
+      lines.push("");
+      continue;
+    }
+    for (const section of report.sections) {
+      lines.push(`  ${section.name}:`);
+      for (const item of section.items) {
+        const prefix = item.state === "done" ? "[x]" : "[ ]";
+        lines.push(`    ${prefix} ${item.text} (L${item.line})`);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function renderMarkdown(reports: ChecklistReport[], options: Options): string {
+  const lines: string[] = [];
+  const timestamp = new Date().toISOString();
+  lines.push(`# Checklist Bulk Processing Summary`);
+  lines.push("");
+  lines.push(`- Generated: ${timestamp}`);
+  lines.push(`- State filter: \`${options.state}\``);
+  lines.push(`- Files processed: ${reports.length}`);
+  lines.push("");
+  if (reports.length === 0) {
+    lines.push("No checklist items matched the provided filters.");
+    return lines.join("\n");
+  }
+
+  for (const report of reports) {
+    const label = options.absolute ? report.absolutePath : report.relativePath;
+    lines.push(`## ${label}`);
+    lines.push("");
+    lines.push(`- Total items: ${report.summary.total}`);
+    lines.push(`- Open: ${report.summary.open}`);
+    lines.push(`- Done: ${report.summary.done}`);
+    lines.push("");
+    if (report.filteredItems.length === 0) {
+      lines.push("No items matched the current state filter.");
+      lines.push("");
+      continue;
+    }
+    for (const section of report.sections) {
+      lines.push(`### ${section.name}`);
+      lines.push("");
+      for (const item of section.items) {
+        const prefix = item.state === "done" ? "x" : " ";
+        lines.push(`- [${prefix}] ${item.text} _(L${item.line})_`);
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderJson(reports: ChecklistReport[], options: Options): string {
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    state: options.state,
+    filesProcessed: reports.length,
+    reports: reports.map((report) => ({
+      path: options.absolute ? report.absolutePath : report.relativePath,
+      summary: report.summary,
+      items: report.filteredItems.map((item) => ({
+        text: item.text,
+        state: item.state,
+        line: item.line,
+        section: item.section,
+      })),
+    })),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+async function main() {
+  const options = parseArgs(Deno.args);
+  if (options.help) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  const reports = await generateReport(options);
+  let output: string;
+  switch (options.format) {
+    case "markdown":
+      output = renderMarkdown(reports, options);
+      break;
+    case "json":
+      output = renderJson(reports, options);
+      break;
+    default:
+      output = renderText(reports, options);
+      break;
+  }
+
+  if (options.output) {
+    const target = join(repoRoot, options.output);
+    await Deno.writeTextFile(target, output);
+    console.log(`Wrote checklist report to ${target}`);
+  } else {
+    console.log(output);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Failed to process checklists:", error.message);
+    Deno.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated documentation hub that groups major project, launch, and integration checklists with their automation keys
- streamline the Dynamic Capital aggregate checklist so it links to the specialized guides instead of duplicating their content
- surface the checklist directory from the README so contributors can locate the right workflow quickly
- introduce a Deno-powered bulk checklist processor and npm script so teams can audit multiple lists at once
- document the bulk processor in the checklist directory for quick discovery and export examples

## Testing
- npm run checklists -- --list
- npm run checklists:process -- --state open

------
https://chatgpt.com/codex/tasks/task_e_68c8e0366c508322bbaea14a9e405925