### PR TITLE
Enhance Codex workflow helper issue tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ miniapp/
 # Miscellaneous
 *.local
 bun.lockb
+.codex-workflow-state.json

--- a/README.md
+++ b/README.md
@@ -458,12 +458,17 @@ npm run codex:post-pull -- --verify            # run verification after syncing
 npm run codex:post-pull -- --no-build          # skip the Lovable build step
 npm run codex:dev -- --no-sync                 # keep existing env values
 npm run codex:post-pull -- --dry-run           # list steps without executing
+npm run codex:post-pull -- --reset-issues      # clear cached failure history & tips
 ```
 
 Available flags mirror the helper's usage (`--no-install`, `--no-sync`,
 `--no-env-check`, `--build-optional`, etc.). See
 `scripts/codex-workflow.js --help` for the full reference, and read
 `docs/codex_cli_workflow.md` for a deeper walkthrough of recommended flows.
+
+The helper remembers which steps failed recently so it can surface
+troubleshooting tips the next time you run it. If you want to start fresh,
+pass `--reset-issues` to clear that history before executing tasks.
 
 Note: for OCR parsing, send an actual Telegram image to the bot; OCR runs only
 on images.

--- a/docs/codex_cli_workflow.md
+++ b/docs/codex_cli_workflow.md
@@ -27,8 +27,14 @@ Common flags accepted by the helper:
 - `--build-optional` – treat build failures as warnings.
 - `--verify` – run `npm run verify` after the post-pull steps.
 - `--dry-run` – preview the steps without executing commands.
+- `--reset-issues` – clear the cached failure history before running tasks again.
 
 Run `scripts/codex-workflow.js --help` to see the full list of options.
+
+The helper keeps a small JSON file (`.codex-workflow-state.json`, ignored by
+Git) that tracks which steps failed recently. When a task fails multiple times,
+the CLI surfaces targeted troubleshooting tips before the next run. Use
+`--reset-issues` if you want to discard that history and silence the reminders.
 
 ## Suggested workflow
 

--- a/scripts/codex-workflow.js
+++ b/scripts/codex-workflow.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -29,8 +29,53 @@ const optionalBuild = flags.has('--build-optional') || flags.has('--optional-bui
 const runVerify = flags.has('--verify');
 const skipVerify = flags.has('--no-verify');
 const dryRun = flags.has('--dry-run');
+const resetIssues = flags.has('--reset-issues') || flags.has('--clear-issues');
 
 const hasNodeModules = existsSync(path.join(repoRoot, 'node_modules'));
+const stateFile = path.join(repoRoot, '.codex-workflow-state.json');
+
+let state = loadState();
+
+if (resetIssues) {
+  if (Object.keys(state.failures).length > 0) {
+    console.log('♻️  Clearing stored Codex workflow issue history.');
+  }
+  state = { failures: {} };
+  saveState(state);
+}
+
+const troubleshootingTips = {
+  'npm install': [
+    'Delete `node_modules` if the tree looks corrupted and reinstall.',
+    'Ensure your Node.js version matches `.nvmrc` (try `nvm use`).',
+    'If lockfile conflicts persist, run `npm ci` from a clean checkout.',
+  ],
+  'npm run sync-env': [
+    'Verify `.env.local` exists and is writable before syncing.',
+    'Re-run `npm install` to make sure the sync script dependencies are available.',
+    'If the Supabase CLI is required, install it via `npm install supabase --global` or use `npx supabase`.',
+  ],
+  'npx tsx scripts/check-env.ts': [
+    'Double-check required environment variables in `.env.local` or the active shell.',
+    'Run `npm run sync-env` to copy placeholders from `.env.example`.',
+    'Use `--no-env-check` temporarily only if you know the missing variables are safe to ignore.',
+  ],
+  'node lovable-build.js': [
+    'Inspect the preceding Next.js or mini app build output for the root error.',
+    'Try `npm run build` directly to reproduce the failure outside the helper.',
+    'Use `--build-optional` if you only need to unblock other steps while debugging the build.',
+  ],
+  'npm run verify': [
+    'Run `npm run lint` and `npm test` individually to narrow down the failure.',
+    'Check generated snapshots or formatting—`npm run format` may resolve lint issues.',
+    'Inspect the full verify logs for the exact command that failed and rerun it locally.',
+  ],
+  'node lovable-dev.js': [
+    'Ensure no other dev server is already running on the same port.',
+    'Reset environment variables if the dev server exits immediately.',
+    'Review the terminal output above for stack traces from the Next.js dev server.',
+  ],
+};
 
 const tasksByMode = {
   'post-pull': () => [
@@ -103,6 +148,9 @@ console.log(`🧰 Codex workflow helper running in "${mode}" mode.`);
 if (flags.size > 0) {
   console.log(`   Flags: ${[...flags].join(', ')}`);
 }
+
+announceRecurringIssues(tasks, state);
+
 if (dryRun) {
   console.log('🔎 Dry run enabled. Listing planned steps without executing them:');
   tasks.forEach((task, idx) => {
@@ -111,36 +159,202 @@ if (dryRun) {
   process.exit(0);
 }
 
-runTasks(tasks);
+runTasks(tasks, state);
 console.log('\n🎉 Codex workflow tasks completed.');
 
 function command(label, cmd, options = {}) {
-  const { optional = false, skip = false } = options;
+  const { optional = false, skip = false, key } = options;
   if (skip) return null;
-  return { label, cmd, optional };
+  return { label, cmd, optional, key: key ?? cmd };
 }
 
-function runTasks(taskList) {
-  taskList.forEach((task, index) => {
+function runTasks(taskList, currentState) {
+  for (let index = 0; index < taskList.length; index += 1) {
+    const task = taskList[index];
     const step = index + 1;
+    const key = taskKey(task);
+    const hadPreviousFailures = Boolean(currentState.failures[key]);
+
     console.log(`\n➡️  Step ${step}/${taskList.length}: ${task.label}`);
     try {
       execSync(task.cmd, { stdio: 'inherit', shell: true });
       console.log(`✅ ${task.label}`);
-    } catch (error) {
-      if (task.optional) {
-        console.warn(`⚠️  ${task.label} failed (optional).`, error?.message ?? '');
-      } else {
-        console.error(`❌ ${task.label} failed.`);
-        if (error?.status) {
-          process.exit(error.status);
-        }
-        process.exit(1);
+      if (recordSuccess(currentState, task) && hadPreviousFailures) {
+        console.log('   ℹ️  Previous issues for this step have been cleared.');
       }
+    } catch (error) {
+      const failureRecord = recordFailure(currentState, task, error);
+      const recurrenceNotice =
+        failureRecord.count > 1 ? ` (seen ${failureRecord.count} times)` : '';
+
+      if (task.optional) {
+        console.warn(`⚠️  ${task.label} failed (optional)${recurrenceNotice}.`, error?.message ?? '');
+        printTroubleshootingTips(task, {
+          header: 'Optional step troubleshooting tips:',
+        });
+        continue;
+      }
+
+      console.error(`❌ ${task.label} failed${recurrenceNotice}.`);
+      if (failureRecord.lastMessage) {
+        console.error(`   Last error: ${failureRecord.lastMessage}`);
+      }
+      printTroubleshootingTips(task, {
+        header: 'Quick troubleshooting tips:',
+      });
+      saveState(currentState);
+      if (error?.status) {
+        process.exit(error.status);
+      }
+      process.exit(1);
     }
-  });
+  }
+
+  saveState(currentState);
 }
 
 function printUsage() {
-  console.log(`Codex CLI workflow helper\n\nUsage: node scripts/codex-workflow.js [mode] [flags]\n\nModes:\n  post-pull (default)  Prepare the repo after pulling from Codex CLI.\n  dev                  Sync env and start Lovable dev server.\n  build                Run env checks and Lovable build.\n  verify               Run the verification suite.\n\nFlags:\n  --no-install         Skip \`npm install\` (post-pull).\n  --no-sync            Skip \`npm run sync-env\`.\n  --no-env-check       Skip env validation (not recommended).\n  --no-build           Skip Lovable build (post-pull/build).\n  --build-optional     Treat Lovable build failures as warnings.\n  --verify             Run \`npm run verify\` after post-pull steps.\n  --no-verify          Skip verify step even if --verify provided.\n  --dry-run            Show planned steps without executing.\n  --help, -h           Show this message.\n`);
+  console.log(`Codex CLI workflow helper\n\nUsage: node scripts/codex-workflow.js [mode] [flags]\n\nModes:\n  post-pull (default)  Prepare the repo after pulling from Codex CLI.\n  dev                  Sync env and start Lovable dev server.\n  build                Run env checks and Lovable build.\n  verify               Run the verification suite.\n\nFlags:\n  --no-install         Skip \`npm install\` (post-pull).\n  --no-sync            Skip \`npm run sync-env\`.\n  --no-env-check       Skip env validation (not recommended).\n  --no-build           Skip Lovable build (post-pull/build).\n  --build-optional     Treat Lovable build failures as warnings.\n  --verify             Run \`npm run verify\` after post-pull steps.\n  --no-verify          Skip verify step even if --verify provided.\n  --dry-run            Show planned steps without executing.\n  --reset-issues       Clear stored failure history for Codex workflow steps.\n  --help, -h           Show this message.\n`);
+}
+
+function taskKey(task) {
+  return task.key ?? task.cmd;
+}
+
+function loadState() {
+  if (!existsSync(stateFile)) {
+    return { failures: {} };
+  }
+
+  try {
+    const contents = readFileSync(stateFile, 'utf8');
+    const parsed = JSON.parse(contents);
+    if (!parsed || typeof parsed !== 'object') {
+      return { failures: {} };
+    }
+    if (!parsed.failures || typeof parsed.failures !== 'object') {
+      parsed.failures = {};
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('⚠️  Unable to read Codex workflow state. Starting fresh.', error?.message ?? error);
+    return { failures: {} };
+  }
+}
+
+function saveState(nextState) {
+  const failures = nextState.failures ?? {};
+  const keys = Object.keys(failures);
+  if (keys.length === 0) {
+    if (existsSync(stateFile)) {
+      rmSync(stateFile);
+    }
+    return;
+  }
+
+  try {
+    writeFileSync(stateFile, JSON.stringify({ failures }, null, 2));
+  } catch (error) {
+    console.warn('⚠️  Failed to persist Codex workflow state.', error?.message ?? error);
+  }
+}
+
+function recordFailure(currentState, task, error) {
+  const key = taskKey(task);
+  const failures = currentState.failures ?? {};
+  const existing = failures[key] ?? { count: 0 };
+  const message = extractErrorSnippet(error);
+
+  const updated = {
+    ...existing,
+    count: (existing.count ?? 0) + 1,
+    label: task.label,
+    lastStatus: typeof error?.status === 'number' ? error.status : null,
+    lastFailure: new Date().toISOString(),
+    lastMessage: message,
+  };
+
+  failures[key] = updated;
+  currentState.failures = failures;
+  return updated;
+}
+
+function recordSuccess(currentState, task) {
+  const key = taskKey(task);
+  const failures = currentState.failures ?? {};
+  if (failures[key]) {
+    delete failures[key];
+    currentState.failures = failures;
+    return true;
+  }
+  return false;
+}
+
+function extractErrorSnippet(error) {
+  if (!error) return undefined;
+  const candidates = [error.stderr, error.stdout, error.message];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const text = Buffer.isBuffer(candidate) ? candidate.toString() : String(candidate);
+    const snippet = text
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+    if (snippet) {
+      return snippet.length > 200 ? `${snippet.slice(0, 197)}...` : snippet;
+    }
+  }
+  return undefined;
+}
+
+function announceRecurringIssues(taskList, currentState) {
+  const problems = [];
+  for (const task of taskList) {
+    const key = taskKey(task);
+    const failure = currentState.failures?.[key];
+    if (failure && failure.count >= 2) {
+      problems.push({ task, failure });
+    }
+  }
+
+  if (problems.length === 0) {
+    return;
+  }
+
+  console.log('\n🔁 Repeated Codex workflow issues detected:');
+  for (const { task, failure } of problems) {
+    const when = failure.lastFailure ? formatTimestamp(failure.lastFailure) : 'recently';
+    console.log(`   • ${task.label} has failed ${failure.count} times (last seen ${when}).`);
+    if (failure.lastMessage) {
+      console.log(`     Last error: ${failure.lastMessage}`);
+    }
+    printTroubleshootingTips(task, {
+      indent: '     ',
+      header: 'Common fixes to try:',
+    });
+  }
+}
+
+function formatTimestamp(iso) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+
+  return date.toLocaleString();
+}
+
+function printTroubleshootingTips(task, options = {}) {
+  const { indent = '   ', header = 'Troubleshooting tips:' } = options;
+  const key = taskKey(task);
+  const tips =
+    troubleshootingTips[key] || troubleshootingTips[task.cmd] || troubleshootingTips[task.label];
+  if (!tips || tips.length === 0) {
+    return;
+  }
+
+  console.log(`${indent}💡 ${header}`);
+  tips.forEach((tip) => {
+    console.log(`${indent}   - ${tip}`);
+  });
 }


### PR DESCRIPTION
## Summary
- add persistent failure tracking to the Codex workflow helper so repeated steps surface targeted troubleshooting tips and can be cleared with a new `--reset-issues` flag
- ignore the generated `.codex-workflow-state.json` state file and document the new flag and guidance in the README and Codex CLI workflow docs

## Testing
- node scripts/codex-workflow.js --help
- node scripts/codex-workflow.js post-pull --dry-run
- node scripts/codex-workflow.js post-pull --dry-run --reset-issues

------
https://chatgpt.com/codex/tasks/task_e_68c936a218ec8322b9c6602c09e84065