### PR TITLE
Load Once UI base styles for landing page

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import '@once-ui-system/core/dist/css/tokens.css';
+import '@once-ui-system/core/dist/css/styles.css';
 import './globals.css';
 import '../env';
 import Footer from '@/components/layout/Footer';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import '@once-ui-system/core/dist/css/tokens.css';
+import '@once-ui-system/core/dist/css/styles.css';
 import App from './App.tsx';
 import './index.css';
 


### PR DESCRIPTION
## Summary
- import the Once UI token and style sheets into the Next.js root layout so shared landing components receive their base styling
- include the same Once UI CSS imports in the Vite entry point to keep the standalone build visually consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd80e9981c832297737deb94008fc7