### PR TITLE
Ensure DigitalOcean builds upload static snapshot

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -73,7 +73,7 @@ spec:
       environment_slug: node-js
       instance_count: 1
       instance_size_slug: basic-xxs
-      build_command: npm run build
+      build_command: node scripts/digitalocean-build.mjs
       run_command: npm run start:web
       http_port: 8080
       routes:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,14 +13,17 @@ single source of truth for deployments. The checked-in spec provisions a single
 Node.js service named `dynamic-capital`, configures
 `dynamic-capital-qazf2.ondigitalocean.app` as the primary domain while registering the
 Vercel and Lovable hosts as aliases, and leaves ingress open so every hostname
-continues to route traffic. The service runs `npm run build` from the
-repository root before starting the Next.js server via `npm run start:web`.
+continues to route traffic. The service runs `node scripts/digitalocean-build.mjs`
+from the repository root before starting the Next.js server via `npm run start:web`.
 Requests are served on port `8080`, and the runtime sets `SITE_URL`,
 `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`, and `MINIAPP_ORIGIN` to
 `https://dynamic-capital-qazf2.ondigitalocean.app` (while allowlisting the companion
 hosts) so the web app, Supabase Edge Functions, and Telegram mini-app
 verification report the DigitalOcean-hosted canonical origin. Update those
-values if you move to a different hostname.
+values if you move to a different hostname. The custom build helper first runs
+the standard `npm run build` pipeline and then uploads the refreshed `_static/`
+snapshot to the configured DigitalOcean Spaces bucket when credentials are
+present, keeping the marketing CDN in sync with each deployment.
 
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`

--- a/scripts/digitalocean-build.mjs
+++ b/scripts/digitalocean-build.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      ...options,
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code, signal) => {
+      if (signal) {
+        resolve(1);
+        return;
+      }
+      resolve(code ?? 0);
+    });
+  });
+}
+
+function isMissing(value) {
+  if (!value) {
+    return true;
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return true;
+  }
+  return false;
+}
+
+async function main() {
+  console.log('DigitalOcean build: running `npm run build`…');
+  const buildCode = await run(npmCommand, ['run', 'build']);
+  if (buildCode !== 0) {
+    console.error('DigitalOcean build: `npm run build` failed. Aborting.');
+    process.exit(buildCode);
+  }
+
+  const requiredKeys = ['CDN_BUCKET', 'CDN_ACCESS_KEY', 'CDN_SECRET_KEY'];
+  const missingKeys = requiredKeys.filter((key) => isMissing(process.env[key]));
+
+  if (missingKeys.length > 0) {
+    console.warn(
+      `DigitalOcean build: skipping static asset upload because credentials are missing (${missingKeys.join(', ')}).`,
+    );
+    console.warn('Set CDN_BUCKET, CDN_ACCESS_KEY, and CDN_SECRET_KEY to enable uploads during the build.');
+    return;
+  }
+
+  console.log('DigitalOcean build: uploading `_static/` assets to Spaces…');
+  const uploadCode = await run(npmCommand, ['run', 'upload-assets']);
+  if (uploadCode !== 0) {
+    console.error('DigitalOcean build: `npm run upload-assets` failed.');
+    process.exit(uploadCode);
+  }
+
+  console.log('DigitalOcean build: static asset upload completed successfully.');
+}
+
+main().catch((error) => {
+  console.error('DigitalOcean build: unexpected error while preparing deployment:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a DigitalOcean-focused build helper that runs the standard build and uploads the refreshed `_static` snapshot when CDN credentials are available
- point the App Platform build command at the helper so deployments keep the static marketing bundle in sync with Spaces
- document the new deployment flow in the runbook for future operators

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd879a17848322a829200c29b61aa3