### PR TITLE
Add MQL5 expert advisor modules

### DIFF
--- a/mql5/Lorentzian_Classification_EA.mq5
+++ b/mql5/Lorentzian_Classification_EA.mq5
@@ -1,0 +1,284 @@
+#property copyright "Copyright 2025, MetaQuotes Ltd."
+#property link      "https://www.mql5.com"
+#property version   "1.00"
+#property strict
+
+// Simplified port of the "Lorentzian Classification" Pine Script indicator
+// Implements a basic KNN classifier using Lorentzian distance on RSI and ADX features.
+// Opens trades based on predicted direction and reports actions to Supabase via WebRequest.
+
+#include <Trade/Trade.mqh>
+#include "logger.mqh"
+CTrade trade;
+
+input int    NeighborsCount    = 8;     // number of neighbors to consider
+input int    MaxBarsBack       = 2000;  // max history size
+input int    RSI_Period        = 14;    // feature 1
+input int    ADX_Period        = 14;    // feature 2
+input double Lots              = 0.10;  // fallback lot size
+
+input double RiskPerTrade      = 1.0;   // % balance risked per trade
+input double StopLossPoints    = 200;   // fallback stop loss in points
+input double TakeProfitPoints  = 400;   // fallback take profit in points
+input double TrailingStopPoints= 100;   // trailing stop distance in points
+input bool   UseADR            = true;  // use ADR-based SL/TP
+input int    ADR_Period        = 14;    // days for ADR calculation
+input double ADR_SL            = 0.5;   // SL fraction of ADR
+input double ADR_TP            = 1.0;   // TP fraction of ADR
+input ENUM_TIMEFRAMES HigherTF = PERIOD_H1; // secondary timeframe
+input int    Slippage          = 5;     // max slippage in points
+input double MaxSpread         = 20;    // max allowed spread in points
+input int    StartHour         = 0;     // trading session start hour
+input int    EndHour           = 24;    // trading session end hour
+input ulong  MagicNumber       = 123456;// unique magic number
+
+string SupabaseURL = "https://xyz.supabase.co/functions/v1/ea-report"; // replace with your endpoint
+
+double CalculateLot(double slPoints);
+void   ApplyTrailingStop();
+double CalculateADR();
+
+// feature storage
+struct FeatureRow
+{
+   double rsi1;
+   double adx1;
+   double rsi2;
+   double adx2;
+   int    label; // 1 long, -1 short, 0 neutral
+};
+
+struct Neighbor
+{
+   double distance;
+   int    label;
+};
+
+FeatureRow rows[];
+int totalRows = 0;
+
+int lastProcessedBar = -1;
+
+int OnInit()
+{
+   ArrayResize(rows, MaxBarsBack);
+   trade.SetExpertMagicNumber(MagicNumber);
+   trade.SetDeviationInPoints(Slippage);
+   LogVersion(VersionID);
+   return(INIT_SUCCEEDED);
+}
+
+void OnTick()
+{
+   ApplyTrailingStop();
+
+   // trading session filter
+   datetime now = TimeCurrent();
+   int hour = TimeHour(now);
+   if(hour < StartHour || hour >= EndHour)
+      return;
+
+   // spread check
+   double spread = (SymbolInfoDouble(_Symbol, SYMBOL_ASK) - SymbolInfoDouble(_Symbol, SYMBOL_BID)) / _Point;
+   if(spread > MaxSpread)
+      return;
+
+   // process only on new bar
+   int currentBar = iBars(_Symbol, PERIOD_CURRENT);
+   if(currentBar == lastProcessedBar)
+      return;
+   lastProcessedBar = currentBar;
+
+   double rsi1 = iRSI(_Symbol, PERIOD_CURRENT, RSI_Period, PRICE_CLOSE, 0);
+   double adx1 = iADX(_Symbol, PERIOD_CURRENT, ADX_Period, 0, PRICE_CLOSE, 0);
+   double rsi2 = iRSI(_Symbol, HigherTF, RSI_Period, PRICE_CLOSE, 0);
+   double adx2 = iADX(_Symbol, HigherTF, ADX_Period, 0, PRICE_CLOSE, 0);
+
+   // store feature row
+   if(totalRows < MaxBarsBack)
+      totalRows++;
+   for(int i = totalRows-1; i > 0; --i)
+      rows[i] = rows[i-1];
+   rows[0].rsi1 = rsi1;
+   rows[0].adx1 = adx1;
+   rows[0].rsi2 = rsi2;
+   rows[0].adx2 = adx2;
+   rows[0].label = 0; // placeholder for future bar label
+
+   // update label for bar 4 bars ago
+   if(totalRows > 4)
+   {
+      double futureClose = iClose(_Symbol, PERIOD_CURRENT, 0);
+      double pastClose   = iClose(_Symbol, PERIOD_CURRENT, 4);
+      rows[4].label = (futureClose > pastClose) ? 1 : (futureClose < pastClose ? -1 : 0);
+   }
+
+   // skip until we have at least neighborsCount bars with labels
+   if(totalRows <= NeighborsCount + 4)
+      return;
+
+   // compute Lorentzian distances for labeled rows
+   Neighbor neighbors[];
+   ArrayResize(neighbors, 0);
+   for(int i = 4; i < totalRows; i++) // skip bars without label
+   {
+      if(i % 4 != 0) continue; // enforce spacing every 4 bars
+      double d = MathLog(1 + MathAbs(rsi1 - rows[i].rsi1)) +
+                 MathLog(1 + MathAbs(adx1 - rows[i].adx1)) +
+                 MathLog(1 + MathAbs(rsi2 - rows[i].rsi2)) +
+                 MathLog(1 + MathAbs(adx2 - rows[i].adx2));
+      Neighbor n;
+      n.distance = d;
+      n.label    = rows[i].label;
+      ArrayPush(neighbors, n);
+   }
+   ArraySort(neighbors, WHOLE_ARRAY, 0, MODE_ASCEND);
+   int limit = MathMin(NeighborsCount, ArraySize(neighbors));
+   int sum = 0;
+   for(int i = 0; i < limit; ++i)
+      sum += neighbors[i].label;
+   int signal = 0;
+   if(sum > 0) signal = 1; else if(sum < 0) signal = -1;
+
+   ManageTrades(signal);
+}
+
+void ManageTrades(int signal)
+{
+   bool hasPosition = PositionSelect(_Symbol);
+   int direction = 0;
+   if(hasPosition)
+      direction = (PositionGetInteger(POSITION_TYPE) == POSITION_TYPE_BUY) ? 1 : -1;
+
+   double slPoints = StopLossPoints;
+   double tpPoints = TakeProfitPoints;
+   if(UseADR)
+   {
+      double adrPoints = CalculateADR();
+      slPoints = adrPoints * ADR_SL;
+      tpPoints = adrPoints * ADR_TP;
+   }
+
+   double lot = CalculateLot(slPoints);
+
+   if(signal > 0 && (!hasPosition || direction < 0))
+   {
+      if(hasPosition)
+         trade.PositionClose(_Symbol);
+      double price = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+      double sl = (slPoints > 0) ? price - slPoints*_Point : 0.0;
+      double tp = (tpPoints > 0) ? price + tpPoints*_Point : 0.0;
+      if(trade.Buy(lot, NULL, 0.0, sl, tp))
+      {
+         Log("Buy order placed");
+         SendReport("buy");
+      }
+   }
+   else if(signal < 0 && (!hasPosition || direction > 0))
+   {
+      if(hasPosition)
+         trade.PositionClose(_Symbol);
+      double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
+      double sl = (slPoints > 0) ? price + slPoints*_Point : 0.0;
+      double tp = (tpPoints > 0) ? price - tpPoints*_Point : 0.0;
+      if(trade.Sell(lot, NULL, 0.0, sl, tp))
+      {
+         Log("Sell order placed");
+         SendReport("sell");
+      }
+   }
+}
+
+double CalculateLot(double slPoints)
+{
+   if(slPoints <= 0)
+      return(Lots);
+
+   double balance   = AccountInfoDouble(ACCOUNT_BALANCE);
+   double riskMoney = balance * RiskPerTrade / 100.0;
+   double tickValue = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
+   double tickSize  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
+   double pointValue = tickValue / tickSize * _Point;
+   double slMoney   = slPoints * pointValue;
+   if(slMoney <= 0)
+      return(Lots);
+   double lot = riskMoney / slMoney;
+   double minLot = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
+   double maxLot = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MAX);
+   double step   = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_STEP);
+   lot = MathMax(minLot, MathMin(maxLot, lot));
+   lot = MathFloor(lot/step)*step;
+   return(lot);
+}
+
+void ApplyTrailingStop()
+{
+   if(TrailingStopPoints <= 0)
+      return;
+   if(!PositionSelect(_Symbol))
+      return;
+
+   double type = PositionGetInteger(POSITION_TYPE);
+   double sl   = PositionGetDouble(POSITION_SL);
+   double tp   = PositionGetDouble(POSITION_TP);
+
+   if(type == POSITION_TYPE_BUY)
+   {
+      double newSL = SymbolInfoDouble(_Symbol, SYMBOL_BID) - TrailingStopPoints*_Point;
+      if(newSL > sl)
+         trade.PositionModify(_Symbol, newSL, tp);
+   }
+   else if(type == POSITION_TYPE_SELL)
+   {
+      double newSL = SymbolInfoDouble(_Symbol, SYMBOL_ASK) + TrailingStopPoints*_Point;
+     if(sl == 0 || newSL < sl)
+         trade.PositionModify(_Symbol, newSL, tp);
+  }
+}
+
+double CalculateADR()
+{
+   int bars = MathMin(ADR_Period, iBars(_Symbol, PERIOD_D1));
+   if(bars <= 0)
+      return(0);
+   double sum = 0;
+   for(int i=1; i<=bars; ++i)
+      sum += (iHigh(_Symbol, PERIOD_D1, i-1) - iLow(_Symbol, PERIOD_D1, i-1)) / _Point;
+   return(sum / bars);
+}
+
+void SendReport(string action)
+{
+   string json = StringFormat("{\"symbol\":\"%s\",\"action\":\"%s\"}", _Symbol, action);
+   char post[]; StringToCharArray(json, post);
+   char result[];
+   string headers = "Content-Type: application/json\r\n";
+   int timeout = 5000;
+   string resHeaders;
+
+   for(int i=0;i<3;i++)
+   {
+      ResetLastError();
+      int status = WebRequest("POST", SupabaseURL, headers, timeout, post, result, resHeaders);
+      if(status == -1)
+      {
+         PrintFormat("WebRequest error %d on attempt %d", GetLastError(), i+1);
+         Sleep(1000);
+         continue;
+      }
+      if(status != 200)
+      {
+         PrintFormat("HTTP status %d on attempt %d", status, i+1);
+         Sleep(1000);
+         continue;
+      }
+      Print("Report sent: ", json);
+      break;
+   }
+}
+
+void OnDeinit(const int reason)
+{
+   // nothing to clean up
+}
+

--- a/mql5/MA_Cross_EA.mq5
+++ b/mql5/MA_Cross_EA.mq5
@@ -1,0 +1,71 @@
+#property copyright "2024"
+#property version   "1.00"
+#property strict
+
+// Simple Moving Average crossover EA template
+// Sends trade updates to Supabase edge function via WebRequest
+
+input int    FastMA = 9;
+input int    SlowMA = 21;
+input double Lots   = 0.10;
+
+#include <Trade/Trade.mqh>
+CTrade trade;
+
+int fastHandle;
+int slowHandle;
+
+int OnInit()
+{
+   fastHandle = iMA(_Symbol, PERIOD_CURRENT, FastMA, 0, MODE_EMA, PRICE_CLOSE);
+   slowHandle = iMA(_Symbol, PERIOD_CURRENT, SlowMA, 0, MODE_EMA, PRICE_CLOSE);
+   return INIT_SUCCEEDED;
+}
+
+void OnTick()
+{
+   double fast[2];
+   double slow[2];
+   if(CopyBuffer(fastHandle,0,0,2,fast) <= 0) return;
+   if(CopyBuffer(slowHandle,0,0,2,slow) <= 0) return;
+
+   bool crossUp   = fast[1] < slow[1] && fast[0] > slow[0];
+   bool crossDown = fast[1] > slow[1] && fast[0] < slow[0];
+
+   if(crossUp)
+   {
+      if(PositionSelect(_Symbol)) trade.PositionClose(_Symbol);
+      trade.Buy(Lots);
+      SendReport("buy");
+   }
+   else if(crossDown)
+   {
+      if(PositionSelect(_Symbol)) trade.PositionClose(_Symbol);
+      trade.Sell(Lots);
+      SendReport("sell");
+   }
+}
+
+void SendReport(string action)
+{
+   string url = "https://xyz.supabase.co/functions/v1/ea-report"; // replace with your endpoint
+   string json = StringFormat("{\"symbol\":\"%s\",\"action\":\"%s\",\"profit\":%f}",
+                              _Symbol, action, AccountInfoDouble(ACCOUNT_PROFIT));
+   char post[];
+   StringToCharArray(json, post);
+
+   char result[];
+   string headers = "Content-Type: application/json\r\n";
+   int timeout = 5000;
+   int res = WebRequest("POST", url, headers, timeout, post, result, NULL);
+   if(res == -1)
+      Print("WebRequest error: ", GetLastError());
+   else
+      Print("Report sent: ", json);
+}
+
+void OnDeinit(const int reason)
+{
+   IndicatorRelease(fastHandle);
+   IndicatorRelease(slowHandle);
+}

--- a/mql5/equity_protection.mqh
+++ b/mql5/equity_protection.mqh
@@ -1,0 +1,43 @@
+//+------------------------------------------------------------------+
+//| Equity protection module                                         |
+//| Provides functions to monitor daily drawdown and equity levels   |
+//+------------------------------------------------------------------+
+#property strict
+#include <Trade/Trade.mqh>
+
+//+------------------------------------------------------------------+
+//| Check if daily drawdown exceeds a maximum percentage             |
+//| Returns true if limit breached                                   |
+//+------------------------------------------------------------------+
+bool CheckDailyDrawdownLimit(double maxLossPercent)
+{
+   MqlDateTime tm; TimeToStruct(TimeCurrent(), tm);
+   tm.hour = tm.min = tm.sec = 0;
+   datetime dayStart = StructToTime(tm);
+   if(!HistorySelect(dayStart, TimeCurrent()))
+      return false;
+   double profit = 0.0;
+   for(int i=0;i<HistoryDealsTotal();i++)
+   {
+      ulong ticket = HistoryDealGetTicket(i);
+      profit += HistoryDealGetDouble(ticket, DEAL_PROFIT) +
+                HistoryDealGetDouble(ticket, DEAL_COMMISSION) +
+                HistoryDealGetDouble(ticket, DEAL_SWAP);
+   }
+   double startBalance = AccountInfoDouble(ACCOUNT_BALANCE) - profit;
+   if(startBalance <= 0)
+      return false;
+   double drawdownPercent = (-profit / startBalance) * 100.0;
+   return drawdownPercent >= maxLossPercent;
+}
+
+//+------------------------------------------------------------------+
+//| Check if account equity is below a minimum threshold             |
+//| Returns true if equity is lower than allowed                     |
+//+------------------------------------------------------------------+
+bool CheckEquityThreshold(double minEquity)
+{
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   return (equity < minEquity);
+}
+

--- a/mql5/logger.mqh
+++ b/mql5/logger.mqh
@@ -1,0 +1,46 @@
+//+------------------------------------------------------------------+
+//| Logger module                                                    |
+//| Provides logging utilities, version reporting and debugging      |
+//+------------------------------------------------------------------+
+#property strict
+
+input bool  DebugMode = false;              // Enable verbose debug output
+string LogFileName = "EA_Log.txt";          // File for persistent logging
+input string VersionID = "1.0";             // EA version identifier
+input string ChangeLog = "Initial release"; // Changelog description
+
+//+------------------------------------------------------------------+
+//| Write a message to log and file                                   |
+//+------------------------------------------------------------------+
+void Log(string msg)
+{
+   Print(msg);
+   int handle = FileOpen(LogFileName, FILE_TXT | FILE_WRITE | FILE_READ | FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_APPEND);
+   if(handle != INVALID_HANDLE)
+   {
+      FileWrite(handle, TimeToString(TimeCurrent(), TIME_DATE|TIME_SECONDS) + " - " + msg);
+      FileClose(handle);
+   }
+}
+
+//+------------------------------------------------------------------+
+//| Log EA version and changelog                                      |
+//+------------------------------------------------------------------+
+void LogVersion(string version)
+{
+   Log("EA Version: " + version);
+   Log("Changelog: " + ChangeLog);
+}
+
+//+------------------------------------------------------------------+
+//| Debugging helper                                                 |
+//+------------------------------------------------------------------+
+void Debug(string msg, bool showInTester)
+{
+   if(DebugMode)
+   {
+      if(showInTester || !MQLInfoInteger(MQL_TESTER))
+         Log("DEBUG: " + msg);
+   }
+}
+

--- a/mql5/multi_timeframe.mqh
+++ b/mql5/multi_timeframe.mqh
@@ -1,0 +1,40 @@
+//+------------------------------------------------------------------+
+//| Multi-timeframe trend detection module                          |
+//| Fetches EMA and ADX values from user-defined higher timeframes. |
+//| Provides helpers to detect bullish or bearish higher timeframe  |
+//| trend conditions.                                               |
+//+------------------------------------------------------------------+
+#property strict
+
+//--- input parameters for higher timeframe analysis
+input ENUM_TIMEFRAMES HTF_EMA_Timeframe   = PERIOD_H4;  // Timeframe for EMA calculations
+input int             HTF_EMA_FastPeriod  = 20;         // Fast EMA period
+input int             HTF_EMA_SlowPeriod  = 50;         // Slow EMA period
+input ENUM_TIMEFRAMES HTF_ADX_Timeframe   = PERIOD_H4;  // Timeframe for ADX calculation
+input int             HTF_ADX_Period      = 14;         // ADX period
+input double          HTF_ADX_Threshold   = 20.0;       // ADX threshold to confirm trend
+
+//+------------------------------------------------------------------+
+//| Helper function to determine if higher timeframe trend is up     |
+//| Conditions: EMA20 > EMA50 and ADX > threshold                    |
+//+------------------------------------------------------------------+
+bool HTF_Trend_Up()
+{
+   double fastEma = iMA(_Symbol, HTF_EMA_Timeframe, HTF_EMA_FastPeriod, 0, MODE_EMA, PRICE_CLOSE, 0);
+   double slowEma = iMA(_Symbol, HTF_EMA_Timeframe, HTF_EMA_SlowPeriod, 0, MODE_EMA, PRICE_CLOSE, 0);
+   double adx     = iADX(_Symbol, HTF_ADX_Timeframe, HTF_ADX_Period, PRICE_CLOSE, MODE_MAIN, 0);
+   return (fastEma > slowEma && adx > HTF_ADX_Threshold);
+}
+
+//+------------------------------------------------------------------+
+//| Helper function to determine if higher timeframe trend is down   |
+//| Conditions: EMA20 < EMA50 and ADX > threshold                    |
+//+------------------------------------------------------------------+
+bool HTF_Trend_Down()
+{
+   double fastEma = iMA(_Symbol, HTF_EMA_Timeframe, HTF_EMA_FastPeriod, 0, MODE_EMA, PRICE_CLOSE, 0);
+   double slowEma = iMA(_Symbol, HTF_EMA_Timeframe, HTF_EMA_SlowPeriod, 0, MODE_EMA, PRICE_CLOSE, 0);
+   double adx     = iADX(_Symbol, HTF_ADX_Timeframe, HTF_ADX_Period, PRICE_CLOSE, MODE_MAIN, 0);
+   return (fastEma < slowEma && adx > HTF_ADX_Threshold);
+}
+

--- a/mql5/position_manager.mqh
+++ b/mql5/position_manager.mqh
@@ -1,0 +1,63 @@
+//+------------------------------------------------------------------+
+//| Position manager module                                         |
+//| Controls trade limits and allows closing of all open positions   |
+//+------------------------------------------------------------------+
+#property strict
+#include <Trade/Trade.mqh>
+
+input int MaxTradesPerSession = 5;   // Maximum trades allowed per session
+int  SessionTradeCount = 0;          // Counter for current session
+
+//+------------------------------------------------------------------+
+//| Check if a new trade can be opened                               |
+//| Considers per-symbol, total limits and session count             |
+//+------------------------------------------------------------------+
+bool CanOpenNewTrade(string symbol, int maxPerSymbol, int maxTotal)
+{
+   if(SessionTradeCount >= MaxTradesPerSession)
+      return false;
+   int total = PositionsTotal();
+   int perSymbol = 0;
+   for(int i=0;i<total;i++)
+   {
+      if(PositionGetTicket(i) > 0 && PositionGetString(POSITION_SYMBOL) == symbol)
+         perSymbol++;
+   }
+   if(total >= maxTotal || perSymbol >= maxPerSymbol)
+      return false;
+   return true;
+}
+
+//+------------------------------------------------------------------+
+//| Close all open positions                                         |
+//+------------------------------------------------------------------+
+void CloseAllTrades()
+{
+   CTrade trade;
+   for(int i=PositionsTotal()-1; i>=0; i--)
+   {
+      if(PositionSelectByIndex(i))
+      {
+         string symbol = PositionGetString(POSITION_SYMBOL);
+         double volume = PositionGetDouble(POSITION_VOLUME);
+         trade.PositionClose(symbol, volume);
+      }
+   }
+}
+
+//+------------------------------------------------------------------+
+//| Increment session trade count                                    |
+//+------------------------------------------------------------------+
+void RegisterNewTrade()
+{
+   SessionTradeCount++;
+}
+
+//+------------------------------------------------------------------+
+//| Reset session trade counter                                      |
+//+------------------------------------------------------------------+
+void ResetSessionTrades()
+{
+   SessionTradeCount = 0;
+}
+

--- a/mql5/risk_management.mqh
+++ b/mql5/risk_management.mqh
@@ -1,0 +1,131 @@
+//+------------------------------------------------------------------+
+//| Risk management module                                           |
+//| Handles lot sizing, SL/TP placement, breakeven and trailing stop |
+//+------------------------------------------------------------------+
+#property strict
+#include <Trade/Trade.mqh>
+
+input double RiskPercent      = 1.0;   // Risk per trade in percent
+input double BreakEvenPips    = 10;    // Pips in profit before moving SL to breakeven
+
+CTrade rm_trade;                       // trade object used for modifications
+
+//+------------------------------------------------------------------+
+//| Calculate lot size based on account balance and SL distance      |
+//+------------------------------------------------------------------+
+double CalculateLotSize(double stopLossPips)
+{
+   if(stopLossPips <= 0)
+      return 0.0;
+   double balance    = AccountInfoDouble(ACCOUNT_BALANCE);
+   double riskMoney  = balance * RiskPercent / 100.0;
+   double tickValue  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
+   double tickSize   = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
+   double pipValue   = tickValue / tickSize * _Point * 10.0; // approximate pip value
+   double lot        = riskMoney / (stopLossPips * pipValue);
+   double lotStep    = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_STEP);
+   double minLot     = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
+   double maxLot     = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MAX);
+   lot = MathMax(minLot, MathMin(maxLot, MathFloor(lot/lotStep)*lotStep));
+   lot = NormalizeDouble(lot, 2);
+   double margin;
+   if(!OrderCalcMargin(ORDER_TYPE_BUY, _Symbol, lot, SymbolInfoDouble(_Symbol, SYMBOL_ASK), margin))
+   {
+      Print("OrderCalcMargin failed: ", GetLastError());
+      return 0.0;
+   }
+   if(margin > AccountInfoDouble(ACCOUNT_FREEMARGIN))
+   {
+      Print("Insufficient margin for lot size: ", lot);
+      return 0.0;
+   }
+   return lot;
+}
+
+//+------------------------------------------------------------------+
+//| Set stop loss and take profit for a position by ticket           |
+//+------------------------------------------------------------------+
+void SetStopLossAndTakeProfit(ulong ticket, double slPips, double tpPips)
+{
+   if(!PositionSelectByTicket(ticket))
+   {
+      Print("SetStopLossAndTakeProfit: position not found");
+      return;
+   }
+   double openPrice = PositionGetDouble(POSITION_PRICE_OPEN);
+   long   type      = PositionGetInteger(POSITION_TYPE);
+   double sl, tp;
+   if(type == POSITION_TYPE_BUY)
+   {
+      sl = openPrice - slPips * _Point;
+      tp = openPrice + tpPips * _Point;
+   }
+   else
+   {
+      sl = openPrice + slPips * _Point;
+      tp = openPrice - tpPips * _Point;
+   }
+   if(!rm_trade.PositionModify(ticket, NormalizeDouble(sl, _Digits), NormalizeDouble(tp, _Digits)))
+      Print("Failed to modify position: ", rm_trade.ResultRetcode());
+}
+
+//+------------------------------------------------------------------+
+//| Move SL to breakeven after trade reaches a certain profit        |
+//+------------------------------------------------------------------+
+void MoveToBreakEven(ulong ticket, double entryPrice)
+{
+   if(!PositionSelectByTicket(ticket))
+      return;
+   long type = PositionGetInteger(POSITION_TYPE);
+   double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_BID)
+                                              : SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+   if(type == POSITION_TYPE_BUY)
+   {
+      if(price - entryPrice >= BreakEvenPips * _Point && PositionGetDouble(POSITION_SL) < entryPrice)
+         rm_trade.PositionModify(ticket, NormalizeDouble(entryPrice, _Digits), PositionGetDouble(POSITION_TP));
+   }
+   else
+   {
+      if(entryPrice - price >= BreakEvenPips * _Point && (PositionGetDouble(POSITION_SL) > entryPrice || PositionGetDouble(POSITION_SL) == 0))
+         rm_trade.PositionModify(ticket, NormalizeDouble(entryPrice, _Digits), PositionGetDouble(POSITION_TP));
+   }
+}
+
+//+------------------------------------------------------------------+
+//| Apply trailing stop once price moves a certain distance          |
+//+------------------------------------------------------------------+
+void ApplyTrailingStop(ulong ticket, double trailStartPips, double trailStepPips)
+{
+   if(!PositionSelectByTicket(ticket))
+      return;
+   long type     = PositionGetInteger(POSITION_TYPE);
+   double open   = PositionGetDouble(POSITION_PRICE_OPEN);
+   double price  = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_BID)
+                                              : SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+   double sl     = PositionGetDouble(POSITION_SL);
+   double newSL  = sl;
+
+   if(type == POSITION_TYPE_BUY)
+   {
+      double start = open + trailStartPips * _Point;
+      if(price > start)
+      {
+         double desired = price - trailStepPips * _Point;
+         if(desired > sl)
+            newSL = desired;
+      }
+   }
+   else
+   {
+      double start = open - trailStartPips * _Point;
+      if(price < start)
+      {
+         double desired = price + trailStepPips * _Point;
+         if(desired < sl || sl == 0)
+            newSL = desired;
+      }
+   }
+   if(newSL != sl)
+      rm_trade.PositionModify(ticket, NormalizeDouble(newSL, _Digits), PositionGetDouble(POSITION_TP));
+}
+

--- a/mql5/session_filter.mqh
+++ b/mql5/session_filter.mqh
@@ -1,0 +1,30 @@
+//+------------------------------------------------------------------+
+//| Trading session filter                                           |
+//| Allows trading only within user-defined time window              |
+//+------------------------------------------------------------------+
+#property strict
+
+input int SessionStartHour   = 8;   // Trading session start hour
+input int SessionStartMinute = 0;   // Trading session start minute
+input int SessionEndHour     = 16;  // Trading session end hour
+input int SessionEndMinute   = 0;   // Trading session end minute
+
+//+------------------------------------------------------------------+
+//| Determine if current broker time is within trading session       |
+//+------------------------------------------------------------------+
+bool IsTradingSession()
+{
+   datetime now = TimeCurrent();
+   MqlDateTime tm; TimeToStruct(now, tm);
+   datetime start = now; datetime end = now;
+   tm.hour = SessionStartHour; tm.min = SessionStartMinute; tm.sec = 0;
+   start = StructToTime(tm);
+   tm.hour = SessionEndHour; tm.min = SessionEndMinute; tm.sec = 0;
+   end = StructToTime(tm);
+   if(end <= start)
+      end += 24 * 60 * 60; // handle sessions crossing midnight
+   if(now >= start && now <= end)
+      return true;
+   return false;
+}
+

--- a/mql5/stats_reporter.mqh
+++ b/mql5/stats_reporter.mqh
@@ -1,0 +1,36 @@
+//+------------------------------------------------------------------+
+//| Stats reporter module                                            |
+//| Sends account statistics to a webhook in JSON format             |
+//+------------------------------------------------------------------+
+#property strict
+
+input string StatsWebhookURL = "";    // URL for posting stats
+
+//+------------------------------------------------------------------+
+//| Gather and send statistics                                       |
+//+------------------------------------------------------------------+
+void SendStats()
+{
+   if(StringLen(StatsWebhookURL) == 0)
+   {
+      Print("StatsReporter: Webhook URL not set");
+      return;
+   }
+   double balance = AccountInfoDouble(ACCOUNT_BALANCE);
+   double equity  = AccountInfoDouble(ACCOUNT_EQUITY);
+   double dd      = (balance - equity) / balance * 100.0;
+   ulong  accNum  = (ulong)AccountInfoInteger(ACCOUNT_LOGIN);
+   string broker  = AccountInfoString(ACCOUNT_COMPANY);
+
+   string payload = StringFormat("{\"account\":%I64u,\"broker\":\"%s\",\"balance\":%.2f,\"equity\":%.2f,\"drawdown\":%.2f}",
+                                  accNum, broker, balance, equity, dd);
+   uchar data[]; uchar result[]; string headers;
+   StringToCharArray(payload, data, 0, WHOLE_ARRAY, CP_UTF8);
+   ResetLastError();
+   int res = WebRequest("POST", StatsWebhookURL, "Content-Type: application/json\r\n", 5000, data, result, headers);
+   if(res == -1)
+      Print("WebRequest failed: ", GetLastError());
+   else
+      Print("StatsReporter: sent with code ", res);
+}
+

--- a/mql5/strategy_logic.mqh
+++ b/mql5/strategy_logic.mqh
@@ -1,0 +1,78 @@
+//+------------------------------------------------------------------+
+//| Lorentzian classifier strategy module                           |
+//| Provides shouldBuy/shouldSell decision helpers using a mock     |
+//| weighted feature model.                                        |
+//+------------------------------------------------------------------+
+#property strict
+
+//--- feature toggles and weights
+input bool   UseEMAFeature      = true;
+input double EMAWeight          = 1.0;
+input bool   UseADXFeature      = true;
+input double ADXWeight          = 1.0;
+input bool   UseBBWidthFeature  = true;
+input double BBWidthWeight      = 1.0;
+input bool   UseCloseFeature    = true;
+input double CloseWeight        = 1.0;
+input double DecisionThreshold  = 2.5;    // Score threshold for signal
+
+//--- parameters for indicators
+input int    EMAPeriodFast      = 20;
+input int    EMAPeriodSlow      = 50;
+input int    ADXPeriod          = 14;
+input int    BBPeriod           = 20;
+input double BBDeviation        = 2.0;
+
+//+------------------------------------------------------------------+
+//| Calculate a weighted score for buy/sell direction                |
+//+------------------------------------------------------------------+
+double CalculateScore(bool forBuy)
+{
+   double score = 0.0;
+   if(UseEMAFeature)
+   {
+      double fast = iMA(_Symbol, _Period, EMAPeriodFast, 0, MODE_EMA, PRICE_CLOSE, 0);
+      double slow = iMA(_Symbol, _Period, EMAPeriodSlow, 0, MODE_EMA, PRICE_CLOSE, 0);
+      if((forBuy && fast > slow) || (!forBuy && fast < slow))
+         score += EMAWeight;
+   }
+   if(UseADXFeature)
+   {
+      double adx = iADX(_Symbol, _Period, ADXPeriod, PRICE_CLOSE, MODE_MAIN, 0);
+      if(adx > 20.0)
+         score += ADXWeight;
+   }
+   if(UseBBWidthFeature)
+   {
+      double upper = iBands(_Symbol, _Period, BBPeriod, 0, BBDeviation, PRICE_CLOSE, MODE_UPPER, 0);
+      double lower = iBands(_Symbol, _Period, BBPeriod, 0, BBDeviation, PRICE_CLOSE, MODE_LOWER, 0);
+      double width = upper - lower;
+      if(width > 0)
+         score += BBWidthWeight;
+   }
+   if(UseCloseFeature)
+   {
+      double close = iClose(_Symbol, _Period, 0);
+      double prev  = iClose(_Symbol, _Period, 1);
+      if((forBuy && close > prev) || (!forBuy && close < prev))
+         score += CloseWeight;
+   }
+   return score;
+}
+
+//+------------------------------------------------------------------+
+//| Return true if buy conditions satisfied                          |
+//+------------------------------------------------------------------+
+bool shouldBuy()
+{
+   return (CalculateScore(true) > DecisionThreshold);
+}
+
+//+------------------------------------------------------------------+
+//| Return true if sell conditions satisfied                         |
+//+------------------------------------------------------------------+
+bool shouldSell()
+{
+   return (CalculateScore(false) > DecisionThreshold);
+}
+

--- a/mql5/utils.mqh
+++ b/mql5/utils.mqh
@@ -1,0 +1,47 @@
+//+------------------------------------------------------------------+
+//| Utility functions                                                |
+//| Miscellaneous helpers for MQL5 EAs                               |
+//+------------------------------------------------------------------+
+#property strict
+
+//+------------------------------------------------------------------+
+//| Convert pips to points                                           |
+//+------------------------------------------------------------------+
+int PipsToPoints(int pips)
+{
+   int factor = (_Digits == 3 || _Digits == 5) ? 10 : 1;
+   return pips * factor;
+}
+
+//+------------------------------------------------------------------+
+//| Normalize price to symbol digits                                 |
+//+------------------------------------------------------------------+
+double NormalizePrice(double price)
+{
+   return NormalizeDouble(price, _Digits);
+}
+
+//+------------------------------------------------------------------+
+//| Check if a new bar has formed                                    |
+//+------------------------------------------------------------------+
+bool IsNewBar()
+{
+   static datetime lastBarTime = 0;
+   datetime current = iTime(_Symbol, _Period, 0);
+   if(current != lastBarTime)
+   {
+      lastBarTime = current;
+      return true;
+   }
+   return false;
+}
+
+//+------------------------------------------------------------------+
+//| Round a value to the nearest pip                                 |
+//+------------------------------------------------------------------+
+double RoundToPip(double value)
+{
+   double pip = (_Digits == 3 || _Digits == 5) ? _Point*10 : _Point;
+   return MathRound(value / pip) * pip;
+}
+


### PR DESCRIPTION
## Summary
- import the Lorentzian classification and moving-average crossover Expert Advisors from the Dynamic Codex repository
- include shared MQL5 modules for logging, session filtering, position management, and risk controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca66db8c888322bcba39e99bf01e02