### PR TITLE
Fix envOrSetting sanitization for server configurations

### DIFF
--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -1,4 +1,5 @@
 import { createClient } from "./client.ts";
+import { maybe } from "./env.ts";
 
 // In-memory fallback map when kv_config table is unavailable
 const memStore = new Map<string, unknown>();
@@ -131,7 +132,7 @@ async function envOrSetting<T = string>(
   envKey: string,
   settingKey = envKey,
 ): Promise<T | null> {
-  const envVal = Deno.env.get(envKey);
+  const envVal = maybe(envKey);
   if (envVal != null) return envVal as unknown as T;
   return await getSetting<T>(settingKey);
 }

--- a/tests/config-softcode.test.ts
+++ b/tests/config-softcode.test.ts
@@ -2,6 +2,9 @@ import test from 'node:test';
 import { equal as assertEquals } from 'node:assert/strict';
 
 test('envOrSetting prefers env over bot_setting', async () => {
+  const prevUrl = process.env.SUPABASE_URL;
+  const prevAnon = process.env.SUPABASE_ANON_KEY;
+  const prevService = process.env.SUPABASE_SERVICE_ROLE_KEY;
   process.env.SUPABASE_URL = 'https://example.com';
   process.env.SUPABASE_ANON_KEY = 'anon';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
@@ -13,4 +16,35 @@ test('envOrSetting prefers env over bot_setting', async () => {
   assertEquals(val, 'env-value');
   cfg.__setGetSetting(original);
   delete process.env.EXAMPLE_KEY;
+  if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl;
+  else delete process.env.SUPABASE_URL;
+  if (prevAnon !== undefined) process.env.SUPABASE_ANON_KEY = prevAnon;
+  else delete process.env.SUPABASE_ANON_KEY;
+  if (prevService !== undefined) {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = prevService;
+  } else delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+});
+
+test('envOrSetting ignores null-like env values', async () => {
+  const prevUrl = process.env.SUPABASE_URL;
+  const prevAnon = process.env.SUPABASE_ANON_KEY;
+  const prevService = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.SUPABASE_URL = 'https://example.com';
+  process.env.SUPABASE_ANON_KEY = 'anon';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
+  const cfg = await import(/* @vite-ignore */ "../supabase/functions/_shared/config.ts");
+  process.env.EXAMPLE_KEY = 'null';
+  const original = cfg.getSetting;
+  cfg.__setGetSetting((async () => 'db-value') as typeof cfg.getSetting);
+  const val = await cfg.envOrSetting('EXAMPLE_KEY', 'EXAMPLE_KEY');
+  assertEquals(val, 'db-value');
+  cfg.__setGetSetting(original);
+  delete process.env.EXAMPLE_KEY;
+  if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl;
+  else delete process.env.SUPABASE_URL;
+  if (prevAnon !== undefined) process.env.SUPABASE_ANON_KEY = prevAnon;
+  else delete process.env.SUPABASE_ANON_KEY;
+  if (prevService !== undefined) {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = prevService;
+  } else delete process.env.SUPABASE_SERVICE_ROLE_KEY;
 });


### PR DESCRIPTION
## Summary
- sanitize env-backed server configuration lookups using the shared helper
- add a regression test to ensure null-like env values fall back to stored settings
- reset Supabase env overrides in config tests to avoid leakage across cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c947aec8f88322a8a15801c71a06d4