### PR TITLE
Refactor landing page shell to remove duplication

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,13 +1,7 @@
-import { ChatAssistantWidget } from '@/components/shared/ChatAssistantWidget';
-import { OnceLandingPageClient } from '@/components/landing/OnceLandingPageClient';
+import { LandingPageShell } from '@/components/landing/LandingPageShell';
 
 export const dynamic = 'force-dynamic';
 
 export default function HomePage() {
-  return (
-    <div className="min-h-screen space-y-16 bg-gradient-to-br from-background via-card/10 to-background pb-24">
-      <OnceLandingPageClient />
-      <ChatAssistantWidget />
-    </div>
-  );
+  return <LandingPageShell />;
 }

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -1,0 +1,38 @@
+import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
+import { cn } from "@/utils";
+
+import { OnceLandingPageClient } from "./OnceLandingPageClient";
+
+export interface LandingPageShellProps {
+  /**
+   * Optional className for the outer wrapper so consuming apps can augment layout spacing.
+   */
+  className?: string;
+  /**
+   * Control whether the chat assistant widget is rendered. Enabled by default.
+   */
+  showAssistant?: boolean;
+  /**
+   * Additional className passed to the chat assistant widget when rendered.
+   */
+  assistantClassName?: string;
+}
+
+export function LandingPageShell({
+  className,
+  showAssistant = true,
+  assistantClassName,
+}: LandingPageShellProps) {
+  return (
+    <div
+      className={cn(
+        "min-h-screen space-y-16 bg-gradient-to-br from-background via-card/10 to-background pb-24",
+        className,
+      )}
+    >
+      <OnceLandingPageClient />
+      {showAssistant ? <ChatAssistantWidget className={assistantClassName} /> : null}
+    </div>
+  );
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,7 @@ import {
 import { MotionConfigProvider } from '@/components/ui/motion-config';
 import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
-import { ChatAssistantWidget } from '@/components/shared/ChatAssistantWidget';
-import { OnceLandingPage } from '@/components/once-ui';
+import { LandingPageShell } from '@/components/landing/LandingPageShell';
 import Footer from '@/components/layout/Footer';
 
 const queryClient = new QueryClient();
@@ -40,52 +39,7 @@ function OnceUIProviders({ children }: { children: ReactNode }) {
 }
 
 function HomePage() {
-  const handleJoinVIP = () => {
-    window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
-  };
-
-  const handleLearnMore = () => {
-    // Smooth scroll to features section
-    const featuresSection = document.getElementById('features');
-    featuresSection?.scrollIntoView({ behavior: 'smooth' });
-  };
-
-  const handleOpenTelegram = () => {
-    window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
-  };
-
-  const handleContactSupport = () => {
-    window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
-  };
-
-  const handleSelectPlan = (planId: string) => {
-    console.log('Selected plan:', planId);
-    window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
-  };
-
-  const handleBankPayment = () => {
-    window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
-  };
-
-  const handleCryptoPayment = () => {
-    window.open('https://t.me/Dynamic_VIP_BOT', '_blank');
-  };
-
-  return (
-    <div className="min-h-screen space-y-16 bg-gradient-to-br from-background via-card/10 to-background pb-24">
-      <OnceLandingPage
-        onJoinVIP={handleJoinVIP}
-        onLearnMore={handleLearnMore}
-        onOpenTelegram={handleOpenTelegram}
-        onPlanSelect={handleSelectPlan}
-        onBankPayment={handleBankPayment}
-        onCryptoPayment={handleCryptoPayment}
-        onContactSupport={handleContactSupport}
-      />
-
-      <ChatAssistantWidget />
-    </div>
-  );
+  return <LandingPageShell />;
 }
 
 function App() {


### PR DESCRIPTION
## Summary
- add a shared `LandingPageShell` component that wraps the Once landing view and assistant widget
- update the Next.js home page to render the new shell component
- simplify the Vite app home route to reuse the shared shell instead of duplicating handlers

## Testing
- npm -w apps/web run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca742204748322947929ce83887637