### PR TITLE
Default origin env for Next build helper

### DIFF
--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -3,15 +3,76 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { copyFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import process from 'node:process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 process.env.NODE_ENV = 'production';
 
+const resolvedOrigin =
+  process.env.SITE_URL ||
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.LOVABLE_ORIGIN ||
+  'http://localhost:8080';
+
+const defaultNotices = [];
+
+if (!process.env.SITE_URL) {
+  process.env.SITE_URL = resolvedOrigin;
+  defaultNotices.push(`SITE_URL → ${resolvedOrigin}`);
+}
+
+if (!process.env.NEXT_PUBLIC_SITE_URL) {
+  process.env.NEXT_PUBLIC_SITE_URL = process.env.SITE_URL;
+  defaultNotices.push(`NEXT_PUBLIC_SITE_URL → ${process.env.SITE_URL}`);
+}
+
+if (!process.env.MINIAPP_ORIGIN) {
+  process.env.MINIAPP_ORIGIN = process.env.SITE_URL;
+  defaultNotices.push(`MINIAPP_ORIGIN → ${process.env.SITE_URL}`);
+}
+
+if (!process.env.ALLOWED_ORIGINS) {
+  process.env.ALLOWED_ORIGINS = process.env.SITE_URL;
+  defaultNotices.push(`ALLOWED_ORIGINS → ${process.env.SITE_URL}`);
+}
+
+if (defaultNotices.length > 0) {
+  console.warn(
+    'Missing environment variables detected. Applying friendly defaults so the Next.js build has a canonical origin.',
+    defaultNotices,
+  );
+}
+
 const cwd = process.cwd();
+const workspaceRoot = path.resolve(__dirname, '..');
+
+const binCandidates = [
+  path.join(cwd, 'node_modules', '.bin'),
+  path.join(workspaceRoot, 'node_modules', '.bin'),
+  path.join(__dirname, 'node_modules', '.bin'),
+];
+
+const existingPathEntries = (process.env.PATH || '')
+  .split(path.delimiter)
+  .filter(Boolean);
+
+for (const dir of binCandidates) {
+  if (existsSync(dir) && !existingPathEntries.includes(dir)) {
+    existingPathEntries.unshift(dir);
+  }
+}
+
+const augmentedEnv = {
+  ...process.env,
+  PATH: existingPathEntries.join(path.delimiter),
+};
 
 const child = spawn('next', ['build'], {
   cwd,
-  env: { ...process.env },
+  env: augmentedEnv,
   stdio: ['ignore', 'pipe', 'pipe'],
 });
 


### PR DESCRIPTION
## Summary
- seed `SITE_URL` and related origin variables with local defaults when `scripts/run-next-build.mjs` runs
- augment the helper's `PATH` so the workspace `next` binary can be resolved outside of npm scripts

## Testing
- node ../../scripts/run-next-build.mjs (from apps/web)


------
https://chatgpt.com/codex/tasks/task_e_68cd47b669008322b9a8bfd09feb0e7d