### PR TITLE
Add VIP plan showcase, checkout flows, and Once UI theming

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,27 @@
+import { Column, Heading, Text } from "@once-ui-system/core";
+
+import { AdminGate } from "@/components/admin/AdminGate";
+import { AdminDashboard } from "@/components/admin/AdminDashboard";
+
+export const metadata = {
+  title: "Admin Dashboard – Dynamic Capital",
+  description: "Monitor VIP members, payments, and bot health from the Dynamic Capital control room.",
+};
+
+export default function AdminPage() {
+  return (
+    <AdminGate>
+      <Column gap="24" paddingY="32" align="center" horizontal="center" fillWidth>
+        <Column maxWidth={28} gap="12" align="center" horizontal="center">
+          <Heading variant="display-strong-s" align="center">
+            Admin control room
+          </Heading>
+          <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+            Review payments, manage VIP seats, and operate the Telegram bot infrastructure.
+          </Text>
+        </Column>
+        <AdminDashboard />
+      </Column>
+    </AdminGate>
+  );
+}

--- a/apps/web/app/checkout/page.tsx
+++ b/apps/web/app/checkout/page.tsx
@@ -1,0 +1,34 @@
+import { Column, Heading, Text } from "@once-ui-system/core";
+
+import { WebCheckout } from "@/components/checkout/WebCheckout";
+
+interface CheckoutPageProps {
+  searchParams?: {
+    plan?: string;
+    promo?: string;
+  };
+}
+
+export const metadata = {
+  title: "Checkout – Dynamic Capital",
+  description: "Complete your Dynamic Capital VIP membership purchase and unlock the trading desk.",
+};
+
+export default function CheckoutPage({ searchParams }: CheckoutPageProps) {
+  const selectedPlan = searchParams?.plan;
+  const promoCode = searchParams?.promo;
+
+  return (
+    <Column gap="24" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={28} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Secure checkout
+        </Heading>
+        <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+          Review your plan, select a payment method, and submit proof if you’re joining via bank transfer or crypto.
+        </Text>
+      </Column>
+      <WebCheckout selectedPlanId={selectedPlan} promoCode={promoCode} />
+    </Column>
+  );
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,10 @@
+import { AuthForm } from "@/components/auth/AuthForm";
+
+export const metadata = {
+  title: "Login – Dynamic Capital",
+  description: "Access your Dynamic Capital trading dashboard and manage VIP membership settings.",
+};
+
+export default function LoginPage() {
+  return <AuthForm />;
+}

--- a/apps/web/app/plans/page.tsx
+++ b/apps/web/app/plans/page.tsx
@@ -1,0 +1,26 @@
+import { Heading, Column, Text } from "@once-ui-system/core";
+
+import { VipPackagesSection } from "@/components/magic-portfolio/home/VipPackagesSection";
+import { CheckoutCallout } from "@/components/magic-portfolio/home/CheckoutCallout";
+
+export const metadata = {
+  title: "VIP Plans – Dynamic Capital",
+  description: "Choose a Dynamic Capital VIP membership package and unlock the full trading desk experience.",
+};
+
+export default function PlansPage() {
+  return (
+    <Column gap="32" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={28} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          VIP membership plans
+        </Heading>
+        <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+          Explore live pricing, compare access levels, and move straight into checkout when you’re ready to join the desk.
+        </Text>
+      </Column>
+      <VipPackagesSection />
+      <CheckoutCallout />
+    </Column>
+  );
+}

--- a/apps/web/components/auth/AuthForm.tsx
+++ b/apps/web/components/auth/AuthForm.tsx
@@ -1,315 +1,287 @@
 "use client";
 
 import { useState } from "react";
-import { useToast } from "@/hooks/useToast";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Eye, EyeOff, Loader2 } from "lucide-react";
+  Button,
+  Column,
+  Heading,
+  Input,
+  PasswordInput,
+  Row,
+  Text,
+} from "@once-ui-system/core";
+
 import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/useToast";
+
+interface AuthFormState {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  confirmPassword: string;
+}
+
+type AuthMode = "signin" | "signup";
+
+const INITIAL_STATE: AuthFormState = {
+  email: "",
+  password: "",
+  firstName: "",
+  lastName: "",
+  confirmPassword: "",
+};
 
 export function AuthForm() {
   const { signIn, signUp } = useAuth();
   const { toast } = useToast();
+  const [mode, setMode] = useState<AuthMode>("signin");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showPassword, setShowPassword] = useState(false);
-  const [formData, setFormData] = useState({
-    email: "",
-    password: "",
-    firstName: "",
-    lastName: "",
-    confirmPassword: "",
-  });
+  const [formData, setFormData] = useState<AuthFormState>(INITIAL_STATE);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData((prev) => ({
-      ...prev,
-      [e.target.name]: e.target.value,
-    }));
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({ ...previous, [name]: value }));
     setError(null);
   };
 
-  const handleSignIn = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const resetForm = () => {
+    setFormData(INITIAL_STATE);
+  };
+
+  const handleSignIn = async (event: React.FormEvent) => {
+    event.preventDefault();
     setLoading(true);
     setError(null);
 
+    if (!formData.email || !formData.password) {
+      setError("Please enter your email and password");
+      setLoading(false);
+      return;
+    }
+
     try {
-      if (!formData.email || !formData.password) {
-        setError("Please fill in all fields");
-        return;
-      }
-
-      const { error } = await signIn(formData.email, formData.password);
-
-      if (error) {
-        if (error.message.includes("Invalid login credentials")) {
-          setError(
-            "Invalid email or password. Please check your credentials and try again.",
-          );
-        } else if (error.message.includes("Email not confirmed")) {
-          setError(
-            "Please check your email and click the confirmation link before signing in.",
-          );
+      const { error: signInError } = await signIn(formData.email, formData.password);
+      if (signInError) {
+        if (signInError.message.includes("Invalid login credentials")) {
+          setError("Invalid email or password. Please try again.");
+        } else if (signInError.message.includes("Email not confirmed")) {
+          setError("Check your inbox and confirm your email before signing in.");
         } else {
-          setError(error.message);
+          setError(signInError.message);
         }
+      } else {
+        resetForm();
+        toast({
+          title: "Welcome back",
+          description: "You’re signed in. Head to the dashboard to continue.",
+        });
       }
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "An unexpected error occurred",
-      );
+      setError(err instanceof Error ? err.message : "Unexpected error");
     } finally {
       setLoading(false);
     }
   };
 
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSignUp = async (event: React.FormEvent) => {
+    event.preventDefault();
     setLoading(true);
     setError(null);
 
+    if (!formData.email || !formData.password || !formData.firstName) {
+      setError("Please fill in all required fields");
+      setLoading(false);
+      return;
+    }
+
+    if (formData.password !== formData.confirmPassword) {
+      setError("Passwords do not match");
+      setLoading(false);
+      return;
+    }
+
+    if (formData.password.length < 6) {
+      setError("Password must be at least 6 characters long");
+      setLoading(false);
+      return;
+    }
+
     try {
-      if (!formData.email || !formData.password || !formData.firstName) {
-        setError("Please fill in all required fields");
-        return;
-      }
-
-      if (formData.password !== formData.confirmPassword) {
-        setError("Passwords do not match");
-        return;
-      }
-
-      if (formData.password.length < 6) {
-        setError("Password must be at least 6 characters long");
-        return;
-      }
-
-      const { error } = await signUp(
+      const { error: signUpError } = await signUp(
         formData.email,
         formData.password,
         formData.firstName,
         formData.lastName,
       );
 
-      if (error) {
-        if (error.message.includes("User already registered")) {
-          setError(
-            "An account with this email already exists. Please sign in instead.",
-          );
+      if (signUpError) {
+        if (signUpError.message.includes("User already registered")) {
+          setError("An account with this email already exists. Please sign in instead.");
         } else {
-          setError(error.message);
+          setError(signUpError.message);
         }
       } else {
-        setError(null);
         toast({
-          title: "Account created successfully",
-          description: "Please check your email for a confirmation link.",
+          title: "Account created",
+          description: "Check your email to confirm your account and unlock access.",
         });
+        resetForm();
+        setMode("signin");
       }
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "An unexpected error occurred",
-      );
+      setError(err instanceof Error ? err.message : "Unexpected error");
     } finally {
       setLoading(false);
     }
   };
 
+  const onSubmit = mode === "signin" ? handleSignIn : handleSignUp;
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted/20 p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold text-center">
-            Dynamic Capital
-          </CardTitle>
-          <CardDescription className="text-center">
-            Access your trading dashboard and manage your VIP membership
-          </CardDescription>
-        </CardHeader>
-
-        <CardContent>
-          <Tabs defaultValue="signin" className="w-full">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="signin">Sign In</TabsTrigger>
-              <TabsTrigger value="signup">Sign Up</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="signin">
-              <form onSubmit={handleSignIn} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="signin-email">Email</Label>
+    <Column
+      fillWidth
+      minHeight="100vh"
+      horizontal="center"
+      align="center"
+      padding="xl"
+      background="page"
+      gap="32"
+    >
+      <Column
+        maxWidth={28}
+        fillWidth
+        background="surface"
+        border="neutral-alpha-medium"
+        radius="l"
+        padding="xl"
+        gap="24"
+        shadow="xl"
+      >
+        <Column gap="12" align="center">
+          <Heading variant="display-strong-xs">Dynamic Capital</Heading>
+          <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+            Access your trading dashboard, manage VIP membership, and review your automation settings.
+          </Text>
+        </Column>
+        <Row gap="12" horizontal="center" wrap>
+          <Button
+            size="s"
+            variant="secondary"
+            data-border="rounded"
+            onClick={() => {
+              setMode("signin");
+              setError(null);
+            }}
+            disabled={mode === "signin"}
+          >
+            Sign in
+          </Button>
+          <Button
+            size="s"
+            variant="secondary"
+            data-border="rounded"
+            onClick={() => {
+              setMode("signup");
+              setError(null);
+            }}
+            disabled={mode === "signup"}
+          >
+            Create account
+          </Button>
+        </Row>
+        <form onSubmit={onSubmit}>
+          <Column gap="16">
+            {mode === "signup" ? (
+              <Row gap="12" wrap>
+                <Column flex={1} minWidth={12} gap="4">
+                  <Text variant="body-default-s" onBackground="neutral-weak">
+                    First name
+                  </Text>
                   <Input
-                    id="signin-email"
-                    name="email"
-                    type="email"
-                    placeholder="Enter your email"
-                    value={formData.email}
+                    id="firstName"
+                    name="firstName"
+                    value={formData.firstName}
                     onChange={handleInputChange}
+                    placeholder="Noah"
+                    aria-label="First name"
                     required
                   />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="signin-password">Password</Label>
-                  <div className="relative">
-                    <Input
-                      id="signin-password"
-                      name="password"
-                      type={showPassword ? "text" : "password"}
-                      placeholder="Enter your password"
-                      value={formData.password}
-                      onChange={handleInputChange}
-                      required
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                      onClick={() => setShowPassword(!showPassword)}
-                    >
-                      {showPassword
-                        ? <EyeOff className="h-4 w-4" />
-                        : <Eye className="h-4 w-4" />}
-                    </Button>
-                  </div>
-                </div>
-
-                {error && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{error}</AlertDescription>
-                  </Alert>
-                )}
-
-                <Button
-                  type="submit"
-                  className="w-full"
-                  disabled={loading}
-                >
-                  {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Sign In
-                </Button>
-              </form>
-            </TabsContent>
-
-            <TabsContent value="signup">
-              <form onSubmit={handleSignUp} className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="firstName">First Name *</Label>
-                    <Input
-                      id="firstName"
-                      name="firstName"
-                      type="text"
-                      placeholder="John"
-                      value={formData.firstName}
-                      onChange={handleInputChange}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="lastName">Last Name</Label>
-                    <Input
-                      id="lastName"
-                      name="lastName"
-                      type="text"
-                      placeholder="Doe"
-                      value={formData.lastName}
-                      onChange={handleInputChange}
-                    />
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="signup-email">Email *</Label>
+                </Column>
+                <Column flex={1} minWidth={12} gap="4">
+                  <Text variant="body-default-s" onBackground="neutral-weak">
+                    Last name
+                  </Text>
                   <Input
-                    id="signup-email"
-                    name="email"
-                    type="email"
-                    placeholder="Enter your email"
-                    value={formData.email}
+                    id="lastName"
+                    name="lastName"
+                    value={formData.lastName}
                     onChange={handleInputChange}
-                    required
+                    placeholder="Sterling"
+                    aria-label="Last name"
                   />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="signup-password">Password *</Label>
-                  <div className="relative">
-                    <Input
-                      id="signup-password"
-                      name="password"
-                      type={showPassword ? "text" : "password"}
-                      placeholder="Create a password"
-                      value={formData.password}
-                      onChange={handleInputChange}
-                      required
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                      onClick={() => setShowPassword(!showPassword)}
-                    >
-                      {showPassword
-                        ? <EyeOff className="h-4 w-4" />
-                        : <Eye className="h-4 w-4" />}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="confirmPassword">Confirm Password *</Label>
-                  <Input
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    type="password"
-                    placeholder="Confirm your password"
-                    value={formData.confirmPassword}
-                    onChange={handleInputChange}
-                    required
-                  />
-                </div>
-
-                {error && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{error}</AlertDescription>
-                  </Alert>
-                )}
-
-                <Button
-                  type="submit"
-                  className="w-full"
-                  disabled={loading}
-                >
-                  {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  Create Account
-                </Button>
-              </form>
-            </TabsContent>
-          </Tabs>
-        </CardContent>
-
-        <CardFooter className="text-center">
-          <p className="text-sm text-muted-foreground">
-            By creating an account, you agree to our terms of service and
-            privacy policy.
-          </p>
-        </CardFooter>
-      </Card>
-    </div>
+                </Column>
+              </Row>
+            ) : null}
+            <Column gap="4">
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                Email
+              </Text>
+              <Input
+                id="email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleInputChange}
+                placeholder="you@dynamic.capital"
+                aria-label="Email"
+                required
+              />
+            </Column>
+            <PasswordInput
+              id="password"
+              name="password"
+              label="Password"
+              value={formData.password}
+              onChange={handleInputChange}
+              required
+            />
+            {mode === "signup" ? (
+              <PasswordInput
+                id="confirmPassword"
+                name="confirmPassword"
+                label="Confirm password"
+                value={formData.confirmPassword}
+                onChange={handleInputChange}
+                required
+              />
+            ) : null}
+            {error ? (
+              <Text variant="body-default-s" onBackground="brand-weak">
+                {error}
+              </Text>
+            ) : null}
+            <Button
+              type="submit"
+              size="m"
+              variant="secondary"
+              data-border="rounded"
+              disabled={loading}
+            >
+              {loading ? "Processing…" : mode === "signin" ? "Sign in" : "Create account"}
+            </Button>
+          </Column>
+        </form>
+        <Column gap="8" align="center">
+          <Text variant="body-default-s" onBackground="neutral-weak" align="center">
+            By continuing you agree to desk security policies and trading disclaimers.
+          </Text>
+        </Column>
+      </Column>
+    </Column>
   );
 }
+
+export default AuthForm;

--- a/apps/web/components/magic-portfolio/Header.tsx
+++ b/apps/web/components/magic-portfolio/Header.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import React, { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
 
 import { Button, Fade, Flex, Line, Row, ToggleButton } from "@once-ui-system/core";
 
 import { display, person, about, blog, work, gallery, isRouteEnabled } from "@/resources";
+import type { IconName } from "@/resources/icons";
 import { useAuth } from "@/hooks/useAuth";
 import { ThemeToggle } from "./ThemeToggle";
 import styles from "./Header.module.scss";
@@ -48,10 +49,74 @@ export const Header = () => {
   const { user, signOut } = useAuth();
 
   const homeEnabled = isRouteEnabled("/");
+  const plansEnabled = isRouteEnabled("/plans");
   const aboutEnabled = isRouteEnabled("/about");
   const workEnabled = isRouteEnabled("/work");
   const blogEnabled = isRouteEnabled("/blog");
   const galleryEnabled = isRouteEnabled("/gallery");
+
+  const navItems = [
+    homeEnabled
+      ? {
+          key: "home",
+          label: "Home",
+          icon: "home" as IconName,
+          href: "/",
+          selected: pathname === "/",
+        }
+      : null,
+    plansEnabled
+      ? {
+          key: "plans",
+          label: "VIP Plans",
+          icon: "crown" as IconName,
+          href: "/plans",
+          selected: pathname.startsWith("/plans"),
+        }
+      : null,
+    aboutEnabled
+      ? {
+          key: "about",
+          label: about.label,
+          icon: "person" as IconName,
+          href: "/about",
+          selected: pathname === "/about",
+        }
+      : null,
+    workEnabled
+      ? {
+          key: "work",
+          label: work.label,
+          icon: "grid" as IconName,
+          href: "/work",
+          selected: pathname.startsWith("/work"),
+        }
+      : null,
+    blogEnabled
+      ? {
+          key: "blog",
+          label: blog.label,
+          icon: "book" as IconName,
+          href: "/blog",
+          selected: pathname.startsWith("/blog"),
+        }
+      : null,
+    galleryEnabled
+      ? {
+          key: "gallery",
+          label: gallery.label,
+          icon: "gallery" as IconName,
+          href: "/gallery",
+          selected: pathname.startsWith("/gallery"),
+        }
+      : null,
+  ].filter((item): item is {
+    key: string;
+    label: string;
+    icon: IconName;
+    href: string;
+    selected: boolean;
+  } => Boolean(item));
 
   return (
     <>
@@ -94,86 +159,41 @@ export const Header = () => {
             zIndex={1}
           >
             <Row gap="4" vertical="center" textVariant="body-default-s" suppressHydrationWarning>
-              {homeEnabled && (
-                <ToggleButton prefixIcon="home" href="/" selected={pathname === "/"} />
-              )}
-              <Line background="neutral-alpha-medium" vert maxHeight="24" />
-              {aboutEnabled && (
-                <>
-                  <Row s={{ hide: true }}>
-                    <ToggleButton
-                      prefixIcon="person"
-                      href="/about"
-                      label={about.label}
-                      selected={pathname === "/about"}
-                    />
-                  </Row>
-                  <Row hide s={{ hide: false }}>
-                    <ToggleButton
-                      prefixIcon="person"
-                      href="/about"
-                      selected={pathname === "/about"}
-                    />
-                  </Row>
-                </>
-              )}
-              {workEnabled && (
-                <>
-                  <Row s={{ hide: true }}>
-                    <ToggleButton
-                      prefixIcon="grid"
-                      href="/work"
-                      label={work.label}
-                      selected={pathname.startsWith("/work")}
-                    />
-                  </Row>
-                  <Row hide s={{ hide: false }}>
-                    <ToggleButton
-                      prefixIcon="grid"
-                      href="/work"
-                      selected={pathname.startsWith("/work")}
-                    />
-                  </Row>
-                </>
-              )}
-              {blogEnabled && (
-                <>
-                  <Row s={{ hide: true }}>
-                    <ToggleButton
-                      prefixIcon="book"
-                      href="/blog"
-                      label={blog.label}
-                      selected={pathname.startsWith("/blog")}
-                    />
-                  </Row>
-                  <Row hide s={{ hide: false }}>
-                    <ToggleButton
-                      prefixIcon="book"
-                      href="/blog"
-                      selected={pathname.startsWith("/blog")}
-                    />
-                  </Row>
-                </>
-              )}
-              {galleryEnabled && (
-                <>
-                  <Row s={{ hide: true }}>
-                    <ToggleButton
-                      prefixIcon="gallery"
-                      href="/gallery"
-                      label={gallery.label}
-                      selected={pathname.startsWith("/gallery")}
-                    />
-                  </Row>
-                  <Row hide s={{ hide: false }}>
-                    <ToggleButton
-                      prefixIcon="gallery"
-                      href="/gallery"
-                      selected={pathname.startsWith("/gallery")}
-                    />
-                  </Row>
-                </>
-              )}
+              {navItems.flatMap((item, index) => {
+                const toggle = (
+                  <React.Fragment key={item.key}>
+                    <Row s={{ hide: true }}>
+                      <ToggleButton
+                        prefixIcon={item.icon}
+                        href={item.href}
+                        label={item.label}
+                        selected={item.selected}
+                      />
+                    </Row>
+                    <Row hide s={{ hide: false }}>
+                      <ToggleButton
+                        prefixIcon={item.icon}
+                        href={item.href}
+                        selected={item.selected}
+                      />
+                    </Row>
+                  </React.Fragment>
+                );
+
+                if (index === 0) {
+                  return [toggle];
+                }
+
+                return [
+                  <Line
+                    key={`divider-${item.key}`}
+                    background="neutral-alpha-medium"
+                    vert
+                    maxHeight="24"
+                  />,
+                  toggle,
+                ];
+              })}
               {display.themeSwitcher && (
                 <>
                   <Line background="neutral-alpha-medium" vert maxHeight="24" />

--- a/apps/web/components/magic-portfolio/MagicLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/MagicLandingPage.tsx
@@ -14,6 +14,9 @@ import { home, about, person, baseURL, isRouteEnabled, toAbsoluteUrl } from "@/r
 import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { Projects } from "@/components/magic-portfolio/work/Projects";
 import { Posts } from "@/components/magic-portfolio/blog/Posts";
+import { AboutShowcase } from "@/components/magic-portfolio/home/AboutShowcase";
+import { VipPackagesSection } from "@/components/magic-portfolio/home/VipPackagesSection";
+import { CheckoutCallout } from "@/components/magic-portfolio/home/CheckoutCallout";
 
 const TELEGRAM_VIP_URL = "https://t.me/Dynamic_VIP_BOT";
 
@@ -96,6 +99,9 @@ export function MagicLandingPage() {
       <RevealFx translateY="16" delay={0.6}>
         <Projects range={[1, 1]} />
       </RevealFx>
+      <RevealFx translateY="20" delay={0.7}>
+        <AboutShowcase />
+      </RevealFx>
       {blogEnabled && (
         <Column fillWidth gap="24" marginBottom="l">
           <Row fillWidth paddingRight="64">
@@ -117,6 +123,12 @@ export function MagicLandingPage() {
         </Column>
       )}
       <Projects range={[2]} />
+      <RevealFx translateY="20" delay={0.8}>
+        <VipPackagesSection />
+      </RevealFx>
+      <RevealFx translateY="20" delay={0.9}>
+        <CheckoutCallout />
+      </RevealFx>
       <Mailchimp />
     </Column>
   );

--- a/apps/web/components/magic-portfolio/home/AboutShowcase.tsx
+++ b/apps/web/components/magic-portfolio/home/AboutShowcase.tsx
@@ -1,0 +1,117 @@
+import { about, person } from "@/resources";
+import { Avatar, Button, Column, Heading, Line, Row, Tag, Text } from "@once-ui-system/core";
+
+const experiences = about.work.experiences ?? [];
+const highlightExperience = experiences[0];
+const secondaryExperience = experiences[1] ?? experiences[0];
+
+export function AboutShowcase() {
+  if (!highlightExperience) {
+    return null;
+  }
+
+  return (
+    <Column
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="32"
+      shadow="l"
+    >
+      <Row gap="24" s={{ direction: "column" }}>
+        <Column flex={3} gap="16">
+          <Row gap="16" vertical="center">
+            <Avatar src={person.avatar} size="l" />
+            <Column>
+              <Heading variant="display-strong-xs">Meet the desk lead</Heading>
+              <Text variant="body-default-m" onBackground="neutral-weak">
+                {person.name} · {person.role}
+              </Text>
+            </Column>
+          </Row>
+          <Text variant="body-default-l" onBackground="neutral-weak">
+            {about.intro.description}
+          </Text>
+          <Row gap="8" wrap>
+            {person.languages?.map((language) => (
+              <Tag key={language} size="m" prefixIcon="globe">
+                {language}
+              </Tag>
+            ))}
+            <Tag size="m" prefixIcon="location">
+              {person.location}
+            </Tag>
+          </Row>
+        </Column>
+        <Column flex={4} gap="20">
+          <Heading as="h3" variant="display-strong-xs">
+            Institutional pedigree
+          </Heading>
+          <Column gap="20">
+            <Column
+              border="brand-alpha-weak"
+              background="brand-alpha-weak"
+              radius="l"
+              padding="m"
+              gap="12"
+            >
+              <Text variant="heading-strong-s">{highlightExperience.company}</Text>
+              <Text variant="body-default-m" onBackground="neutral-weak">
+                {highlightExperience.role} · {highlightExperience.timeframe}
+              </Text>
+              <Column as="ul" gap="8">
+                {highlightExperience.achievements.map((achievement, index) => (
+                  <Text as="li" key={index} variant="body-default-m">
+                    {achievement}
+                  </Text>
+                ))}
+              </Column>
+            </Column>
+            {secondaryExperience ? (
+              <Column border="neutral-alpha-weak" radius="l" padding="m" gap="12">
+                <Text variant="heading-strong-s">{secondaryExperience.company}</Text>
+                <Text variant="body-default-m" onBackground="neutral-weak">
+                  {secondaryExperience.role} · {secondaryExperience.timeframe}
+                </Text>
+                <Column as="ul" gap="8">
+                  {secondaryExperience.achievements.map((achievement, index) => (
+                    <Text as="li" key={index} variant="body-default-m">
+                      {achievement}
+                    </Text>
+                  ))}
+                </Column>
+              </Column>
+            ) : null}
+          </Column>
+        </Column>
+      </Row>
+      <Line background="neutral-alpha-weak" />
+      <Row gap="16" s={{ direction: "column" }}>
+        <Button
+          href="/about"
+          variant="secondary"
+          size="m"
+          data-border="rounded"
+          arrowIcon
+        >
+          Dive into the full story
+        </Button>
+        {about.calendar.display ? (
+          <Button
+            href={about.calendar.link}
+            variant="secondary"
+            size="m"
+            data-border="rounded"
+            prefixIcon="calendar"
+          >
+            Book a desk consult
+          </Button>
+        ) : null}
+      </Row>
+    </Column>
+  );
+}
+
+export default AboutShowcase;

--- a/apps/web/components/magic-portfolio/home/CheckoutCallout.tsx
+++ b/apps/web/components/magic-portfolio/home/CheckoutCallout.tsx
@@ -1,0 +1,46 @@
+import { Button, Column, Heading, Row, Text } from "@once-ui-system/core";
+
+export function CheckoutCallout() {
+  return (
+    <Column
+      fillWidth
+      background="brand-alpha-weak"
+      border="brand-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="20"
+      horizontal="center"
+      align="center"
+      style={{ textAlign: "center" }}
+    >
+      <Heading variant="display-strong-xs" wrap="balance">
+        Ready to activate the desk?
+      </Heading>
+      <Text variant="body-default-l" onBackground="brand-on-background-weak" wrap="balance">
+        Move through checkout in under two minutes and gain access to the real-time signal desk, vault of trading systems, and live mentorship calendar.
+      </Text>
+      <Row gap="12" s={{ direction: "column" }}>
+        <Button
+          href="/checkout"
+          size="m"
+          variant="secondary"
+          data-border="rounded"
+          prefixIcon="rocket"
+        >
+          Go to secure checkout
+        </Button>
+        <Button
+          href="/telegram"
+          size="m"
+          variant="secondary"
+          data-border="rounded"
+          arrowIcon
+        >
+          Explore the admin dashboard
+        </Button>
+      </Row>
+    </Column>
+  );
+}
+
+export default CheckoutCallout;

--- a/apps/web/components/magic-portfolio/home/VipPackagesSection.tsx
+++ b/apps/web/components/magic-portfolio/home/VipPackagesSection.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Button,
+  Column,
+  Heading,
+  Icon,
+  Line,
+  Row,
+  Spinner,
+  Tag,
+  Text,
+} from "@once-ui-system/core";
+
+import { OnceButton } from "@/components/once-ui";
+import { callEdgeFunction } from "@/config/supabase";
+import { formatPrice } from "@/utils";
+import type { Plan } from "@/types/plan";
+
+interface PlansResponse {
+  plans: Plan[];
+}
+
+const FALLBACK_PLANS: Plan[] = [
+  {
+    id: "vip-monthly",
+    name: "VIP Monthly",
+    price: 49,
+    currency: "USD",
+    duration_months: 1,
+    is_lifetime: false,
+    features: [
+      "24/7 signal desk coverage",
+      "Live trade recaps",
+      "Priority mentor Q&A",
+    ],
+  },
+  {
+    id: "vip-quarterly",
+    name: "VIP Quarterly",
+    price: 129,
+    currency: "USD",
+    duration_months: 3,
+    is_lifetime: false,
+    features: [
+      "Everything in VIP Monthly",
+      "Quarterly strategy audit",
+      "Automation checklist upgrades",
+    ],
+  },
+  {
+    id: "vip-lifetime",
+    name: "VIP Lifetime",
+    price: 990,
+    currency: "USD",
+    duration_months: 0,
+    is_lifetime: true,
+    features: [
+      "Lifetime signal desk access",
+      "Priority desk hotline",
+      "Founders circle workshops",
+    ],
+  },
+];
+
+const formatDuration = (plan: Plan) => {
+  if (plan.is_lifetime) {
+    return "Lifetime access";
+  }
+  if (plan.duration_months === 1) {
+    return "Monthly";
+  }
+  if (plan.duration_months % 12 === 0) {
+    const years = plan.duration_months / 12;
+    return `${years} year${years > 1 ? "s" : ""}`;
+  }
+  return `${plan.duration_months} months`;
+};
+
+export function VipPackagesSection() {
+  const [plans, setPlans] = useState<Plan[]>(FALLBACK_PLANS);
+  const [loading, setLoading] = useState(true);
+  const [usingFallback, setUsingFallback] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchPlans = async () => {
+      try {
+        const { data, error } = await callEdgeFunction<PlansResponse>("PLANS");
+        if (!mounted) {
+          return;
+        }
+        if (!error && data?.plans && data.plans.length > 0) {
+          setPlans(data.plans);
+          setUsingFallback(false);
+        }
+      } catch (err) {
+        console.warn("Failed to load live plans, falling back to defaults", err);
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchPlans();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleCheckout = (planId: string) => {
+    router.push(`/checkout?plan=${encodeURIComponent(planId)}`);
+  };
+
+  return (
+    <Column
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="32"
+      shadow="l"
+    >
+      <Column gap="12" maxWidth={32}>
+        <Heading variant="display-strong-xs">VIP membership packages</Heading>
+        <Text variant="body-default-l" onBackground="neutral-weak">
+          Choose the desk access that matches your trading cadence. Every package includes live signals, trade accountability, and automation templates.
+        </Text>
+        {usingFallback ? (
+          <Text variant="body-default-s" onBackground="brand-weak">
+            Live pricing will refresh once the Supabase connection is available. Showing reference packages in the meantime.
+          </Text>
+        ) : null}
+      </Column>
+      {loading ? (
+        <Row fillWidth horizontal="center" paddingY="32" gap="16">
+          <Spinner />
+          <Text variant="body-default-m">Loading plans…</Text>
+        </Row>
+      ) : (
+        <Column gap="20">
+          <Row gap="16" wrap>
+            {plans.map((plan) => (
+              <Column
+                key={plan.id}
+                flex={1}
+                minWidth={18}
+                maxWidth={24}
+                background="page"
+                border={plan.is_lifetime ? "brand-alpha-medium" : "neutral-alpha-weak"}
+                radius="l"
+                padding="l"
+                gap="20"
+                shadow={plan.is_lifetime ? "l" : undefined}
+              >
+                <Column gap="12">
+                  <Row horizontal="between" vertical="center">
+                    <Text variant="heading-strong-m">{plan.name}</Text>
+                    <Tag size="s" prefixIcon={plan.is_lifetime ? "infinity" : "calendar"}>
+                      {formatDuration(plan)}
+                    </Tag>
+                  </Row>
+                  <Heading variant="display-strong-s">
+                    {formatPrice(plan.price, plan.currency)}
+                    {!plan.is_lifetime ? <Text as="span" variant="body-default-m" onBackground="neutral-weak">/period</Text> : null}
+                  </Heading>
+                  <Text variant="body-default-m" onBackground="neutral-weak">
+                    {plan.is_lifetime
+                      ? "Lifetime access to every desk upgrade and live mentor cohort."
+                      : "Recurring access with automation updates and weekly accountability."
+                    }
+                  </Text>
+                </Column>
+                {plan.features?.length ? (
+                  <Column as="ul" gap="8">
+                    {plan.features.slice(0, 4).map((feature, index) => (
+                      <Row key={index} gap="8" vertical="center">
+                        <Icon name="check" onBackground="brand-medium" />
+                        <Text as="li" variant="body-default-m">
+                          {feature}
+                        </Text>
+                      </Row>
+                    ))}
+                    {plan.features.length > 4 ? (
+                      <Text variant="body-default-s" onBackground="neutral-weak">
+                        +{plan.features.length - 4} more desk utilities
+                      </Text>
+                    ) : null}
+                  </Column>
+                ) : null}
+                <Row gap="12" s={{ direction: "column" }}>
+                  <Button
+                    size="m"
+                    variant="secondary"
+                    data-border="rounded"
+                    onClick={() => handleCheckout(plan.id)}
+                    prefixIcon="sparkles"
+                  >
+                    Continue to checkout
+                  </Button>
+                  <Button
+                    size="m"
+                    variant="secondary"
+                    data-border="rounded"
+                    href={`/checkout?plan=${encodeURIComponent(plan.id)}`}
+                    arrowIcon
+                  >
+                    Preview payment options
+                  </Button>
+                </Row>
+              </Column>
+            ))}
+          </Row>
+          <Line background="neutral-alpha-weak" />
+          <Row gap="16" s={{ direction: "column" }}>
+            <OnceButton onClick={() => router.push("/checkout")}>Open checkout</OnceButton>
+            <OnceButton
+              variant="outline"
+              onClick={() => router.push("/telegram")}
+            >
+              View bot dashboard
+            </OnceButton>
+          </Row>
+        </Column>
+      )}
+    </Column>
+  );
+}
+
+export default VipPackagesSection;

--- a/apps/web/resources/icons.ts
+++ b/apps/web/resources/icons.ts
@@ -12,6 +12,10 @@ import {
   HiOutlineDocument,
   HiOutlineGlobeAsiaAustralia,
   HiOutlineRocketLaunch,
+  HiMapPin,
+  HiCheckCircle,
+  HiSparkles,
+  HiInfinity,
 } from "react-icons/hi2";
 
 import {
@@ -20,6 +24,7 @@ import {
   PiGridFourDuotone,
   PiBookBookmarkDuotone,
   PiImageDuotone,
+  PiCrownSimpleDuotone,
 } from "react-icons/pi";
 
 import {
@@ -43,6 +48,7 @@ export const iconLibrary: Record<string, IconType> = {
   calendar: HiCalendarDays,
   home: PiHouseDuotone,
   gallery: PiImageDuotone,
+  crown: PiCrownSimpleDuotone,
   discord: FaDiscord,
   eye: HiOutlineEye,
   eyeOff: HiOutlineEyeSlash,
@@ -54,6 +60,10 @@ export const iconLibrary: Record<string, IconType> = {
   arrowUpRightFromSquare: HiArrowTopRightOnSquare,
   document: HiOutlineDocument,
   rocket: HiOutlineRocketLaunch,
+  location: HiMapPin,
+  check: HiCheckCircle,
+  sparkles: HiSparkles,
+  infinity: HiInfinity,
   javascript: SiJavascript,
   nextjs: SiNextdotjs,
   supabase: SiSupabase,

--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -18,6 +18,10 @@ const baseURL: string = "https://dynamic.capital";
 const routes: RoutesConfig = {
   "/": true,
   "/about": true,
+  "/plans": true,
+  "/checkout": true,
+  "/login": true,
+  "/admin": true,
   "/work": { enabled: true, includeChildren: true },
   "/blog": { enabled: true, includeChildren: true },
   "/gallery": true,


### PR DESCRIPTION
## Summary
- enrich the landing experience with Once UI based About, VIP packages, and checkout callout sections
- add dedicated /plans, /checkout, /login, and /admin routes aligned to the Once UI visual system
- restyle the chat assistant, login form, and admin gate to the Once UI theme while wiring new icon support and navigation entry for VIP plans

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9f2d4e548322ba49f9588bf000f8