### PR TITLE
Fix client utils import to avoid node modules

### DIFF
--- a/apps/web/utils/index.ts
+++ b/apps/web/utils/index.ts
@@ -6,8 +6,6 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export { formatPrice } from "./format-price.ts";
-export {
-  getAppRoutes,
-  getPageRoutes,
-  type RouteRecord,
-} from "./routes.ts";
+// Route-related helpers rely on Node.js modules. Import them directly from
+// `./routes.ts` in server-only contexts to avoid bundling Node-specific code in
+// client modules.

--- a/apps/web/utils/routes.ts
+++ b/apps/web/utils/routes.ts
@@ -1,3 +1,5 @@
+'server-only';
+
 import fs from "node:fs";
 import path from "node:path";
 


### PR DESCRIPTION
## Summary
- stop re-exporting the route utilities from the shared utils barrel so client bundles no longer pull in Node.js modules
- mark the route helper module as server-only to make its Node.js dependencies explicit

## Testing
- npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68ce8b86ae808322b07ff1ffd0252a95