### PR TITLE
feat: add offline ML workflow and backtesting harness

### DIFF
--- a/algorithms/__init__.py
+++ b/algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package for Dynamic Capital algorithm implementations."""

--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -1,27 +1,6 @@
 """Python trading strategy utilities for Dynamic Capital."""
 
-from .trade_logic import (
-    ActivePosition,
-    MarketSnapshot,
-    RiskManager,
-    RiskParameters,
-    TradeConfig,
-    TradeDecision,
-    TradeLogic,
-    TradeSignal,
-    kernels,
-    ml,
-)
+from . import trade_logic as _trade_logic
 
-__all__ = [
-    "ActivePosition",
-    "MarketSnapshot",
-    "RiskManager",
-    "RiskParameters",
-    "TradeConfig",
-    "TradeDecision",
-    "TradeLogic",
-    "TradeSignal",
-    "ml",
-    "kernels",
-]
+__all__ = getattr(_trade_logic, "__all__", [])  # type: ignore[attr-defined]
+globals().update({name: getattr(_trade_logic, name) for name in __all__})

--- a/algorithms/python/backtesting.py
+++ b/algorithms/python/backtesting.py
@@ -1,0 +1,126 @@
+"""Simple backtesting harness for the Lorentzian k-NN strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+from .trade_logic import (
+    ActivePosition,
+    CompletedTrade,
+    MarketSnapshot,
+    PerformanceMetrics,
+    TradeDecision,
+    TradeLogic,
+)
+
+
+@dataclass(slots=True)
+class BacktestResult:
+    decisions: List[TradeDecision]
+    trades: List[CompletedTrade]
+    performance: PerformanceMetrics
+    ending_equity: float
+
+
+class Backtester:
+    """Streams historical bars through :class:`TradeLogic` to generate metrics."""
+
+    def __init__(self, logic: TradeLogic, *, initial_equity: float = 10_000.0, slippage_pips: float = 0.0) -> None:
+        self.logic = logic
+        self.initial_equity = initial_equity
+        self.slippage_pips = slippage_pips
+
+    def run(self, snapshots: Sequence[MarketSnapshot]) -> BacktestResult:
+        open_positions: List[ActivePosition] = []
+        decisions: List[TradeDecision] = []
+        trades: List[CompletedTrade] = []
+        equity = self.initial_equity
+        last_snapshot: Optional[MarketSnapshot] = None
+        for snapshot in snapshots:
+            self.logic.risk.update_equity(equity, timestamp=snapshot.timestamp)
+            generated = self.logic.on_bar(snapshot, open_positions=open_positions, account_equity=equity)
+            decisions.extend(generated)
+            for decision in generated:
+                if decision.action == "close":
+                    trade = self._close_position(decision, snapshot, open_positions)
+                    if trade:
+                        equity += trade.profit
+                        trades.append(trade)
+                        self.logic.risk.record_closed_trade(trade)
+                elif decision.action == "open":
+                    self._open_position(decision, snapshot, open_positions)
+            last_snapshot = snapshot
+        if last_snapshot is not None and open_positions:
+            for pos in list(open_positions):
+                forced = self._force_close(pos, last_snapshot)
+                equity += forced.profit
+                trades.append(forced)
+                self.logic.risk.record_closed_trade(forced)
+                open_positions.remove(pos)
+        performance = self.logic.risk.metrics()
+        return BacktestResult(decisions=decisions, trades=trades, performance=performance, ending_equity=equity)
+
+    def _open_position(self, decision: TradeDecision, snapshot: MarketSnapshot, open_positions: List[ActivePosition]) -> None:
+        entry_price = decision.entry or snapshot.close
+        if self.slippage_pips:
+            entry_price += self.slippage_pips * snapshot.pip_size * (1 if decision.direction > 0 else -1)
+        open_positions.append(
+            ActivePosition(
+                symbol=decision.symbol,
+                direction=decision.direction or 0,
+                size=decision.size or 0.0,
+                entry_price=entry_price,
+                stop_loss=decision.stop_loss,
+                take_profit=decision.take_profit,
+                opened_at=snapshot.timestamp,
+            )
+        )
+
+    def _close_position(
+        self,
+        decision: TradeDecision,
+        snapshot: MarketSnapshot,
+        open_positions: List[ActivePosition],
+    ) -> Optional[CompletedTrade]:
+        for idx, pos in enumerate(open_positions):
+            if pos.symbol == decision.symbol and pos.direction == decision.direction:
+                exit_price = snapshot.close
+                if self.slippage_pips:
+                    exit_price -= self.slippage_pips * snapshot.pip_size * (1 if pos.direction > 0 else -1)
+                pips = (exit_price - pos.entry_price) / snapshot.pip_size * pos.direction
+                profit = pips * snapshot.pip_value * pos.size
+                trade = CompletedTrade(
+                    symbol=pos.symbol,
+                    direction=pos.direction,
+                    size=pos.size,
+                    entry_price=pos.entry_price,
+                    exit_price=exit_price,
+                    open_time=pos.opened_at or snapshot.timestamp,
+                    close_time=snapshot.timestamp,
+                    profit=profit,
+                    pips=pips,
+                    metadata={"reason": decision.reason},
+                )
+                del open_positions[idx]
+                return trade
+        return None
+
+    def _force_close(self, pos: ActivePosition, snapshot: MarketSnapshot) -> CompletedTrade:
+        pips = (snapshot.close - pos.entry_price) / snapshot.pip_size * pos.direction
+        profit = pips * snapshot.pip_value * pos.size
+        return CompletedTrade(
+            symbol=pos.symbol,
+            direction=pos.direction,
+            size=pos.size,
+            entry_price=pos.entry_price,
+            exit_price=snapshot.close,
+            open_time=pos.opened_at or snapshot.timestamp,
+            close_time=snapshot.timestamp,
+            profit=profit,
+            pips=pips,
+            metadata={"forced_exit": True},
+        )
+
+
+__all__ = ["Backtester", "BacktestResult"]

--- a/algorithms/python/data_pipeline.py
+++ b/algorithms/python/data_pipeline.py
@@ -1,0 +1,219 @@
+"""Historical data ingestion utilities for Dynamic Capital trading models."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+from .trade_logic import MarketSnapshot
+
+
+@dataclass(slots=True)
+class RawBar:
+    """Minimal OHLCV container used by the ingestion job."""
+
+    timestamp: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+
+
+@dataclass(slots=True)
+class InstrumentMeta:
+    """Instrument metadata required to mirror live feature inputs."""
+
+    symbol: str
+    pip_size: float
+    pip_value: float
+
+
+def _rolling_mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values)
+
+
+def _compute_rsi(closes: Sequence[float], period: int) -> List[Optional[float]]:
+    if period <= 0:
+        raise ValueError("RSI period must be positive")
+    rsis: List[Optional[float]] = [None] * len(closes)
+    gains: List[float] = [0.0]
+    losses: List[float] = [0.0]
+    for idx in range(1, len(closes)):
+        change = closes[idx] - closes[idx - 1]
+        gains.append(max(change, 0.0))
+        losses.append(abs(min(change, 0.0)))
+    for idx in range(period, len(closes)):
+        if idx == period:
+            avg_gain = _rolling_mean(gains[1 : period + 1])
+            avg_loss = _rolling_mean(losses[1 : period + 1])
+        else:
+            avg_gain = (avg_gain * (period - 1) + gains[idx]) / period  # type: ignore[name-defined]
+            avg_loss = (avg_loss * (period - 1) + losses[idx]) / period  # type: ignore[name-defined]
+        if avg_loss == 0:
+            rs = math.inf
+        else:
+            rs = avg_gain / avg_loss
+        rsi = 100 - (100 / (1 + rs))
+        rsis[idx] = rsi
+    return rsis
+
+
+def _compute_adx(
+    highs: Sequence[float],
+    lows: Sequence[float],
+    closes: Sequence[float],
+    period: int,
+) -> List[Optional[float]]:
+    if period <= 0:
+        raise ValueError("ADX period must be positive")
+    adx_values: List[Optional[float]] = [None] * len(closes)
+    tr_values: List[float] = [0.0]
+    plus_dm: List[float] = [0.0]
+    minus_dm: List[float] = [0.0]
+    for idx in range(1, len(closes)):
+        high = highs[idx]
+        low = lows[idx]
+        prev_close = closes[idx - 1]
+        up_move = high - highs[idx - 1]
+        down_move = lows[idx - 1] - low
+        plus_dm.append(up_move if up_move > down_move and up_move > 0 else 0.0)
+        minus_dm.append(down_move if down_move > up_move and down_move > 0 else 0.0)
+        true_range = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        tr_values.append(true_range)
+    for idx in range(period, len(closes)):
+        if idx == period:
+            tr_sum = sum(tr_values[1 : period + 1])
+            plus_dm_sum = sum(plus_dm[1 : period + 1])
+            minus_dm_sum = sum(minus_dm[1 : period + 1])
+        else:
+            tr_sum = tr_sum - (tr_sum / period) + tr_values[idx]  # type: ignore[name-defined]
+            plus_dm_sum = plus_dm_sum - (plus_dm_sum / period) + plus_dm[idx]  # type: ignore[name-defined]
+            minus_dm_sum = minus_dm_sum - (minus_dm_sum / period) + minus_dm[idx]  # type: ignore[name-defined]
+        if tr_sum == 0:
+            plus_di = 0.0
+            minus_di = 0.0
+        else:
+            plus_di = 100 * (plus_dm_sum / tr_sum)
+            minus_di = 100 * (minus_dm_sum / tr_sum)
+        di_diff = abs(plus_di - minus_di)
+        di_sum = plus_di + minus_di
+        dx = 0.0 if di_sum == 0 else (di_diff / di_sum) * 100
+        if idx == period:
+            adx = _rolling_mean([dx] * period)
+        else:
+            adx = (adx * (period - 1) + dx) / period  # type: ignore[name-defined]
+        adx_values[idx] = adx
+    return adx_values
+
+
+class MarketDataIngestionJob:
+    """Builds :class:`MarketSnapshot` rows from historical OHLC data."""
+
+    def __init__(
+        self,
+        *,
+        rsi_fast: int = 9,
+        rsi_slow: int = 14,
+        adx_fast: int = 9,
+        adx_slow: int = 14,
+    ) -> None:
+        self.rsi_fast = rsi_fast
+        self.rsi_slow = rsi_slow
+        self.adx_fast = adx_fast
+        self.adx_slow = adx_slow
+
+    def run(self, bars: Iterable[RawBar], instrument: InstrumentMeta) -> List[MarketSnapshot]:
+        rows = sorted(list(bars), key=lambda bar: bar.timestamp)
+        closes = [row.close for row in rows]
+        highs = [row.high for row in rows]
+        lows = [row.low for row in rows]
+
+        rsi_fast_values = _compute_rsi(closes, self.rsi_fast)
+        rsi_slow_values = _compute_rsi(closes, self.rsi_slow)
+        adx_fast_values = _compute_adx(highs, lows, closes, self.adx_fast)
+        adx_slow_values = _compute_adx(highs, lows, closes, self.adx_slow)
+
+        snapshots: List[MarketSnapshot] = []
+        daily_high: Optional[float] = None
+        daily_low: Optional[float] = None
+        current_day: Optional[date] = None
+        for idx, bar in enumerate(rows):
+            snapshot_day = bar.timestamp.date()
+            if snapshot_day != current_day:
+                current_day = snapshot_day
+                daily_high = bar.high
+                daily_low = bar.low
+            else:
+                daily_high = max(daily_high or bar.high, bar.high)
+                daily_low = min(daily_low or bar.low, bar.low)
+
+            rsi_fast = rsi_fast_values[idx]
+            rsi_slow = rsi_slow_values[idx]
+            adx_fast = adx_fast_values[idx]
+            adx_slow = adx_slow_values[idx]
+            if None in (rsi_fast, rsi_slow, adx_fast, adx_slow):
+                continue
+            snapshots.append(
+                MarketSnapshot(
+                    symbol=instrument.symbol,
+                    timestamp=bar.timestamp,
+                    close=bar.close,
+                    rsi_fast=float(rsi_fast),
+                    adx_fast=float(adx_fast),
+                    rsi_slow=float(rsi_slow),
+                    adx_slow=float(adx_slow),
+                    pip_size=instrument.pip_size,
+                    pip_value=instrument.pip_value,
+                    daily_high=daily_high,
+                    daily_low=daily_low,
+                )
+            )
+        return snapshots
+
+    def save_csv(self, snapshots: Sequence[MarketSnapshot], output_path: Path) -> None:
+        import csv
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fieldnames = [
+            "symbol",
+            "timestamp",
+            "close",
+            "rsi_fast",
+            "adx_fast",
+            "rsi_slow",
+            "adx_slow",
+            "pip_size",
+            "pip_value",
+            "daily_high",
+            "daily_low",
+        ]
+        with output_path.open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            for snapshot in snapshots:
+                writer.writerow(
+                    {
+                        "symbol": snapshot.symbol,
+                        "timestamp": snapshot.timestamp.isoformat(),
+                        "close": snapshot.close,
+                        "rsi_fast": snapshot.rsi_fast,
+                        "adx_fast": snapshot.adx_fast,
+                        "rsi_slow": snapshot.rsi_slow,
+                        "adx_slow": snapshot.adx_slow,
+                        "pip_size": snapshot.pip_size,
+                        "pip_value": snapshot.pip_value,
+                        "daily_high": snapshot.daily_high,
+                        "daily_low": snapshot.daily_low,
+                    }
+                )
+
+
+__all__ = [
+    "InstrumentMeta",
+    "MarketDataIngestionJob",
+    "RawBar",
+]

--- a/algorithms/python/dataset_builder.py
+++ b/algorithms/python/dataset_builder.py
@@ -1,0 +1,90 @@
+"""Dataset packaging utilities for Dynamic Capital research workflows."""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+from dataclasses import asdict
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .trade_logic import LabeledFeature
+
+try:  # pragma: no cover - optional dependency for parquet output
+    import pandas as _pd  # type: ignore
+except Exception:  # pragma: no cover
+    _pd = None
+
+
+class DatasetWriter:
+    """Writes labelled samples into reproducible train/val/test splits."""
+
+    def __init__(
+        self,
+        output_dir: Path | str,
+        *,
+        seed: int = 13,
+        file_format: str = "parquet",
+    ) -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.seed = seed
+        self.file_format = file_format.lower()
+
+    def write(
+        self,
+        samples: Sequence[LabeledFeature],
+        *,
+        splits: Tuple[float, float, float] = (0.7, 0.15, 0.15),
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> Dict[str, List[dict]]:
+        if not samples:
+            raise ValueError("no labelled samples provided")
+        if not math.isclose(sum(splits), 1.0, rel_tol=1e-3):
+            raise ValueError("dataset splits must sum to 1.0")
+        random_gen = random.Random(self.seed)
+        records = [self._to_record(sample) for sample in samples]
+        random_gen.shuffle(records)
+        total = len(records)
+        train_end = int(total * splits[0])
+        val_end = train_end + int(total * splits[1])
+        partitions = {
+            "train": records[:train_end],
+            "validation": records[train_end:val_end],
+            "test": records[val_end:],
+        }
+        for split_name, split_records in partitions.items():
+            self._write_split(split_name, split_records)
+        meta = metadata or {}
+        meta_payload = {
+            "seed": self.seed,
+            "format": self.file_format,
+            "counts": {key: len(value) for key, value in partitions.items()},
+            "metadata": meta,
+        }
+        (self.output_dir / "metadata.json").write_text(json.dumps(meta_payload, indent=2))
+        return partitions
+
+    def _write_split(self, split: str, records: List[dict]) -> None:
+        path = self.output_dir / f"{split}.{self.file_format if self.file_format != 'json' else 'jsonl'}"
+        if self.file_format == "parquet" and _pd is not None:
+            frame = _pd.DataFrame.from_records(records)
+            frame.to_parquet(path, index=False)
+            return
+        if self.file_format in {"json", "jsonl"}:
+            with path.open("w") as handle:
+                for record in records:
+                    handle.write(json.dumps(record) + "\n")
+            return
+        raise ValueError(f"Unsupported dataset format: {self.file_format}")
+
+    @staticmethod
+    def _to_record(sample: LabeledFeature) -> dict:
+        payload = asdict(sample)
+        payload["timestamp"] = sample.timestamp.isoformat()
+        payload["features"] = list(sample.features)
+        return payload
+
+
+__all__ = ["DatasetWriter"]

--- a/algorithms/python/hyperparameter_search.py
+++ b/algorithms/python/hyperparameter_search.py
@@ -1,0 +1,56 @@
+"""Configuration-driven hyperparameter search for the trading strategy."""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import asdict
+from typing import Callable, Dict, Iterable, List, Tuple
+
+from .backtesting import Backtester, BacktestResult
+from .trade_logic import TradeConfig, TradeLogic
+
+
+class HyperparameterSearch:
+    """Simple grid search helper around :class:`TradeLogic`."""
+
+    def __init__(
+        self,
+        snapshots,
+        search_space: Dict[str, Iterable],
+        *,
+        base_config: TradeConfig | None = None,
+        scoring: Callable[[BacktestResult], float] | None = None,
+        initial_equity: float = 10_000.0,
+    ) -> None:
+        self.snapshots = list(snapshots)
+        self.search_space = search_space
+        self.base_config = base_config or TradeConfig()
+        self.scoring = scoring or (lambda result: result.performance.profit_factor)
+        self.initial_equity = initial_equity
+
+    def run(self) -> Tuple[TradeConfig, BacktestResult, List[Tuple[TradeConfig, BacktestResult]]]:
+        keys = list(self.search_space.keys())
+        values = [self.search_space[key] for key in keys]
+        best_score = float("-inf")
+        best_config = self.base_config
+        best_result: BacktestResult | None = None
+        history: List[Tuple[TradeConfig, BacktestResult]] = []
+        for combination in itertools.product(*values):
+            config_dict = asdict(self.base_config)
+            config_dict.update(dict(zip(keys, combination)))
+            config = TradeConfig(**config_dict)
+            logic = TradeLogic(config=config)
+            backtester = Backtester(logic, initial_equity=self.initial_equity)
+            result = backtester.run(self.snapshots)
+            score = self.scoring(result)
+            history.append((config, result))
+            if score > best_score:
+                best_score = score
+                best_config = config
+                best_result = result
+        if best_result is None:
+            raise RuntimeError("hyperparameter search did not evaluate any configurations")
+        return best_config, best_result, history
+
+
+__all__ = ["HyperparameterSearch"]

--- a/algorithms/python/model_artifacts.py
+++ b/algorithms/python/model_artifacts.py
@@ -1,0 +1,57 @@
+"""Utilities to persist and reload trained model artefacts."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from .trade_logic import TradeLogic
+
+
+@dataclass(slots=True)
+class ModelArtifacts:
+    config: Dict[str, Any]
+    model: Dict[str, Any]
+
+
+def _encode(obj: Any) -> Any:
+    if isinstance(obj, bytes):
+        return {"__type__": "bytes", "data": base64.b64encode(obj).decode("ascii")}
+    if isinstance(obj, dict):
+        return {key: _encode(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_encode(value) for value in obj]
+    return obj
+
+
+def _decode(obj: Any) -> Any:
+    if isinstance(obj, dict) and obj.get("__type__") == "bytes":
+        return base64.b64decode(obj["data"])
+    if isinstance(obj, dict):
+        return {key: _decode(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_decode(value) for value in obj]
+    return obj
+
+
+def save_artifacts(path: Path | str, logic: TradeLogic) -> ModelArtifacts:
+    payload = logic.export_artifacts()
+    artefacts = ModelArtifacts(config=payload["config"], model=payload["model"])
+    encoded = {"config": _encode(artefacts.config), "model": _encode(artefacts.model)}
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(encoded, indent=2))
+    return artefacts
+
+
+def load_artifacts(path: Path | str, logic: TradeLogic) -> ModelArtifacts:
+    data = json.loads(Path(path).read_text())
+    artefacts = ModelArtifacts(config=_decode(data["config"]), model=_decode(data["model"]))
+    logic.load_artifacts({"config": artefacts.config, "model": artefacts.model})
+    return artefacts
+
+
+__all__ = ["ModelArtifacts", "load_artifacts", "save_artifacts"]

--- a/algorithms/python/offline_labeler.py
+++ b/algorithms/python/offline_labeler.py
@@ -1,0 +1,78 @@
+"""Offline labelling utilities that mirror the live strategy behaviour."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional, Sequence
+
+from .trade_logic import FeaturePipeline, LabeledFeature, MarketSnapshot
+
+
+@dataclass(slots=True)
+class LabelingConfig:
+    lookahead: int = 4
+    neutral_zone_pips: float = 2.0
+
+
+class OfflineLabeler:
+    """Replays the on-bar lookahead logic used by the live strategy."""
+
+    def __init__(self, *, pipeline: Optional[FeaturePipeline] = None) -> None:
+        self.pipeline = pipeline or FeaturePipeline()
+
+    def label(
+        self,
+        snapshots: Sequence[MarketSnapshot],
+        config: Optional[LabelingConfig] = None,
+        *,
+        metadata_fn: Optional[Callable[[MarketSnapshot], dict]] = None,
+    ) -> List[LabeledFeature]:
+        cfg = config or LabelingConfig()
+        if cfg.lookahead <= 0:
+            raise ValueError("lookahead must be positive for offline labelling")
+        transformed: List[tuple[MarketSnapshot, tuple[float, ...]]] = []
+        for snapshot in snapshots:
+            features = self.pipeline.transform(snapshot.feature_vector(), update=True)
+            transformed.append((snapshot, features))
+        labelled: List[LabeledFeature] = []
+        for idx, (snapshot, features) in enumerate(transformed):
+            target_idx = idx + cfg.lookahead
+            if target_idx >= len(transformed):
+                break
+            future_snapshot = transformed[target_idx][0]
+            move_pips = abs(future_snapshot.close - snapshot.close) / snapshot.pip_size
+            if move_pips < cfg.neutral_zone_pips:
+                label = 0
+            else:
+                label = 1 if future_snapshot.close > snapshot.close else -1
+            metadata = metadata_fn(snapshot) if metadata_fn else {}
+            metadata = dict(metadata)
+            metadata.update(
+                {
+                    "lookahead_target": future_snapshot.timestamp.isoformat(),
+                    "source_timestamp": snapshot.timestamp.isoformat(),
+                }
+            )
+            labelled.append(
+                LabeledFeature(
+                    features=features,
+                    label=label,
+                    close=snapshot.close,
+                    timestamp=snapshot.timestamp,
+                    metadata=metadata,
+                )
+            )
+        return labelled
+
+    def state_dict(self) -> dict:
+        return {"pipeline": self.pipeline.state_dict()}
+
+    def load_state_dict(self, state: dict) -> None:
+        if "pipeline" in state:
+            self.pipeline.load_state_dict(state["pipeline"])
+
+
+__all__ = [
+    "LabelingConfig",
+    "OfflineLabeler",
+]

--- a/algorithms/python/realtime.py
+++ b/algorithms/python/realtime.py
@@ -1,0 +1,127 @@
+"""Realtime execution helpers that wrap :class:`TradeLogic`."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, List, Optional, Protocol, Sequence
+
+from .trade_logic import ActivePosition, MarketSnapshot, TradeDecision, TradeLogic
+
+logger = logging.getLogger(__name__)
+
+
+class BrokerConnector(Protocol):  # pragma: no cover - interface definition
+    def fetch_open_positions(self) -> Sequence[ActivePosition]:
+        ...
+
+    def execute(self, decision: TradeDecision) -> None:
+        ...
+
+
+class StateStore(Protocol):  # pragma: no cover - interface definition
+    def load(self) -> Sequence[ActivePosition]:
+        ...
+
+    def save(self, positions: Sequence[ActivePosition]) -> None:
+        ...
+
+
+class HealthMonitor(Protocol):  # pragma: no cover - interface definition
+    def record_status(self, status: str, *, timestamp: datetime, details: Optional[dict] = None) -> None:
+        ...
+
+
+@dataclass
+class InMemoryStateStore:
+    positions: List[ActivePosition] | None = None
+
+    def load(self) -> Sequence[ActivePosition]:  # pragma: no cover - simple accessors
+        return list(self.positions or [])
+
+    def save(self, positions: Sequence[ActivePosition]) -> None:
+        self.positions = list(positions)
+
+
+class NullHealthMonitor:
+    def record_status(self, status: str, *, timestamp: datetime, details: Optional[dict] = None) -> None:  # pragma: no cover
+        logger.debug("Health status %s at %s: %s", status, timestamp.isoformat(), details)
+
+
+class RealtimeExecutor:
+    """Coordinates live snapshots, the trading logic, and broker execution."""
+
+    def __init__(
+        self,
+        logic: TradeLogic,
+        broker: BrokerConnector,
+        *,
+        state_store: Optional[StateStore] = None,
+        health_monitor: Optional[HealthMonitor] = None,
+    ) -> None:
+        self.logic = logic
+        self.broker = broker
+        self.state_store = state_store or InMemoryStateStore()
+        self.health_monitor = health_monitor or NullHealthMonitor()
+        self._fallback_positions: List[ActivePosition] = list(self.state_store.load())
+
+    def process_snapshot(
+        self,
+        snapshot: MarketSnapshot,
+        *,
+        account_equity: Optional[float] = None,
+    ) -> List[TradeDecision]:
+        try:
+            open_positions = list(self.broker.fetch_open_positions())
+        except Exception as exc:  # pragma: no cover - broker outages
+            logger.warning("Falling back to cached positions after broker error: %s", exc)
+            open_positions = list(self._fallback_positions)
+        decisions = self.logic.on_bar(snapshot, open_positions=open_positions, account_equity=account_equity)
+        for decision in decisions:
+            try:
+                self.broker.execute(decision)
+                self._apply_decision(decision, snapshot, open_positions)
+            except Exception:
+                logger.exception("Failed to execute trade decision %s", decision)
+        self.state_store.save(open_positions)
+        self._fallback_positions = list(open_positions)
+        self.health_monitor.record_status(
+            "ok",
+            timestamp=snapshot.timestamp,
+            details={"decisions": len(decisions)},
+        )
+        return decisions
+
+    def _apply_decision(
+        self,
+        decision: TradeDecision,
+        snapshot: MarketSnapshot,
+        positions: List[ActivePosition],
+    ) -> None:
+        if decision.action == "open":
+            positions.append(
+                ActivePosition(
+                    symbol=decision.symbol,
+                    direction=decision.direction or 0,
+                    size=decision.size or 0.0,
+                    entry_price=decision.entry or snapshot.close,
+                    stop_loss=decision.stop_loss,
+                    take_profit=decision.take_profit,
+                    opened_at=snapshot.timestamp,
+                )
+            )
+        elif decision.action == "close":
+            for idx, pos in enumerate(positions):
+                if pos.symbol == decision.symbol and pos.direction == decision.direction:
+                    del positions[idx]
+                    break
+
+
+__all__ = [
+    "BrokerConnector",
+    "HealthMonitor",
+    "InMemoryStateStore",
+    "RealtimeExecutor",
+    "StateStore",
+]

--- a/algorithms/python/tests/test_trading_workflow.py
+++ b/algorithms/python/tests/test_trading_workflow.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from algorithms.python.backtesting import Backtester
+from algorithms.python.data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+from algorithms.python.model_artifacts import load_artifacts, save_artifacts
+from algorithms.python.offline_labeler import LabelingConfig, OfflineLabeler
+from algorithms.python.realtime import InMemoryStateStore, RealtimeExecutor
+from algorithms.python.trade_logic import (
+    ActivePosition,
+    FeaturePipeline,
+    LabeledFeature,
+    LorentzianKNNModel,
+    MarketSnapshot,
+    TradeDecision,
+    TradeConfig,
+    TradeLogic,
+)
+
+
+def _build_snapshots() -> list[MarketSnapshot]:
+    start = datetime(2024, 1, 1, 0, 0)
+    bars = []
+    price = 100.0
+    for idx in range(20):
+        high = price + 0.5
+        low = price - 0.5
+        close = price + (0.2 if idx % 2 == 0 else -0.1)
+        bars.append(
+            RawBar(
+                timestamp=start + timedelta(minutes=idx * 5),
+                open=price,
+                high=high,
+                low=low,
+                close=close,
+            )
+        )
+        price = close
+    job = MarketDataIngestionJob()
+    snapshots = job.run(bars, InstrumentMeta(symbol="XAUUSD", pip_size=0.1, pip_value=1.0))
+    assert snapshots, "expected non-empty snapshots from ingestion job"
+    return snapshots
+
+
+def test_feature_pipeline_persistence_round_trip():
+    pipeline = FeaturePipeline()
+    vector = (10.0, 20.0, 30.0, 40.0)
+    transformed = pipeline.transform(vector, update=True)
+    state = pipeline.state_dict()
+    restored = FeaturePipeline()
+    restored.load_state_dict(state)
+    replay = restored.transform(vector, update=False)
+    assert pytest.approx(transformed) == replay
+
+
+def test_offline_labeler_produces_labeled_features():
+    snapshots = _build_snapshots()
+    labeler = OfflineLabeler()
+    labelled = labeler.label(snapshots, LabelingConfig(lookahead=3, neutral_zone_pips=0.5))
+    assert labelled, "offline labeler should produce labelled samples"
+    assert all(isinstance(sample.label, int) for sample in labelled)
+
+
+def test_lorentzian_knn_model_predicts_direction():
+    timestamp = datetime.now(timezone.utc)
+    samples = [
+        LabeledFeature(features=(0.0, 0.0, 0.0, 0.0), label=1, close=1.0, timestamp=timestamp),
+        LabeledFeature(features=(5.0, 5.0, 5.0, 5.0), label=-1, close=1.0, timestamp=timestamp),
+    ]
+    model = LorentzianKNNModel(neighbors=1)
+    model.fit(samples)
+    signal = model.predict((0.1, 0.1, 0.1, 0.1))
+    assert signal is not None
+    assert signal.direction == 1
+
+
+def test_backtester_generates_performance_metrics(tmp_path: Path):
+    snapshots = _build_snapshots()
+    config = TradeConfig(neighbors=1, label_lookahead=2, min_confidence=0.0)
+    logic = TradeLogic(config=config)
+    backtester = Backtester(logic)
+    result = backtester.run(snapshots[: len(snapshots) - 2])
+    assert result.performance.total_trades >= 0
+    artefact_path = tmp_path / "model.json"
+    save_artifacts(artefact_path, logic)
+    new_logic = TradeLogic(config=TradeConfig())
+    load_artifacts(artefact_path, new_logic)
+    assert new_logic.config.neighbors == config.neighbors
+
+
+def test_realtime_executor_updates_state():
+    snapshots = _build_snapshots()[:5]
+    config = TradeConfig(neighbors=1, label_lookahead=2, min_confidence=0.0)
+    logic = TradeLogic(config=config)
+
+    class MemoryBroker:
+        def __init__(self) -> None:
+            self.decisions: list[TradeDecision] = []
+            self.positions: list[ActivePosition] = []
+
+        def fetch_open_positions(self):
+            return list(self.positions)
+
+        def execute(self, decision):
+            self.decisions.append(decision)
+
+    broker = MemoryBroker()
+    executor = RealtimeExecutor(logic, broker, state_store=InMemoryStateStore())
+    total = 0
+    for snapshot in snapshots:
+        total += len(executor.process_snapshot(snapshot))
+    stored_positions = executor.state_store.load()
+    assert isinstance(stored_positions, list)
+    assert total >= 0

--- a/docs/trading-runbook.md
+++ b/docs/trading-runbook.md
@@ -1,0 +1,87 @@
+# Trading Operations Runbook
+
+This runbook describes the end-to-end operational lifecycle for the Lorentzian k-NN
+strategy that powers Dynamic Capital's discretionary trading stack.
+
+## 1. Daily Data Refresh
+
+1. Export the previous trading day's OHLC candles from the broker or data vendor.
+2. Run the historical ingestion job:
+   ```python
+   from pathlib import Path
+
+   from algorithms.python.data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+
+   job = MarketDataIngestionJob()
+   bars = [...]  # Iterable of RawBar instances ordered chronologically
+   instrument = InstrumentMeta(symbol="XAUUSD", pip_size=0.1, pip_value=1.0)
+   snapshots = job.run(bars, instrument)
+   job.save_csv(snapshots, Path("data/xauusd_snapshots.csv"))
+   ```
+3. Store the resulting snapshots in the research data lake (e.g. S3 or Supabase
+   storage) and update the catalogue entry with the generated metadata file.
+
+## 2. Offline Labelling & Dataset Packaging
+
+1. Pull the latest curated snapshots and feed them through the offline labeler:
+   ```python
+   from algorithms.python.offline_labeler import LabelingConfig, OfflineLabeler
+
+   labeler = OfflineLabeler()
+   labelled = labeler.label(snapshots, LabelingConfig(lookahead=4, neutral_zone_pips=2.0))
+   ```
+2. Persist the feature-scaling state returned by `labeler.state_dict()` so the
+   same normalisation can be reapplied during evaluation and production reloads.
+3. Split the labelled samples into train/validation/test sets with
+   `DatasetWriter`, committing the resulting Parquet files and metadata.json to
+   version control to guarantee reproducibility across experiments.
+
+## 3. Model Training & Hyperparameter Search
+
+1. Define a search grid in code (or YAML) covering neighbour counts, lookahead
+   windows, neutral zones, and ADR factors.
+2. Execute the search:
+   ```python
+   from algorithms.python.hyperparameter_search import HyperparameterSearch
+
+   search = HyperparameterSearch(snapshots, {"neighbors": [4, 8, 16], "label_lookahead": [2, 4, 6]})
+   best_config, best_result, history = search.run()
+   ```
+3. Review the resulting `BacktestResult` metrics (hit rate, profit factor,
+   drawdown) and promote the best configuration into the staging registry.
+4. Freeze the trained artefacts via `model_artifacts.save_artifacts`, storing the
+   scaler state, neighbour set, and configuration document.
+
+## 4. Pre-Deployment Validation
+
+1. Run the automated pytest suite (`pytest algorithms/python/tests`) to verify
+   label edge-cases, ADR handling, and risk gating logic.
+2. Replay the chosen configuration through the `Backtester` using an out-of-
+   sample dataset to produce an equity curve and risk analytics report.
+3. Log the backtest summary in the research notebook and obtain sign-off from
+   risk management before moving to production.
+
+## 5. Production Deployment
+
+1. Publish the saved model artefacts to the model registry or object storage
+   bucket accessible by the live trading service.
+2. Update the production configuration file to reference the new artefact path
+   and risk guardrails (daily drawdown, lot limits, etc.).
+3. Perform a canary deploy by spinning up a single inference replica. Monitor
+   the health feed exposed by `RealtimeExecutor` and confirm that trade
+   decisions align with expectations in the staging environment.
+4. Promote the release to all replicas once the canary remains healthy for a
+   full trading session.
+
+## 6. Ongoing Monitoring & Maintenance
+
+1. Continuously track the exported performance metrics (hit rate, profit factor,
+   drawdown) published by the `RiskManager` monitoring hooks.
+2. Schedule weekly data refresh + retraining jobs. Archive the generated
+   artefacts with semantic version tags (e.g. `lorentzian-knn-v2024.05.01`).
+3. Review operational dashboards each trading day to ensure ADR feeds, broker
+   connectors, and persistence stores remain healthy.
+4. Trigger the rollback procedure (redeploy the previous artefact version) if
+   production performance deviates materially from backtest expectations or if
+   risk limits are breached.
+


### PR DESCRIPTION
## Summary
- add historical ingestion, offline labeling, dataset packaging, and an operations runbook for the Lorentzian k-NN strategy
- refactor the trading core to expose fit/predict, persist scaler state, and emit risk analytics with monitoring hooks
- introduce backtesting, hyperparameter search, realtime execution utilities, and accompanying pytest coverage

## Testing
- pytest algorithms/python/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68caef23dde48322a286c613f2f18158