### PR TITLE
Allow DigitalOcean API sync to operate on local specs

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -117,6 +117,33 @@ Flags:
 
 Use `npm run doctl:sync-site -- --help` to see all available options.
 
+When the DigitalOcean CLI is unavailable (for example in CI pipelines), the
+repository now also ships `scripts/digitalocean/sync-site-config.mjs`, which
+talks directly to the DigitalOcean REST API. Provide an API token via
+`--token` or the `DIGITALOCEAN_TOKEN` environment variable:
+
+```bash
+# Fetch, normalize, and optionally write the spec without applying.
+node scripts/digitalocean/sync-site-config.mjs \
+  --app-id $DIGITALOCEAN_APP_ID \
+  --site-url https://dynamic-capital.ondigitalocean.app \
+  --token $DIGITALOCEAN_TOKEN \
+  --output .do/app.yml \
+  --show-spec
+
+# Push the rendered spec back to DigitalOcean via the REST API.
+node scripts/digitalocean/sync-site-config.mjs \
+  --app-id $DIGITALOCEAN_APP_ID \
+  --site-url https://dynamic-capital.ondigitalocean.app \
+  --token $DIGITALOCEAN_TOKEN \
+  --apply
+```
+
+The API-powered helper shares flags with the `doctl` variant (including
+`--spec`, `--allowed-origins`, `--domain`, and `--zone`) so workflows can swap
+between them without additional changes. Run `npm run do:sync-site -- --help`
+for the full list of options.
+
 ### CDN configuration for DigitalOcean Spaces
 
 Static assets are uploaded to DigitalOcean Spaces by `scripts/upload-assets.js`.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "node scripts/check-static-homepage.js && deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check",
     "verify": "bash scripts/verify/verify_all.sh",
     "sync-env": "deno run -A scripts/sync-env.ts",
+    "do:sync-site": "node scripts/digitalocean/sync-site-config.mjs",
     "doctl:sync-site": "node scripts/doctl/sync-site-config.mjs",
     "checklists": "node scripts/run-checklists.js",
     "export": "npm run build",

--- a/scripts/digitalocean/site-config-utils.mjs
+++ b/scripts/digitalocean/site-config-utils.mjs
@@ -1,0 +1,187 @@
+import { URL } from 'node:url';
+
+export const PRODUCTION_ALLOWED_ORIGINS = [
+  'https://dynamic-capital.ondigitalocean.app',
+  'https://dynamic-capital.vercel.app',
+  'https://dynamic-capital.lovable.app',
+];
+
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeOrigin(value) {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return '';
+  }
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+function parseAllowedOrigins(value) {
+  return value
+    .split(',')
+    .map(normalizeOrigin)
+    .filter((origin) => origin.length > 0);
+}
+
+function resolveAllowedOrigins({ requested, existing, canonicalOrigin }) {
+  const baseList = requested
+    ? parseAllowedOrigins(requested)
+    : existing
+      ? parseAllowedOrigins(existing)
+      : [...PRODUCTION_ALLOWED_ORIGINS];
+
+  if (!baseList.includes(canonicalOrigin)) {
+    baseList.push(canonicalOrigin);
+  }
+
+  return Array.from(new Set(baseList)).join(',');
+}
+
+function formatChangeLabel(key, value, context) {
+  if (context && context.length > 0) {
+    return `${context}: ${key} → ${value}`;
+  }
+  return `${key} → ${value}`;
+}
+
+function upsertEnv(envs, key, value, scope, changes, context) {
+  const entry = envs.find((item) => item?.key === key);
+  const changeLabel = formatChangeLabel(key, value, context);
+  if (entry) {
+    if (entry.value !== value) {
+      changes.add(changeLabel);
+    }
+    entry.value = value;
+    if (!entry.scope) {
+      entry.scope = scope;
+    }
+  } else {
+    envs.push({ key, value, scope });
+    changes.add(changeLabel);
+  }
+}
+
+function parseSiteUrl(siteUrl) {
+  try {
+    return new URL(siteUrl);
+  } catch (error) {
+    throw new Error(`Invalid site URL: ${siteUrl}. ${error instanceof Error ? error.message : ''}`);
+  }
+}
+
+export function normalizeAppSpec({
+  spec: inputSpec,
+  siteUrl,
+  domain,
+  zone,
+  serviceName = 'dynamic-capital',
+  allowedOriginsOverride,
+}) {
+  if (!inputSpec || typeof inputSpec !== 'object') {
+    throw new Error('Unexpected spec format received. Expected an object.');
+  }
+  if (!siteUrl) {
+    throw new Error('siteUrl is required.');
+  }
+
+  const parsedSiteUrl = parseSiteUrl(siteUrl);
+  const canonicalSiteUrl = parsedSiteUrl.toString().replace(/\/$/, '');
+  const canonicalOrigin = parsedSiteUrl.origin;
+  const finalDomain = domain ?? parsedSiteUrl.host;
+  const finalZone = zone ?? finalDomain;
+
+  const spec = inputSpec;
+  const changes = new Set();
+
+  spec.envs = ensureArray(spec.envs);
+  const existingAllowedOrigins = spec.envs.find((item) => item?.key === 'ALLOWED_ORIGINS')?.value;
+  const allowedOrigins = resolveAllowedOrigins({
+    requested: allowedOriginsOverride,
+    existing: existingAllowedOrigins,
+    canonicalOrigin,
+  });
+
+  const globalContext = 'app env';
+  upsertEnv(spec.envs, 'SITE_URL', canonicalSiteUrl, 'RUN_AND_BUILD_TIME', changes, globalContext);
+  upsertEnv(spec.envs, 'NEXT_PUBLIC_SITE_URL', canonicalSiteUrl, 'RUN_AND_BUILD_TIME', changes, globalContext);
+  upsertEnv(spec.envs, 'ALLOWED_ORIGINS', allowedOrigins, 'RUN_AND_BUILD_TIME', changes, globalContext);
+  upsertEnv(spec.envs, 'MINIAPP_ORIGIN', canonicalOrigin, 'RUN_AND_BUILD_TIME', changes, globalContext);
+
+  function updateComponentEnvs(components, { includeAllowedOrigins = false, label }) {
+    const list = ensureArray(components);
+    for (const component of list) {
+      if (!component || typeof component !== 'object') {
+        continue;
+      }
+      component.envs = ensureArray(component.envs);
+      const componentContext = component.name ? `${label} '${component.name}'` : label;
+      upsertEnv(component.envs, 'SITE_URL', canonicalSiteUrl, 'RUN_AND_BUILD_TIME', changes, componentContext);
+      upsertEnv(component.envs, 'NEXT_PUBLIC_SITE_URL', canonicalSiteUrl, 'RUN_AND_BUILD_TIME', changes, componentContext);
+      if (includeAllowedOrigins) {
+        upsertEnv(component.envs, 'ALLOWED_ORIGINS', allowedOrigins, 'RUN_AND_BUILD_TIME', changes, componentContext);
+      }
+      upsertEnv(component.envs, 'MINIAPP_ORIGIN', canonicalOrigin, 'RUN_AND_BUILD_TIME', changes, componentContext);
+    }
+    return list;
+  }
+
+  spec.services = ensureArray(spec.services);
+  const service = spec.services.find((svc) => svc && typeof svc === 'object' && svc.name === serviceName);
+  if (service) {
+    updateComponentEnvs([service], { label: 'service' });
+  } else if (spec.services.length > 0) {
+    console.warn(`Warning: Service '${serviceName}' not found. Updating all services instead.`);
+    updateComponentEnvs(spec.services, { label: 'service' });
+  } else {
+    console.warn('Warning: No services defined in the app spec. Only global env vars were updated.');
+  }
+
+  spec.static_sites = updateComponentEnvs(spec.static_sites, { includeAllowedOrigins: true, label: 'static site' });
+  spec.workers = updateComponentEnvs(spec.workers, { label: 'worker' });
+  spec.jobs = updateComponentEnvs(spec.jobs, { label: 'job' });
+  spec.functions = updateComponentEnvs(spec.functions, { label: 'function' });
+
+  if (spec.ingress && typeof spec.ingress === 'object') {
+    spec.ingress.rules = ensureArray(spec.ingress.rules);
+    for (const rule of spec.ingress.rules) {
+      if (rule && typeof rule === 'object' && rule.match && typeof rule.match === 'object' && rule.match.authority) {
+        const authority = rule.match.authority;
+        if (authority.exact !== finalDomain) {
+          authority.exact = finalDomain;
+          changes.add(`ingress authority exact → ${finalDomain}`);
+        }
+      }
+    }
+  }
+
+  spec.domains = ensureArray(spec.domains);
+  if (spec.domains.length === 0) {
+    spec.domains.push({ domain: finalDomain, type: 'PRIMARY', wildcard: false, zone: finalZone });
+    changes.add(`domains[0] set to ${finalDomain} (zone: ${finalZone})`);
+  } else {
+    const primary = spec.domains.find((item) => item && item.type === 'PRIMARY') ?? spec.domains[0];
+    if (primary.domain !== finalDomain) {
+      primary.domain = finalDomain;
+      changes.add(`primary domain → ${finalDomain}`);
+    }
+    if (primary.zone !== finalZone) {
+      primary.zone = finalZone;
+      changes.add(`primary zone → ${finalZone}`);
+    }
+    if (primary.wildcard === undefined) {
+      primary.wildcard = false;
+    }
+  }
+
+  return {
+    spec,
+    canonicalSiteUrl,
+    canonicalOrigin,
+    domain: finalDomain,
+    zone: finalZone,
+    allowedOrigins,
+    changes: Array.from(changes),
+  };
+}

--- a/scripts/digitalocean/sync-site-config.mjs
+++ b/scripts/digitalocean/sync-site-config.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import process from 'node:process';
+import { promises as fs } from 'node:fs';
+import { parseArgs } from 'node:util';
+import YAML from 'yaml';
+
+import { normalizeAppSpec } from './site-config-utils.mjs';
+
+const API_BASE_URL = 'https://api.digitalocean.com/v2';
+const USER_AGENT = 'dynamic-capital-sync-site-config/1.0';
+
+function usage() {
+  console.log(`Sync the DigitalOcean App Platform spec using the DigitalOcean REST API.\n\n` +
+    `Usage:\n  node scripts/digitalocean/sync-site-config.mjs --app-id <id> --site-url https://example.com [options]\n\n` +
+    `Options:\n` +
+    `  --app-id <id>             DigitalOcean App Platform app ID (required unless --spec is used)\n` +
+    `  --site-url <url>         Canonical site URL to enforce (required)\n` +
+    `  --token <value>          DigitalOcean API token (defaults to DIGITALOCEAN_TOKEN env var)\n` +
+    `  --allowed-origins <list> Override the comma-separated CORS allow list\n` +
+    `  --domain <host>          Override the hostname portion of the site URL\n` +
+    `  --zone <domain>          DNS zone name (defaults to the site URL host)\n` +
+    `  --service <name>         Service name to update (default: dynamic-capital)\n` +
+    `  --spec <path>           Load an existing app spec from a local YAML file\n` +
+    `  --output <path>          Write the updated spec YAML to a file\n` +
+    `  --apply                  Push the updated spec via the DigitalOcean API\n` +
+    `  --show-spec              Print the rendered YAML to stdout\n` +
+    `  --help                   Display this help message\n`);
+}
+
+function resolveToken(tokenFlag) {
+  return tokenFlag ?? process.env.DIGITALOCEAN_TOKEN ?? '';
+}
+
+function assertToken(token, { require }) {
+  if (require && (!token || token.trim().length === 0)) {
+    throw new Error('A DigitalOcean API token is required. Provide --token or set DIGITALOCEAN_TOKEN.');
+  }
+}
+
+async function fetchAppSpec(appId, token) {
+  const response = await fetch(`${API_BASE_URL}/apps/${appId}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'User-Agent': USER_AGENT,
+    },
+  });
+
+  if (!response.ok) {
+    let message = `DigitalOcean API request failed with status ${response.status}`;
+    try {
+      const errorBody = await response.json();
+      if (errorBody?.message) {
+        message += `: ${errorBody.message}`;
+      }
+    } catch (error) {
+      // ignore JSON parse issues
+    }
+    throw new Error(message);
+  }
+
+  const payload = await response.json();
+  const spec = payload?.app?.spec;
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('DigitalOcean API response did not include an app spec.');
+  }
+
+  return { spec };
+}
+
+async function updateAppSpecRemote(appId, token, spec) {
+  const response = await fetch(`${API_BASE_URL}/apps/${appId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'User-Agent': USER_AGENT,
+    },
+    body: JSON.stringify({ spec }),
+  });
+
+  if (!response.ok) {
+    let message = `Failed to update app spec via DigitalOcean API (status ${response.status})`;
+    try {
+      const errorBody = await response.json();
+      if (errorBody?.message) {
+        message += `: ${errorBody.message}`;
+      }
+    } catch (error) {
+      // ignore JSON parse issues
+    }
+    throw new Error(message);
+  }
+
+  return await response.json();
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      'app-id': { type: 'string' },
+      'site-url': { type: 'string' },
+      token: { type: 'string' },
+      'allowed-origins': { type: 'string' },
+      domain: { type: 'string' },
+      zone: { type: 'string' },
+      service: { type: 'string', default: 'dynamic-capital' },
+      spec: { type: 'string' },
+      output: { type: 'string' },
+      apply: { type: 'boolean', default: false },
+      'show-spec': { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    usage();
+    process.exit(0);
+  }
+
+  const appId = values['app-id'];
+  const siteUrl = values['site-url'];
+  const specPath = values.spec ? path.resolve(process.cwd(), values.spec) : undefined;
+  const tokenFlag = values.token;
+  const token = resolveToken(tokenFlag);
+
+  if (!appId && !specPath) {
+    usage();
+    throw new Error('--app-id is required unless --spec supplies a local app spec.');
+  }
+
+  if (!siteUrl) {
+    usage();
+    throw new Error('--site-url is required (e.g. https://dynamic-capital.ondigitalocean.app).');
+  }
+
+  if (!specPath) {
+    assertToken(token, { require: true });
+  }
+
+  const domainOverride = values.domain;
+  const zoneOverride = values.zone;
+  const serviceName = values.service ?? 'dynamic-capital';
+  const requestedAllowedOrigins = values['allowed-origins'];
+
+  let parsedSpec;
+  let specSource;
+
+  if (specPath) {
+    try {
+      const fileContents = await fs.readFile(specPath, 'utf8');
+      parsedSpec = YAML.parse(fileContents);
+      specSource = specPath;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(`Unable to read spec file at ${specPath}. ${reason}`);
+    }
+  } else {
+    const { spec } = await fetchAppSpec(appId, token);
+    parsedSpec = { spec };
+    specSource = 'DigitalOcean API';
+  }
+
+  const spec = (parsedSpec && typeof parsedSpec === 'object' && parsedSpec.spec)
+    ? parsedSpec.spec
+    : parsedSpec;
+
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('Unexpected spec format encountered.');
+  }
+
+  const {
+    canonicalSiteUrl,
+    canonicalOrigin,
+    domain,
+    zone,
+    allowedOrigins,
+    changes,
+  } = normalizeAppSpec({
+    spec,
+    siteUrl,
+    domain: domainOverride,
+    zone: zoneOverride,
+    serviceName,
+    allowedOriginsOverride: requestedAllowedOrigins,
+  });
+
+  const rendered = YAML.stringify(parsedSpec, { lineWidth: 0 });
+  const outputPath = values.output
+    ? path.resolve(process.cwd(), values.output)
+    : undefined;
+
+  if (outputPath) {
+    await fs.writeFile(outputPath, rendered, 'utf8');
+    console.log(`Updated spec written to ${outputPath}.`);
+  }
+
+  if (values['show-spec']) {
+    console.log('\n----- Updated spec preview -----\n');
+    console.log(rendered);
+    console.log('----- End preview -----\n');
+  }
+
+  console.log('DigitalOcean app configuration summary:');
+  if (appId) {
+    console.log(`  App ID: ${appId}`);
+  } else {
+    console.log('  App ID: (not provided; local spec only)');
+  }
+  console.log(`  Service: ${serviceName}`);
+  console.log(`  Site URL: ${canonicalSiteUrl}`);
+  console.log(`  Domain: ${domain}`);
+  console.log(`  Zone: ${zone}`);
+  console.log(`  Allowed origins: ${allowedOrigins}`);
+  console.log(`  Miniapp origin: ${canonicalOrigin}`);
+  console.log(`  Spec source: ${specSource}`);
+  if (outputPath) {
+    console.log(`  Output: ${outputPath}`);
+  } else {
+    console.log('  Output: (dry-run only; pass --output to write the updated spec)');
+  }
+
+  if (changes.length > 0) {
+    console.log('  Applied updates:');
+    for (const change of changes) {
+      console.log(`    - ${change}`);
+    }
+  } else {
+    console.log('  No changes detected; the spec already matched the requested configuration.');
+  }
+
+  if (values.apply) {
+    assertToken(token, { require: true });
+    if (!appId) {
+      throw new Error('--apply requires --app-id to target the DigitalOcean app.');
+    }
+    console.log('\nApplying spec update via DigitalOcean API...');
+    await updateAppSpecRemote(appId, token, spec);
+    console.log('✅ App spec updated successfully.');
+  } else {
+    console.log('\nDry run complete. Re-run with --apply to push the spec to DigitalOcean.');
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- relax the DigitalOcean API sync helper so --app-id is only required when reading or applying remote specs
- clarify the usage text and runtime summary when the command is run against a local spec file
- enforce an explicit app ID when attempting to push updates via the REST API

## Testing
- npm run do:sync-site

------
https://chatgpt.com/codex/tasks/task_e_68cd16a18ffc8322b9b69fe609419a61