### PR TITLE
feat: add Supabase-driven MT5 bridge

### DIFF
--- a/algorithms/mql5/tradingview_to_mt5_bridge/.env.example
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/.env.example
@@ -1,0 +1,44 @@
+# Supabase configuration
+SUPABASE_URL=https://your-project.supabase.co
+# Option 1: export directly (only for local dev)
+SUPABASE_SERVICE_KEY=service-role-key
+# Option 2: store securely in Windows Credential Manager and reference the target here
+# SUPABASE_CREDENTIAL_TARGET=DynamicCapital-Supabase-ServiceKey
+SUPABASE_SIGNALS_TABLE=signals
+SUPABASE_STATUS_COLUMN=status
+SUPABASE_PENDING_STATUS=pending
+SUPABASE_QUEUED_STATUS=queued
+SUPABASE_IN_PROGRESS_STATUS=in_progress
+SUPABASE_FILLED_STATUS=filled
+SUPABASE_FAILED_STATUS=failed
+SUPABASE_ERROR_STATUS=error
+SUPABASE_POLL_INTERVAL=2.0
+SUPABASE_BATCH_SIZE=25
+
+# Redis connection for queue + metrics
+REDIS_URL=redis://127.0.0.1:6379/0
+REDIS_QUEUE_NAME=mt5:signals
+REDIS_PROCESSING_SUFFIX=:processing
+REDIS_METRICS_KEY=mt5_bridge:health
+
+# Bridge runtime tuning
+BRIDGE_NODE_ID=mt5-vps-01
+BRIDGE_BACKOFF_INITIAL=1.0
+BRIDGE_BACKOFF_MAX=30.0
+BRIDGE_HEALTH_TTL_SECONDS=600
+BRIDGE_METRICS_NAMESPACE=mt5_bridge
+BRIDGE_LOG_LEVEL=INFO
+
+# MT5 + risk settings (demo safe defaults)
+MT5_DEMO_MODE=true
+MT5_SERVER=MetaQuotes-Demo
+MT5_LOGIN=
+# MT5_PASSWORD can be stored in Windows Credential Manager by setting
+# MT5_PASSWORD_CREDENTIAL_TARGET=DynamicCapital-MT5-Password
+MT5_TERMINAL_PATH=C:\\Program Files\\MetaTrader 5\\terminal64.exe
+RISK_BALANCE=100000
+RISK_PER_TRADE=0.01
+RISK_MIN_LOT=0.01
+RISK_MAX_LOT=50
+RISK_DEFAULT_STOP_PIPS=50
+RISK_DEFAULT_PIP_VALUE=10

--- a/algorithms/mql5/tradingview_to_mt5_bridge/.gitignore
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/algorithms/mql5/tradingview_to_mt5_bridge/README.md
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/README.md
@@ -1,0 +1,102 @@
+# TradingView → MetaTrader 5 Bridge
+
+This directory vendors the runtime that watches Supabase for TradingView alerts,
+queues them in Redis, and executes the resulting trades in MT5. It replaces the
+upstream mitmproxy alert flow with a Supabase-native listener so the Dynamic
+Capital EA can operate against managed services.
+
+## 1. Getting started
+
+1. Install Python 3.11 on the VPS alongside MetaTrader 5.
+2. Clone this repository and create a virtual environment:
+
+   ```powershell
+   cd C:\path\to\Dynamic-Capital\algorithms\mql5\tradingview_to_mt5_bridge
+   python -m venv .venv
+   .\.venv\Scripts\Activate.ps1
+   pip install -r requirements.txt
+   ```
+
+3. Copy `.env.example` to `.env` and populate the Supabase, Redis, and MT5
+   settings. When running on Windows, leave `SUPABASE_SERVICE_KEY` empty and set
+   `SUPABASE_CREDENTIAL_TARGET` to the name of the Windows Credential Manager
+   secret that contains the service role key. The worker will fall back to that
+   credential if the environment variable is not set.
+
+4. Provision Redis. The supplied `docker-compose.yml` from the upstream project
+   can still be used locally if you do not have a managed Redis instance.
+
+## 2. Runtime commands
+
+| Command | Description |
+| --- | --- |
+| `python run.py supabase-listener` | Poll Supabase for `status = pending` signals, claim them, and enqueue them in Redis. |
+| `python run.py worker` | Consume queued signals, apply EA risk controls, execute the trade in MT5 (simulated when `MT5_DEMO_MODE=true`), and post the ticket status back to Supabase. |
+| `python run.py demo-dry-run` | Enqueue a synthetic signal and process it through the worker in demo mode. Use this before connecting to live services to validate configuration. |
+
+Both long-running services log health metrics into Redis (`mt5_bridge:health` by
+default), recording heartbeats, queue depth, and processing counts. Monitor these
+keys with `redis-cli HGETALL mt5_bridge:health` to verify liveness.
+
+## 3. Supabase integration
+
+- The listener polls `SUPABASE_SIGNALS_TABLE` for `status = SUPABASE_PENDING_STATUS`.
+- Claiming a row updates it to `SUPABASE_QUEUED_STATUS` and stamps
+  `bridge_claimed_at`, `bridge_node_id`, and `bridge_expires_at` for optimistic
+  locking.
+- The worker marks the row `SUPABASE_IN_PROGRESS_STATUS` before trading and uses
+  `SUPABASE_FILLED_STATUS` or `SUPABASE_ERROR_STATUS` after execution. Fills record
+  the MT5 ticket, executed price, and volume. Failures log the error message.
+- API calls use the Supabase service role key; secure it in Windows Credential
+  Manager or environment variables that never leave the VPS.
+
+## 4. Risk controls
+
+`src/services/risk.py` mirrors the EA's risk-per-trade logic. Signals inherit the
+configured balance, risk fraction, and default pip values from the environment.
+Missing stop-loss or take-profit instructions are derived from offsets around the
+entry price so even minimal signals remain bounded.
+
+## 5. Health, logging, and retries
+
+- Redis metrics capture listener/worker heartbeats, queue depth, and processing
+  timestamps. Set `BRIDGE_HEALTH_TTL_SECONDS` to control expiry.
+- Supabase and MT5 interactions use exponential backoff on failure to prevent
+  tight retry loops.
+- Application logs stream to STDOUT; redirect them to a central sink on the VPS
+  per the operations checklist.
+
+## 6. Credential management on Windows
+
+1. Open **Credential Manager → Windows Credentials**.
+2. Add a **Generic Credential** named `DynamicCapital-Supabase-ServiceKey` (or
+   the value you set in `SUPABASE_CREDENTIAL_TARGET`). Paste the Supabase service
+   role key into the password field.
+3. Optional: repeat for the MT5 password with `MT5_PASSWORD_CREDENTIAL_TARGET`.
+4. Ensure the bridge services run under the same Windows user that owns the
+   credential so lookups succeed.
+
+## 7. Demo-account dry runs
+
+1. Set `MT5_DEMO_MODE=true` and run `python run.py demo-dry-run` to confirm risk
+   calculations and simulated execution succeed without hitting Supabase.
+2. Point the listener at a Supabase table in your staging project and insert a
+   row manually:
+
+   ```sql
+   insert into signals (id, symbol, side, status, entry, stop_loss_pips, risk_fraction)
+   values ('demo-001', 'EURUSD', 'buy', 'pending', 1.10234, 25, 0.01);
+   ```
+
+3. Start the listener and worker in separate terminals. Verify that the row
+   transitions through `queued → in_progress → filled` (or `error` if the trade
+   fails) and that Redis metrics update accordingly.
+4. Once satisfied, disable demo mode, point the configuration at the demo MT5
+   account credentials, and repeat the dry run to ensure end-to-end connectivity
+   before promoting to production credentials.
+
+## 8. Follow-up tasks
+
+- Wire Redis logs to the central observability stack.
+- Automate Windows Task Scheduler jobs to start the listener and worker on boot.
+- Retire the legacy mitmproxy assets after migration is complete.

--- a/algorithms/mql5/tradingview_to_mt5_bridge/THIRD_PARTY.md
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/THIRD_PARTY.md
@@ -1,0 +1,11 @@
+# Third-party Attributions
+
+This bridge builds on design patterns and queue conventions from the
+[`abhidp/tradingview-to-metatrader5`](https://github.com/abhidp/tradingview-to-metatrader5)
+project (commit `139a8595a353841dfe88771cfb54320d4489fe03`). The upstream code is
+licensed under the MIT License. The Dynamic Capital fork introduces:
+
+- Supabase ingestion instead of the original mitmproxy alert path.
+- A Redis-backed reliable queue with health metrics for listener and worker.
+- Supabase status updates for optimistic locking and execution telemetry.
+- Documentation for securing credentials on Windows hosts.

--- a/algorithms/mql5/tradingview_to_mt5_bridge/docker-compose.yml
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/docker-compose.yml
@@ -1,0 +1,77 @@
+services:
+  db:
+    image: postgres:16
+    container_name: tradingview_db
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
+    command: >
+      postgres
+      -c logging_collector=on
+      -c log_statement=all
+      -c log_connections=on
+      -c log_disconnections=on
+      -c log_directory=/var/log/postgresql
+      -c max_connections=100
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./postgres-logs:/var/log/postgresql
+    networks:
+      - tradingview_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 512M
+
+  redis:
+    image: redis:7
+    container_name: tradingview_redis
+    command: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - tradingview_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 256M
+
+volumes:
+  postgres_data:
+    name: tradingview_postgres_data
+  redis_data:
+    name: tradingview_redis_data
+
+networks:
+  tradingview_network:
+    name: tradingview_network
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.0.0/16

--- a/algorithms/mql5/tradingview_to_mt5_bridge/requirements.txt
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv==1.0.1
+redis==5.0.3
+requests==2.31.0

--- a/algorithms/mql5/tradingview_to_mt5_bridge/run.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/run.py
@@ -1,0 +1,84 @@
+"""Entry point for managing the TradingView → MT5 bridge services."""
+from __future__ import annotations
+
+import argparse
+import threading
+import time
+
+from src.config.settings import Settings, get_settings
+from src.services.supabase_client import SupabaseClient
+from src.utils.logging import configure_logging
+from src.utils.redis_queue import RedisQueue
+from src.workers.mt5_worker import MT5Worker
+from src.workers.supabase_listener import SupabaseListener
+
+
+def build_queue(settings: Settings) -> RedisQueue:
+    return RedisQueue(
+        url=settings.redis_url,
+        queue_name=settings.redis_queue_name,
+        processing_suffix=settings.redis_processing_suffix,
+        metrics_key=settings.redis_metrics_key,
+        health_ttl=settings.health_ttl_seconds,
+    )
+
+
+def run_listener(settings: Settings) -> None:
+    configure_logging(settings.log_level)
+    client = SupabaseClient(settings)
+    queue = build_queue(settings)
+    listener = SupabaseListener(settings, client, queue)
+    listener.start()
+
+
+def run_worker(settings: Settings) -> None:
+    configure_logging(settings.log_level)
+    client = SupabaseClient(settings)
+    queue = build_queue(settings)
+    worker = MT5Worker(settings, queue, client)
+    worker.start()
+
+
+def run_demo(settings: Settings) -> None:
+    """Fire a single simulated signal through the worker."""
+    configure_logging(settings.log_level)
+    queue = build_queue(settings)
+    client = None
+    worker = MT5Worker(settings, queue, client)
+
+    fake_signal = {
+        "id": "demo-signal",
+        "symbol": "EURUSD",
+        "side": "buy",
+        "entry": 1.1000,
+        "stop_loss_pips": 35,
+        "take_profit_offset": 70,
+        "risk_fraction": 0.01,
+        "account_balance": 25_000,
+    }
+    queue.enqueue(fake_signal)
+
+    thread = threading.Thread(target=worker.run, daemon=True)
+    thread.start()
+    time.sleep(2)
+    worker.stop()
+    thread.join(timeout=5)
+
+
+COMMANDS = {
+    "supabase-listener": run_listener,
+    "worker": run_worker,
+    "demo-dry-run": run_demo,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TradingView to MT5 bridge controller")
+    parser.add_argument("command", choices=COMMANDS.keys())
+    args = parser.parse_args()
+    settings = get_settings()
+    COMMANDS[args.command](settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/__init__.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/__init__.py
@@ -1,0 +1,16 @@
+"""TradingView → MT5 bridge package."""
+
+from .config import Settings, get_settings
+from .services import MT5Service, RiskManager, SupabaseClient, SupabaseError
+from .workers import MT5Worker, SupabaseListener
+
+__all__ = [
+    "MT5Service",
+    "MT5Worker",
+    "RiskManager",
+    "Settings",
+    "SupabaseClient",
+    "SupabaseError",
+    "SupabaseListener",
+    "get_settings",
+]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/config/__init__.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/config/__init__.py
@@ -1,0 +1,4 @@
+"""Configuration utilities for the TradingView → MT5 bridge."""
+from .settings import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/config/settings.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/config/settings.py
@@ -1,0 +1,127 @@
+"""Configuration loader for the TradingView → MT5 bridge."""
+from __future__ import annotations
+
+import os
+import platform
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+
+from dotenv import load_dotenv
+
+from src.utils.credentials import load_secret
+
+# Load a .env file when present to simplify local development.
+load_dotenv()
+
+
+def _bool(value: Optional[str], default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class Settings:
+    """Container for bridge runtime configuration."""
+
+    supabase_url: str
+    supabase_service_key: str
+    supabase_signals_table: str = "signals"
+    supabase_status_column: str = "status"
+    supabase_pending_status: str = "pending"
+    supabase_queued_status: str = "queued"
+    supabase_in_progress_status: str = "in_progress"
+    supabase_filled_status: str = "filled"
+    supabase_failed_status: str = "failed"
+    supabase_error_status: str = "error"
+    supabase_batch_size: int = 25
+    supabase_poll_interval: float = 2.0
+    supabase_claim_ttl_seconds: int = 300
+    supabase_credential_target: Optional[str] = None
+
+    redis_url: str = "redis://127.0.0.1:6379/0"
+    redis_queue_name: str = "mt5:signals"
+    redis_processing_suffix: str = ":processing"
+    redis_metrics_key: str = "mt5_bridge:health"
+
+    bridge_node_id: str = platform.node()
+    backoff_initial: float = 1.0
+    backoff_max: float = 30.0
+    log_level: str = os.getenv("BRIDGE_LOG_LEVEL", "INFO")
+
+    mt5_demo_mode: bool = False
+    mt5_server: Optional[str] = None
+    mt5_login: Optional[str] = None
+    mt5_password: Optional[str] = None
+    mt5_path: Optional[str] = None
+
+    risk_balance: float = 100_000.0
+    risk_per_trade: float = 0.01
+    risk_min_lot: float = 0.01
+    risk_max_lot: float = 50.0
+    risk_default_stop_pips: float = 50.0
+    risk_default_pip_value: float = 10.0
+
+    health_ttl_seconds: int = 600
+    metrics_namespace: str = "mt5_bridge"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Load settings from the current environment."""
+    credential_target = os.getenv("SUPABASE_CREDENTIAL_TARGET")
+
+    supabase_key = load_secret("SUPABASE_SERVICE_KEY", credential_target)
+    if not supabase_key:
+        raise RuntimeError(
+            "SUPABASE_SERVICE_KEY is required. Provide it via environment variables "
+            "or configure SUPABASE_CREDENTIAL_TARGET to read from the Windows "
+            "Credential Manager."
+        )
+
+    supabase_url = os.getenv("SUPABASE_URL")
+    if not supabase_url:
+        raise RuntimeError("SUPABASE_URL must be configured")
+
+    settings = Settings(
+        supabase_url=supabase_url,
+        supabase_service_key=supabase_key,
+        supabase_signals_table=os.getenv("SUPABASE_SIGNALS_TABLE", "signals"),
+        supabase_status_column=os.getenv("SUPABASE_STATUS_COLUMN", "status"),
+        supabase_pending_status=os.getenv("SUPABASE_PENDING_STATUS", "pending"),
+        supabase_queued_status=os.getenv("SUPABASE_QUEUED_STATUS", "queued"),
+        supabase_in_progress_status=os.getenv("SUPABASE_IN_PROGRESS_STATUS", "in_progress"),
+        supabase_filled_status=os.getenv("SUPABASE_FILLED_STATUS", "filled"),
+        supabase_failed_status=os.getenv("SUPABASE_FAILED_STATUS", "failed"),
+        supabase_error_status=os.getenv("SUPABASE_ERROR_STATUS", "error"),
+        supabase_batch_size=int(os.getenv("SUPABASE_BATCH_SIZE", "25")),
+        supabase_poll_interval=float(os.getenv("SUPABASE_POLL_INTERVAL", "2.0")),
+        supabase_claim_ttl_seconds=int(os.getenv("SUPABASE_CLAIM_TTL_SECONDS", "300")),
+        supabase_credential_target=credential_target,
+        redis_url=os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0"),
+        redis_queue_name=os.getenv("REDIS_QUEUE_NAME", "mt5:signals"),
+        redis_processing_suffix=os.getenv("REDIS_PROCESSING_SUFFIX", ":processing"),
+        redis_metrics_key=os.getenv("REDIS_METRICS_KEY", "mt5_bridge:health"),
+        bridge_node_id=os.getenv("BRIDGE_NODE_ID", platform.node()),
+        backoff_initial=float(os.getenv("BRIDGE_BACKOFF_INITIAL", "1.0")),
+        backoff_max=float(os.getenv("BRIDGE_BACKOFF_MAX", "30.0")),
+        log_level=os.getenv("BRIDGE_LOG_LEVEL", "INFO"),
+        mt5_demo_mode=_bool(os.getenv("MT5_DEMO_MODE"), default=True),
+        mt5_server=os.getenv("MT5_SERVER"),
+        mt5_login=os.getenv("MT5_LOGIN"),
+        mt5_password=load_secret("MT5_PASSWORD", os.getenv("MT5_PASSWORD_CREDENTIAL_TARGET")),
+        mt5_path=os.getenv("MT5_TERMINAL_PATH"),
+        risk_balance=float(os.getenv("RISK_BALANCE", "100000")),
+        risk_per_trade=float(os.getenv("RISK_PER_TRADE", "0.01")),
+        risk_min_lot=float(os.getenv("RISK_MIN_LOT", "0.01")),
+        risk_max_lot=float(os.getenv("RISK_MAX_LOT", "50")),
+        risk_default_stop_pips=float(os.getenv("RISK_DEFAULT_STOP_PIPS", "50")),
+        risk_default_pip_value=float(os.getenv("RISK_DEFAULT_PIP_VALUE", "10")),
+        health_ttl_seconds=int(os.getenv("BRIDGE_HEALTH_TTL_SECONDS", "600")),
+        metrics_namespace=os.getenv("BRIDGE_METRICS_NAMESPACE", "mt5_bridge"),
+    )
+    return settings
+
+
+__all__ = ["Settings", "get_settings"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/services/__init__.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/services/__init__.py
@@ -1,0 +1,12 @@
+"""Service layer exports."""
+from .mt5_service import MT5Service
+from .risk import ExecutionPlan, RiskManager
+from .supabase_client import SupabaseClient, SupabaseError
+
+__all__ = [
+    "ExecutionPlan",
+    "MT5Service",
+    "RiskManager",
+    "SupabaseClient",
+    "SupabaseError",
+]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/services/mt5_service.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/services/mt5_service.py
@@ -1,0 +1,100 @@
+"""Wrapper around the MetaTrader5 package with a simulation fallback."""
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass
+
+try:  # pragma: no cover - MetaTrader5 only available on Windows
+    import MetaTrader5 as mt5  # type: ignore
+except Exception:  # pragma: no cover
+    mt5 = None
+
+from src.config.settings import Settings
+from src.services.risk import ExecutionPlan
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionResult:
+    ticket: str
+    price: float
+    volume: float
+
+
+class MT5Service:
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.initialized = False
+
+    def initialize(self) -> None:
+        if self.initialized:
+            return
+        if self.settings.mt5_demo_mode or mt5 is None:
+            logger.info("MT5 service running in demo mode – trades are simulated")
+            self.initialized = True
+            return
+        if not mt5.initialize(path=self.settings.mt5_path):
+            raise RuntimeError(f"Failed to initialize MT5: {mt5.last_error()}")
+        if self.settings.mt5_login and self.settings.mt5_password:
+            authorized = mt5.login(
+                int(self.settings.mt5_login),
+                password=self.settings.mt5_password,
+                server=self.settings.mt5_server,
+            )
+            if not authorized:
+                error = mt5.last_error()
+                raise RuntimeError(f"Unable to login to MT5: {error}")
+        self.initialized = True
+        logger.info("MT5 terminal initialized")
+
+    def shutdown(self) -> None:
+        if mt5 and not self.settings.mt5_demo_mode:
+            mt5.shutdown()
+        self.initialized = False
+
+    def execute(self, plan: ExecutionPlan) -> ExecutionResult:
+        self.initialize()
+        signal = plan.signal
+        side = (signal.get("side") or "buy").lower()
+        symbol = signal.get("symbol") or signal.get("ticker")
+        if not symbol:
+            raise RuntimeError("Signal missing symbol")
+
+        if self.settings.mt5_demo_mode or mt5 is None:
+            price = float(signal.get("entry") or signal.get("price") or 0.0)
+            if price == 0:
+                price = round(random.uniform(1.0, 2.0), 5)
+            ticket = f"SIM-{int(time.time() * 1000)}"
+            logger.info(
+                "Simulated %s order for %s volume %.2f at %.5f", side, symbol, plan.volume, price
+            )
+            return ExecutionResult(ticket=ticket, price=price, volume=plan.volume)
+
+        order_type = mt5.ORDER_TYPE_BUY if side == "buy" else mt5.ORDER_TYPE_SELL
+        request = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": symbol,
+            "volume": plan.volume,
+            "type": order_type,
+            "price": mt5.symbol_info_tick(symbol).ask if side == "buy" else mt5.symbol_info_tick(symbol).bid,
+            "deviation": int(signal.get("slippage", 20)),
+            "type_filling": mt5.ORDER_FILLING_IOC,
+        }
+        if plan.stop_loss is not None:
+            request["sl"] = plan.stop_loss
+        if plan.take_profit is not None:
+            request["tp"] = plan.take_profit
+
+        logger.debug("Sending MT5 order: %s", request)
+        result = mt5.order_send(request)
+        if result is None:
+            raise RuntimeError(f"order_send returned None: {mt5.last_error()}")
+        if result.retcode != mt5.TRADE_RETCODE_DONE:
+            raise RuntimeError(f"order_send failed: {result.retcode} - {result.comment}")
+        return ExecutionResult(ticket=str(result.order), price=float(result.price), volume=plan.volume)
+
+
+__all__ = ["MT5Service", "ExecutionResult"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/services/risk.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/services/risk.py
@@ -1,0 +1,67 @@
+"""Risk controls aligned with Dynamic Capital EA defaults."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from src.config.settings import Settings
+
+
+@dataclass
+class ExecutionPlan:
+    signal: Dict[str, Any]
+    volume: float
+    stop_loss: Optional[float]
+    take_profit: Optional[float]
+    risk_amount: float
+
+
+class RiskManager:
+    """Small helper that mirrors the EA risk guards."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+
+    def build_execution_plan(self, signal: Dict[str, Any]) -> ExecutionPlan:
+        balance = float(signal.get("account_balance", self.settings.risk_balance))
+        risk_fraction = min(
+            float(signal.get("risk_fraction", self.settings.risk_per_trade)),
+            self.settings.risk_per_trade,
+        )
+        risk_amount = balance * risk_fraction
+
+        stop_pips = float(signal.get("stop_loss_pips", self.settings.risk_default_stop_pips))
+        pip_value = float(signal.get("pip_value", self.settings.risk_default_pip_value))
+        if stop_pips <= 0 or pip_value <= 0:
+            stop_pips = self.settings.risk_default_stop_pips
+            pip_value = self.settings.risk_default_pip_value
+
+        volume = risk_amount / (stop_pips * pip_value)
+        volume = max(self.settings.risk_min_lot, min(self.settings.risk_max_lot, volume))
+
+        stop_loss = signal.get("stop_loss")
+        take_profit = signal.get("take_profit")
+        if stop_loss is None and signal.get("entry") is not None:
+            direction = (signal.get("side") or "buy").lower()
+            entry = float(signal.get("entry"))
+            stop_offset = float(signal.get("stop_offset", stop_pips)) * 0.0001
+            stop_loss = entry - stop_offset if direction == "buy" else entry + stop_offset
+        if take_profit is None and signal.get("entry") is not None:
+            direction = (signal.get("side") or "buy").lower()
+            entry = float(signal.get("entry"))
+            tp_offset = float(signal.get("take_profit_offset", stop_pips)) * 0.0001
+            take_profit = entry + tp_offset if direction == "buy" else entry - tp_offset
+
+        stop_loss_value = float(stop_loss) if stop_loss is not None else None
+        take_profit_value = float(take_profit) if take_profit is not None else None
+
+        return ExecutionPlan(
+            signal=signal,
+            volume=round(volume, 2),
+            stop_loss=stop_loss_value,
+            take_profit=take_profit_value,
+            risk_amount=risk_amount,
+        )
+
+
+__all__ = ["ExecutionPlan", "RiskManager"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/services/supabase_client.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/services/supabase_client.py
@@ -1,0 +1,145 @@
+"""Minimal Supabase REST client tailored to the bridge."""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import requests
+
+from src.config.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseError(RuntimeError):
+    """Raised when Supabase returns a non-successful response."""
+
+
+class SupabaseClient:
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.base_url = settings.supabase_url.rstrip("/") + "/rest/v1/"
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "apikey": settings.supabase_service_key,
+                "Authorization": f"Bearer {settings.supabase_service_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
+
+    def _url(self, table: str) -> str:
+        return urljoin(self.base_url, table)
+
+    def _handle_response(self, response: requests.Response) -> List[Dict[str, Any]]:
+        if response.status_code >= 400:
+            raise SupabaseError(
+                f"Supabase error {response.status_code}: {response.text}"
+            )
+        if not response.text:
+            return []
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise SupabaseError(f"Invalid JSON response: {exc}") from exc
+        if isinstance(data, list):
+            return data
+        return [data]
+
+    def fetch_pending_signals(self) -> List[Dict[str, Any]]:
+        params = {
+            self.settings.supabase_status_column: f"eq.{self.settings.supabase_pending_status}",
+            "order": "created_at.asc",
+            "limit": str(self.settings.supabase_batch_size),
+        }
+        response = self._request(
+            "get",
+            self._url(self.settings.supabase_signals_table),
+            params=params,
+        )
+        return self._handle_response(response)
+
+    def claim_signal(self, signal_id: Any, node_id: str) -> Optional[Dict[str, Any]]:
+        now = datetime.now(timezone.utc).isoformat()
+        payload = {
+            self.settings.supabase_status_column: self.settings.supabase_queued_status,
+            "bridge_claimed_at": now,
+            "bridge_node_id": node_id,
+            "bridge_expires_at": datetime.fromtimestamp(
+                time.time() + self.settings.supabase_claim_ttl_seconds,
+                tz=timezone.utc,
+            ).isoformat(),
+        }
+        params = {
+            "id": f"eq.{signal_id}",
+            self.settings.supabase_status_column: f"eq.{self.settings.supabase_pending_status}",
+        }
+        headers = {"Prefer": "return=representation"}
+        response = self._request(
+            "patch",
+            self._url(self.settings.supabase_signals_table),
+            params=params,
+            json=payload,
+            headers=headers,
+        )
+        data = self._handle_response(response)
+        return data[0] if data else None
+
+    def mark_in_progress(self, signal_id: Any) -> None:
+        payload = {
+            self.settings.supabase_status_column: self.settings.supabase_in_progress_status,
+            "bridge_started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._update_signal(signal_id, payload)
+
+    def mark_failed(self, signal_id: Any, message: str) -> None:
+        payload = {
+            self.settings.supabase_status_column: self.settings.supabase_failed_status,
+            "bridge_error": message,
+            "bridge_finished_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._update_signal(signal_id, payload)
+
+    def mark_filled(self, signal_id: Any, ticket: str, price: float, volume: float) -> None:
+        payload = {
+            self.settings.supabase_status_column: self.settings.supabase_filled_status,
+            "mt5_ticket_id": ticket,
+            "executed_price": price,
+            "executed_volume": volume,
+            "bridge_finished_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._update_signal(signal_id, payload)
+
+    def mark_error(self, signal_id: Any, message: str) -> None:
+        payload = {
+            self.settings.supabase_status_column: self.settings.supabase_error_status,
+            "bridge_error": message,
+            "bridge_finished_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._update_signal(signal_id, payload)
+
+    def _update_signal(self, signal_id: Any, payload: Dict[str, Any]) -> None:
+        params = {"id": f"eq.{signal_id}"}
+        headers = {"Prefer": "return=representation"}
+        response = self._request(
+            "patch",
+            self._url(self.settings.supabase_signals_table),
+            params=params,
+            json=payload,
+            headers=headers,
+        )
+        self._handle_response(response)
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        try:
+            response = self.session.request(method, url, timeout=30, **kwargs)
+            return response
+        except requests.RequestException as exc:
+            raise SupabaseError(f"Supabase request failed: {exc}") from exc
+
+
+__all__ = ["SupabaseClient", "SupabaseError"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/__init__.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/__init__.py
@@ -1,0 +1,12 @@
+"""Utility helpers."""
+from .credentials import load_secret
+from .logging import configure_logging, get_logger
+from .redis_queue import QueueItem, RedisQueue
+
+__all__ = [
+    "QueueItem",
+    "RedisQueue",
+    "configure_logging",
+    "get_logger",
+    "load_secret",
+]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/credentials.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/credentials.py
@@ -1,0 +1,58 @@
+"""Helpers for retrieving secrets in multiple runtime environments."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def load_secret(env_var: str, credential_target: Optional[str] = None) -> Optional[str]:
+    """Return a secret from environment variables or Windows Credential Manager.
+
+    Parameters
+    ----------
+    env_var:
+        Name of the environment variable to read.
+    credential_target:
+        Optional identifier stored in the Windows Credential Manager. If the
+        environment variable is empty and the host is Windows, we attempt to
+        pull the credential from the manager.
+
+    Returns
+    -------
+    Optional[str]
+        The secret if it could be resolved, otherwise ``None``.
+    """
+    value = os.getenv(env_var)
+    if value:
+        return value
+
+    if credential_target and os.name == "nt":  # pragma: no cover - only on Windows
+        try:
+            import win32cred  # type: ignore
+
+            credential = win32cred.CredRead(
+                credential_target, win32cred.CRED_TYPE_GENERIC
+            )
+            secret = credential.get("CredentialBlob") or b""
+            try:
+                return secret.decode("utf-16-le")
+            except Exception:  # pragma: no cover - best effort decode fallback
+                return secret.decode("utf-8", errors="ignore")
+        except ImportError:
+            logger.warning(
+                "Windows credential target '%s' requested but pywin32 is not installed.",
+                credential_target,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error(
+                "Failed to load credential '%s' from Windows Credential Manager: %s",
+                credential_target,
+                exc,
+            )
+    return value
+
+
+__all__ = ["load_secret"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/logging.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/logging.py
@@ -1,0 +1,26 @@
+"""Centralised logging configuration for the bridge."""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure root logging handlers only once."""
+    if logging.getLogger().handlers:
+        return
+
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Helper to fetch a configured logger."""
+    return logging.getLogger(name)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/redis_queue.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/utils/redis_queue.py
@@ -1,0 +1,90 @@
+"""Redis-backed work queue helpers."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import redis
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class QueueItem:
+    raw: str
+    payload: Dict[str, Any]
+
+
+class RedisQueue:
+    """Simple reliable queue built on Redis lists."""
+
+    def __init__(
+        self,
+        url: str,
+        queue_name: str,
+        processing_suffix: str = ":processing",
+        metrics_key: Optional[str] = None,
+        health_ttl: int = 600,
+    ) -> None:
+        self.redis = redis.Redis.from_url(url, decode_responses=True)
+        self.queue_name = queue_name
+        self.processing_queue = f"{queue_name}{processing_suffix}"
+        self.metrics_key = metrics_key or f"{queue_name}:health"
+        self.health_ttl = health_ttl
+
+    def enqueue(self, payload: Dict[str, Any]) -> str:
+        raw = json.dumps(payload)
+        self.redis.lpush(self.queue_name, raw)
+        self._record_metric(
+            {
+                "last_enqueued_at": time.time(),
+                "queue_depth": self.redis.llen(self.queue_name),
+            }
+        )
+        logger.debug("Enqueued signal %s", payload.get("id"))
+        return raw
+
+    def pop_for_processing(self, timeout: int = 5) -> Optional[QueueItem]:
+        raw = self.redis.brpoplpush(self.queue_name, self.processing_queue, timeout=timeout)
+        if raw is None:
+            return None
+        payload = json.loads(raw)
+        self._record_metric(
+            {
+                "last_dequeued_at": time.time(),
+                "processing_depth": self.redis.llen(self.processing_queue),
+            }
+        )
+        return QueueItem(raw=raw, payload=payload)
+
+    def ack(self, item: QueueItem) -> None:
+        self.redis.lrem(self.processing_queue, 1, item.raw)
+        self._record_metric(
+            {
+                "last_ack_at": time.time(),
+                "processing_depth": self.redis.llen(self.processing_queue),
+            }
+        )
+
+    def requeue(self, item: QueueItem) -> None:
+        self.redis.lrem(self.processing_queue, 1, item.raw)
+        self.redis.rpush(self.queue_name, item.raw)
+        self._record_metric({"last_requeue_at": time.time()})
+
+    def heartbeat(self, role: str) -> None:
+        self._record_metric({f"{role}_heartbeat": time.time()})
+
+    def _record_metric(self, data: Dict[str, Any]) -> None:
+        try:
+            self.redis.hset(self.metrics_key, mapping=data)
+            if self.health_ttl:
+                self.redis.expire(self.metrics_key, self.health_ttl)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("Failed to record queue metrics: %s", exc)
+
+
+__all__ = ["RedisQueue", "QueueItem"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/workers/__init__.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/workers/__init__.py
@@ -1,0 +1,5 @@
+"""Worker exports."""
+from .mt5_worker import MT5Worker
+from .supabase_listener import SupabaseListener
+
+__all__ = ["MT5Worker", "SupabaseListener"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/workers/mt5_worker.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/workers/mt5_worker.py
@@ -1,0 +1,101 @@
+"""Worker that pulls queued signals and executes them in MT5."""
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+import time
+from typing import Optional
+
+from src.config.settings import Settings
+from src.services.mt5_service import MT5Service
+from src.services.risk import RiskManager
+from src.services.supabase_client import SupabaseClient, SupabaseError
+from src.utils.redis_queue import QueueItem, RedisQueue
+
+logger = logging.getLogger(__name__)
+
+
+class MT5Worker:
+    def __init__(
+        self,
+        settings: Settings,
+        queue: RedisQueue,
+        client: Optional[SupabaseClient] = None,
+    ) -> None:
+        self.settings = settings
+        self.queue = queue
+        self.client = client
+        self.stop_event = threading.Event()
+        self.risk = RiskManager(settings)
+        self.mt5 = MT5Service(settings)
+        self._current_backoff = settings.backoff_initial
+
+    def start(self) -> None:
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+        logger.info("MT5 worker starting")
+        self.run()
+
+    def run(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                item = self.queue.pop_for_processing(timeout=5)
+                self.queue.heartbeat("worker")
+                if item is None:
+                    continue
+                self._current_backoff = self.settings.backoff_initial
+                self._process_item(item)
+            except SupabaseError as exc:
+                logger.error("Supabase error while processing trade: %s", exc)
+                self._sleep_with_backoff()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Unexpected error in MT5 worker: %s", exc)
+                self._sleep_with_backoff()
+
+    def _process_item(self, item: QueueItem) -> None:
+        signal_data = item.payload
+        signal_id = signal_data.get("id")
+        try:
+            if self.client:
+                self.client.mark_in_progress(signal_id)
+            plan = self.risk.build_execution_plan(signal_data)
+            result = self.mt5.execute(plan)
+            if self.client:
+                self.client.mark_filled(signal_id, result.ticket, result.price, result.volume)
+            logger.info(
+                "Executed signal %s at %.5f lot %.2f (ticket %s)",
+                signal_id,
+                result.price,
+                result.volume,
+                result.ticket,
+            )
+            self.queue.ack(item)
+        except SupabaseError:
+            self.queue.requeue(item)
+            raise
+        except Exception as exc:
+            logger.error("Trade execution failed for signal %s: %s", signal_id, exc)
+            if self.client and signal_id is not None:
+                try:
+                    self.client.mark_error(signal_id, str(exc))
+                except SupabaseError as supa_exc:
+                    logger.error("Failed to mark signal %s as error: %s", signal_id, supa_exc)
+            self.queue.requeue(item)
+            time.sleep(1)
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        self.mt5.shutdown()
+
+    def _sleep_with_backoff(self) -> None:
+        logger.info("Worker backing off for %.1fs", self._current_backoff)
+        time.sleep(self._current_backoff)
+        self._current_backoff = min(self._current_backoff * 2, self.settings.backoff_max)
+
+    def _handle_signal(self, signum, frame) -> None:  # pragma: no cover - signal handling
+        logger.info("Received signal %s, stopping worker", signum)
+        self.stop()
+
+
+__all__ = ["MT5Worker"]

--- a/algorithms/mql5/tradingview_to_mt5_bridge/src/workers/supabase_listener.py
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/src/workers/supabase_listener.py
@@ -1,0 +1,75 @@
+"""Supabase polling worker that pushes signals into Redis."""
+from __future__ import annotations
+
+import logging
+import signal
+import threading
+import time
+
+from src.config.settings import Settings
+from src.services.supabase_client import SupabaseClient, SupabaseError
+from src.utils.redis_queue import RedisQueue
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseListener:
+    def __init__(self, settings: Settings, client: SupabaseClient, queue: RedisQueue) -> None:
+        self.settings = settings
+        self.client = client
+        self.queue = queue
+        self.stop_event = threading.Event()
+        self._current_backoff = settings.backoff_initial
+
+    def start(self) -> None:
+        logger.info("Supabase listener starting (poll interval %.1fs)", self.settings.supabase_poll_interval)
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+        self.run()
+
+    def run(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                self._poll_once()
+                self._current_backoff = self.settings.backoff_initial
+                time.sleep(self.settings.supabase_poll_interval)
+            except SupabaseError as exc:
+                logger.error("Supabase API error: %s", exc)
+                self._sleep_with_backoff()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Unexpected error in Supabase listener: %s", exc)
+                self._sleep_with_backoff()
+
+    def _poll_once(self) -> None:
+        self.queue.heartbeat("listener")
+        pending = self.client.fetch_pending_signals()
+        if not pending:
+            logger.debug("No pending signals detected")
+            return
+        logger.info("Fetched %d pending signals", len(pending))
+        for signal in pending:
+            if self.stop_event.is_set():
+                break
+            claimed = self.client.claim_signal(signal.get("id"), self.settings.bridge_node_id)
+            if not claimed:
+                logger.debug("Signal %s already claimed", signal.get("id"))
+                continue
+            claimed["bridge_node_id"] = self.settings.bridge_node_id
+            claimed["bridge_claimed_at"] = claimed.get("bridge_claimed_at")
+            self.queue.enqueue(claimed)
+            logger.info("Signal %s enqueued", claimed.get("id"))
+
+    def _sleep_with_backoff(self) -> None:
+        logger.info("Backing off for %.1fs", self._current_backoff)
+        time.sleep(self._current_backoff)
+        self._current_backoff = min(self._current_backoff * 2, self.settings.backoff_max)
+
+    def stop(self) -> None:
+        self.stop_event.set()
+
+    def _handle_signal(self, signum, frame) -> None:  # pragma: no cover - signal handling
+        logger.info("Received signal %s, shutting down listener", signum)
+        self.stop()
+
+
+__all__ = ["SupabaseListener"]


### PR DESCRIPTION
## Summary
- vendor a Supabase-driven TradingView → MT5 bridge with CLI commands and README guidance for Windows deployments
- add Supabase listener and MT5 worker services that use Redis queues, risk controls, and Supabase status updates
- provide configuration templates, secure credential helpers, and third-party attribution for the upstream copier

## Testing
- python -m compileall algorithms/mql5/tradingview_to_mt5_bridge

------
https://chatgpt.com/codex/tasks/task_e_68cd3f4e260083229cd43f1c68ed4951