### PR TITLE
Refactor MQL5 EAs to integrate shared risk and telemetry modules

### DIFF
--- a/mql5/Lorentzian_Classification_EA.mq5
+++ b/mql5/Lorentzian_Classification_EA.mq5
@@ -1,51 +1,60 @@
 #property copyright "Copyright 2025, MetaQuotes Ltd."
 #property link      "https://www.mql5.com"
-#property version   "1.00"
+#property version   "1.10"
 #property strict
-
-// Simplified port of the "Lorentzian Classification" Pine Script indicator
-// Implements a basic KNN classifier using Lorentzian distance on RSI and ADX features.
-// Opens trades based on predicted direction and reports actions to Supabase via WebRequest.
 
 #include <Trade/Trade.mqh>
 #include "logger.mqh"
-CTrade trade;
+#include "utils.mqh"
+#include "risk_management.mqh"
+#include "session_filter.mqh"
+#include "equity_protection.mqh"
+#include "position_manager.mqh"
+#include "stats_reporter.mqh"
 
-input int    NeighborsCount    = 8;     // number of neighbors to consider
-input int    MaxBarsBack       = 2000;  // max history size
-input int    RSI_Period        = 14;    // feature 1
-input int    ADX_Period        = 14;    // feature 2
-input double Lots              = 0.10;  // fallback lot size
+input int    NeighborsCount        = 8;      // number of neighbours to consider
+input int    MaxBarsBack           = 2000;   // max history size retained in buffer
+input int    LabelLookahead        = 4;      // bars ahead used for labelling
+input double LabelNeutralZonePips  = 2.0;    // ignore price moves smaller than this
+input int    RSI_Period            = 14;     // RSI lookback
+input int    ADX_Period            = 14;     // ADX lookback
+input ENUM_TIMEFRAMES HigherTF     = PERIOD_H1; // secondary timeframe for confirmation
+input int    SlippagePoints        = 5;      // max slippage in points
 
-input double RiskPerTrade      = 1.0;   // % balance risked per trade
-input double StopLossPoints    = 200;   // fallback stop loss in points
-input double TakeProfitPoints  = 400;   // fallback take profit in points
-input double TrailingStopPoints= 100;   // trailing stop distance in points
-input bool   UseADR            = true;  // use ADR-based SL/TP
-input int    ADR_Period        = 14;    // days for ADR calculation
-input double ADR_SL            = 0.5;   // SL fraction of ADR
-input double ADR_TP            = 1.0;   // TP fraction of ADR
-input ENUM_TIMEFRAMES HigherTF = PERIOD_H1; // secondary timeframe
-input int    Slippage          = 5;     // max slippage in points
-input double MaxSpread         = 20;    // max allowed spread in points
-input int    StartHour         = 0;     // trading session start hour
-input int    EndHour           = 24;    // trading session end hour
-input ulong  MagicNumber       = 123456;// unique magic number
+input bool   UseADR                = true;   // use ADR to size SL/TP
+input int    ADR_Period            = 14;     // days for ADR calculation
+input double ADR_SL                = 0.5;    // SL fraction of ADR
+input double ADR_TP                = 1.0;    // TP fraction of ADR
+input double ManualStopLossPips    = 30;     // fallback stop loss in pips
+input double ManualTakeProfitPips  = 60;     // fallback take profit in pips
+input double TrailStartPips        = 25;     // start trailing once in profit
+input double TrailStepPips         = 15;     // trailing step size
 
-string SupabaseURL = "https://xyz.supabase.co/functions/v1/ea-report"; // replace with your endpoint
+input ulong  MagicNumber           = 123456; // unique magic number for orders
+input int    MaxTradesPerSymbol    = 1;      // max concurrent positions per symbol
+input int    MaxOpenTrades         = 3;      // max concurrent positions overall
+input double MaxDailyDrawdown      = 5.0;    // % drawdown to halt trading (0 disables)
+input double MinEquity             = 0.0;    // minimum equity to continue (0 disables)
 
-double CalculateLot(double slPoints);
-void   ApplyTrailingStop();
-double CalculateADR();
+input string ReportWebhookURL      = "";    // Supabase function/table endpoint
+input string SupabaseApiKey        = "";    // optional apikey header
+input string SupabaseAuthToken     = "";    // optional bearer token
+input int    HttpTimeoutMs         = 5000;   // WebRequest timeout in ms
+input int    ReportMaxRetries      = 3;      // max attempts per telemetry payload
+input int    ReportRetrySeconds    = 30;     // delay between retries
 
-// feature storage
+input int    TimerResolutionSeconds= 30;     // OnTimer cadence for telemetry
+input int    TelemetryIntervalMinutes = 15;  // cadence for stats reporter (0 disables)
+
 struct FeatureRow
 {
-   double rsi1;
-   double adx1;
-   double rsi2;
-   double adx2;
-   int    label; // 1 long, -1 short, 0 neutral
+   double rsiFast;
+   double adxFast;
+   double rsiSlow;
+   double adxSlow;
+   double closePrice;
+   int    label;      // 1 long, -1 short, 0 neutral
+   datetime barTime;
 };
 
 struct Neighbor
@@ -54,231 +63,459 @@ struct Neighbor
    int    label;
 };
 
-FeatureRow rows[];
-int totalRows = 0;
+struct ReportPayload
+{
+   string   json;
+   int      attempts;
+   datetime nextAttempt;
+};
 
-int lastProcessedBar = -1;
+CTrade trade;
+FeatureRow g_rows[];
+int g_head = -1;
+int g_count = 0;
+bool g_sessionActive = false;
+ReportPayload g_reports[];
+datetime g_lastStats = 0;
+int g_rsiFastHandle   = INVALID_HANDLE;
+int g_rsiSlowHandle   = INVALID_HANDLE;
+int g_adxFastHandle   = INVALID_HANDLE;
+int g_adxSlowHandle   = INVALID_HANDLE;
+
+int    PipFactor();
+void   StoreFeatureRow(double rsiFast, double adxFast, double rsiSlow, double adxSlow, double closePrice, datetime barTime);
+int    EvaluateSignal(double rsiFast, double adxFast, double rsiSlow, double adxSlow);
+double CalculateADRPips();
+void   ManageTrades(int signal, double closePrice);
+void   ManageActivePosition();
+bool   HandleSessionGate();
+bool   ShouldHaltForRisk();
+void   QueueTradeReport(const string action, double volume, double price, double sl, double tp, ulong ticket);
+void   ProcessPendingReports();
+string BuildRequestHeaders();
+void   SortNeighbors(Neighbor &arr[]);
+void   RemoveReport(const int index);
 
 int OnInit()
 {
-   ArrayResize(rows, MaxBarsBack);
+   ArrayResize(g_rows, MaxBarsBack);
    trade.SetExpertMagicNumber(MagicNumber);
-   trade.SetDeviationInPoints(Slippage);
+   trade.SetDeviationInPoints(SlippagePoints);
    LogVersion(VersionID);
+
+   g_rsiFastHandle = iRSI(_Symbol, PERIOD_CURRENT, RSI_Period, PRICE_CLOSE);
+   g_rsiSlowHandle = iRSI(_Symbol, HigherTF, RSI_Period, PRICE_CLOSE);
+   g_adxFastHandle = iADX(_Symbol, PERIOD_CURRENT, ADX_Period);
+   g_adxSlowHandle = iADX(_Symbol, HigherTF, ADX_Period);
+
+   if(g_rsiFastHandle == INVALID_HANDLE || g_rsiSlowHandle == INVALID_HANDLE ||
+      g_adxFastHandle == INVALID_HANDLE || g_adxSlowHandle == INVALID_HANDLE)
+   {
+      Log("Indicator handle creation failed");
+      return(INIT_FAILED);
+   }
+
+   int timer = MathMax(1, TimerResolutionSeconds);
+   EventSetTimer(timer);
+
    return(INIT_SUCCEEDED);
-}
-
-void OnTick()
-{
-   ApplyTrailingStop();
-
-   // trading session filter
-   datetime now = TimeCurrent();
-   int hour = TimeHour(now);
-   if(hour < StartHour || hour >= EndHour)
-      return;
-
-   // spread check
-   double spread = (SymbolInfoDouble(_Symbol, SYMBOL_ASK) - SymbolInfoDouble(_Symbol, SYMBOL_BID)) / _Point;
-   if(spread > MaxSpread)
-      return;
-
-   // process only on new bar
-   int currentBar = iBars(_Symbol, PERIOD_CURRENT);
-   if(currentBar == lastProcessedBar)
-      return;
-   lastProcessedBar = currentBar;
-
-   double rsi1 = iRSI(_Symbol, PERIOD_CURRENT, RSI_Period, PRICE_CLOSE, 0);
-   double adx1 = iADX(_Symbol, PERIOD_CURRENT, ADX_Period, 0, PRICE_CLOSE, 0);
-   double rsi2 = iRSI(_Symbol, HigherTF, RSI_Period, PRICE_CLOSE, 0);
-   double adx2 = iADX(_Symbol, HigherTF, ADX_Period, 0, PRICE_CLOSE, 0);
-
-   // store feature row
-   if(totalRows < MaxBarsBack)
-      totalRows++;
-   for(int i = totalRows-1; i > 0; --i)
-      rows[i] = rows[i-1];
-   rows[0].rsi1 = rsi1;
-   rows[0].adx1 = adx1;
-   rows[0].rsi2 = rsi2;
-   rows[0].adx2 = adx2;
-   rows[0].label = 0; // placeholder for future bar label
-
-   // update label for bar 4 bars ago
-   if(totalRows > 4)
-   {
-      double futureClose = iClose(_Symbol, PERIOD_CURRENT, 0);
-      double pastClose   = iClose(_Symbol, PERIOD_CURRENT, 4);
-      rows[4].label = (futureClose > pastClose) ? 1 : (futureClose < pastClose ? -1 : 0);
-   }
-
-   // skip until we have at least neighborsCount bars with labels
-   if(totalRows <= NeighborsCount + 4)
-      return;
-
-   // compute Lorentzian distances for labeled rows
-   Neighbor neighbors[];
-   ArrayResize(neighbors, 0);
-   for(int i = 4; i < totalRows; i++) // skip bars without label
-   {
-      if(i % 4 != 0) continue; // enforce spacing every 4 bars
-      double d = MathLog(1 + MathAbs(rsi1 - rows[i].rsi1)) +
-                 MathLog(1 + MathAbs(adx1 - rows[i].adx1)) +
-                 MathLog(1 + MathAbs(rsi2 - rows[i].rsi2)) +
-                 MathLog(1 + MathAbs(adx2 - rows[i].adx2));
-      Neighbor n;
-      n.distance = d;
-      n.label    = rows[i].label;
-      ArrayPush(neighbors, n);
-   }
-   ArraySort(neighbors, WHOLE_ARRAY, 0, MODE_ASCEND);
-   int limit = MathMin(NeighborsCount, ArraySize(neighbors));
-   int sum = 0;
-   for(int i = 0; i < limit; ++i)
-      sum += neighbors[i].label;
-   int signal = 0;
-   if(sum > 0) signal = 1; else if(sum < 0) signal = -1;
-
-   ManageTrades(signal);
-}
-
-void ManageTrades(int signal)
-{
-   bool hasPosition = PositionSelect(_Symbol);
-   int direction = 0;
-   if(hasPosition)
-      direction = (PositionGetInteger(POSITION_TYPE) == POSITION_TYPE_BUY) ? 1 : -1;
-
-   double slPoints = StopLossPoints;
-   double tpPoints = TakeProfitPoints;
-   if(UseADR)
-   {
-      double adrPoints = CalculateADR();
-      slPoints = adrPoints * ADR_SL;
-      tpPoints = adrPoints * ADR_TP;
-   }
-
-   double lot = CalculateLot(slPoints);
-
-   if(signal > 0 && (!hasPosition || direction < 0))
-   {
-      if(hasPosition)
-         trade.PositionClose(_Symbol);
-      double price = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
-      double sl = (slPoints > 0) ? price - slPoints*_Point : 0.0;
-      double tp = (tpPoints > 0) ? price + tpPoints*_Point : 0.0;
-      if(trade.Buy(lot, NULL, 0.0, sl, tp))
-      {
-         Log("Buy order placed");
-         SendReport("buy");
-      }
-   }
-   else if(signal < 0 && (!hasPosition || direction > 0))
-   {
-      if(hasPosition)
-         trade.PositionClose(_Symbol);
-      double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
-      double sl = (slPoints > 0) ? price + slPoints*_Point : 0.0;
-      double tp = (tpPoints > 0) ? price - tpPoints*_Point : 0.0;
-      if(trade.Sell(lot, NULL, 0.0, sl, tp))
-      {
-         Log("Sell order placed");
-         SendReport("sell");
-      }
-   }
-}
-
-double CalculateLot(double slPoints)
-{
-   if(slPoints <= 0)
-      return(Lots);
-
-   double balance   = AccountInfoDouble(ACCOUNT_BALANCE);
-   double riskMoney = balance * RiskPerTrade / 100.0;
-   double tickValue = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
-   double tickSize  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
-   double pointValue = tickValue / tickSize * _Point;
-   double slMoney   = slPoints * pointValue;
-   if(slMoney <= 0)
-      return(Lots);
-   double lot = riskMoney / slMoney;
-   double minLot = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
-   double maxLot = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MAX);
-   double step   = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_STEP);
-   lot = MathMax(minLot, MathMin(maxLot, lot));
-   lot = MathFloor(lot/step)*step;
-   return(lot);
-}
-
-void ApplyTrailingStop()
-{
-   if(TrailingStopPoints <= 0)
-      return;
-   if(!PositionSelect(_Symbol))
-      return;
-
-   double type = PositionGetInteger(POSITION_TYPE);
-   double sl   = PositionGetDouble(POSITION_SL);
-   double tp   = PositionGetDouble(POSITION_TP);
-
-   if(type == POSITION_TYPE_BUY)
-   {
-      double newSL = SymbolInfoDouble(_Symbol, SYMBOL_BID) - TrailingStopPoints*_Point;
-      if(newSL > sl)
-         trade.PositionModify(_Symbol, newSL, tp);
-   }
-   else if(type == POSITION_TYPE_SELL)
-   {
-      double newSL = SymbolInfoDouble(_Symbol, SYMBOL_ASK) + TrailingStopPoints*_Point;
-     if(sl == 0 || newSL < sl)
-         trade.PositionModify(_Symbol, newSL, tp);
-  }
-}
-
-double CalculateADR()
-{
-   int bars = MathMin(ADR_Period, iBars(_Symbol, PERIOD_D1));
-   if(bars <= 0)
-      return(0);
-   double sum = 0;
-   for(int i=1; i<=bars; ++i)
-      sum += (iHigh(_Symbol, PERIOD_D1, i-1) - iLow(_Symbol, PERIOD_D1, i-1)) / _Point;
-   return(sum / bars);
-}
-
-void SendReport(string action)
-{
-   string json = StringFormat("{\"symbol\":\"%s\",\"action\":\"%s\"}", _Symbol, action);
-   char post[]; StringToCharArray(json, post);
-   char result[];
-   string headers = "Content-Type: application/json\r\n";
-   int timeout = 5000;
-   string resHeaders;
-
-   for(int i=0;i<3;i++)
-   {
-      ResetLastError();
-      int status = WebRequest("POST", SupabaseURL, headers, timeout, post, result, resHeaders);
-      if(status == -1)
-      {
-         PrintFormat("WebRequest error %d on attempt %d", GetLastError(), i+1);
-         Sleep(1000);
-         continue;
-      }
-      if(status != 200)
-      {
-         PrintFormat("HTTP status %d on attempt %d", status, i+1);
-         Sleep(1000);
-         continue;
-      }
-      Print("Report sent: ", json);
-      break;
-   }
 }
 
 void OnDeinit(const int reason)
 {
-   // nothing to clean up
+   if(g_rsiFastHandle != INVALID_HANDLE)
+      IndicatorRelease(g_rsiFastHandle);
+   if(g_rsiSlowHandle != INVALID_HANDLE)
+      IndicatorRelease(g_rsiSlowHandle);
+   if(g_adxFastHandle != INVALID_HANDLE)
+      IndicatorRelease(g_adxFastHandle);
+   if(g_adxSlowHandle != INVALID_HANDLE)
+      IndicatorRelease(g_adxSlowHandle);
+   EventKillTimer();
 }
 
+void OnTick()
+{
+   ProcessPendingReports();
+   ManageActivePosition();
+
+   if(!IsNewBar())
+      return;
+
+   if(!HandleSessionGate())
+      return;
+
+   if(ShouldHaltForRisk())
+      return;
+
+   double rsiFastBuf[1];
+   double rsiSlowBuf[1];
+   double adxFastBuf[1];
+   double adxSlowBuf[1];
+
+   if(CopyBuffer(g_rsiFastHandle, 0, 1, 1, rsiFastBuf) < 1)
+      return;
+   if(CopyBuffer(g_rsiSlowHandle, 0, 1, 1, rsiSlowBuf) < 1)
+      return;
+   if(CopyBuffer(g_adxFastHandle, 0, 1, 1, adxFastBuf) < 1)
+      return;
+   if(CopyBuffer(g_adxSlowHandle, 0, 1, 1, adxSlowBuf) < 1)
+      return;
+
+   double rsiFast = rsiFastBuf[0];
+   double adxFast = adxFastBuf[0];
+   double rsiSlow = rsiSlowBuf[0];
+   double adxSlow = adxSlowBuf[0];
+   double closePrice = iClose(_Symbol, PERIOD_CURRENT, 1);
+   datetime barTime = iTime(_Symbol, PERIOD_CURRENT, 1);
+
+   if(rsiFast == EMPTY_VALUE || adxFast == EMPTY_VALUE || rsiSlow == EMPTY_VALUE || adxSlow == EMPTY_VALUE)
+      return;
+
+   StoreFeatureRow(rsiFast, adxFast, rsiSlow, adxSlow, closePrice, barTime);
+   int signal = EvaluateSignal(rsiFast, adxFast, rsiSlow, adxSlow);
+   if(signal != 0)
+      ManageTrades(signal, closePrice);
+}
+
+void OnTimer()
+{
+   ProcessPendingReports();
+   if(TelemetryIntervalMinutes <= 0)
+      return;
+   datetime now = TimeCurrent();
+   if(now - g_lastStats >= TelemetryIntervalMinutes * 60)
+   {
+      SendStats();
+      g_lastStats = now;
+   }
+}
+
+int PipFactor()
+{
+   return (_Digits == 3 || _Digits == 5) ? 10 : 1;
+}
+
+double PointsToPips(double points)
+{
+   return points / PipFactor();
+}
+
+void StoreFeatureRow(double rsiFast, double adxFast, double rsiSlow, double adxSlow, double closePrice, datetime barTime)
+{
+   if(MaxBarsBack <= 0)
+      return;
+   g_head = (g_head + 1) % MaxBarsBack;
+   g_rows[g_head].rsiFast = rsiFast;
+   g_rows[g_head].adxFast = adxFast;
+   g_rows[g_head].rsiSlow = rsiSlow;
+   g_rows[g_head].adxSlow = adxSlow;
+   g_rows[g_head].closePrice = closePrice;
+   g_rows[g_head].barTime = barTime;
+   g_rows[g_head].label = 0;
+
+   if(g_count < MaxBarsBack)
+      g_count++;
+
+   if(LabelLookahead <= 0 || g_count <= LabelLookahead)
+      return;
+
+   int labelIndex = (g_head - LabelLookahead + MaxBarsBack) % MaxBarsBack;
+   double baseClose = g_rows[labelIndex].closePrice;
+   double futureClose = closePrice;
+   double movePips = PointsToPips(MathAbs(futureClose - baseClose) / _Point);
+   if(movePips < LabelNeutralZonePips)
+   {
+      g_rows[labelIndex].label = 0;
+   }
+   else
+   {
+      g_rows[labelIndex].label = (futureClose > baseClose) ? 1 : -1;
+   }
+}
+
+int EvaluateSignal(double rsiFast, double adxFast, double rsiSlow, double adxSlow)
+{
+   if(g_count <= NeighborsCount)
+      return 0;
+
+   Neighbor neighbors[];
+   ArrayResize(neighbors, 0);
+
+   for(int i = 0; i < g_count; ++i)
+   {
+      int index = (g_head - i + MaxBarsBack) % MaxBarsBack;
+      int label = g_rows[index].label;
+      if(label == 0)
+         continue;
+      double distance = MathLog(1.0 + MathAbs(rsiFast - g_rows[index].rsiFast)) +
+                        MathLog(1.0 + MathAbs(adxFast - g_rows[index].adxFast)) +
+                        MathLog(1.0 + MathAbs(rsiSlow - g_rows[index].rsiSlow)) +
+                        MathLog(1.0 + MathAbs(adxSlow - g_rows[index].adxSlow));
+      int size = ArraySize(neighbors);
+      ArrayResize(neighbors, size + 1);
+      neighbors[size].distance = distance;
+      neighbors[size].label = label;
+   }
+
+   int neighbourCount = ArraySize(neighbors);
+   if(neighbourCount == 0)
+      return 0;
+
+   SortNeighbors(neighbors);
+   int limit = MathMin(NeighborsCount, neighbourCount);
+   int vote = 0;
+   for(int i = 0; i < limit; ++i)
+      vote += neighbors[i].label;
+
+   if(vote > 0)
+      return 1;
+   if(vote < 0)
+      return -1;
+   return 0;
+}
+
+void SortNeighbors(Neighbor &arr[])
+{
+   int count = ArraySize(arr);
+   for(int i = 1; i < count; ++i)
+   {
+      Neighbor key = arr[i];
+      int j = i - 1;
+      while(j >= 0 && arr[j].distance > key.distance)
+      {
+         arr[j + 1] = arr[j];
+         j--;
+      }
+      arr[j + 1] = key;
+   }
+}
+
+double CalculateADRPips()
+{
+   int bars = MathMin(ADR_Period, iBars(_Symbol, PERIOD_D1));
+   if(bars <= 0)
+      return 0.0;
+   double sumPoints = 0.0;
+   for(int i = 1; i <= bars; ++i)
+      sumPoints += (iHigh(_Symbol, PERIOD_D1, i) - iLow(_Symbol, PERIOD_D1, i)) / _Point;
+   return PointsToPips(sumPoints / bars);
+}
+
+void ManageTrades(int signal, double closePrice)
+{
+   bool hasPosition = PositionSelect(_Symbol);
+   int currentDirection = 0;
+   if(hasPosition)
+      currentDirection = (PositionGetInteger(POSITION_TYPE) == POSITION_TYPE_BUY) ? 1 : -1;
+
+   double slPips = ManualStopLossPips;
+   double tpPips = ManualTakeProfitPips;
+   if(UseADR)
+   {
+      double adr = CalculateADRPips();
+      if(adr > 0)
+      {
+         slPips = adr * ADR_SL;
+         tpPips = adr * ADR_TP;
+      }
+   }
+
+   double lot = CalculateLotSize(slPips);
+   if(lot <= 0.0)
+   {
+      lot = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
+      lot = NormalizeDouble(lot, 2);
+   }
+
+   double slDistance = slPips * PipFactor() * _Point;
+   double tpDistance = tpPips * PipFactor() * _Point;
+
+   bool opened = false;
+
+   if(signal > 0 && (!hasPosition || currentDirection < 0))
+   {
+      if(hasPosition && currentDirection < 0)
+         trade.PositionClose(_Symbol);
+
+      if(CanOpenNewTrade(_Symbol, MaxTradesPerSymbol, MaxOpenTrades))
+      {
+         double price = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+         double sl = (slPips > 0) ? price - slDistance : 0.0;
+         double tp = (tpPips > 0) ? price + tpDistance : 0.0;
+         if(trade.Buy(lot, NULL, 0.0, sl, tp))
+         {
+            ulong ticket = trade.ResultOrder();
+            if(ticket == 0)
+               ticket = (ulong)trade.ResultDeal();
+            RegisterNewTrade();
+            opened = true;
+            QueueTradeReport("buy", lot, price, sl, tp, ticket);
+            Log("Buy order placed");
+         }
+      }
+   }
+   else if(signal < 0 && (!hasPosition || currentDirection > 0))
+   {
+      if(hasPosition && currentDirection > 0)
+         trade.PositionClose(_Symbol);
+
+      if(CanOpenNewTrade(_Symbol, MaxTradesPerSymbol, MaxOpenTrades))
+      {
+         double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
+         double sl = (slPips > 0) ? price + slDistance : 0.0;
+         double tp = (tpPips > 0) ? price - tpDistance : 0.0;
+         if(trade.Sell(lot, NULL, 0.0, sl, tp))
+         {
+            ulong ticket = trade.ResultOrder();
+            if(ticket == 0)
+               ticket = (ulong)trade.ResultDeal();
+            RegisterNewTrade();
+            opened = true;
+            QueueTradeReport("sell", lot, price, sl, tp, ticket);
+            Log("Sell order placed");
+         }
+      }
+   }
+
+   if(opened)
+   {
+      ulong ticket;
+      if(PositionSelect(_Symbol))
+      {
+         ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+         SetStopLossAndTakeProfit(ticket, slPips, tpPips);
+      }
+   }
+}
+
+void ManageActivePosition()
+{
+   if(!PositionSelect(_Symbol))
+      return;
+   ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   MoveToBreakEven(ticket, entry);
+   if(TrailStartPips > 0 && TrailStepPips > 0)
+      ApplyTrailingStop(ticket, TrailStartPips, TrailStepPips);
+}
+
+bool HandleSessionGate()
+{
+   bool session = IsTradingSession();
+   if(!session)
+   {
+      if(g_sessionActive)
+      {
+         ResetSessionTrades();
+         g_sessionActive = false;
+      }
+      return false;
+   }
+
+   if(!g_sessionActive)
+   {
+      ResetSessionTrades();
+      g_sessionActive = true;
+   }
+   return true;
+}
+
+bool ShouldHaltForRisk()
+{
+   if(MaxDailyDrawdown > 0.0 && CheckDailyDrawdownLimit(MaxDailyDrawdown))
+   {
+      Log("Trading halted: daily drawdown limit reached");
+      return true;
+   }
+   if(MinEquity > 0.0 && CheckEquityThreshold(MinEquity))
+   {
+      Log("Trading halted: equity threshold breached");
+      return true;
+   }
+   return false;
+}
+
+void QueueTradeReport(const string action, double volume, double price, double sl, double tp, ulong ticket)
+{
+   if(StringLen(ReportWebhookURL) == 0)
+      return;
+
+   string payload = StringFormat(
+      "{\"symbol\":\"%s\",\"action\":\"%s\",\"volume\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"ticket\":%I64u,\"balance\":%.2f,\"equity\":%.2f}",
+      _Symbol, action, volume, price, sl, tp, ticket,
+      AccountInfoDouble(ACCOUNT_BALANCE),
+      AccountInfoDouble(ACCOUNT_EQUITY));
+
+   int size = ArraySize(g_reports);
+   ArrayResize(g_reports, size + 1);
+   g_reports[size].json = payload;
+   g_reports[size].attempts = 0;
+   g_reports[size].nextAttempt = TimeCurrent();
+}
+
+void ProcessPendingReports()
+{
+   if(StringLen(ReportWebhookURL) == 0)
+      return;
+
+   datetime now = TimeCurrent();
+   for(int i = ArraySize(g_reports) - 1; i >= 0; --i)
+   {
+      if(g_reports[i].nextAttempt > now)
+         continue;
+
+      uchar data[];
+      uchar result[];
+      string headers = BuildRequestHeaders();
+      StringToCharArray(g_reports[i].json, data, 0, WHOLE_ARRAY, CP_UTF8);
+      ResetLastError();
+      string resHeaders;
+      int status = WebRequest("POST", ReportWebhookURL, headers, HttpTimeoutMs, data, result, resHeaders);
+      if(status == -1)
+      {
+         Debug(StringFormat("Report send error %d", GetLastError()), false);
+      }
+      else if(status < 200 || status >= 300)
+      {
+         Debug(StringFormat("Report HTTP status %d", status), false);
+      }
+      else
+      {
+         Log("Report sent: " + g_reports[i].json);
+         RemoveReport(i);
+         continue;
+      }
+
+      g_reports[i].attempts++;
+      if(g_reports[i].attempts >= ReportMaxRetries)
+      {
+         Log("Dropping report after max retries: " + g_reports[i].json);
+         RemoveReport(i);
+      }
+      else
+      {
+         g_reports[i].nextAttempt = now + ReportRetrySeconds;
+      }
+   }
+}
+
+void RemoveReport(const int index)
+{
+   int size = ArraySize(g_reports);
+   if(index < 0 || index >= size)
+      return;
+   if(index < size - 1)
+      ArrayCopy(g_reports, g_reports, index, index + 1, size - index - 1);
+   ArrayResize(g_reports, size - 1);
+}
+
+string BuildRequestHeaders()
+{
+   string headers = "Content-Type: application/json\r\n";
+   if(StringLen(SupabaseApiKey) > 0)
+      headers += "apikey: " + SupabaseApiKey + "\r\n";
+   if(StringLen(SupabaseAuthToken) > 0)
+      headers += "Authorization: Bearer " + SupabaseAuthToken + "\r\n";
+   return headers;
+}

--- a/mql5/MA_Cross_EA.mq5
+++ b/mql5/MA_Cross_EA.mq5
@@ -1,71 +1,353 @@
 #property copyright "2024"
-#property version   "1.00"
+#property version   "1.10"
 #property strict
 
-// Simple Moving Average crossover EA template
-// Sends trade updates to Supabase edge function via WebRequest
-
-input int    FastMA = 9;
-input int    SlowMA = 21;
-input double Lots   = 0.10;
-
 #include <Trade/Trade.mqh>
-CTrade trade;
+#include "logger.mqh"
+#include "utils.mqh"
+#include "risk_management.mqh"
+#include "session_filter.mqh"
+#include "equity_protection.mqh"
+#include "position_manager.mqh"
+#include "stats_reporter.mqh"
 
-int fastHandle;
-int slowHandle;
+input int    FastMA                = 9;
+input int    SlowMA                = 21;
+input ENUM_MA_METHOD MaMethod      = MODE_EMA;
+input ENUM_APPLIED_PRICE MaPrice   = PRICE_CLOSE;
+input int    SlippagePoints        = 5;
+
+input double ManualStopLossPips    = 20;
+input double ManualTakeProfitPips  = 40;
+input double TrailStartPips        = 15;
+input double TrailStepPips         = 10;
+
+input ulong  MagicNumber           = 654321;
+input int    MaxTradesPerSymbol    = 1;
+input int    MaxOpenTrades         = 3;
+input double MaxDailyDrawdown      = 5.0;
+input double MinEquity             = 0.0;
+
+input string ReportWebhookURL      = "";
+input string SupabaseApiKey        = "";
+input string SupabaseAuthToken     = "";
+input int    HttpTimeoutMs         = 5000;
+input int    ReportMaxRetries      = 3;
+input int    ReportRetrySeconds    = 30;
+
+input int    TimerResolutionSeconds= 30;
+input int    TelemetryIntervalMinutes = 15;
+
+struct ReportPayload
+{
+   string   json;
+   int      attempts;
+   datetime nextAttempt;
+};
+
+CTrade trade;
+int fastHandle = INVALID_HANDLE;
+int slowHandle = INVALID_HANDLE;
+bool g_sessionActive = false;
+ReportPayload g_reports[];
+datetime g_lastStats = 0;
+
+int PipFactor();
+double PointsToPips(double points);
+void   ManageActivePosition();
+bool   HandleSessionGate();
+bool   ShouldHaltForRisk();
+void   ExecuteSignal(int signal);
+void   QueueTradeReport(const string action, double volume, double price, double sl, double tp, ulong ticket);
+void   ProcessPendingReports();
+void   RemoveReport(const int index);
+string BuildRequestHeaders();
 
 int OnInit()
 {
-   fastHandle = iMA(_Symbol, PERIOD_CURRENT, FastMA, 0, MODE_EMA, PRICE_CLOSE);
-   slowHandle = iMA(_Symbol, PERIOD_CURRENT, SlowMA, 0, MODE_EMA, PRICE_CLOSE);
+   trade.SetExpertMagicNumber(MagicNumber);
+   trade.SetDeviationInPoints(SlippagePoints);
+   LogVersion(VersionID);
+
+   fastHandle = iMA(_Symbol, PERIOD_CURRENT, FastMA, 0, MaMethod, MaPrice);
+   slowHandle = iMA(_Symbol, PERIOD_CURRENT, SlowMA, 0, MaMethod, MaPrice);
+   if(fastHandle == INVALID_HANDLE || slowHandle == INVALID_HANDLE)
+      return INIT_FAILED;
+
+   EventSetTimer(MathMax(1, TimerResolutionSeconds));
    return INIT_SUCCEEDED;
-}
-
-void OnTick()
-{
-   double fast[2];
-   double slow[2];
-   if(CopyBuffer(fastHandle,0,0,2,fast) <= 0) return;
-   if(CopyBuffer(slowHandle,0,0,2,slow) <= 0) return;
-
-   bool crossUp   = fast[1] < slow[1] && fast[0] > slow[0];
-   bool crossDown = fast[1] > slow[1] && fast[0] < slow[0];
-
-   if(crossUp)
-   {
-      if(PositionSelect(_Symbol)) trade.PositionClose(_Symbol);
-      trade.Buy(Lots);
-      SendReport("buy");
-   }
-   else if(crossDown)
-   {
-      if(PositionSelect(_Symbol)) trade.PositionClose(_Symbol);
-      trade.Sell(Lots);
-      SendReport("sell");
-   }
-}
-
-void SendReport(string action)
-{
-   string url = "https://xyz.supabase.co/functions/v1/ea-report"; // replace with your endpoint
-   string json = StringFormat("{\"symbol\":\"%s\",\"action\":\"%s\",\"profit\":%f}",
-                              _Symbol, action, AccountInfoDouble(ACCOUNT_PROFIT));
-   char post[];
-   StringToCharArray(json, post);
-
-   char result[];
-   string headers = "Content-Type: application/json\r\n";
-   int timeout = 5000;
-   int res = WebRequest("POST", url, headers, timeout, post, result, NULL);
-   if(res == -1)
-      Print("WebRequest error: ", GetLastError());
-   else
-      Print("Report sent: ", json);
 }
 
 void OnDeinit(const int reason)
 {
-   IndicatorRelease(fastHandle);
-   IndicatorRelease(slowHandle);
+   if(fastHandle != INVALID_HANDLE)
+      IndicatorRelease(fastHandle);
+   if(slowHandle != INVALID_HANDLE)
+      IndicatorRelease(slowHandle);
+   EventKillTimer();
+}
+
+void OnTick()
+{
+   ProcessPendingReports();
+   ManageActivePosition();
+
+   if(!IsNewBar())
+      return;
+
+   if(!HandleSessionGate())
+      return;
+
+   if(ShouldHaltForRisk())
+      return;
+
+   double fast[3];
+   double slow[3];
+   if(CopyBuffer(fastHandle, 0, 0, 3, fast) < 3)
+      return;
+   if(CopyBuffer(slowHandle, 0, 0, 3, slow) < 3)
+      return;
+
+   double fastPrev = fast[2];
+   double fastLast = fast[1];
+   double slowPrev = slow[2];
+   double slowLast = slow[1];
+
+   bool crossUp = fastPrev <= slowPrev && fastLast > slowLast;
+   bool crossDown = fastPrev >= slowPrev && fastLast < slowLast;
+
+   int signal = 0;
+   if(crossUp)
+      signal = 1;
+   else if(crossDown)
+      signal = -1;
+
+   if(signal != 0)
+      ExecuteSignal(signal);
+}
+
+void OnTimer()
+{
+   ProcessPendingReports();
+   if(TelemetryIntervalMinutes <= 0)
+      return;
+   datetime now = TimeCurrent();
+   if(now - g_lastStats >= TelemetryIntervalMinutes * 60)
+   {
+      SendStats();
+      g_lastStats = now;
+   }
+}
+
+int PipFactor()
+{
+   return (_Digits == 3 || _Digits == 5) ? 10 : 1;
+}
+
+double PointsToPips(double points)
+{
+   return points / PipFactor();
+}
+
+void ManageActivePosition()
+{
+   if(!PositionSelect(_Symbol))
+      return;
+   ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+   double entry = PositionGetDouble(POSITION_PRICE_OPEN);
+   MoveToBreakEven(ticket, entry);
+   if(TrailStartPips > 0 && TrailStepPips > 0)
+      ApplyTrailingStop(ticket, TrailStartPips, TrailStepPips);
+}
+
+bool HandleSessionGate()
+{
+   bool session = IsTradingSession();
+   if(!session)
+   {
+      if(g_sessionActive)
+      {
+         ResetSessionTrades();
+         g_sessionActive = false;
+      }
+      return false;
+   }
+   if(!g_sessionActive)
+   {
+      ResetSessionTrades();
+      g_sessionActive = true;
+   }
+   return true;
+}
+
+bool ShouldHaltForRisk()
+{
+   if(MaxDailyDrawdown > 0.0 && CheckDailyDrawdownLimit(MaxDailyDrawdown))
+   {
+      Log("Trading halted: daily drawdown limit reached");
+      return true;
+   }
+   if(MinEquity > 0.0 && CheckEquityThreshold(MinEquity))
+   {
+      Log("Trading halted: equity threshold breached");
+      return true;
+   }
+   return false;
+}
+
+void ExecuteSignal(int signal)
+{
+   bool hasPosition = PositionSelect(_Symbol);
+   int direction = 0;
+   if(hasPosition)
+      direction = (PositionGetInteger(POSITION_TYPE) == POSITION_TYPE_BUY) ? 1 : -1;
+
+   double slPips = ManualStopLossPips;
+   double tpPips = ManualTakeProfitPips;
+   double lot = CalculateLotSize(slPips);
+   if(lot <= 0)
+   {
+      lot = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
+      lot = NormalizeDouble(lot, 2);
+   }
+
+   double slDistance = slPips * PipFactor() * _Point;
+   double tpDistance = tpPips * PipFactor() * _Point;
+
+   bool opened = false;
+
+   if(signal > 0 && (!hasPosition || direction < 0))
+   {
+      if(hasPosition && direction < 0)
+         trade.PositionClose(_Symbol);
+
+      if(CanOpenNewTrade(_Symbol, MaxTradesPerSymbol, MaxOpenTrades))
+      {
+         double price = SymbolInfoDouble(_Symbol, SYMBOL_ASK);
+         double sl = (slPips > 0) ? price - slDistance : 0.0;
+         double tp = (tpPips > 0) ? price + tpDistance : 0.0;
+         if(trade.Buy(lot, NULL, 0.0, sl, tp))
+         {
+            ulong ticket = trade.ResultOrder();
+            if(ticket == 0)
+               ticket = (ulong)trade.ResultDeal();
+            RegisterNewTrade();
+            opened = true;
+            QueueTradeReport("buy", lot, price, sl, tp, ticket);
+            Log("Buy order placed");
+         }
+      }
+   }
+   else if(signal < 0 && (!hasPosition || direction > 0))
+   {
+      if(hasPosition && direction > 0)
+         trade.PositionClose(_Symbol);
+
+      if(CanOpenNewTrade(_Symbol, MaxTradesPerSymbol, MaxOpenTrades))
+      {
+         double price = SymbolInfoDouble(_Symbol, SYMBOL_BID);
+         double sl = (slPips > 0) ? price + slDistance : 0.0;
+         double tp = (tpPips > 0) ? price - tpDistance : 0.0;
+         if(trade.Sell(lot, NULL, 0.0, sl, tp))
+         {
+            ulong ticket = trade.ResultOrder();
+            if(ticket == 0)
+               ticket = (ulong)trade.ResultDeal();
+            RegisterNewTrade();
+            opened = true;
+            QueueTradeReport("sell", lot, price, sl, tp, ticket);
+            Log("Sell order placed");
+         }
+      }
+   }
+
+   if(opened && PositionSelect(_Symbol))
+   {
+      ulong ticket = (ulong)PositionGetInteger(POSITION_TICKET);
+      SetStopLossAndTakeProfit(ticket, slPips, tpPips);
+   }
+}
+
+void QueueTradeReport(const string action, double volume, double price, double sl, double tp, ulong ticket)
+{
+   if(StringLen(ReportWebhookURL) == 0)
+      return;
+
+   string payload = StringFormat(
+      "{\"symbol\":\"%s\",\"action\":\"%s\",\"volume\":%.2f,\"price\":%.5f,\"sl\":%.5f,\"tp\":%.5f,\"ticket\":%I64u,\"profit\":%.2f,\"equity\":%.2f}",
+      _Symbol, action, volume, price, sl, tp, ticket,
+      AccountInfoDouble(ACCOUNT_PROFIT),
+      AccountInfoDouble(ACCOUNT_EQUITY));
+
+   int size = ArraySize(g_reports);
+   ArrayResize(g_reports, size + 1);
+   g_reports[size].json = payload;
+   g_reports[size].attempts = 0;
+   g_reports[size].nextAttempt = TimeCurrent();
+}
+
+void ProcessPendingReports()
+{
+   if(StringLen(ReportWebhookURL) == 0)
+      return;
+
+   datetime now = TimeCurrent();
+   for(int i = ArraySize(g_reports) - 1; i >= 0; --i)
+   {
+      if(g_reports[i].nextAttempt > now)
+         continue;
+
+      uchar data[];
+      uchar result[];
+      string headers = BuildRequestHeaders();
+      StringToCharArray(g_reports[i].json, data, 0, WHOLE_ARRAY, CP_UTF8);
+      ResetLastError();
+      string resHeaders;
+      int status = WebRequest("POST", ReportWebhookURL, headers, HttpTimeoutMs, data, result, resHeaders);
+      if(status == -1)
+      {
+         Debug(StringFormat("Report send error %d", GetLastError()), false);
+      }
+      else if(status < 200 || status >= 300)
+      {
+         Debug(StringFormat("Report HTTP status %d", status), false);
+      }
+      else
+      {
+         Log("Report sent: " + g_reports[i].json);
+         RemoveReport(i);
+         continue;
+      }
+
+      g_reports[i].attempts++;
+      if(g_reports[i].attempts >= ReportMaxRetries)
+      {
+         Log("Dropping report after max retries: " + g_reports[i].json);
+         RemoveReport(i);
+      }
+      else
+      {
+         g_reports[i].nextAttempt = now + ReportRetrySeconds;
+      }
+   }
+}
+
+void RemoveReport(const int index)
+{
+   int size = ArraySize(g_reports);
+   if(index < 0 || index >= size)
+      return;
+   if(index < size - 1)
+      ArrayCopy(g_reports, g_reports, index, index + 1, size - index - 1);
+   ArrayResize(g_reports, size - 1);
+}
+
+string BuildRequestHeaders()
+{
+   string headers = "Content-Type: application/json\r\n";
+   if(StringLen(SupabaseApiKey) > 0)
+      headers += "apikey: " + SupabaseApiKey + "\r\n";
+   if(StringLen(SupabaseAuthToken) > 0)
+      headers += "Authorization: Bearer " + SupabaseAuthToken + "\r\n";
+   return headers;
 }


### PR DESCRIPTION
## Summary
- Rebuilt the Lorentzian classification EA around the shared risk/session modules, a ring buffer feature store, forward-looking labels, and queued Supabase telemetry
- Updated the MA crossover EA to reuse the common protections, configurable inputs, and non-blocking reporting pipeline for Supabase integration

## Testing
- not run (MQL5 EAs require manual Strategy Tester validation)


------
https://chatgpt.com/codex/tasks/task_e_68ca73bec1188322b65d0f07f700c804