### PR TITLE
Fix DigitalOcean app spec domain configuration

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -25,7 +25,7 @@ spec:
           name: dynamic-capital
         match:
           authority:
-            exact: ""
+            exact: dynamic-capital-qazf2.ondigitalocean.app
           path:
             prefix: /
   envs:
@@ -42,7 +42,7 @@ spec:
       value: https://dynamic-capital-qazf2.ondigitalocean.app
       scope: RUN_AND_BUILD_TIME
     - key: ALLOWED_ORIGINS
-      value: "https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
+      value: https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app
       scope: RUN_AND_BUILD_TIME
     - key: MINIAPP_ORIGIN
       value: https://dynamic-capital-qazf2.ondigitalocean.app
@@ -90,3 +90,7 @@ spec:
         - key: MINIAPP_ORIGIN
           value: https://dynamic-capital-qazf2.ondigitalocean.app
           scope: RUN_AND_BUILD_TIME
+  static_sites: []
+  workers: []
+  jobs: []
+  functions: []


### PR DESCRIPTION
## Summary
- align the DigitalOcean App Platform spec ingress authority with the canonical domain so doctl syncs stop leaving it blank
- normalize the allowed-origins value and explicitly include empty component lists for clarity

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd64cda888322b42b3de6d37c27c2