### PR TITLE
Add doctl context configuration support

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,6 +55,7 @@ Lovable domain aligned with the expected records:
 ```bash
 # Preview the proposed DNS mutations
 deno run -A scripts/configure-digitalocean-dns.ts --dry-run
+# Append --context <name> to target a specific authenticated doctl context.
 
 # Apply the plan via doctl (requires an authenticated doctl session)
 deno run -A scripts/configure-digitalocean-dns.ts
@@ -70,12 +71,16 @@ stays aligned with Cloudflare.
 
 Example usage:
 
+Set `DOCTL_CONTEXT` to the `doctl` context you authenticated (omit the flag if
+you only use the default context):
+
 ```bash
 # Update the app spec, aligning env vars, ingress, and primary domain.
 node scripts/doctl/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
   --site-url https://dynamic-capital.vercel.app \
   --zone dynamic-capital.ondigitalocean.app \
+  --context $DOCTL_CONTEXT \
   --show-spec
 
 # Apply the spec changes and import the DNS zone in one go.
@@ -83,6 +88,7 @@ node scripts/doctl/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
   --site-url https://dynamic-capital.vercel.app \
   --zone dynamic-capital.ondigitalocean.app \
+  --context $DOCTL_CONTEXT \
   --apply \
   --apply-zone
 ```
@@ -94,6 +100,7 @@ Flags:
   `SITE_URL`, `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`, and
   `MINIAPP_ORIGIN` globally, on the `dynamic-capital` service, and on any
   static site components.
+- `--context` – doctl context to run commands against (defaults to the active context).
 - `--zone` – DNS zone to import. Defaults to the site URL host.
 - `--zone-file` – Override the zone file path (defaults to
   `dns/<zone>.zone`).

--- a/scripts/doctl/sync-site-config.mjs
+++ b/scripts/doctl/sync-site-config.mjs
@@ -18,6 +18,7 @@ function usage() {
     `  --domain <host>          Override the hostname portion of the site URL\n` +
     `  --zone <domain>          DNS zone to import (defaults to domain)\n` +
     `  --service <name>         Service name to update (default: dynamic-capital)\n` +
+    `  --context <name>        doctl context to use (defaults to active context)\n` +
     `  --zone-file <path>       Zone file to import when --apply-zone is set\n` +
     `  --output <path>          Write the updated spec YAML to a file\n` +
     `  --apply                  Push the updated spec via doctl\n` +
@@ -109,10 +110,11 @@ class DoctlError extends Error {
   }
 }
 
-async function runDoctl(args, { inherit = false } = {}) {
+async function runDoctl(args, { inherit = false, context } = {}) {
   return await new Promise((resolve, reject) => {
     const stdio = inherit ? ['inherit', 'inherit', 'inherit'] : ['ignore', 'pipe', 'pipe'];
-    const child = spawn('doctl', args, { stdio });
+    const finalArgs = context ? ['--context', context, ...args] : args;
+    const child = spawn('doctl', finalArgs, { stdio });
     const stdoutChunks = [];
     const stderrChunks = [];
 
@@ -134,7 +136,7 @@ async function runDoctl(args, { inherit = false } = {}) {
     child.on('close', (code) => {
       if (code !== 0) {
         const stderr = Buffer.concat(stderrChunks).toString('utf8');
-        reject(new DoctlError(`doctl ${args.join(' ')} exited with code ${code}.`, stderr, code));
+        reject(new DoctlError(`doctl ${finalArgs.join(' ')} exited with code ${code}.`, stderr, code));
         return;
       }
 
@@ -168,6 +170,7 @@ async function main() {
       domain: { type: 'string' },
       zone: { type: 'string' },
       service: { type: 'string', default: 'dynamic-capital' },
+      context: { type: 'string' },
       'zone-file': { type: 'string' },
       output: { type: 'string' },
       apply: { type: 'boolean', default: false },
@@ -201,10 +204,11 @@ async function main() {
   const zone = values.zone ?? domain;
   const serviceName = values.service ?? 'dynamic-capital';
   const requestedAllowedOrigins = values['allowed-origins'];
+  const context = values.context;
 
   let specOutput;
   try {
-    specOutput = await runDoctl(['apps', 'spec', 'get', appId]);
+    specOutput = await runDoctl(['apps', 'spec', 'get', appId], { context });
   } catch (error) {
     if (error instanceof DoctlError && error.stderr) {
       console.error(error.stderr.trim());
@@ -314,6 +318,9 @@ async function main() {
   console.log(`  Domain: ${domain}`);
   console.log(`  Zone: ${zone}`);
   console.log(`  Allowed origins: ${allowedOrigins}`);
+  if (context) {
+    console.log(`  doctl context: ${context}`);
+  }
 
   if (changes.size > 0) {
     console.log('  Applied updates:');
@@ -330,7 +337,7 @@ async function main() {
     await fs.writeFile(tempFile, rendered, 'utf8');
     console.log(`\nApplying spec update via doctl (temporary file: ${tempFile})...`);
     try {
-      await runDoctl(['apps', 'spec', 'update', appId, '--spec', tempFile], { inherit: true });
+      await runDoctl(['apps', 'spec', 'update', appId, '--spec', tempFile], { inherit: true, context });
       console.log('✅ App spec updated successfully.');
     } finally {
       await fs.rm(tmpBase, { recursive: true, force: true });
@@ -342,7 +349,7 @@ async function main() {
   if (values['apply-zone']) {
     const zoneFile = await ensureZoneFile(zone, values['zone-file']);
     console.log(`\nImporting DNS zone '${zone}' via doctl (zone file: ${zoneFile})...`);
-    await runDoctl(['compute', 'domain', 'records', 'import', zone, '--zone-file', zoneFile], { inherit: true });
+    await runDoctl(['compute', 'domain', 'records', 'import', zone, '--zone-file', zoneFile], { inherit: true, context });
     console.log('✅ DNS zone imported successfully.');
   } else {
     const hint = values['zone-file']


### PR DESCRIPTION
## Summary
- allow the DigitalOcean DNS and spec sync helpers to run under a specific doctl context
- document how to invoke the scripts when you manage multiple doctl contexts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb976b220c83228d58f1e56fcb8c81