### PR TITLE
Configure shared locale handling for Next.js

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,16 +1,32 @@
 import { NextIntlClientProvider } from 'next-intl';
 import { ReactNode } from 'react';
 import messages from './messages';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/config/localization';
+
+const SUPPORTED_LOCALE_SET = new Set(SUPPORTED_LOCALES);
+
+type LocaleParams = {
+  locale: string;
+};
+
+function resolveLocale(locale: string): string {
+  return SUPPORTED_LOCALE_SET.has(locale)
+    ? locale
+    : DEFAULT_LOCALE;
+}
 
 export default async function LocaleLayout({
   children,
   params,
 }: {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
+  params: Promise<LocaleParams>;
 }) {
-  const { locale } = await params;
-  const localeMessages = (messages as Record<string, any>)[locale] || messages.en;
+  const resolvedParams = await params;
+  const locale = resolveLocale(resolvedParams.locale);
+  const fallbackMessages = (messages as Record<string, any>)[DEFAULT_LOCALE] ?? {};
+  const localeMessages =
+    (messages as Record<string, any>)[locale] ?? fallbackMessages;
   return (
     <NextIntlClientProvider locale={locale} messages={localeMessages}>
       {children}

--- a/apps/web/config/locales.json
+++ b/apps/web/config/locales.json
@@ -1,0 +1,4 @@
+{
+  "defaultLocale": "en",
+  "locales": ["en"]
+}

--- a/apps/web/config/localization.ts
+++ b/apps/web/config/localization.ts
@@ -1,0 +1,26 @@
+import localizationConfig from './locales.json';
+
+const FALLBACK_LOCALE = 'en';
+
+function normalizeLocale(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+const configuredLocales = Array.isArray(localizationConfig?.locales)
+  ? localizationConfig.locales
+      .map((locale) => normalizeLocale(locale))
+      .filter((locale): locale is string => Boolean(locale))
+  : [];
+
+export const SUPPORTED_LOCALES =
+  configuredLocales.length > 0 ? configuredLocales : [FALLBACK_LOCALE];
+
+const configuredDefault = normalizeLocale(localizationConfig?.defaultLocale);
+
+export const DEFAULT_LOCALE =
+  configuredDefault && SUPPORTED_LOCALES.includes(configuredDefault)
+    ? configuredDefault
+    : SUPPORTED_LOCALES[0];

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { buildCorsHeaders } from '@/utils/http.ts';
 import createIntlMiddleware from 'next-intl/middleware';
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/config/localization';
 
 const intlMiddleware = createIntlMiddleware({
-  locales: ['en'],
-  defaultLocale: 'en'
+  locales: SUPPORTED_LOCALES,
+  defaultLocale: DEFAULT_LOCALE,
 });
 
 export function middleware(req: NextRequest) {
@@ -32,5 +33,9 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/(en)/:path*', '/api/:path*'],
+  matcher: [
+    '/',
+    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/api/:path*',
+  ],
 };

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import nextPWA from 'next-pwa';
 import bundleAnalyzer from '@next/bundle-analyzer';
+import localeConfig from './config/locales.json' with { type: 'json' };
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -132,6 +133,28 @@ if (!CANONICAL_HOST) {
 
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || SITE_URL;
 
+function normalizeLocale(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+const configuredLocales = Array.isArray(localeConfig?.locales)
+  ? localeConfig.locales
+      .map((locale) => normalizeLocale(locale))
+      .filter((locale) => Boolean(locale))
+  : [];
+
+const FALLBACK_LOCALE = 'en';
+const LOCALES = configuredLocales.length > 0 ? configuredLocales : [FALLBACK_LOCALE];
+
+const configuredDefaultLocale = normalizeLocale(localeConfig?.defaultLocale);
+const DEFAULT_LOCALE =
+  configuredDefaultLocale && LOCALES.includes(configuredDefaultLocale)
+    ? configuredDefaultLocale
+    : LOCALES[0];
+
 process.env.SUPABASE_URL = SUPABASE_URL;
 process.env.SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
 process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
@@ -139,6 +162,8 @@ process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
 process.env.SITE_URL = SITE_URL;
 process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
 process.env.ALLOWED_ORIGINS = ALLOWED_ORIGINS;
+process.env.DEFAULT_LOCALE = DEFAULT_LOCALE;
+process.env.NEXT_PUBLIC_DEFAULT_LOCALE = DEFAULT_LOCALE;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -151,6 +176,8 @@ const nextConfig = {
     SITE_URL,
     NEXT_PUBLIC_SITE_URL: SITE_URL,
     ALLOWED_ORIGINS,
+    DEFAULT_LOCALE,
+    NEXT_PUBLIC_DEFAULT_LOCALE: DEFAULT_LOCALE,
   },
   eslint: {
     ignoreDuringBuilds: true,


### PR DESCRIPTION
## Summary
- add a locale configuration file and helper to centralize the supported locales and default locale
- update the Next.js middleware and layout to consume the shared locale configuration
- read the locale configuration in the Next.js config to surface default locale env values for the client and server

## Testing
- npm run lint -w apps/web
- npm run build -w apps/web

------
https://chatgpt.com/codex/tasks/task_e_68cd6cdd12688322bd5eb62814ae6cdf