### PR TITLE
Update doctl sync script for static site envs

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -92,7 +92,8 @@ Flags:
 - `--app-id` – App Platform UUID (`doctl apps list`).
 - `--site-url` – Canonical host for the deployment. The script updates
   `SITE_URL`, `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`, and
-  `MINIAPP_ORIGIN` globally and on the `dynamic-capital` service.
+  `MINIAPP_ORIGIN` globally, on the `dynamic-capital` service, and on any
+  static site components.
 - `--zone` – DNS zone to import. Defaults to the site URL host.
 - `--zone-file` – Override the zone file path (defaults to
   `dns/<zone>.zone`).


### PR DESCRIPTION
## Summary
- extend the DigitalOcean sync helper to tag change summaries with component context
- update static site components alongside global and service env vars when reconciling the spec
- document the broader coverage in the deployment guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb90ce71f483228f2853613a6839a2