### PR TITLE
Add CLI support for scaffolding AlgoKit functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Modify the files to suit your needs before running the build.
 - Review the [Checklist Directory](docs/CHECKLISTS.md) to find the right project, launch, or integration checklist and see which ones have automation keys (`npm run checklists`).
 - Keep `docs/env.md` in sync when introducing deployment settings such as `FUNCTIONS_BASE_URL` or log drain credentials (`LOGTAIL_SOURCE_TOKEN`, `LOGTAIL_URL`). Pair updates with the summary script so both docs reference the same keys.
 - When rotating the Telegram webhook secret, run `deno run -A scripts/set-webhook.ts` (or `deno task set:webhook`) after deploying the updated function to re-register the webhook with BotFather.
+- Scaffold AlgoKit runtime functions with `python tools/algo-cli/algokit.py function strategy-name --lang both` to create matching Python and TypeScript stubs from the command line.
 
 ## Development Process Overview
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -202,6 +202,7 @@ The Dynamic Capital project is now integrated with **Lovable Codex** for enhance
 - Request specific debugging information via chat
 - Ask for code explanations and optimization suggestions
 - Request new feature implementations with detailed specifications
+- Scaffold AlgoKit runtime functions via `python tools/algo-cli/algokit.py function <name> --lang both`
 
 ### Integration with GitHub
 - **Bidirectional Sync**: Changes in Codex automatically sync to GitHub


### PR DESCRIPTION
## Summary
- add a `function` subcommand to `tools/algo-cli/algokit.py` for generating synced Python/TypeScript stubs
- automatically create runtime package helpers and update the TypeScript entrypoint when scaffolding functions
- document the new command in the README and agent workflow guide

## Testing
- python tools/algo-cli/algokit.py --help
- python tools/algo-cli/algokit.py init demo-bot --dry-run
- tmpdir=$(mktemp -d); python tools/algo-cli/algokit.py init sample-bot --directory "$tmpdir"; python tools/algo-cli/algokit.py function momentum-signal --project "$tmpdir/sample-bot" --lang both

------
https://chatgpt.com/codex/tasks/task_e_68c93018bfc48322ab044423410f32ac