### PR TITLE
chore: scaffold algorithm workspaces

### DIFF
--- a/algorithms/README.md
+++ b/algorithms/README.md
@@ -1,0 +1,19 @@
+# Algorithm Development Workspace
+
+This directory tree groups together all source code and artifacts required for the
+TradingView → Vercel → Supabase → MetaTrader 5 automation pipeline. Each
+sub-folder is intentionally scoped so that strategy builders, automation
+engineers, and QA can collaborate without stepping on each other's toes.
+
+## Directory Overview
+
+- `pine-script/` – TradingView strategy and indicator source files, including
+  alert payload documentation and reusable include snippets.
+- `vercel-webhook/` – Vercel serverless function project used to ingest webhook
+  alerts and forward structured events into Supabase.
+- `mql5/` – MetaTrader 5 Expert Advisor implementation, supporting libraries,
+  and backtesting artifacts.
+
+Refer to the README in each sub-folder for layout details, build commands, and
+handoff expectations between teams. Supabase database migrations and functions
+remain in the top-level `supabase/` directory.

--- a/algorithms/mql5/README.md
+++ b/algorithms/mql5/README.md
@@ -1,0 +1,27 @@
+# MetaTrader 5 Expert Advisor Workspace
+
+Store the Expert Advisor (EA) implementation and supporting tooling in this
+folder. Keeping the MQL5 source alongside its backtesting artifacts ensures the
+trading logic remains auditable.
+
+## Proposed Structure
+
+```
+mql5/
+├── Experts/
+│   └── DynamicCapitalEA.mq5     # Primary EA entry point
+├── Include/                     # Shared classes and utilities (.mqh)
+├── Tests/                       # Strategy Tester presets, results, reports
+├── Docs/                        # Runbooks, deployment notes, changelog
+└── tools/                       # Scripts for builds, linting, CI helpers
+```
+
+Create folders as the EA evolves—MetaTrader only recognizes the `Experts/` and
+`Include/` casing above.
+
+## Handoff Requirements
+
+- Document how the EA retrieves signals from Supabase (polling vs. websockets).
+- Provide compilation instructions (`metaeditor` CLI or Docker-based builds).
+- Capture both backtest and forward-test evidence in `Tests/` for audit trails.
+- Note any secrets or environment variables required on the VPS host.

--- a/algorithms/pine-script/README.md
+++ b/algorithms/pine-script/README.md
@@ -1,0 +1,31 @@
+# Pine Script Workspace
+
+Use this folder to manage every TradingView deliverable that powers the Dynamic
+Capital automation loop.
+
+## Suggested Layout
+
+```
+pine-script/
+├── strategies/        # Primary strategy files (.pine)
+├── indicators/        # Supporting indicator scripts
+├── includes/          # Shared functions/importable snippets
+├── alerts/            # Example alert JSON payloads and docs
+└── tests/             # Backtest exports, validation notebooks, etc.
+```
+
+Create the sub-folders above as you add real assets. Keeping strategy,
+indicator, and helper code split makes it easier to hand off artifacts to the
+automation and EA teams.
+
+## Naming Guidelines
+
+- Use semantic filenames, e.g. `momentum_breakout_strategy.pine`.
+- Keep strategy version history in Git; avoid appending `v2` to filenames.
+- Document alert payload fields in `alerts/README.md` once implemented.
+
+## Next Steps
+
+1. Finalize the TradingView strategy/indicator logic.
+2. Document webhook alert JSON payloads so the Vercel function can parse them.
+3. Commit exported backtests or validation notes inside `tests/` for QA.

--- a/algorithms/vercel-webhook/README.md
+++ b/algorithms/vercel-webhook/README.md
@@ -1,0 +1,27 @@
+# Vercel Webhook Receiver Workspace
+
+Place the TradingView webhook ingestion project in this directory. The goal is
+to keep the serverless function isolated and reproducible so it can be deployed
+independently of the rest of the app.
+
+## Recommended Project Skeleton
+
+```
+vercel-webhook/
+├── api/
+│   └── tradingview-alerts.ts   # Primary Vercel function handler
+├── lib/                        # Shared validation/normalization helpers
+├── tests/                      # Unit/integration tests (Vitest, Jest, etc.)
+├── vercel.json                 # Function routing configuration
+└── README.md                   # Deployment/runbook notes
+```
+
+## Implementation Checklist
+
+- Validate shared secret or signature headers before processing payloads.
+- Normalize symbol names and map fields to Supabase inserts.
+- Provide retry-safe idempotency handling for rapid alerts.
+- Log structured events so downstream monitoring can parse them.
+
+Document build commands, environment variables, and deployment steps once the
+project is scaffolded.

--- a/docs/REPO_INVENTORY.md
+++ b/docs/REPO_INVENTORY.md
@@ -62,3 +62,7 @@ _Last updated: 2025-09-15 (UTC)._
 | `apps/web/app/telegram/` | Telegram bot dashboard route now served from the main Next.js build.【F:apps/web/app/telegram/page.tsx†L1-L11】 |
 | `db/` | TypeScript database client/schema utilities.【ddbcb5†L1-L2】 |
 | `Procfile` | Platform startup definition pointing at the Next.js standalone server build.【1512da†L1-L2】 |
+
+## 7. Trading automation scaffolding
+
+- **`algorithms/`** – Workspace for the TradingView Pine Script strategies, Vercel webhook receiver, and MetaTrader 5 Expert Advisor. Each sub-folder ships with a README that outlines recommended structure, handoff expectations, and next steps so the automation pipeline can come together incrementally.【F:algorithms/README.md†L1-L18】【F:algorithms/pine-script/README.md†L1-L33】【F:algorithms/vercel-webhook/README.md†L1-L29】【F:algorithms/mql5/README.md†L1-L31】


### PR DESCRIPTION
## Summary
- add an `algorithms/` workspace that outlines the Pine Script, Vercel webhook, and MetaTrader 5 deliverables for the trading automation project
- provide README guides inside each trading automation sub-folder to standardize structure and handoff expectations
- document the new workspace in `docs/REPO_INVENTORY.md` so contributors can find the algo artifacts quickly

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ca5bec83d08322b23f60f6353f2bb1