### PR TITLE
Add indexes for Codex Supabase tables

### DIFF
--- a/external/dynamic_codex/README.md
+++ b/external/dynamic_codex/README.md
@@ -43,6 +43,7 @@ The database migration will be automatically applied when you connect to Supabas
 - `messages` table with proper structure
 - Row Level Security (RLS) policies
 - Real-time subscriptions enabled
+- Performance indexes on `messages` and `ea_reports` for fast queries
 
 ### 5. Deploy Edge Functions
 

--- a/external/dynamic_codex/supabase/migrations/20250913123000_add_codex_indexes.sql
+++ b/external/dynamic_codex/supabase/migrations/20250913123000_add_codex_indexes.sql
@@ -1,0 +1,18 @@
+/*
+  Add indexes to optimize telegram Codex tables
+*/
+
+-- Messages table indexes
+CREATE INDEX IF NOT EXISTS idx_messages_created_at_desc
+  ON messages (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_messages_user_id_created_at_desc
+  ON messages (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_messages_date_desc
+  ON messages (date DESC);
+
+-- EA reports table index
+CREATE INDEX IF NOT EXISTS idx_ea_reports_created_at_desc
+  ON ea_reports (created_at DESC);
+


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates descending indexes for the Codex messages and EA report tables
- document that the Codex setup now provisions performance indexes alongside the tables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c924b040a483228a4ec2b7c042af29