### PR TITLE
Add shared Node environment helper

### DIFF
--- a/apps/web/app/healthz/route.ts
+++ b/apps/web/app/healthz/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
+import { NODE_ENV } from '@/config/node-env';
 
 export async function GET() {
   return NextResponse.json({ 
     status: 'ok', 
     timestamp: new Date().toISOString(),
-    environment: process.env.NODE_ENV
+    environment: NODE_ENV
   });
 }

--- a/apps/web/config/node-env.ts
+++ b/apps/web/config/node-env.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared helper for determining the current runtime environment.
+ * Supports both Node (process.env) and Deno (Deno.env) execution contexts.
+ */
+
+declare const process:
+  | { env?: Record<string, string | undefined> }
+  | undefined;
+declare const Deno:
+  | { env?: { get(name: string): string | undefined } }
+  | undefined;
+
+type NodeEnv = 'development' | 'test' | 'production';
+
+function sanitize(value: string | undefined | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const lower = trimmed.toLowerCase();
+  if (lower === 'undefined' || lower === 'null') {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function readEnv(name: string): string | undefined {
+  if (typeof process !== 'undefined' && process?.env) {
+    const value = process.env[name];
+    if (typeof value === 'string') return value;
+  }
+  if (typeof Deno !== 'undefined' && typeof Deno.env?.get === 'function') {
+    try {
+      const value = Deno.env.get(name);
+      if (typeof value === 'string') return value;
+    } catch {
+      // Access to Deno.env may be restricted in some contexts; ignore.
+    }
+  }
+  return undefined;
+}
+
+function resolveNodeEnv(): NodeEnv {
+  const raw = sanitize(readEnv('NODE_ENV'))?.toLowerCase();
+  switch (raw) {
+    case 'production':
+      return 'production';
+    case 'test':
+      return 'test';
+    default:
+      return 'development';
+  }
+}
+
+export const NODE_ENV: NodeEnv = resolveNodeEnv();
+export const isProduction = NODE_ENV === 'production';
+export const isDevelopment = NODE_ENV === 'development';
+export const isTest = NODE_ENV === 'test';
+
+export type { NodeEnv };

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,4 +1,5 @@
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { isProduction } from '@/config/node-env';
 
 export async function register() {
   // Ensure Next.js' OpenTelemetry context is registered first to avoid null context errors
@@ -12,10 +13,7 @@ export async function register() {
   registerInstrumentations({ instrumentations: [] });
 
   // Only enable Sentry when explicitly requested and not during production build
-  if (
-    process.env.NODE_ENV === 'production' ||
-    process.env.ENABLE_SENTRY !== 'true'
-  ) {
+  if (isProduction || process.env.ENABLE_SENTRY !== 'true') {
     return;
   }
 

--- a/apps/web/utils/logger.ts
+++ b/apps/web/utils/logger.ts
@@ -1,3 +1,5 @@
+import { isProduction } from '@/config/node-env';
+
 // Allow running in both Node and Deno environments
 declare const Deno: { env?: { get(name: string): string | undefined } } | undefined;
 
@@ -11,7 +13,7 @@ function getEnv(name: string): string | undefined {
   return undefined;
 }
 
-const defaultLevel = getEnv('NODE_ENV') !== 'production' ? 'debug' : 'info';
+const defaultLevel = isProduction ? 'info' : 'debug';
 type Level = 'debug' | 'info' | 'warn' | 'error';
 const levelWeights: Record<Level, number> = {
   debug: 10,

--- a/tests/node-env-config.test.ts
+++ b/tests/node-env-config.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import { equal as assertEqual } from 'node:assert/strict';
+import { freshImport } from './utils/freshImport.ts';
+
+const importNodeEnv = async () => {
+  const moduleUrl = new URL('../apps/web/config/node-env.ts', import.meta.url);
+  return await freshImport(moduleUrl);
+};
+
+async function withNodeEnv(value: string | undefined, run: () => Promise<void>) {
+  const original = process.env.NODE_ENV;
+  if (value === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = value;
+  }
+  try {
+    await run();
+  } finally {
+    if (original === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = original;
+    }
+  }
+}
+
+test('defaults to development when NODE_ENV missing', async () => {
+  await withNodeEnv(undefined, async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'development');
+    assertEqual(mod.isDevelopment, true);
+    assertEqual(mod.isProduction, false);
+    assertEqual(mod.isTest, false);
+  });
+});
+
+test('recognizes production NODE_ENV', async () => {
+  await withNodeEnv('production', async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'production');
+    assertEqual(mod.isProduction, true);
+    assertEqual(mod.isDevelopment, false);
+  });
+});
+
+test('unknown NODE_ENV values fallback to development', async () => {
+  await withNodeEnv('staging', async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'development');
+    assertEqual(mod.isDevelopment, true);
+  });
+});
+
+test('recognizes test NODE_ENV values regardless of casing', async () => {
+  await withNodeEnv(' TEST ', async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'test');
+    assertEqual(mod.isTest, true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper that normalizes NODE_ENV across Node and Deno runtimes
- update logger, health check, and instrumentation modules to rely on the centralized environment helper
- cover the helper with node-based tests to lock in expected behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c97d0172888322b6dbf66869fdaff7