### PR TITLE
Switch canonical domain to Vercel and allow load sharing

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -28,16 +28,16 @@ spec:
       value: "1"
       scope: RUN_AND_BUILD_TIME
     - key: SITE_URL
-      value: https://dynamic-capital.lovable.app
+      value: https://dynamic-capital.vercel.app
       scope: RUN_AND_BUILD_TIME
     - key: NEXT_PUBLIC_SITE_URL
-      value: https://dynamic-capital.lovable.app
+      value: https://dynamic-capital.vercel.app
       scope: RUN_AND_BUILD_TIME
     - key: ALLOWED_ORIGINS
-      value: https://dynamic-capital.lovable.app
+      value: "https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://dynamic-capital.ondigitalocean.app"
       scope: RUN_AND_BUILD_TIME
     - key: MINIAPP_ORIGIN
-      value: https://dynamic-capital.lovable.app
+      value: https://dynamic-capital.vercel.app
       scope: RUN_AND_BUILD_TIME
     - key: NEXT_PUBLIC_SUPABASE_URL
       value: https://qeejuomcapbdlhnjqjcc.supabase.co
@@ -74,11 +74,11 @@ spec:
         http_path: /
       envs:
         - key: SITE_URL
-          value: https://dynamic-capital.lovable.app
+          value: https://dynamic-capital.vercel.app
           scope: RUN_AND_BUILD_TIME
         - key: NEXT_PUBLIC_SITE_URL
-          value: https://dynamic-capital.lovable.app
+          value: https://dynamic-capital.vercel.app
           scope: RUN_AND_BUILD_TIME
         - key: MINIAPP_ORIGIN
-          value: https://dynamic-capital.lovable.app
+          value: https://dynamic-capital.vercel.app
           scope: RUN_AND_BUILD_TIME

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,13 +11,15 @@ at [`.do/app.yml`](../.do/app.yml). Keep the spec in sync with any component or
 environment changes described in this document so the repository remains a
 single source of truth for deployments. The checked-in spec provisions a single
 Node.js service named `dynamic-capital`, configures the
-`dynamic-capital.lovable.app` domain with ingress, pins the load balancer rule
-to that authority, and runs `npm run build` from the repository root before
-starting the Next.js server via `npm run start:web`. Requests are served on port
-`8080`, and the service sets `SITE_URL`, `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`,
-and `MINIAPP_ORIGIN` to `https://dynamic-capital.lovable.app` so the web app,
-Supabase Edge Functions, and Telegram mini-app verification report the same
-origin. Update those values if you move to a different hostname.
+`dynamic-capital.lovable.app` domain with ingress so the Lovable host continues
+serving traffic, pins the load balancer rule to that authority, and runs
+`npm run build` from the repository root before starting the Next.js server via
+`npm run start:web`. Requests are served on port `8080`, and the service now sets
+`SITE_URL`, `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`, and `MINIAPP_ORIGIN` to
+`https://dynamic-capital.vercel.app` (while allowlisting the companion hosts) so
+the web app, Supabase Edge Functions, and Telegram mini-app verification report
+the new canonical origin. Update those values if you move to a different
+hostname.
 
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
@@ -45,10 +47,10 @@ domain. Its exported zone file lives in
 [`dns/dynamic-capital.ondigitalocean.app.zone`](../dns/dynamic-capital.ondigitalocean.app.zone)
 and captures the required NS and A records (162.159.140.98 and 172.66.0.96).
 Use that file if you need to rehydrate the fallback host while keeping
-Cloudflare in front of the service. Production traffic should target
-`dynamic-capital.lovable.app` once the Lovable domain is live. The helper
-`configure-digitalocean-dns.ts` script keeps the Lovable domain aligned with the
-expected records:
+Cloudflare in front of the service. Production traffic now targets
+`dynamic-capital.vercel.app`, with `dynamic-capital.lovable.app` staying active
+for load sharing. The helper `configure-digitalocean-dns.ts` script keeps the
+Lovable domain aligned with the expected records:
 
 ```bash
 # Preview the proposed DNS mutations
@@ -72,14 +74,14 @@ Example usage:
 # Update the app spec, aligning env vars, ingress, and primary domain.
 node scripts/doctl/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
-  --site-url https://dynamic-capital.lovable.app \
+  --site-url https://dynamic-capital.vercel.app \
   --zone dynamic-capital.ondigitalocean.app \
   --show-spec
 
 # Apply the spec changes and import the DNS zone in one go.
 node scripts/doctl/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
-  --site-url https://dynamic-capital.lovable.app \
+  --site-url https://dynamic-capital.vercel.app \
   --zone dynamic-capital.ondigitalocean.app \
   --apply \
   --apply-zone
@@ -147,7 +149,8 @@ sync with local expectations. Update both the spec and this section if the
 build or runtime command changes.
 
 The `SITE_URL` variable must match your public domain, e.g.
-`https://dynamic-capital.lovable.app`.
+`https://dynamic-capital.vercel.app`, and `ALLOWED_ORIGINS` should include the
+Lovable and DigitalOcean hosts if you continue to share load across them.
 
 ## Deployment logs
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -87,8 +87,8 @@ You can confirm access with `doctl spaces list`.
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
-| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `http://localhost:3000`). | No       | `https://example.com`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
-| `MINIAPP_ORIGIN`      | Origins allowed to call Telegram verification and mini-app APIs.              | No (required for production bots) | `https://dynamic-capital.lovable.app` | `supabase/functions/verify-telegram/index.ts` |
+| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `http://localhost:3000`). | No       | `https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `MINIAPP_ORIGIN`      | Origins allowed to call Telegram verification and mini-app APIs.              | No (required for production bots) | `https://dynamic-capital.vercel.app` | `supabase/functions/verify-telegram/index.ts` |
 | `LOG_LEVEL`           | Minimum log level for server logs (`debug`, `info`, `warn`, `error`). | No       | `warn`                    | `utils/logger.ts` |
 | `FUNCTIONS_BASE_URL`   | Override Supabase functions host when provisioning database webhooks. | No       | `https://custom.functions.supabase.co` | `scripts/setup-db-webhooks.ts` |
 | `LOGTAIL_SOURCE_TOKEN` | Logtail source token used for Supabase log drain setup.              | No       | `gls_xxx`                    | `scripts/setup-log-drain.ts` |

--- a/lovable-build.js
+++ b/lovable-build.js
@@ -13,7 +13,12 @@ import {
   error as logError,
 } from './scripts/utils/friendly-logger.js';
 
-const PRODUCTION_ORIGIN = 'https://dynamic-capital.lovable.app';
+const PRODUCTION_ORIGIN = 'https://dynamic-capital.vercel.app';
+const PRODUCTION_ALLOWED_ORIGINS = [
+  'https://dynamic-capital.vercel.app',
+  'https://dynamic-capital.lovable.app',
+  'https://dynamic-capital.ondigitalocean.app',
+].join(',');
 const resolvedOrigin =
   process.env.LOVABLE_ORIGIN ||
   process.env.SITE_URL ||
@@ -30,18 +35,22 @@ const defaultedKeys = [];
 for (const key of [
   'SITE_URL',
   'NEXT_PUBLIC_SITE_URL',
-  'ALLOWED_ORIGINS',
   'MINIAPP_ORIGIN',
 ]) {
   if (!process.env[key]) {
     process.env[key] = resolvedOrigin;
-    defaultedKeys.push(key);
+    defaultedKeys.push(`${key} → ${resolvedOrigin}`);
   }
 }
 
+if (!process.env.ALLOWED_ORIGINS) {
+  process.env.ALLOWED_ORIGINS = PRODUCTION_ALLOWED_ORIGINS;
+  defaultedKeys.push(`ALLOWED_ORIGINS → ${PRODUCTION_ALLOWED_ORIGINS}`);
+}
+
 if (defaultedKeys.length > 0) {
-  warn('Origin variables were missing. Applying the resolved origin to keep builds consistent.', {
-    details: defaultedKeys.map((key) => `${key} → ${resolvedOrigin}`),
+  warn('Origin variables were missing. Applying defaults to keep builds consistent.', {
+    details: defaultedKeys,
   });
 } else {
   success('All origin-related environment variables are ready to go.');

--- a/lovable-dev.js
+++ b/lovable-dev.js
@@ -12,7 +12,12 @@ import {
   error as logError,
 } from './scripts/utils/friendly-logger.js';
 
-const PRODUCTION_ORIGIN = 'https://dynamic-capital.lovable.app';
+const PRODUCTION_ORIGIN = 'https://dynamic-capital.vercel.app';
+const PRODUCTION_ALLOWED_ORIGINS = [
+  'https://dynamic-capital.vercel.app',
+  'https://dynamic-capital.lovable.app',
+  'https://dynamic-capital.ondigitalocean.app',
+].join(',');
 const resolvedOrigin =
   process.env.LOVABLE_ORIGIN ||
   process.env.SITE_URL ||
@@ -29,18 +34,22 @@ const defaultedKeys = [];
 for (const key of [
   'SITE_URL',
   'NEXT_PUBLIC_SITE_URL',
-  'ALLOWED_ORIGINS',
   'MINIAPP_ORIGIN',
 ]) {
   if (!process.env[key]) {
     process.env[key] = resolvedOrigin;
-    defaultedKeys.push(key);
+    defaultedKeys.push(`${key} → ${resolvedOrigin}`);
   }
 }
 
+if (!process.env.ALLOWED_ORIGINS) {
+  process.env.ALLOWED_ORIGINS = PRODUCTION_ALLOWED_ORIGINS;
+  defaultedKeys.push(`ALLOWED_ORIGINS → ${PRODUCTION_ALLOWED_ORIGINS}`);
+}
+
 if (defaultedKeys.length > 0) {
-  warn('Origin variables were missing. Filling them with the resolved origin so previews stay happy.', {
-    details: defaultedKeys.map((key) => `${key} → ${resolvedOrigin}`),
+  warn('Origin variables were missing. Filling them with defaults so previews stay happy.', {
+    details: defaultedKeys,
   });
 } else {
   success('All origin-related environment variables were already set. Nice!');

--- a/project.toml
+++ b/project.toml
@@ -30,15 +30,15 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://dynamic-capital.lovable.app"
+    value = "https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://dynamic-capital.ondigitalocean.app"
 
   [[build.env]]
     name = "SITE_URL"
-    value = "https://dynamic-capital.lovable.app/"
+    value = "https://dynamic-capital.vercel.app/"
 
   [[build.env]]
     name = "MINIAPP_ORIGIN"
-    value = "https://dynamic-capital.lovable.app"
+    value = "https://dynamic-capital.vercel.app"
 
   [[build.env]]
     name = "NEXT_TELEMETRY_DISABLED"

--- a/scripts/doctl/sync-site-config.mjs
+++ b/scripts/doctl/sync-site-config.mjs
@@ -144,7 +144,7 @@ async function main() {
 
   if (!siteUrl) {
     usage();
-    throw new Error('--site-url is required (e.g. https://dynamic-capital.lovable.app).');
+    throw new Error('--site-url is required (e.g. https://dynamic-capital.vercel.app).');
   }
 
   const parsedSiteUrl = parseSiteUrl(siteUrl);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,14 +1,16 @@
 project_id = "qeejuomcapbdlhnjqjcc"
 
 [global]
-  site_url = "https://dynamic-capital.lovable.app"
+  site_url = "https://dynamic-capital.vercel.app"
   additional_redirect_urls = [
+    "https://dynamic-capital.vercel.app",
     "https://dynamic-capital.lovable.app",
+    "https://dynamic-capital.ondigitalocean.app",
   ]
 
 [functions]
   [functions.env]
-    SITE_URL = "https://dynamic-capital.lovable.app"
-    NEXT_PUBLIC_SITE_URL = "https://dynamic-capital.lovable.app"
-    ALLOWED_ORIGINS = "https://dynamic-capital.lovable.app"
-    MINIAPP_ORIGIN = "https://dynamic-capital.lovable.app"
+    SITE_URL = "https://dynamic-capital.vercel.app"
+    NEXT_PUBLIC_SITE_URL = "https://dynamic-capital.vercel.app"
+    ALLOWED_ORIGINS = "https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://dynamic-capital.ondigitalocean.app"
+    MINIAPP_ORIGIN = "https://dynamic-capital.vercel.app"

--- a/vercel.json
+++ b/vercel.json
@@ -5,16 +5,9 @@
   "outputDirectory": "apps/web/.next",
   "devCommand": "npm run dev -- --port $PORT",
   "env": {
-    "SITE_URL": "https://dynamic-capital.lovable.app",
-    "NEXT_PUBLIC_SITE_URL": "https://dynamic-capital.lovable.app",
-    "ALLOWED_ORIGINS": "https://dynamic-capital.lovable.app",
-    "MINIAPP_ORIGIN": "https://dynamic-capital.lovable.app"
-  },
-  "redirects": [
-    {
-      "source": "/(.*)",
-      "destination": "https://dynamic-capital.lovable.app/$1",
-      "permanent": false
-    }
-  ]
+    "SITE_URL": "https://dynamic-capital.vercel.app",
+    "NEXT_PUBLIC_SITE_URL": "https://dynamic-capital.vercel.app",
+    "ALLOWED_ORIGINS": "https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://dynamic-capital.ondigitalocean.app",
+    "MINIAPP_ORIGIN": "https://dynamic-capital.vercel.app"
+  }
 }


### PR DESCRIPTION
## Summary
- point SITE_URL, NEXT_PUBLIC_SITE_URL, MINIAPP_ORIGIN, and related automation defaults to https://dynamic-capital.vercel.app
- allowlist dynamic-capital.lovable.app and dynamic-capital.ondigitalocean.app across Supabase, Vercel, and build tooling so all hosts can share load
- refresh deployment and networking docs to describe the multi-domain setup and updated DNS workflows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8248025c83228c621fff0332fd61