### PR TITLE
feat: add trading signals pipeline schema

### DIFF
--- a/apps/web/integrations/supabase/types.ts
+++ b/apps/web/integrations/supabase/types.ts
@@ -1225,6 +1225,133 @@ export type Database = {
           },
         ]
       }
+      signal_dispatches: {
+        Row: {
+          claimed_at: string
+          completed_at: string | null
+          created_at: string
+          failed_at: string | null
+          id: string
+          last_heartbeat_at: string | null
+          metadata: Json
+          retry_count: number
+          signal_id: string
+          status: Database["public"]["Enums"]["signal_dispatch_status_enum"]
+          updated_at: string
+          worker_id: string
+        }
+        Insert: {
+          claimed_at?: string
+          completed_at?: string | null
+          created_at?: string
+          failed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          retry_count?: number
+          signal_id: string
+          status?: Database["public"]["Enums"]["signal_dispatch_status_enum"]
+          updated_at?: string
+          worker_id: string
+        }
+        Update: {
+          claimed_at?: string
+          completed_at?: string | null
+          created_at?: string
+          failed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          retry_count?: number
+          signal_id?: string
+          status?: Database["public"]["Enums"]["signal_dispatch_status_enum"]
+          updated_at?: string
+          worker_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signal_dispatches_signal_id_fkey"
+            columns: ["signal_id"]
+            isOneToOne: false
+            referencedRelation: "signals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      signals: {
+        Row: {
+          account_id: string | null
+          acknowledged_at: string | null
+          alert_id: string
+          cancelled_at: string | null
+          created_at: string
+          direction: string
+          error_reason: string | null
+          executed_at: string | null
+          id: string
+          last_heartbeat_at: string | null
+          next_poll_at: string
+          order_type: string
+          payload: Json
+          priority: number
+          source: string
+          status: Database["public"]["Enums"]["signal_status_enum"]
+          symbol: string
+          timeframe: string | null
+          updated_at: string
+        }
+        Insert: {
+          account_id?: string | null
+          acknowledged_at?: string | null
+          alert_id: string
+          cancelled_at?: string | null
+          created_at?: string
+          direction: string
+          error_reason?: string | null
+          executed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          next_poll_at?: string
+          order_type?: string
+          payload?: Json
+          priority?: number
+          source?: string
+          status?: Database["public"]["Enums"]["signal_status_enum"]
+          symbol: string
+          timeframe?: string | null
+          updated_at?: string
+        }
+        Update: {
+          account_id?: string | null
+          acknowledged_at?: string | null
+          alert_id?: string
+          cancelled_at?: string | null
+          created_at?: string
+          direction?: string
+          error_reason?: string | null
+          executed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          next_poll_at?: string
+          order_type?: string
+          payload?: Json
+          priority?: number
+          source?: string
+          status?: Database["public"]["Enums"]["signal_status_enum"]
+          symbol?: string
+          timeframe?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signals_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "trading_accounts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       subscription_audit_log: {
         Row: {
           action_type: string
@@ -1298,6 +1425,129 @@ export type Database = {
           is_lifetime?: boolean
           name?: string
           price?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      trades: {
+        Row: {
+          account_id: string | null
+          closed_at: string | null
+          created_at: string
+          direction: string
+          error_reason: string | null
+          execution_payload: Json
+          filled_at: string | null
+          filled_price: number | null
+          id: string
+          mt5_ticket_id: string | null
+          opened_at: string
+          order_type: string
+          requested_price: number | null
+          signal_id: string | null
+          status: Database["public"]["Enums"]["trade_status_enum"]
+          stop_loss: number | null
+          symbol: string
+          take_profit: number | null
+          updated_at: string
+          volume: number | null
+        }
+        Insert: {
+          account_id?: string | null
+          closed_at?: string | null
+          created_at?: string
+          direction: string
+          error_reason?: string | null
+          execution_payload?: Json
+          filled_at?: string | null
+          filled_price?: number | null
+          id?: string
+          mt5_ticket_id?: string | null
+          opened_at?: string
+          order_type?: string
+          requested_price?: number | null
+          signal_id?: string | null
+          status?: Database["public"]["Enums"]["trade_status_enum"]
+          stop_loss?: number | null
+          symbol: string
+          take_profit?: number | null
+          updated_at?: string
+          volume?: number | null
+        }
+        Update: {
+          account_id?: string | null
+          closed_at?: string | null
+          created_at?: string
+          direction?: string
+          error_reason?: string | null
+          execution_payload?: Json
+          filled_at?: string | null
+          filled_price?: number | null
+          id?: string
+          mt5_ticket_id?: string | null
+          opened_at?: string
+          order_type?: string
+          requested_price?: number | null
+          signal_id?: string | null
+          status?: Database["public"]["Enums"]["trade_status_enum"]
+          stop_loss?: number | null
+          symbol?: string
+          take_profit?: number | null
+          updated_at?: string
+          volume?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trades_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "trading_accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trades_signal_id_fkey"
+            columns: ["signal_id"]
+            isOneToOne: false
+            referencedRelation: "signals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      trading_accounts: {
+        Row: {
+          account_code: string
+          broker: string | null
+          created_at: string
+          display_name: string | null
+          environment: string
+          id: string
+          last_heartbeat_at: string | null
+          metadata: Json
+          status: Database["public"]["Enums"]["trading_account_status_enum"]
+          updated_at: string
+        }
+        Insert: {
+          account_code: string
+          broker?: string | null
+          created_at?: string
+          display_name?: string | null
+          environment?: string
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          status?: Database["public"]["Enums"]["trading_account_status_enum"]
+          updated_at?: string
+        }
+        Update: {
+          account_code?: string
+          broker?: string | null
+          created_at?: string
+          display_name?: string | null
+          environment?: string
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          status?: Database["public"]["Enums"]["trading_account_status_enum"]
           updated_at?: string
         }
         Relationships: []
@@ -1765,6 +2015,27 @@ export type Database = {
       }
     }
     Enums: {
+      signal_dispatch_status_enum:
+        | "pending"
+        | "claimed"
+        | "processing"
+        | "completed"
+        | "failed"
+      signal_status_enum:
+        | "pending"
+        | "claimed"
+        | "processing"
+        | "executed"
+        | "failed"
+        | "cancelled"
+      trade_status_enum:
+        | "pending"
+        | "executing"
+        | "partial_fill"
+        | "filled"
+        | "failed"
+        | "cancelled"
+      trading_account_status_enum: "active" | "maintenance" | "disabled"
       user_role_enum: "admin" | "user"
     }
     CompositeTypes: {

--- a/apps/web/types/supabase.ts
+++ b/apps/web/types/supabase.ts
@@ -1225,6 +1225,133 @@ export type Database = {
           },
         ]
       }
+      signal_dispatches: {
+        Row: {
+          claimed_at: string
+          completed_at: string | null
+          created_at: string
+          failed_at: string | null
+          id: string
+          last_heartbeat_at: string | null
+          metadata: Json
+          retry_count: number
+          signal_id: string
+          status: Database["public"]["Enums"]["signal_dispatch_status_enum"]
+          updated_at: string
+          worker_id: string
+        }
+        Insert: {
+          claimed_at?: string
+          completed_at?: string | null
+          created_at?: string
+          failed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          retry_count?: number
+          signal_id: string
+          status?: Database["public"]["Enums"]["signal_dispatch_status_enum"]
+          updated_at?: string
+          worker_id: string
+        }
+        Update: {
+          claimed_at?: string
+          completed_at?: string | null
+          created_at?: string
+          failed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          retry_count?: number
+          signal_id?: string
+          status?: Database["public"]["Enums"]["signal_dispatch_status_enum"]
+          updated_at?: string
+          worker_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signal_dispatches_signal_id_fkey"
+            columns: ["signal_id"]
+            isOneToOne: false
+            referencedRelation: "signals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      signals: {
+        Row: {
+          account_id: string | null
+          acknowledged_at: string | null
+          alert_id: string
+          cancelled_at: string | null
+          created_at: string
+          direction: string
+          error_reason: string | null
+          executed_at: string | null
+          id: string
+          last_heartbeat_at: string | null
+          next_poll_at: string
+          order_type: string
+          payload: Json
+          priority: number
+          source: string
+          status: Database["public"]["Enums"]["signal_status_enum"]
+          symbol: string
+          timeframe: string | null
+          updated_at: string
+        }
+        Insert: {
+          account_id?: string | null
+          acknowledged_at?: string | null
+          alert_id: string
+          cancelled_at?: string | null
+          created_at?: string
+          direction: string
+          error_reason?: string | null
+          executed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          next_poll_at?: string
+          order_type?: string
+          payload?: Json
+          priority?: number
+          source?: string
+          status?: Database["public"]["Enums"]["signal_status_enum"]
+          symbol: string
+          timeframe?: string | null
+          updated_at?: string
+        }
+        Update: {
+          account_id?: string | null
+          acknowledged_at?: string | null
+          alert_id?: string
+          cancelled_at?: string | null
+          created_at?: string
+          direction?: string
+          error_reason?: string | null
+          executed_at?: string | null
+          id?: string
+          last_heartbeat_at?: string | null
+          next_poll_at?: string
+          order_type?: string
+          payload?: Json
+          priority?: number
+          source?: string
+          status?: Database["public"]["Enums"]["signal_status_enum"]
+          symbol?: string
+          timeframe?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signals_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "trading_accounts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       subscription_audit_log: {
         Row: {
           action_type: string
@@ -1298,6 +1425,129 @@ export type Database = {
           is_lifetime?: boolean
           name?: string
           price?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      trades: {
+        Row: {
+          account_id: string | null
+          closed_at: string | null
+          created_at: string
+          direction: string
+          error_reason: string | null
+          execution_payload: Json
+          filled_at: string | null
+          filled_price: number | null
+          id: string
+          mt5_ticket_id: string | null
+          opened_at: string
+          order_type: string
+          requested_price: number | null
+          signal_id: string | null
+          status: Database["public"]["Enums"]["trade_status_enum"]
+          stop_loss: number | null
+          symbol: string
+          take_profit: number | null
+          updated_at: string
+          volume: number | null
+        }
+        Insert: {
+          account_id?: string | null
+          closed_at?: string | null
+          created_at?: string
+          direction: string
+          error_reason?: string | null
+          execution_payload?: Json
+          filled_at?: string | null
+          filled_price?: number | null
+          id?: string
+          mt5_ticket_id?: string | null
+          opened_at?: string
+          order_type?: string
+          requested_price?: number | null
+          signal_id?: string | null
+          status?: Database["public"]["Enums"]["trade_status_enum"]
+          stop_loss?: number | null
+          symbol: string
+          take_profit?: number | null
+          updated_at?: string
+          volume?: number | null
+        }
+        Update: {
+          account_id?: string | null
+          closed_at?: string | null
+          created_at?: string
+          direction?: string
+          error_reason?: string | null
+          execution_payload?: Json
+          filled_at?: string | null
+          filled_price?: number | null
+          id?: string
+          mt5_ticket_id?: string | null
+          opened_at?: string
+          order_type?: string
+          requested_price?: number | null
+          signal_id?: string | null
+          status?: Database["public"]["Enums"]["trade_status_enum"]
+          stop_loss?: number | null
+          symbol?: string
+          take_profit?: number | null
+          updated_at?: string
+          volume?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trades_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "trading_accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trades_signal_id_fkey"
+            columns: ["signal_id"]
+            isOneToOne: false
+            referencedRelation: "signals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      trading_accounts: {
+        Row: {
+          account_code: string
+          broker: string | null
+          created_at: string
+          display_name: string | null
+          environment: string
+          id: string
+          last_heartbeat_at: string | null
+          metadata: Json
+          status: Database["public"]["Enums"]["trading_account_status_enum"]
+          updated_at: string
+        }
+        Insert: {
+          account_code: string
+          broker?: string | null
+          created_at?: string
+          display_name?: string | null
+          environment?: string
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          status?: Database["public"]["Enums"]["trading_account_status_enum"]
+          updated_at?: string
+        }
+        Update: {
+          account_code?: string
+          broker?: string | null
+          created_at?: string
+          display_name?: string | null
+          environment?: string
+          id?: string
+          last_heartbeat_at?: string | null
+          metadata?: Json
+          status?: Database["public"]["Enums"]["trading_account_status_enum"]
           updated_at?: string
         }
         Relationships: []
@@ -1765,6 +2015,27 @@ export type Database = {
       }
     }
     Enums: {
+      signal_dispatch_status_enum:
+        | "pending"
+        | "claimed"
+        | "processing"
+        | "completed"
+        | "failed"
+      signal_status_enum:
+        | "pending"
+        | "claimed"
+        | "processing"
+        | "executed"
+        | "failed"
+        | "cancelled"
+      trade_status_enum:
+        | "pending"
+        | "executing"
+        | "partial_fill"
+        | "filled"
+        | "failed"
+        | "cancelled"
+      trading_account_status_enum: "active" | "maintenance" | "disabled"
       user_role_enum: "admin" | "user"
     }
     CompositeTypes: {

--- a/docs/TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md
+++ b/docs/TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md
@@ -18,6 +18,7 @@ Use this list when spinning up the TradingView webhook to MetaTrader 5 automatio
 ## 3. Webhook ingestion service
 - [ ] Stand up the webhook receiver (Vercel serverless function or Python service) following repo conventions.
 - [ ] Implement authentication (shared secret, signature) and reject unauthorized payloads.
+- [ ] Record shared secrets such as `TRADING_SIGNALS_WEBHOOK_SECRET` and `MT5_BRIDGE_WORKER_ID` in the deployment checklist so they map cleanly to Supabase.
 - [ ] Normalize symbols, timestamps, and payload shape to match Supabase expectations.
 - [ ] Add idempotency or deduplication to prevent duplicate trade executions.
 - [ ] Emit structured logs and capture metrics for received, processed, and failed alerts.
@@ -25,6 +26,7 @@ Use this list when spinning up the TradingView webhook to MetaTrader 5 automatio
 
 ## 4. Supabase backend enablement
 - [ ] Design and migrate tables such as `signals`, `trades`, `positions`, and configuration stores.
+- [ ] Apply the `20250920000000_trading_signals_pipeline.sql` migration so `trading_accounts`, `signals`, `signal_dispatches`, and `trades` exist with polling indexes.
 - [ ] Define RLS policies or restrict access via service-role keys for automation components.
 - [ ] Enable Realtime channels or RPC endpoints that the EA/process will consume.
 - [ ] Run manual inserts from the webhook service to confirm database connectivity.
@@ -35,6 +37,7 @@ Use this list when spinning up the TradingView webhook to MetaTrader 5 automatio
 - [ ] Parse incoming payloads and map to MT5 trade parameters with validation.
 - [ ] Implement execution logic, risk management, and post-trade reconciliation.
 - [ ] Forward execution status, fills, and error states back to Supabase for observability.
+- [ ] Exercise the `claim_trading_signal`, `mark_trading_signal_status`, and `record_trade_update` RPC helpers before wiring production order flow.
 - [ ] Add robust logging, retries, and fail-safes for network or broker issues.
 - [ ] Backtest and forward-test with demo accounts using staged signals.
 

--- a/docs/automated-trading-checklist.md
+++ b/docs/automated-trading-checklist.md
@@ -22,9 +22,11 @@ Use this checklist to track progress when implementing the TradingView → Verce
 
 ## 3. Supabase Backend
 - [ ] Design database schema (e.g., `signals`, `trades`, `settings` tables).
+- [ ] Apply `supabase/migrations/20250920000000_trading_signals_pipeline.sql` to provision `trading_accounts`, `signals`, `signal_dispatches`, and `trades` with realtime + polling indexes.
 - [ ] Apply migrations and verify table indexes/constraints.
 - [ ] Enable Supabase Realtime for relevant tables/channels.
 - [ ] Create policies or use service-role key to secure inserts/reads.
+- [ ] Smoke test RPC helpers (`claim_trading_signal`, `mark_trading_signal_status`, `record_trade_update`) with a local Supabase client before wiring the MT5 listener.
 - [ ] Test manual insert to confirm Vercel → Supabase integration.
 - [ ] Document API endpoints or client libraries used by the EA.
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -19,6 +19,14 @@ example value, and where it's referenced in the repository.
        | `scripts/update-telegram-miniapp.ts`, `scripts/setup-db-webhooks.ts`                                      |
 | `SUPABASE_DB_PASSWORD`      | Postgres password for local or CI usage.                  | No       | `super-secret`              | Supabase CLI only                                                                                         |
 
+## Trading Automation
+
+| Key                          | Purpose                                                                         | Required | Example                 | Used in |
+| ---------------------------- | ------------------------------------------------------------------------------- | -------- | ----------------------- | ------- |
+| `TRADING_SIGNALS_WEBHOOK_SECRET` | Shared secret that TradingView webhooks must include when posting alerts.     | Yes      | `supabase-shared`       | `algorithms/vercel-webhook` ingestion handler (see TradingView→MT5 docs) |
+| `MT5_BRIDGE_WORKER_ID`       | Identifier passed to the MT5 listener when claiming Supabase signals.           | Yes      | `worker-nyc-01`         | MT5 bridge runtime (`claim_trading_signal` / `record_trade_update` RPC calls) |
+| `SUPABASE_SIGNALS_CHANNEL`   | Optional override for the realtime channel the MT5 bridge subscribes to.       | No       | `realtime:public:signals` | Trading bridge listener configuration |
+
 ## Telegram
 
 | Key                       | Purpose                                                      | Required | Example                                          | Used in                                                              |

--- a/supabase/migrations/20250920000000_trading_signals_pipeline.sql
+++ b/supabase/migrations/20250920000000_trading_signals_pipeline.sql
@@ -1,0 +1,420 @@
+-- Trading automation schema for the TradingView → Supabase → MT5 bridge
+
+-- Ensure enums exist for status columns used by the bridge tables
+DO $$ BEGIN
+  CREATE TYPE public.signal_status_enum AS ENUM (
+    'pending',
+    'claimed',
+    'processing',
+    'executed',
+    'failed',
+    'cancelled'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE public.trade_status_enum AS ENUM (
+    'pending',
+    'executing',
+    'partial_fill',
+    'filled',
+    'failed',
+    'cancelled'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE public.signal_dispatch_status_enum AS ENUM (
+    'pending',
+    'claimed',
+    'processing',
+    'completed',
+    'failed'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE public.trading_account_status_enum AS ENUM (
+    'active',
+    'maintenance',
+    'disabled'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Master record for MT5 / copier accounts
+CREATE TABLE IF NOT EXISTS public.trading_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_code text NOT NULL UNIQUE,
+  display_name text,
+  broker text,
+  environment text NOT NULL DEFAULT 'demo' CHECK (environment IN ('demo', 'live')),
+  status public.trading_account_status_enum NOT NULL DEFAULT 'active',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  last_heartbeat_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.trading_accounts ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_trading_accounts_status_env
+  ON public.trading_accounts(status, environment);
+
+DROP TRIGGER IF EXISTS trg_trading_accounts_updated_at ON public.trading_accounts;
+CREATE TRIGGER trg_trading_accounts_updated_at
+  BEFORE UPDATE ON public.trading_accounts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Incoming TradingView alerts normalized for MT5 consumption
+CREATE TABLE IF NOT EXISTS public.signals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  alert_id text NOT NULL,
+  account_id uuid REFERENCES public.trading_accounts(id) ON DELETE SET NULL,
+  source text NOT NULL DEFAULT 'tradingview',
+  symbol text NOT NULL,
+  timeframe text,
+  direction text NOT NULL CHECK (direction IN ('long', 'short', 'flat')),
+  order_type text NOT NULL DEFAULT 'market' CHECK (order_type IN ('market', 'limit', 'stop', 'stop_limit')),
+  status public.signal_status_enum NOT NULL DEFAULT 'pending',
+  priority integer NOT NULL DEFAULT 0,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  error_reason text,
+  next_poll_at timestamptz NOT NULL DEFAULT now(),
+  acknowledged_at timestamptz,
+  last_heartbeat_at timestamptz,
+  executed_at timestamptz,
+  cancelled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT signals_alert_id_unique UNIQUE (alert_id)
+);
+
+ALTER TABLE public.signals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.signals REPLICA IDENTITY FULL;
+
+CREATE INDEX IF NOT EXISTS idx_signals_status_poll
+  ON public.signals(status, next_poll_at, priority DESC, created_at)
+  WHERE status IN ('pending', 'claimed', 'processing');
+
+CREATE INDEX IF NOT EXISTS idx_signals_account_status
+  ON public.signals(account_id, status);
+
+DROP TRIGGER IF EXISTS trg_signals_updated_at ON public.signals;
+CREATE TRIGGER trg_signals_updated_at
+  BEFORE UPDATE ON public.signals
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Worker dispatch tracking so the MT5 bridge can record heartbeats
+CREATE TABLE IF NOT EXISTS public.signal_dispatches (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  signal_id uuid NOT NULL REFERENCES public.signals(id) ON DELETE CASCADE,
+  worker_id text NOT NULL,
+  status public.signal_dispatch_status_enum NOT NULL DEFAULT 'claimed',
+  retry_count integer NOT NULL DEFAULT 0,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  claimed_at timestamptz NOT NULL DEFAULT now(),
+  last_heartbeat_at timestamptz,
+  completed_at timestamptz,
+  failed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.signal_dispatches ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS idx_signal_dispatches_signal
+  ON public.signal_dispatches(signal_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_signal_dispatches_status
+  ON public.signal_dispatches(status, claimed_at);
+
+DROP TRIGGER IF EXISTS trg_signal_dispatches_updated_at ON public.signal_dispatches;
+CREATE TRIGGER trg_signal_dispatches_updated_at
+  BEFORE UPDATE ON public.signal_dispatches
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Executed MT5 trades mapped back to originating signals
+CREATE TABLE IF NOT EXISTS public.trades (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  signal_id uuid REFERENCES public.signals(id) ON DELETE SET NULL,
+  account_id uuid REFERENCES public.trading_accounts(id) ON DELETE SET NULL,
+  mt5_ticket_id bigint,
+  status public.trade_status_enum NOT NULL DEFAULT 'pending',
+  symbol text NOT NULL,
+  direction text NOT NULL CHECK (direction IN ('long', 'short', 'flat')),
+  order_type text NOT NULL DEFAULT 'market' CHECK (order_type IN ('market', 'limit', 'stop', 'stop_limit')),
+  volume numeric(14, 2),
+  requested_price numeric(18, 8),
+  filled_price numeric(18, 8),
+  stop_loss numeric(18, 8),
+  take_profit numeric(18, 8),
+  execution_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  error_reason text,
+  opened_at timestamptz NOT NULL DEFAULT now(),
+  filled_at timestamptz,
+  closed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT trades_mt5_ticket_unique UNIQUE (mt5_ticket_id)
+);
+
+ALTER TABLE public.trades ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.trades REPLICA IDENTITY FULL;
+
+CREATE INDEX IF NOT EXISTS idx_trades_status_opened
+  ON public.trades(status, opened_at);
+
+CREATE INDEX IF NOT EXISTS idx_trades_signal
+  ON public.trades(signal_id);
+
+CREATE INDEX IF NOT EXISTS idx_trades_open_accounts
+  ON public.trades(account_id, status)
+  WHERE status IN ('pending', 'executing', 'partial_fill');
+
+DROP TRIGGER IF EXISTS trg_trades_updated_at ON public.trades;
+CREATE TRIGGER trg_trades_updated_at
+  BEFORE UPDATE ON public.trades
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- Expose the new tables via realtime so the MT5 listener can subscribe
+ALTER PUBLICATION supabase_realtime ADD TABLE public.signals;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.trades;
+
+-- RPC helpers for the MT5 bridge workflow
+CREATE OR REPLACE FUNCTION public.claim_trading_signal(
+  p_worker_id text,
+  p_account_code text DEFAULT NULL
+)
+RETURNS public.signals
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_signal public.signals;
+  v_account_id uuid;
+  v_retry integer := 0;
+BEGIN
+  IF coalesce(trim(p_worker_id), '') = '' THEN
+    RAISE EXCEPTION 'worker_id is required';
+  END IF;
+
+  IF p_account_code IS NOT NULL THEN
+    SELECT id INTO v_account_id
+    FROM public.trading_accounts
+    WHERE account_code = p_account_code
+    LIMIT 1;
+  END IF;
+
+  WITH candidate AS (
+    SELECT s.id
+    FROM public.signals s
+    WHERE s.status = 'pending'
+      AND (v_account_id IS NULL OR s.account_id = v_account_id)
+    ORDER BY s.priority DESC, s.next_poll_at, s.created_at
+    FOR UPDATE SKIP LOCKED
+    LIMIT 1
+  )
+  UPDATE public.signals s
+  SET status = 'claimed',
+      acknowledged_at = now(),
+      last_heartbeat_at = now(),
+      updated_at = now()
+  FROM candidate c
+  WHERE s.id = c.id
+  RETURNING s.* INTO v_signal;
+
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT coalesce(max(retry_count) + 1, 0) INTO v_retry
+  FROM public.signal_dispatches
+  WHERE signal_id = v_signal.id;
+
+  INSERT INTO public.signal_dispatches (
+    signal_id,
+    worker_id,
+    status,
+    retry_count,
+    metadata,
+    claimed_at,
+    last_heartbeat_at,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    v_signal.id,
+    p_worker_id,
+    'claimed',
+    v_retry,
+    '{}'::jsonb,
+    now(),
+    now(),
+    now(),
+    now()
+  );
+
+  RETURN v_signal;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_trading_signal_status(
+  p_signal_id uuid,
+  p_status public.signal_status_enum,
+  p_error text DEFAULT NULL,
+  p_next_poll_at timestamptz DEFAULT NULL,
+  p_worker_id text DEFAULT NULL,
+  p_dispatch_status public.signal_dispatch_status_enum DEFAULT NULL
+)
+RETURNS public.signals
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_signal public.signals;
+  v_now timestamptz := now();
+  v_dispatch_id uuid;
+BEGIN
+  UPDATE public.signals
+  SET status = p_status,
+      error_reason = p_error,
+      next_poll_at = COALESCE(p_next_poll_at, next_poll_at),
+      last_heartbeat_at = CASE WHEN p_worker_id IS NOT NULL THEN v_now ELSE last_heartbeat_at END,
+      executed_at = CASE WHEN p_status = 'executed' THEN COALESCE(executed_at, v_now) ELSE executed_at END,
+      cancelled_at = CASE WHEN p_status = 'cancelled' THEN COALESCE(cancelled_at, v_now) ELSE cancelled_at END,
+      updated_at = v_now
+  WHERE id = p_signal_id
+  RETURNING * INTO v_signal;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'signal % not found', p_signal_id;
+  END IF;
+
+  IF p_worker_id IS NOT NULL THEN
+    SELECT id INTO v_dispatch_id
+    FROM public.signal_dispatches
+    WHERE signal_id = p_signal_id
+      AND worker_id = p_worker_id
+    ORDER BY claimed_at DESC
+    LIMIT 1;
+
+    IF FOUND THEN
+      UPDATE public.signal_dispatches
+      SET status = COALESCE(p_dispatch_status, status),
+          last_heartbeat_at = v_now,
+          completed_at = CASE
+            WHEN COALESCE(p_dispatch_status, status) = 'completed'
+              THEN COALESCE(completed_at, v_now)
+            ELSE completed_at
+          END,
+          failed_at = CASE
+            WHEN COALESCE(p_dispatch_status, status) = 'failed'
+              THEN COALESCE(failed_at, v_now)
+            ELSE failed_at
+          END,
+          updated_at = v_now
+      WHERE id = v_dispatch_id;
+    END IF;
+  END IF;
+
+  RETURN v_signal;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_trade_update(
+  p_signal_id uuid,
+  p_mt5_ticket_id bigint,
+  p_status public.trade_status_enum,
+  p_payload jsonb DEFAULT '{}'::jsonb
+)
+RETURNS public.trades
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_signal public.signals;
+  v_trade public.trades;
+  v_now timestamptz := now();
+BEGIN
+  SELECT * INTO v_signal
+  FROM public.signals
+  WHERE id = p_signal_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'signal % not found', p_signal_id;
+  END IF;
+
+  INSERT INTO public.trades (
+    signal_id,
+    account_id,
+    mt5_ticket_id,
+    status,
+    symbol,
+    direction,
+    order_type,
+    volume,
+    requested_price,
+    filled_price,
+    stop_loss,
+    take_profit,
+    execution_payload,
+    error_reason,
+    opened_at,
+    filled_at,
+    closed_at,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    v_signal.id,
+    v_signal.account_id,
+    p_mt5_ticket_id,
+    p_status,
+    v_signal.symbol,
+    v_signal.direction,
+    v_signal.order_type,
+    NULLIF(p_payload ->> 'volume', '')::numeric,
+    NULLIF(p_payload ->> 'requested_price', '')::numeric,
+    NULLIF(p_payload ->> 'filled_price', '')::numeric,
+    NULLIF(p_payload ->> 'stop_loss', '')::numeric,
+    NULLIF(p_payload ->> 'take_profit', '')::numeric,
+    COALESCE(p_payload, '{}'::jsonb),
+    p_payload ->> 'error_reason',
+    COALESCE(NULLIF(p_payload ->> 'opened_at', '')::timestamptz, v_now),
+    NULLIF(p_payload ->> 'filled_at', '')::timestamptz,
+    NULLIF(p_payload ->> 'closed_at', '')::timestamptz,
+    v_now,
+    v_now
+  )
+  ON CONFLICT (mt5_ticket_id) DO UPDATE
+    SET status = EXCLUDED.status,
+        execution_payload = COALESCE(p_payload, '{}'::jsonb),
+        volume = EXCLUDED.volume,
+        requested_price = EXCLUDED.requested_price,
+        filled_price = EXCLUDED.filled_price,
+        stop_loss = EXCLUDED.stop_loss,
+        take_profit = EXCLUDED.take_profit,
+        error_reason = EXCLUDED.error_reason,
+        filled_at = COALESCE(EXCLUDED.filled_at, trades.filled_at),
+        closed_at = COALESCE(EXCLUDED.closed_at, trades.closed_at),
+        updated_at = v_now
+  RETURNING * INTO v_trade;
+
+  RETURN v_trade;
+END;
+$$;

--- a/tests/supabase-client-stub.ts
+++ b/tests/supabase-client-stub.ts
@@ -1,8 +1,111 @@
+type SignalStatus =
+  | "pending"
+  | "claimed"
+  | "processing"
+  | "executed"
+  | "failed"
+  | "cancelled";
+
+type SignalDispatchStatus =
+  | "pending"
+  | "claimed"
+  | "processing"
+  | "completed"
+  | "failed";
+
+type TradeStatus =
+  | "pending"
+  | "executing"
+  | "partial_fill"
+  | "filled"
+  | "failed"
+  | "cancelled";
+
+type TradingAccountStatus = "active" | "maintenance" | "disabled";
+
+interface TradingAccountRow {
+  id: string;
+  account_code: string;
+  display_name: string | null;
+  broker: string | null;
+  environment: string;
+  status: TradingAccountStatus;
+  metadata: unknown;
+  last_heartbeat_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SignalRow {
+  id: string;
+  alert_id: string;
+  account_id: string | null;
+  source: string;
+  symbol: string;
+  timeframe: string | null;
+  direction: string;
+  order_type: string;
+  status: SignalStatus;
+  priority: number;
+  payload: unknown;
+  error_reason: string | null;
+  next_poll_at: string;
+  acknowledged_at: string | null;
+  last_heartbeat_at: string | null;
+  executed_at: string | null;
+  cancelled_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SignalDispatchRow {
+  id: string;
+  signal_id: string;
+  worker_id: string;
+  status: SignalDispatchStatus;
+  retry_count: number;
+  metadata: unknown;
+  claimed_at: string;
+  last_heartbeat_at: string | null;
+  completed_at: string | null;
+  failed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TradeRow {
+  id: string;
+  signal_id: string | null;
+  account_id: string | null;
+  mt5_ticket_id: string | null;
+  status: TradeStatus;
+  symbol: string;
+  direction: string;
+  order_type: string;
+  volume: number | null;
+  requested_price: number | null;
+  filled_price: number | null;
+  stop_loss: number | null;
+  take_profit: number | null;
+  execution_payload: unknown;
+  error_reason: string | null;
+  opened_at: string;
+  filled_at: string | null;
+  closed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 interface StubState {
   payments: Map<string, Record<string, unknown>>;
   userSubscriptions: Map<string, Record<string, unknown>>;
   receiptsByHash: Map<string, Record<string, unknown>>;
   storageFiles: Map<string, Blob>;
+  tradingAccounts: Map<string, TradingAccountRow>;
+  signals: Map<string, SignalRow>;
+  signalDispatches: Map<string, SignalDispatchRow>;
+  trades: Map<string, TradeRow>;
+  tradeTickets: Map<string, string>;
 }
 
 const stubState: StubState = {
@@ -10,6 +113,11 @@ const stubState: StubState = {
   userSubscriptions: new Map(),
   receiptsByHash: new Map(),
   storageFiles: new Map(),
+  tradingAccounts: new Map(),
+  signals: new Map(),
+  signalDispatches: new Map(),
+  trades: new Map(),
+  tradeTickets: new Map(),
 };
 
 export const __testSupabaseState = stubState;
@@ -19,10 +127,99 @@ export function __resetSupabaseState() {
   stubState.userSubscriptions.clear();
   stubState.receiptsByHash.clear();
   stubState.storageFiles.clear();
+  stubState.tradingAccounts.clear();
+  stubState.signals.clear();
+  stubState.signalDispatches.clear();
+  stubState.trades.clear();
+  stubState.tradeTickets.clear();
 }
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value));
+}
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+type QueryBuilder<T> = {
+  eq(field: string, value: unknown): QueryBuilder<T>;
+  order(column: string, options?: { ascending?: boolean }): QueryBuilder<T>;
+  limit(count: number): QueryBuilder<T>;
+  range(from: number, to: number): QueryBuilder<T>;
+  maybeSingle(): Promise<{ data: T | null; error: { message: string } | null }>;
+  single(): Promise<{ data: T | null; error: { message: string } | null }>;
+  then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((
+      value: { data: T[]; error: { message: string } | null },
+    ) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | undefined | null,
+  ): Promise<TResult1 | TResult2>;
+  get(): Promise<{ data: T[]; error: { message: string } | null }>;
+};
+
+function createQueryBuilder<T extends Record<string, unknown>>(rows: T[]): QueryBuilder<T> {
+  let results = rows.map((row) => clone(row));
+  const builder: Partial<QueryBuilder<T>> = {
+    eq(field: string, value: unknown) {
+      results = results.filter((row) => row[field] === value);
+      return builder as QueryBuilder<T>;
+    },
+    order(column: string, options?: { ascending?: boolean }) {
+      const asc = options?.ascending !== false;
+      results.sort((a, b) => {
+        const av = a[column];
+        const bv = b[column];
+        if (av === bv) return 0;
+        if (av === undefined) return asc ? 1 : -1;
+        if (bv === undefined) return asc ? -1 : 1;
+        if (typeof av === "number" && typeof bv === "number") {
+          return asc ? av - bv : bv - av;
+        }
+        const as = String(av);
+        const bs = String(bv);
+        return asc ? as.localeCompare(bs) : bs.localeCompare(as);
+      });
+      return builder as QueryBuilder<T>;
+    },
+    limit(count: number) {
+      results = results.slice(0, count);
+      return builder as QueryBuilder<T>;
+    },
+    range(from: number, to: number) {
+      results = results.slice(from, to + 1);
+      return builder as QueryBuilder<T>;
+    },
+    async maybeSingle() {
+      return { data: results[0] ?? null, error: null };
+    },
+    async single() {
+      if (results.length === 1) {
+        return { data: results[0], error: null };
+      }
+      if (results.length === 0) {
+        return { data: null, error: { message: "no rows" } };
+      }
+      return { data: null, error: { message: "multiple rows" } };
+    },
+    then(onfulfilled, onrejected) {
+      return (builder as QueryBuilder<T>)
+        .get()
+        .then(onfulfilled, onrejected);
+    },
+    async get() {
+      return { data: results.map((row) => clone(row)), error: null };
+    },
+  };
+  return builder as QueryBuilder<T>;
 }
 
 function paymentsHandlers(state: StubState) {
@@ -139,6 +336,521 @@ function receiptsHandlers(state: StubState) {
   };
 }
 
+function tradingAccountsHandlers(state: StubState) {
+  return {
+    select(_columns?: string) {
+      return createQueryBuilder(Array.from(state.tradingAccounts.values()));
+    },
+    insert(values: Record<string, unknown> | Record<string, unknown>[]) {
+      const rows = Array.isArray(values) ? values : [values];
+      const inserted: TradingAccountRow[] = [];
+      for (const row of rows) {
+        if (!row.account_code) {
+          return { data: null, error: { message: "account_code required" } };
+        }
+        const id = String(row.id ?? crypto.randomUUID());
+        const now = isoNow();
+        const record: TradingAccountRow = {
+          id,
+          account_code: String(row.account_code),
+          display_name: row.display_name === undefined
+            ? null
+            : row.display_name === null
+            ? null
+            : String(row.display_name),
+          broker: row.broker === undefined
+            ? null
+            : row.broker === null
+            ? null
+            : String(row.broker),
+          environment: String(row.environment ?? "demo"),
+          status: (row.status as TradingAccountStatus) ?? "active",
+          metadata: row.metadata ?? {},
+          last_heartbeat_at: row.last_heartbeat_at === undefined
+            ? null
+            : row.last_heartbeat_at === null
+            ? null
+            : String(row.last_heartbeat_at),
+          created_at: row.created_at ? String(row.created_at) : now,
+          updated_at: row.updated_at ? String(row.updated_at) : now,
+        };
+        state.tradingAccounts.set(id, record);
+        inserted.push(record);
+      }
+      const data = inserted.map((row) => clone(row));
+      return {
+        data,
+        error: null,
+        select() {
+          return Promise.resolve({ data, error: null });
+        },
+      };
+    },
+    update(values: Record<string, unknown>) {
+      return {
+        eq(field: string, value: unknown) {
+          if (field !== "id") {
+            return { data: null, error: { message: "unsupported field" } };
+          }
+          const key = String(value);
+          const existing = state.tradingAccounts.get(key);
+          if (!existing) {
+            return { data: null, error: { message: "not found" } };
+          }
+          const updated: TradingAccountRow = {
+            ...existing,
+            ...values,
+            updated_at: values.updated_at ? String(values.updated_at) : isoNow(),
+          };
+          state.tradingAccounts.set(key, updated);
+          return { data: [clone(updated)], error: null };
+        },
+      };
+    },
+  };
+}
+
+function signalsHandlers(state: StubState) {
+  return {
+    select(_columns?: string) {
+      return createQueryBuilder(Array.from(state.signals.values()));
+    },
+    insert(values: Record<string, unknown> | Record<string, unknown>[]) {
+      const rows = Array.isArray(values) ? values : [values];
+      const inserted: SignalRow[] = [];
+      for (const row of rows) {
+        if (!row.alert_id || !row.symbol || !row.direction) {
+          return { data: null, error: { message: "missing required fields" } };
+        }
+        const id = String(row.id ?? crypto.randomUUID());
+        if (Array.from(state.signals.values()).some((sig) => sig.alert_id === row.alert_id)) {
+          return { data: null, error: { message: "duplicate alert_id" } };
+        }
+        const now = isoNow();
+        const record: SignalRow = {
+          id,
+          alert_id: String(row.alert_id),
+          account_id: row.account_id === undefined
+            ? null
+            : row.account_id === null
+            ? null
+            : String(row.account_id),
+          source: String(row.source ?? "tradingview"),
+          symbol: String(row.symbol),
+          timeframe: row.timeframe === undefined
+            ? null
+            : row.timeframe === null
+            ? null
+            : String(row.timeframe),
+          direction: String(row.direction),
+          order_type: String(row.order_type ?? "market"),
+          status: (row.status as SignalStatus) ?? "pending",
+          priority: Number(row.priority ?? 0),
+          payload: row.payload ?? {},
+          error_reason: row.error_reason === undefined
+            ? null
+            : row.error_reason === null
+            ? null
+            : String(row.error_reason),
+          next_poll_at: row.next_poll_at ? String(row.next_poll_at) : now,
+          acknowledged_at: row.acknowledged_at === undefined
+            ? null
+            : row.acknowledged_at === null
+            ? null
+            : String(row.acknowledged_at),
+          last_heartbeat_at: row.last_heartbeat_at === undefined
+            ? null
+            : row.last_heartbeat_at === null
+            ? null
+            : String(row.last_heartbeat_at),
+          executed_at: row.executed_at === undefined
+            ? null
+            : row.executed_at === null
+            ? null
+            : String(row.executed_at),
+          cancelled_at: row.cancelled_at === undefined
+            ? null
+            : row.cancelled_at === null
+            ? null
+            : String(row.cancelled_at),
+          created_at: row.created_at ? String(row.created_at) : now,
+          updated_at: row.updated_at ? String(row.updated_at) : now,
+        };
+        state.signals.set(id, record);
+        inserted.push(record);
+      }
+      const data = inserted.map((row) => clone(row));
+      return {
+        data,
+        error: null,
+        select() {
+          return Promise.resolve({ data, error: null });
+        },
+      };
+    },
+    update(values: Record<string, unknown>) {
+      return {
+        eq(field: string, value: unknown) {
+          if (field !== "id") {
+            return { data: null, error: { message: "unsupported field" } };
+          }
+          const key = String(value);
+          const existing = state.signals.get(key);
+          if (!existing) {
+            return { data: null, error: { message: "not found" } };
+          }
+          const now = isoNow();
+          const updated: SignalRow = {
+            ...existing,
+            ...values,
+            status: (values.status as SignalStatus) ?? existing.status,
+            updated_at: values.updated_at ? String(values.updated_at) : now,
+          };
+          state.signals.set(key, updated);
+          return { data: [clone(updated)], error: null };
+        },
+      };
+    },
+  };
+}
+
+function signalDispatchesHandlers(state: StubState) {
+  return {
+    select(_columns?: string) {
+      return createQueryBuilder(Array.from(state.signalDispatches.values()));
+    },
+  };
+}
+
+function tradesHandlers(state: StubState) {
+  return {
+    select(_columns?: string) {
+      return createQueryBuilder(Array.from(state.trades.values()));
+    },
+    insert(values: Record<string, unknown> | Record<string, unknown>[]) {
+      const rows = Array.isArray(values) ? values : [values];
+      const inserted: TradeRow[] = [];
+      for (const row of rows) {
+        const id = String(row.id ?? crypto.randomUUID());
+        const now = isoNow();
+        const mt5Ticket = row.mt5_ticket_id === undefined
+          ? null
+          : row.mt5_ticket_id === null
+          ? null
+          : String(row.mt5_ticket_id);
+        const record: TradeRow = {
+          id,
+          signal_id: row.signal_id === undefined
+            ? null
+            : row.signal_id === null
+            ? null
+            : String(row.signal_id),
+          account_id: row.account_id === undefined
+            ? null
+            : row.account_id === null
+            ? null
+            : String(row.account_id),
+          mt5_ticket_id: mt5Ticket,
+          status: (row.status as TradeStatus) ?? "pending",
+          symbol: row.symbol ? String(row.symbol) : "",
+          direction: row.direction ? String(row.direction) : "",
+          order_type: String(row.order_type ?? "market"),
+          volume: toNumber(row.volume),
+          requested_price: toNumber(row.requested_price),
+          filled_price: toNumber(row.filled_price),
+          stop_loss: toNumber(row.stop_loss),
+          take_profit: toNumber(row.take_profit),
+          execution_payload: row.execution_payload ?? {},
+          error_reason: row.error_reason === undefined
+            ? null
+            : row.error_reason === null
+            ? null
+            : String(row.error_reason),
+          opened_at: row.opened_at ? String(row.opened_at) : now,
+          filled_at: row.filled_at === undefined
+            ? null
+            : row.filled_at === null
+            ? null
+            : String(row.filled_at),
+          closed_at: row.closed_at === undefined
+            ? null
+            : row.closed_at === null
+            ? null
+            : String(row.closed_at),
+          created_at: row.created_at ? String(row.created_at) : now,
+          updated_at: row.updated_at ? String(row.updated_at) : now,
+        };
+        state.trades.set(id, record);
+        if (mt5Ticket) {
+          state.tradeTickets.set(mt5Ticket, id);
+        }
+        inserted.push(record);
+      }
+      const data = inserted.map((row) => clone(row));
+      return {
+        data,
+        error: null,
+        select() {
+          return Promise.resolve({ data, error: null });
+        },
+      };
+    },
+    update(values: Record<string, unknown>) {
+      return {
+        eq(field: string, value: unknown) {
+          if (field !== "id") {
+            return { data: null, error: { message: "unsupported field" } };
+          }
+          const key = String(value);
+          const existing = state.trades.get(key);
+          if (!existing) {
+            return { data: null, error: { message: "not found" } };
+          }
+          const now = isoNow();
+          const updated: TradeRow = {
+            ...existing,
+            ...values,
+            status: (values.status as TradeStatus) ?? existing.status,
+            mt5_ticket_id: values.mt5_ticket_id === undefined
+              ? existing.mt5_ticket_id
+              : values.mt5_ticket_id === null
+              ? null
+              : String(values.mt5_ticket_id),
+            updated_at: values.updated_at ? String(values.updated_at) : now,
+          };
+          state.trades.set(key, updated);
+          if (updated.mt5_ticket_id) {
+            state.tradeTickets.set(updated.mt5_ticket_id, key);
+          }
+          return { data: [clone(updated)], error: null };
+        },
+      };
+    },
+  };
+}
+
+function handleClaimTradingSignal(state: StubState, params: Record<string, unknown>) {
+  const workerIdRaw = params.p_worker_id ?? params.worker_id;
+  const workerId = workerIdRaw === undefined || workerIdRaw === null
+    ? ""
+    : String(workerIdRaw).trim();
+  if (!workerId) {
+    throw new Error("worker_id is required");
+  }
+
+  const accountCodeRaw = params.p_account_code ?? params.account_code;
+  let accountId: string | null = null;
+  if (accountCodeRaw !== undefined && accountCodeRaw !== null) {
+    const code = String(accountCodeRaw);
+    for (const account of state.tradingAccounts.values()) {
+      if (account.account_code === code) {
+        accountId = account.id;
+        break;
+      }
+    }
+    if (accountId === null) {
+      return null;
+    }
+  }
+
+  const candidates = Array.from(state.signals.values()).filter((signal) => {
+    if (signal.status !== "pending") return false;
+    if (accountId === null) return true;
+    return signal.account_id === accountId;
+  });
+
+  candidates.sort((a, b) => {
+    if (b.priority !== a.priority) return b.priority - a.priority;
+    const poll = a.next_poll_at.localeCompare(b.next_poll_at);
+    if (poll !== 0) return poll;
+    return a.created_at.localeCompare(b.created_at);
+  });
+
+  const candidate = candidates[0];
+  if (!candidate) return null;
+
+  const now = isoNow();
+  candidate.status = "claimed";
+  candidate.acknowledged_at = now;
+  candidate.last_heartbeat_at = now;
+  candidate.updated_at = now;
+
+  const retry = Math.max(
+    -1,
+    ...Array.from(state.signalDispatches.values())
+      .filter((dispatch) => dispatch.signal_id === candidate.id)
+      .map((dispatch) => dispatch.retry_count),
+  ) + 1;
+
+  const dispatch: SignalDispatchRow = {
+    id: crypto.randomUUID(),
+    signal_id: candidate.id,
+    worker_id: workerId,
+    status: "claimed",
+    retry_count: retry,
+    metadata: {},
+    claimed_at: now,
+    last_heartbeat_at: now,
+    completed_at: null,
+    failed_at: null,
+    created_at: now,
+    updated_at: now,
+  };
+  state.signalDispatches.set(dispatch.id, dispatch);
+
+  return clone(candidate);
+}
+
+function handleMarkTradingSignalStatus(state: StubState, params: Record<string, unknown>) {
+  const signalIdRaw = params.p_signal_id ?? params.signal_id;
+  if (signalIdRaw === undefined || signalIdRaw === null) {
+    throw new Error("p_signal_id is required");
+  }
+  const statusRaw = params.p_status ?? params.status;
+  if (statusRaw === undefined || statusRaw === null) {
+    throw new Error("p_status is required");
+  }
+  const status = statusRaw as SignalStatus;
+  const signalId = String(signalIdRaw);
+  const signal = state.signals.get(signalId);
+  if (!signal) {
+    throw new Error(`signal ${signalId} not found`);
+  }
+
+  const now = isoNow();
+  signal.status = status;
+  if ("p_error" in params) {
+    const error = params.p_error;
+    signal.error_reason = error === undefined || error === null ? null : String(error);
+  }
+  if (params.p_next_poll_at !== undefined && params.p_next_poll_at !== null) {
+    signal.next_poll_at = String(params.p_next_poll_at);
+  }
+  const workerIdParam = params.p_worker_id ?? params.worker_id;
+  if (workerIdParam !== undefined && workerIdParam !== null) {
+    signal.last_heartbeat_at = now;
+  }
+  if (status === "executed" && !signal.executed_at) {
+    signal.executed_at = now;
+  }
+  if (status === "cancelled" && !signal.cancelled_at) {
+    signal.cancelled_at = now;
+  }
+  signal.updated_at = now;
+
+  const dispatchStatus = params.p_dispatch_status ?? params.dispatch_status;
+  if (workerIdParam !== undefined && workerIdParam !== null) {
+    const workerId = String(workerIdParam);
+    const dispatches = Array.from(state.signalDispatches.values())
+      .filter((row) => row.signal_id === signalId && row.worker_id === workerId)
+      .sort((a, b) => b.claimed_at.localeCompare(a.claimed_at));
+    const dispatch = dispatches[0];
+    if (dispatch) {
+      if (dispatchStatus !== undefined && dispatchStatus !== null) {
+        dispatch.status = dispatchStatus as SignalDispatchStatus;
+      }
+      dispatch.last_heartbeat_at = now;
+      if (dispatch.status === "completed" && !dispatch.completed_at) {
+        dispatch.completed_at = now;
+      }
+      if (dispatch.status === "failed" && !dispatch.failed_at) {
+        dispatch.failed_at = now;
+      }
+      dispatch.updated_at = now;
+    }
+  }
+
+  return clone(signal);
+}
+
+function handleRecordTradeUpdate(state: StubState, params: Record<string, unknown>) {
+  const signalIdRaw = params.p_signal_id ?? params.signal_id;
+  if (signalIdRaw === undefined || signalIdRaw === null) {
+    throw new Error("p_signal_id is required");
+  }
+  const signalId = String(signalIdRaw);
+  const signal = state.signals.get(signalId);
+  if (!signal) {
+    throw new Error(`signal ${signalId} not found`);
+  }
+
+  const statusParam = params.p_status ?? params.status;
+  const status = (statusParam as TradeStatus) ?? "pending";
+  const payload = (params.p_payload ?? params.payload ?? {}) as Record<string, unknown>;
+  const ticketParam = params.p_mt5_ticket_id ?? params.mt5_ticket_id;
+  const ticket = ticketParam === undefined || ticketParam === null
+    ? null
+    : String(ticketParam);
+  const now = isoNow();
+
+  let tradeId = ticket ? state.tradeTickets.get(ticket) : undefined;
+  let record: TradeRow | undefined = tradeId ? state.trades.get(tradeId) : undefined;
+  if (!record) {
+    tradeId = crypto.randomUUID();
+    record = {
+      id: tradeId,
+      signal_id: signal.id,
+      account_id: signal.account_id,
+      mt5_ticket_id: ticket,
+      status,
+      symbol: signal.symbol,
+      direction: signal.direction,
+      order_type: signal.order_type,
+      volume: null,
+      requested_price: null,
+      filled_price: null,
+      stop_loss: null,
+      take_profit: null,
+      execution_payload: payload,
+      error_reason: null,
+      opened_at: payload.opened_at ? String(payload.opened_at) : now,
+      filled_at: payload.filled_at ? String(payload.filled_at) : null,
+      closed_at: payload.closed_at ? String(payload.closed_at) : null,
+      created_at: now,
+      updated_at: now,
+    };
+  }
+
+  record.signal_id = signal.id;
+  record.account_id = signal.account_id;
+  record.mt5_ticket_id = ticket;
+  record.status = status;
+  record.symbol = signal.symbol;
+  record.direction = signal.direction;
+  record.order_type = signal.order_type;
+  record.volume = toNumber(payload.volume);
+  record.requested_price = toNumber(payload.requested_price);
+  record.filled_price = toNumber(payload.filled_price);
+  record.stop_loss = toNumber(payload.stop_loss);
+  record.take_profit = toNumber(payload.take_profit);
+  record.execution_payload = payload ?? {};
+  record.error_reason = payload.error_reason === undefined || payload.error_reason === null
+    ? null
+    : String(payload.error_reason);
+  if (payload.opened_at !== undefined && payload.opened_at !== null) {
+    record.opened_at = String(payload.opened_at);
+  }
+  if (payload.filled_at !== undefined && payload.filled_at !== null) {
+    record.filled_at = String(payload.filled_at);
+  }
+  if (payload.closed_at !== undefined && payload.closed_at !== null) {
+    record.closed_at = String(payload.closed_at);
+  }
+  record.updated_at = now;
+  if (!record.created_at) {
+    record.created_at = now;
+  }
+
+  const finalId = record.id ?? tradeId ?? crypto.randomUUID();
+  record.id = finalId;
+  state.trades.set(finalId, record);
+  if (ticket) {
+    state.tradeTickets.set(ticket, finalId);
+  }
+
+  return clone(record);
+}
+
 class SupabaseStub {
   constructor(private readonly state: StubState) {}
 
@@ -150,16 +862,74 @@ class SupabaseStub {
         return userSubscriptionsHandlers(this.state);
       case "receipts":
         return receiptsHandlers(this.state);
+      case "trading_accounts":
+        return tradingAccountsHandlers(this.state);
+      case "signals":
+        return signalsHandlers(this.state);
+      case "signal_dispatches":
+        return signalDispatchesHandlers(this.state);
+      case "trades":
+        return tradesHandlers(this.state);
       default:
         return {
           select() {
+            return createQueryBuilder([] as Record<string, unknown>[]);
+          },
+          insert(values?: Record<string, unknown> | Record<string, unknown>[]) {
+            const rows = Array.isArray(values)
+              ? values
+              : values
+              ? [values]
+              : [];
+            const data = rows.map((row) => clone(row));
             return {
-              async maybeSingle() {
-                return { data: null, error: null };
+              data,
+              error: null,
+              select() {
+                return Promise.resolve({ data, error: null });
+              },
+            };
+          },
+          update() {
+            return {
+              eq() {
+                return { data: [], error: null };
               },
             };
           },
         };
+    }
+  }
+
+  rpc(name: string, params: Record<string, unknown> = {}) {
+    try {
+      switch (name) {
+        case "claim_trading_signal":
+          return Promise.resolve({
+            data: handleClaimTradingSignal(this.state, params),
+            error: null,
+          });
+        case "mark_trading_signal_status":
+          return Promise.resolve({
+            data: handleMarkTradingSignalStatus(this.state, params),
+            error: null,
+          });
+        case "record_trade_update":
+          return Promise.resolve({
+            data: handleRecordTradeUpdate(this.state, params),
+            error: null,
+          });
+        default:
+          return Promise.resolve({
+            data: null,
+            error: { message: `rpc not implemented: ${name}` },
+          });
+      }
+    } catch (error) {
+      return Promise.resolve({
+        data: null,
+        error: { message: (error as Error).message },
+      });
     }
   }
 

--- a/tests/trading-signals-flow.test.ts
+++ b/tests/trading-signals-flow.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __resetSupabaseState, createClient } from './supabase-client-stub.ts';
+
+function createSupabase() {
+  return createClient() as {
+    from(table: string): any;
+    rpc(name: string, params?: Record<string, unknown>): Promise<{
+      data: any;
+      error: { message: string } | null;
+    }>;
+  };
+}
+
+test('trading signal lifecycle through RPC helpers', async () => {
+  __resetSupabaseState();
+  const supabase = createSupabase();
+
+  const accountInsert = await supabase.from('trading_accounts').insert({
+    id: 'acct-1',
+    account_code: 'DEMO',
+    environment: 'demo',
+    status: 'active',
+  });
+  assert.equal(accountInsert.error, null);
+
+  const signalInsert = await supabase.from('signals').insert({
+    alert_id: 'alert-123',
+    account_id: 'acct-1',
+    symbol: 'XAUUSD',
+    direction: 'long',
+    payload: { entry: 2350.5 },
+  });
+  assert.equal(signalInsert.error, null);
+  assert.ok(Array.isArray(signalInsert.data));
+  const signalId = signalInsert.data[0].id as string;
+
+  const claim = await supabase.rpc('claim_trading_signal', {
+    p_worker_id: 'worker-1',
+    p_account_code: 'DEMO',
+  });
+  assert.equal(claim.error, null);
+  assert.ok(claim.data);
+  assert.equal(claim.data.status, 'claimed');
+
+  const markProcessing = await supabase.rpc('mark_trading_signal_status', {
+    p_signal_id: signalId,
+    p_status: 'processing',
+    p_worker_id: 'worker-1',
+    p_dispatch_status: 'processing',
+  });
+  assert.equal(markProcessing.error, null);
+  assert.equal(markProcessing.data.status, 'processing');
+
+  const trade = await supabase.rpc('record_trade_update', {
+    p_signal_id: signalId,
+    p_mt5_ticket_id: '555',
+    p_status: 'executing',
+    p_payload: {
+      volume: 1,
+      requested_price: 2350.5,
+      opened_at: new Date().toISOString(),
+    },
+  });
+  assert.equal(trade.error, null);
+  assert.equal(trade.data.status, 'executing');
+  assert.equal(trade.data.mt5_ticket_id, '555');
+
+  const markExecuted = await supabase.rpc('mark_trading_signal_status', {
+    p_signal_id: signalId,
+    p_status: 'executed',
+    p_worker_id: 'worker-1',
+    p_dispatch_status: 'completed',
+  });
+  assert.equal(markExecuted.error, null);
+  assert.equal(markExecuted.data.status, 'executed');
+  assert.ok(markExecuted.data.executed_at);
+
+  const pending = await supabase.from('signals').select('*').eq('status', 'pending');
+  assert.equal(pending.error, null);
+  assert.ok(Array.isArray(pending.data));
+  assert.equal(pending.data.length, 0);
+
+  const storedTrade = await supabase
+    .from('trades')
+    .select('*')
+    .eq('mt5_ticket_id', '555')
+    .maybeSingle();
+  assert.equal(storedTrade.error, null);
+  assert.ok(storedTrade.data);
+  assert.equal(storedTrade.data.status, 'executing');
+});


### PR DESCRIPTION
## Summary
- add trading signals pipeline migration defining trading_accounts, signals, signal_dispatches, and trades tables with realtime publication, indexes, and RPC helpers
- refresh generated Supabase TypeScript types and local Supabase stub to cover the new tables, enums, and RPC behaviour
- document trading automation environment variables and rollout checklists; add an integration test covering the end-to-end RPC flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3f4e9be883229b1c39eae3f84457