### PR TITLE
Allow Telegram dashboard route

### DIFF
--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -21,6 +21,7 @@ const routes: RoutesConfig = {
   "/work": true,
   "/blog": true,
   "/gallery": true,
+  "/telegram": true,
 };
 
 const display: DisplayConfig = {


### PR DESCRIPTION
## Summary
- allow the once-ui routes configuration to enable the Telegram dashboard path so the route guard stops forcing a 404

## Testing
- npm run build *(fails: Cannot find package '@next/mdx' imported from apps/web/next.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6e6d6c508322987cb74ce3017e7c