### PR TITLE
Make home page static to avoid 404

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,6 @@
 import { LandingPageShell } from '@/components/landing/LandingPageShell';
 import { StaticLandingPage } from '@/components/landing/StaticLandingPage';
 
-export const dynamic = 'force-dynamic';
-
 export default function HomePage() {
   const isStaticSnapshot = globalThis?.process?.env?.['STATIC_SNAPSHOT'] === 'true';
 


### PR DESCRIPTION
## Summary
- remove the force-dynamic configuration from the home page so that Next.js can prerender it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce93449fb483229c12d60a6638a84a