### PR TITLE
Handle missing Supabase env for config client

### DIFF
--- a/tests/utils-config-env.test.ts
+++ b/tests/utils-config-env.test.ts
@@ -1,16 +1,19 @@
 import test from 'node:test';
-import { rejects } from 'node:assert/strict';
+import { equal, rejects } from 'node:assert/strict';
 import { freshImport } from './utils/freshImport.ts';
 
-test('utils/config requires Supabase env vars', async () => {
+const CONFIG_DISABLED = /Supabase configuration is missing/;
+
+test('utils/config falls back to defaults when Supabase env vars are missing', async () => {
   const prevUrl = process.env.SUPABASE_URL;
   const prevKey = process.env.SUPABASE_ANON_KEY;
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_ANON_KEY;
-  await rejects(
-    freshImport(new URL('../apps/web/utils/config.ts', import.meta.url)),
-    /Missing required env: SUPABASE_URL/,
+  const { configClient } = await freshImport(
+    new URL('../apps/web/utils/config.ts', import.meta.url),
   );
+  equal(await configClient.getFlag('test_feature', true), true);
+  await rejects(configClient.setFlag('test_feature', true), CONFIG_DISABLED);
   if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl; else delete process.env.SUPABASE_URL;
   if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey; else delete process.env.SUPABASE_ANON_KEY;
 });
@@ -20,10 +23,11 @@ test('utils/config rejects null-like env values', async () => {
   const prevKey = process.env.SUPABASE_ANON_KEY;
   process.env.SUPABASE_URL = 'null';
   process.env.SUPABASE_ANON_KEY = 'undefined';
-  await rejects(
-    freshImport(new URL('../apps/web/utils/config.ts', import.meta.url)),
-    /Missing required env: SUPABASE_URL/,
+  const { configClient } = await freshImport(
+    new URL('../apps/web/utils/config.ts', import.meta.url),
   );
+  equal(await configClient.getFlag('test_feature', false), false);
+  await rejects(configClient.publish(), CONFIG_DISABLED);
   if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl; else delete process.env.SUPABASE_URL;
   if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey; else delete process.env.SUPABASE_ANON_KEY;
 });


### PR DESCRIPTION
## Summary
- fall back to stub Supabase configuration when env vars are missing and disable remote config calls
- ensure config client returns safe defaults and surfaces helpful errors when Supabase is unavailable
- update config env tests to cover the new fallback behavior and null-like env values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9304024bc8322ab29c25c2132d6fe