### PR TITLE
Enhance node env detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Node environment: development, test, or production
 NODE_ENV=development
+# Optional: set when mirroring Vercel deployments; used when NODE_ENV is absent
+# VERCEL_ENV=development
 SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/docs/REPO_SUMMARY.md
+++ b/docs/REPO_SUMMARY.md
@@ -1,6 +1,6 @@
 # Repository Summary — Dynamic-Capital
 
-**Generated:** Wed, 17 Sep 2025 08:28:10 GMT
+**Generated:** Wed, 17 Sep 2025 10:33:26 GMT
 **Repo root:** Dynamic-Capital
 
 ## Directory Map (top-level)
@@ -94,7 +94,7 @@
 | system-health | supabase/functions/system-health/index.ts | Yes |
 | telegram-bot | supabase/functions/telegram-bot/index.ts | Yes |
 | telegram-bot-sync | supabase/functions/telegram-bot-sync/index.ts | Yes |
-| telegram-bot/admin-handlers | supabase/functions/telegram-bot/admin-handlers/index.ts | No |
+| telegram-bot/admin-handlers | supabase/functions/telegram-bot/admin-handlers/index.ts | Yes |
 | telegram-getwebhook | supabase/functions/telegram-getwebhook/index.ts | Yes |
 | telegram-setwebhook | supabase/functions/telegram-setwebhook/index.ts | Yes |
 | telegram-webhook | supabase/functions/telegram-webhook/index.ts | Yes |
@@ -120,6 +120,7 @@
 - ADMIN_API_SECRET
 - ALLOWED_ORIGINS
 - ANALYZE
+- APP_URL
 - CDN_ACCESS_KEY
 - CDN_BUCKET
 - CDN_ENDPOINT
@@ -134,6 +135,10 @@
 - DEBUG
 - DENO_DEPLOYMENT_ID
 - DENO_REGION
+- DEPLOY_URL
+- DEPLOYMENT_URL
+- DIGITALOCEAN_APP_SITE_DOMAIN
+- DIGITALOCEAN_APP_URL
 - ENABLE_SENTRY
 - EXAMPLE_KEY
 - FUNCTIONS_BASE
@@ -162,6 +167,7 @@
 - NODE_EXTRA_CA_CERTS
 - PORT
 - PREVIEW_URL
+- PUBLIC_URL
 - QUEUE_PENDING_THRESHOLD
 - RETENTION_DAYS
 - SENTRY_DSN
@@ -183,6 +189,9 @@
 - TELEGRAM_ID
 - TELEGRAM_WEBHOOK_SECRET
 - TELEGRAM_WEBHOOK_URL
+- URL
+- VERCEL_ENV
+- VERCEL_URL
 
 ## Automation Notes
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -83,6 +83,8 @@ You can confirm access with `doctl spaces list`.
 | --------------------- | ---------------------------------------- | -------- | ------------------------- | --------------------------------- |
 | `SITE_URL`            | Base URL for the deployed site; used for redirects and canonical host checks. | Yes      | `http://localhost:3000` | `next.config.mjs`, `hooks/useAuth.tsx` |
 | `NEXT_PUBLIC_API_URL`  | Base URL for client API requests (defaults to same-origin `/api`). | No | `http://localhost:3000/api` | `env.ts` |
+| `NODE_ENV`             | Node runtime environment (`development`, `test`, or `production`). | No       | `development`             | `apps/web/config/node-env.ts`, `apps/web/app/healthz/route.ts`, `apps/web/instrumentation.ts` |
+| `VERCEL_ENV`           | Deployment stage provided by Vercel; used as a fallback when `NODE_ENV` is unset. | No       | `production`              | `apps/web/config/node-env.ts` |
 | `NODE_EXTRA_CA_CERTS` | Additional CA bundle for outbound HTTPS. | No       | `/etc/ssl/custom.pem`     | `apps/web/utils/http-ca.ts`            |
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |

--- a/tests/node-env-config.test.ts
+++ b/tests/node-env-config.test.ts
@@ -7,22 +7,34 @@ const importNodeEnv = async () => {
   return await freshImport(moduleUrl);
 };
 
-async function withNodeEnv(value: string | undefined, run: () => Promise<void>) {
-  const original = process.env.NODE_ENV;
-  if (value === undefined) {
-    delete process.env.NODE_ENV;
-  } else {
-    process.env.NODE_ENV = value;
+async function withEnv(
+  values: Record<string, string | undefined>,
+  run: () => Promise<void>,
+) {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
   }
   try {
     await run();
   } finally {
-    if (original === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = original;
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
   }
+}
+
+async function withNodeEnv(value: string | undefined, run: () => Promise<void>) {
+  await withEnv({ NODE_ENV: value }, run);
 }
 
 test('defaults to development when NODE_ENV missing', async () => {
@@ -54,6 +66,30 @@ test('unknown NODE_ENV values fallback to development', async () => {
 
 test('recognizes test NODE_ENV values regardless of casing', async () => {
   await withNodeEnv(' TEST ', async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'test');
+    assertEqual(mod.isTest, true);
+  });
+});
+
+test('falls back to VERCEL_ENV when NODE_ENV missing', async () => {
+  await withEnv({ NODE_ENV: undefined, VERCEL_ENV: 'production' }, async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'production');
+    assertEqual(mod.isProduction, true);
+  });
+});
+
+test('treats VERCEL_ENV preview as production', async () => {
+  await withEnv({ NODE_ENV: undefined, VERCEL_ENV: 'preview' }, async () => {
+    const mod = await importNodeEnv();
+    assertEqual(mod.NODE_ENV, 'production');
+    assertEqual(mod.isProduction, true);
+  });
+});
+
+test('recognizes CI alias as test environment', async () => {
+  await withNodeEnv('ci', async () => {
     const mod = await importNodeEnv();
     assertEqual(mod.NODE_ENV, 'test');
     assertEqual(mod.isTest, true);


### PR DESCRIPTION
## Summary
- extend the Node environment helper to recognise alias values and fall back to Vercel's VERCEL_ENV flag
- document the new behaviour in env docs and the example env file
- expand the node-env test coverage for Vercel fallback and CI aliases

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ca8d782d0c8322bbb44c45714e2108