### PR TITLE
Align Node server CORS defaults with site origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,8 @@ PII; rate limits enabled.
 Full list and usage notes: [docs/env.md](docs/env.md).
 
 - The `ALLOWED_ORIGINS` variable controls which domains may call the API and
-  edge functions. If unset, only `http://localhost:3000` is allowed.
+  edge functions. If unset, it falls back to `SITE_URL` (or
+  `http://localhost:3000` when `SITE_URL` is missing).
 - See [docs/NETWORKING.md](docs/NETWORKING.md) for port mappings, reverse proxy
   tips, and Cloudflare ingress IPs.
 - Copy `.env.example` to `.env.local` and replace the placeholder values with

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -22,7 +22,7 @@ This project relies on a Next.js service and Supabase Edge Functions. Use the fo
 
 ## Environment variables
 - Copy `.env.example` to `.env.local` and fill in credentials.
-- `ALLOWED_ORIGINS` defines a comma-separated list of domains allowed to call the API and edge functions. If unset, only `http://localhost:3000` is permitted.
+- `ALLOWED_ORIGINS` defines a comma-separated list of domains allowed to call the API and edge functions. If unset, it falls back to `SITE_URL` (or `http://localhost:3000` when `SITE_URL` is missing).
 
 ## Exposing the app
 - Run the app in Docker (or similar) and map the container's port `8080` to your host.

--- a/docs/env.md
+++ b/docs/env.md
@@ -87,7 +87,7 @@ You can confirm access with `doctl spaces list`.
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
-| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `http://localhost:3000`). | No       | `https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `SITE_URL` or `http://localhost:3000`). | No       | `https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
 | `MINIAPP_ORIGIN`      | Origins allowed to call Telegram verification and mini-app APIs.              | No (required for production bots) | `https://dynamic-capital.vercel.app` | `supabase/functions/verify-telegram/index.ts` |
 | `LOG_LEVEL`           | Minimum log level for server logs (`debug`, `info`, `warn`, `error`). | No       | `warn`                    | `utils/logger.ts` |
 | `FUNCTIONS_BASE_URL`   | Override Supabase functions host when provisioning database webhooks. | No       | `https://custom.functions.supabase.co` | `scripts/setup-db-webhooks.ts` |


### PR DESCRIPTION
## Summary
- reuse the SITE_URL fallback when ALLOWED_ORIGINS is unset and normalise the allow list for the static Node server
- expand the server CORS headers to cover additional methods and custom headers while caching preflight responses longer
- document the revised ALLOWED_ORIGINS default behaviour in the README and networking/env docs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafe88fed883229b3de12f11a9266b