### PR TITLE
Sync .env and .env.local from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ backed by Supabase.
 
 ## Environment Setup
 
-Copy `.env.example` to `.env.local` and adjust values for your environment:
+Copy `.env.example` to `.env` and `.env.local`, then adjust values for your
+environment. Running `npm run sync-env` later will append newly added variables
+from the example file into both destinations without overwriting your values:
 
 ```bash
+cp .env.example .env
 cp .env.example .env.local
 ```
 
@@ -58,7 +61,7 @@ NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 ```
 
-Store these in your hosting platform's environment settings or in `.env.local`
+Store these in your hosting platform's environment settings or in `.env`/`.env.local`
 for local development. The static site should have access to the same values at
 build time.
 
@@ -68,9 +71,9 @@ Keep secrets such as `SUPABASE_SERVICE_ROLE_KEY` or `TELEGRAM_BOT_TOKEN` only in
 the environment for the Next.js component. Do **not** prefix them with
 `NEXT_PUBLIC_` or expose them in the static site.
 
-For local work, create a `.env.local` inside `next-app/` and run `npm run dev`
-to load the variables. In production, manage secrets through your platform's
-configuration for each component.
+For local work, create `.env`/`.env.local` at the repository root and run
+`npm run dev` to load the variables. In production, manage secrets through your
+platform's configuration for each component.
 
 ## Project Structure
 
@@ -431,9 +434,10 @@ success, or error states based on the fetch result.
 ### Local Development
 
 ```bash
-# Create your local environment file
+# Create your local environment files
+cp .env.example .env
 cp .env.example .env.local
-# Ensure .env.local has all variables
+# Ensure .env and .env.local have all variables
 npm run sync-env
 
 # Start local stack

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -9,8 +9,9 @@ This guide outlines eight high-level steps to run, build, and deploy the Telegra
    - Install Node.js 22.x (LTS), Deno, and the Supabase CLI.
 
 3. **Prepare environment variables**
-   - Copy `.env.example` to `.env.local` and populate values:
+   - Copy `.env.example` to `.env` and `.env.local`, then populate values:
    ```bash
+   cp .env.example .env
    cp .env.example .env.local
    npm run sync-env
    ```

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -21,7 +21,7 @@ This project relies on a Next.js service and Supabase Edge Functions. Use the fo
   records from [`dns/dynamic-capital.lovable.app.json`](../dns/dynamic-capital.lovable.app.json).
 
 ## Environment variables
-- Copy `.env.example` to `.env.local` and fill in credentials.
+- Copy `.env.example` to `.env` and `.env.local`, then fill in credentials.
 - `ALLOWED_ORIGINS` defines a comma-separated list of domains allowed to call the API and edge functions. If unset, it falls back to `SITE_URL` (or `http://localhost:3000` when `SITE_URL` is missing).
 
 ## Exposing the app

--- a/docs/codex_cli_workflow.md
+++ b/docs/codex_cli_workflow.md
@@ -8,8 +8,8 @@ can reproduce Codex's build steps locally and keep your environment in sync.
 
 | Command | Purpose |
 | --- | --- |
-| `npm run codex:post-pull` | Install dependencies, sync `.env.local`, validate core environment variables, and execute the combined `lovable-build.js` pipeline. |
-| `npm run codex:dev` | Optionally sync `.env.local` before delegating to `lovable-dev.js`, which runs preflight checks and launches the Next.js dev server. |
+| `npm run codex:post-pull` | Install dependencies, sync `.env`/`.env.local`, validate core environment variables, and execute the combined `lovable-build.js` pipeline. |
+| `npm run codex:dev` | Optionally sync `.env`/`.env.local` before delegating to `lovable-dev.js`, which runs preflight checks and launches the Next.js dev server. |
 | `npm run codex:build` | Run the Lovable production build locally (Next.js dashboard + Telegram mini app). |
 | `npm run codex:verify` | Execute `scripts/verify/verify_all.sh` for the full repository verification sweep. |
 

--- a/docs/coding-efficiency-checklist.md
+++ b/docs/coding-efficiency-checklist.md
@@ -15,7 +15,7 @@ Use this checklist to stay aligned with the existing automation, docs, and workf
 - [ ] Draft a lightweight implementation plan that lists the modules/functions you expect to change and how they integrate.
 
 ## 2. Prepare the Environment
-- [ ] Duplicate `.env.example` to `.env.local` (or the relevant workspace file).
+- [ ] Duplicate `.env.example` to `.env` and `.env.local` (or the relevant workspace file).
 - [ ] Run `npm run sync-env` to populate required variables.
 - [ ] Start local dependencies as needed: `npm run supabase:start`, `supabase functions serve telegram-bot --no-verify-jwt`, or other commands from the workflow guide.
 - [ ] When prototyping with Lovable, launch `npm run dev:lovable` to backfill origins, validate env keys, and ping Supabase for early configuration issues.

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -23,7 +23,7 @@ Run `npm run checklists -- --list` to see automation-friendly tasks mapped to th
 
 Use the automation helper (or run commands directly) to complete the recurring repo health checks before audits, launches, or large merges. Track the results in your PR/issue notes so reviewers can see the evidence.
 
-- [ ] Sync `.env.local` with `.env.example` (`npm run sync-env`) to ensure new environment keys are captured locally.
+- [ ] Sync `.env` and `.env.local` with `.env.example` (`npm run sync-env`) to ensure new environment keys are captured locally.
 - [ ] Run the repository test suite (`npm run test`) so Deno and Next.js smoke tests cover the latest changes.
 - [ ] Execute the fix-and-check script (`bash scripts/fix_and_check.sh`) to apply formatting and rerun Deno format/lint/type checks.
 - [ ] Run the aggregated verification suite (`npm run verify`) for the bundled static, runtime, and integration safety checks.

--- a/scripts/codex-workflow.js
+++ b/scripts/codex-workflow.js
@@ -82,12 +82,12 @@ const troubleshootingTips = {
     'If lockfile conflicts persist, run `npm ci` from a clean checkout.',
   ],
   'npm run sync-env': [
-    'Verify `.env.local` exists and is writable before syncing.',
+    'Verify `.env` and `.env.local` exist and are writable before syncing.',
     'Re-run `npm install` to make sure the sync script dependencies are available.',
     'If the Supabase CLI is required, install it via `npm install supabase --global` or use `npx supabase`.',
   ],
   'npx tsx scripts/check-env.ts': [
-    'Double-check required environment variables in `.env.local` or the active shell.',
+    'Double-check required environment variables in `.env`/`.env.local` or the active shell.',
     'Run `npm run sync-env` to copy placeholders from `.env.example`.',
     'Use `--no-env-check` temporarily only if you know the missing variables are safe to ignore.',
   ],

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -5,11 +5,11 @@ import process from 'node:process';
 const TASK_LIBRARY = {
   'sync-env': {
     id: 'sync-env',
-    label: 'Sync .env.local with .env.example (npm run sync-env)',
+    label: 'Sync .env and .env.local with .env.example (npm run sync-env)',
     command: 'npm run sync-env',
     optional: false,
     docs: ['docs/coding-efficiency-checklist.md', 'docs/dynamic-capital-checklist.md'],
-    notes: ['Appends any missing keys from .env.example into .env.local without overwriting existing values.'],
+    notes: ['Appends any missing keys from .env.example into .env and .env.local without overwriting existing values.'],
   },
   'repo-test': {
     id: 'repo-test',

--- a/scripts/sync-env.ts
+++ b/scripts/sync-env.ts
@@ -1,46 +1,70 @@
 // scripts/sync-env.ts
-// Sync missing variables from .env.example into .env.local, preserving existing values.
+// Sync missing variables from .env.example into .env and .env.local, preserving existing values.
 
 const examplePath = ".env.example";
-const localPath = ".env.local";
-
-try {
-  await Deno.stat(localPath);
-} catch {
-  await Deno.writeTextFile(localPath, "");
-}
+const targetPaths = [".env", ".env.local"];
 
 const exampleContent = await Deno.readTextFile(examplePath);
-const localContent = await Deno.readTextFile(localPath);
 
-const localKeys = new Set<string>();
-for (const line of localContent.split(/\r?\n/)) {
-  const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
-  if (m) localKeys.add(m[1]);
+async function ensureFile(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    await Deno.writeTextFile(path, "");
+    return false;
+  }
 }
 
-const additions: string[] = [];
-let buffer: string[] = [];
-for (const line of exampleContent.split(/\r?\n/)) {
-  if (/^\s*(#.*)?$/.test(line)) {
-    buffer.push(line);
-    continue;
+function parseKeys(content: string): Set<string> {
+  const keys = new Set<string>();
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+    if (m) keys.add(m[1]);
   }
-  const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
-  if (m) {
-    const key = m[1];
-    if (!localKeys.has(key)) {
-      additions.push(...buffer, line);
+  return keys;
+}
+
+function computeAdditions(
+  example: string,
+  existingKeys: Set<string>,
+): string[] {
+  const additions: string[] = [];
+  let buffer: string[] = [];
+  for (const line of example.split(/\r?\n/)) {
+    if (/^\s*(#.*)?$/.test(line)) {
+      buffer.push(line);
+      continue;
     }
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/);
+    if (m) {
+      const key = m[1];
+      if (!existingKeys.has(key)) {
+        additions.push(...buffer, line);
+      }
+    }
+    buffer = [];
   }
-  buffer = [];
+  return additions;
 }
 
-if (additions.length > 0) {
-  const prefix = localContent.endsWith("\n") || localContent.length === 0 ? "" : "\n";
-  const newContent = localContent + prefix + additions.join("\n") + "\n";
-  await Deno.writeTextFile(localPath, newContent);
-  console.log("Appended", additions.filter((l) => !l.startsWith("#") && l).length, "variables to .env.local");
-} else {
-  console.log(".env.local is up to date");
+for (const target of targetPaths) {
+  const existed = await ensureFile(target);
+  const currentContent = await Deno.readTextFile(target);
+  const keys = parseKeys(currentContent);
+  const additions = computeAdditions(exampleContent, keys);
+  if (additions.length > 0) {
+    const prefix = currentContent.endsWith("\n") || currentContent.length === 0
+      ? ""
+      : "\n";
+    const newContent = currentContent + prefix + additions.join("\n") + "\n";
+    await Deno.writeTextFile(target, newContent);
+    const appendedCount = additions.filter((line) => {
+      const trimmed = line.trim();
+      return trimmed !== "" && !trimmed.startsWith("#");
+    }).length;
+    console.log("Appended", appendedCount, `variables to ${target}`);
+  } else {
+    console.log(`${target} is up to date${existed ? "" : " (created)"}`);
+  }
 }


### PR DESCRIPTION
## Summary
- update the sync-env helper to populate both .env and .env.local from .env.example
- refresh documentation and checklist references so they note both environment files
- expand Codex automation messaging to reflect the broader sync coverage

## Testing
- npx deno run -A scripts/sync-env.ts

------
https://chatgpt.com/codex/tasks/task_e_68cba01509488322847dcb1573211fad