### PR TITLE
Add proprietary license docs and certificate inventory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2024 Dynamic Capital. All rights reserved.
+
+This repository and the contents within are proprietary to Dynamic Capital, Inc.
+and may not be copied, modified, distributed, sublicensed, or used for any
+commercial or non-commercial purpose without prior written permission from
+Dynamic Capital, Inc.
+
+You may review the source solely for evaluation or integration with Dynamic
+Capital services. Any other use is prohibited.
+
+Third-party software included in this project remains the property of the
+respective copyright holders and is provided under their own licenses as noted
+in docs/legal/THIRD_PARTY_LICENSES.md.

--- a/README.md
+++ b/README.md
@@ -678,8 +678,10 @@ and syncing changes through GitHub to maintain a seamless deployment pipeline.
 
 ## License / contributions
 
-Proprietary / All rights reserved. Personal project; external PRs/issues are
-closed by default.
+Proprietary / All rights reserved. Review the root [`LICENSE`](LICENSE) file for
+usage terms and [`docs/legal/THIRD_PARTY_LICENSES.md`](docs/legal/THIRD_PARTY_LICENSES.md)
+for attribution of bundled open-source components. Personal project; external
+PRs/issues are closed by default.
 
 ## Notes
 

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -11,6 +11,10 @@ Dynamic Capital maintains independent, third-party verified certifications and a
 | GDPR (EU & UK) | [gdpr.md](gdpr.md) | EuroTrust Compliance BV | DC-GDPR-2024 | 2024-04-22 | 2025-04-21 |
 | EU–US Data Privacy Framework | [dpf.md](dpf.md) | U.S. Department of Commerce | DPF-EE-2024-8821 | 2024-04-29 | 2025-04-28 |
 
+The machine-readable certificate inventory stored in
+[certificates.json](certificates.json) mirrors the table above for teams that
+need to automate vendor reviews or track renewal dates programmatically.
+
 ## Verification Process
 
 1. Review the individual certificate file for scope, controls, and the validation channel maintained by the issuing body.
@@ -32,3 +36,5 @@ Dynamic Capital maintains independent, third-party verified certifications and a
 - Certificate records are versioned in Git and mirrored to the secure GRC portal.
 - Any updates must include links to supporting audit evidence stored in the portal.
 - When a certificate is superseded, retain the previous markdown file with a suffix indicating the retired year (for example, `iso-27001-2023.md`).
+- Update `certificates.json` with the new record and move the retired entry to
+  the history array used by governance tooling.

--- a/docs/compliance/certificates.json
+++ b/docs/compliance/certificates.json
@@ -1,0 +1,65 @@
+{
+  "current": [
+    {
+      "framework": "ISO/IEC 27001:2022",
+      "certificate_id": "DC-ISMS-27001-2024",
+      "issuer": "Apex Assurance Ltd.",
+      "issued": "2024-02-12",
+      "expires": "2027-02-11",
+      "status": "active",
+      "evidence": "grc/iso/2024/DC-ISMS-27001-2024.pdf",
+      "verification": "https://apexassurance.com/verify"
+    },
+    {
+      "framework": "SOC 2 Type II",
+      "certificate_id": "DC-SOC2-2024-T2",
+      "issuer": "Langford & Ames, LLP",
+      "issued": "2024-03-31",
+      "coverage_period": "2023-03-01/2024-02-29",
+      "status": "active",
+      "evidence": "grc/soc2/DC-SOC2-2024-T2.pdf",
+      "verification": "assurance@langford-ames.com"
+    },
+    {
+      "framework": "PCI DSS v4.0 Level 1",
+      "certificate_id": "DC-PCI-2024-L1",
+      "issuer": "TrustShield QSA Services",
+      "issued": "2024-01-18",
+      "expires": "2025-01-17",
+      "status": "active",
+      "evidence": "grc/pci/2024/DC-PCI-2024-L1.zip",
+      "verification": "https://portal.trustshieldqsa.com/verify"
+    },
+    {
+      "framework": "HIPAA Security & Privacy Rules Assessment",
+      "certificate_id": "DC-HIPAA-2024",
+      "issuer": "Veritas Healthcare Assessors",
+      "issued": "2024-05-06",
+      "expires": "2026-05-05",
+      "status": "active",
+      "evidence": "grc/hipaa/2024/DC-HIPAA-2024.zip",
+      "verification": "attestations@veritashealthassessors.com"
+    },
+    {
+      "framework": "GDPR Article 27 Representation & Compliance",
+      "certificate_id": "DC-GDPR-2024",
+      "issuer": "EuroTrust Compliance BV",
+      "issued": "2024-04-22",
+      "expires": "2025-04-21",
+      "status": "active",
+      "evidence": "grc/gdpr/2024/DC-GDPR-2024.zip",
+      "verification": "https://verify.eurotrustcompliance.eu"
+    },
+    {
+      "framework": "EU–US Data Privacy Framework",
+      "certificate_id": "DPF-EE-2024-8821",
+      "issuer": "U.S. Department of Commerce",
+      "issued": "2024-04-29",
+      "renewal_due": "2025-04-28",
+      "status": "active",
+      "evidence": "grc/dpf/2024/DPF-EE-2024-8821.zip",
+      "verification": "https://www.dataprivacyframework.gov/s/participant-search"
+    }
+  ],
+  "history": []
+}

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,0 +1,18 @@
+# Licensing Overview
+
+Dynamic Capital retains all rights to the source code and assets in this
+repository. The proprietary license is documented in the root-level `LICENSE`
+file. This directory collects references for components that ship under
+separate third-party licenses so downstream teams can perform due diligence and
+maintain attribution when integrating the Dynamic Capital stack.
+
+- [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md) enumerates the primary
+  open-source libraries bundled with the application along with links to their
+  canonical license texts.
+- Compliance attestations and governance documents live under
+  [`../compliance`](../compliance). Refer to the machine-readable certificate
+  inventory (`certificates.json`) when verifying renewal dates or automating
+  vendor assessments.
+
+Questions about commercial licensing or redistribution should be directed to
+`legal@dynamic.capital`.

--- a/docs/legal/THIRD_PARTY_LICENSES.md
+++ b/docs/legal/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,26 @@
+# Third-party Licenses
+
+The Dynamic Capital application relies on the following upstream projects. Each
+component remains the property of its respective authors and is distributed
+under the licenses indicated below. Follow the linked license texts when
+reviewing obligations such as copyright notices or attribution requirements.
+
+| Package / Component | Usage | License | Reference |
+| --- | --- | --- | --- |
+| Next.js | Core web application framework | MIT License | https://github.com/vercel/next.js/blob/canary/license.md |
+| React | UI library powering the web and mini app clients | MIT License | https://github.com/facebook/react/blob/main/LICENSE |
+| Supabase JS SDK & Supabase CLI | Database, authentication, and local development tooling | Apache License 2.0 | https://github.com/supabase/supabase/blob/master/LICENSE |
+| Once UI System | Design system tokens and components for the marketing site | MIT License | https://github.com/once-ui/once-ui/blob/main/LICENSE |
+| Tailwind CSS | Utility-first styling used across the landing and dashboard experiences | MIT License | https://github.com/tailwindlabs/tailwindcss/blob/master/LICENSE |
+| Lucide React | Icon set used in the dashboard and mini app | ISC License | https://github.com/lucide-icons/lucide/blob/main/LICENSE |
+| Framer Motion | Animation primitives for interactive UI elements | MIT License | https://github.com/framer/motion/blob/main/LICENSE |
+| TanStack Query | Client-side data fetching and caching | MIT License | https://github.com/TanStack/query/blob/main/LICENSE |
+| Inngest | Background job orchestration for queue and worker processes | Apache License 2.0 | https://github.com/inngest/inngest-js/blob/main/LICENSE |
+| AWS SDK for JavaScript v3 | DigitalOcean Spaces and S3-compatible uploads | Apache License 2.0 | https://github.com/aws/aws-sdk-js-v3/blob/main/LICENSE |
+| PostHog JS | Product analytics instrumentation | MIT License | https://github.com/PostHog/posthog-js/blob/master/LICENSE |
+| Sonner | Toast notifications within the dashboard | MIT License | https://github.com/emilkowalski/sonner/blob/main/LICENSE |
+
+For transitive dependencies bundled through npm or Deno, consult the package
+manager manifests (`package-lock.json`, `deno.lock`) or run the relevant license
+reporting tools in CI. Requests for additional attribution or a comprehensive
+Software Bill of Materials can be directed to `legal@dynamic.capital`.


### PR DESCRIPTION
## Summary
- add a root proprietary LICENSE file and link it from the README
- document key third-party licenses under docs/legal for attribution
- publish a machine-readable certificates.json inventory and update the compliance guide accordingly

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce83ead3508322a47dc0736343327b