### PR TITLE
Fix Once UI CSS imports

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import '@once-ui-system/core/dist/css/tokens.css';
-import '@once-ui-system/core/dist/css/styles.css';
+import '@once-ui-system/core/css/tokens.css';
+import '@once-ui-system/core/css/styles.css';
 import './globals.css';
 import '../env';
 import Footer from '@/components/layout/Footer';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import '@once-ui-system/core/dist/css/tokens.css';
-import '@once-ui-system/core/dist/css/styles.css';
+import '@once-ui-system/core/css/tokens.css';
+import '@once-ui-system/core/css/styles.css';
 import App from './App.tsx';
 import './index.css';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,11 +43,11 @@ export default defineConfig(({ mode }) => ({
       '@': path.resolve(__dirname, 'apps/web'),
       '@once-ui-system/core/css': path.resolve(
         __dirname,
-        'apps/web/node_modules/@once-ui-system/core/dist/css',
+        'node_modules/@once-ui-system/core/dist/css',
       ),
       '@once-ui-system/core': path.resolve(
         __dirname,
-        'apps/web/node_modules/@once-ui-system/core',
+        'node_modules/@once-ui-system/core',
       ),
     }
   }


### PR DESCRIPTION
## Summary
- update Once UI CSS imports to use the package export paths consumed by both Next.js and Vite
- point the Vite alias at the workspace root node_modules so shared CSS resolves correctly

## Testing
- npm -w apps/web run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8df137488322999a8f785ae35a8f