### PR TITLE
feat: load vip plans dynamically across landing

### DIFF
--- a/apps/web/components/landing/VipPriceSwitcher.tsx
+++ b/apps/web/components/landing/VipPriceSwitcher.tsx
@@ -1,16 +1,184 @@
 "use client";
 
-import { useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
-import { Button } from '@/components/ui/button';
+import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { useSubscriptionPlans } from "@/hooks/useSubscriptionPlans";
+import { formatPrice } from "@/utils";
+import type { Plan } from "@/types/plan";
+
+const getPlanLabel = (plan: Plan) => {
+  if (plan.is_lifetime) {
+    return "Lifetime";
+  }
+
+  const months = plan.duration_months;
+
+  if (months === 1) return "Monthly";
+  if (months === 3) return "Quarterly";
+  if (months === 6) return "Semi-annual";
+  if (months === 12) return "Annual";
+  if (months % 12 === 0) {
+    const years = months / 12;
+    return `${years} year${years > 1 ? "s" : ""}`;
+  }
+
+  return `${months} months`;
+};
+
+const describePlanFrequency = (plan: Plan) => {
+  if (plan.is_lifetime) {
+    return "One-time investment";
+  }
+
+  const months = plan.duration_months;
+
+  if (months === 1) return "per month";
+  if (months === 3) return "per quarter";
+  if (months === 6) return "every 6 months";
+  if (months === 12) return "per year";
+  if (months % 12 === 0) {
+    const years = months / 12;
+    return `every ${years} years`;
+  }
+
+  return `every ${months} months`;
+};
 
 const VipPriceSwitcher = () => {
-  const [billing, setBilling] = useState<'monthly' | 'annual'>('monthly');
+  const { plans, loading, error, hasData, refresh } = useSubscriptionPlans();
+
+  const orderedPlans = useMemo(() => {
+    return [...plans].sort((a, b) => {
+      if (a.is_lifetime && !b.is_lifetime) return 1;
+      if (!a.is_lifetime && b.is_lifetime) return -1;
+      return a.duration_months - b.duration_months;
+    });
+  }, [plans]);
+
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (orderedPlans.length === 0) {
+      setSelectedPlanId(null);
+      return;
+    }
+
+    if (!selectedPlanId || !orderedPlans.some((plan) => plan.id === selectedPlanId)) {
+      setSelectedPlanId(orderedPlans[0].id);
+    }
+  }, [orderedPlans, selectedPlanId]);
+
+  const selectedPlan = useMemo(
+    () => orderedPlans.find((plan) => plan.id === selectedPlanId) ?? null,
+    [orderedPlans, selectedPlanId],
+  );
+
+  const monthlyPlan = useMemo(
+    () => orderedPlans.find((plan) => !plan.is_lifetime && plan.duration_months === 1) ?? null,
+    [orderedPlans],
+  );
+
+  const savings = useMemo(() => {
+    if (!selectedPlan || !monthlyPlan) return null;
+    if (selectedPlan.is_lifetime) return null;
+    if (selectedPlan.duration_months <= 1) return null;
+    if (selectedPlan.currency !== monthlyPlan.currency) return null;
+
+    const monthlyEquivalent = selectedPlan.price / selectedPlan.duration_months;
+    if (monthlyEquivalent >= monthlyPlan.price) return null;
+
+    const percent = Math.round((1 - monthlyEquivalent / monthlyPlan.price) * 100);
+    const amountSaved = monthlyPlan.price * selectedPlan.duration_months - selectedPlan.price;
+    return { percent, amountSaved };
+  }, [selectedPlan, monthlyPlan]);
+
+  const renderPricingContent = () => {
+    if (loading) {
+      return (
+        <motion.div
+          key="loading"
+          initial={{ opacity: 0, y: 20, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -20, scale: 0.95 }}
+          transition={{ duration: 0.3 }}
+          className="text-center"
+        >
+          <div className="text-lg text-muted-foreground">Loading live pricing…</div>
+        </motion.div>
+      );
+    }
+
+    if (error) {
+      return (
+        <motion.div
+          key="error"
+          initial={{ opacity: 0, y: 20, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -20, scale: 0.95 }}
+          transition={{ duration: 0.3 }}
+          className="text-center space-y-4"
+        >
+          <div className="text-lg text-muted-foreground">Unable to load live pricing right now.</div>
+          <Button variant="outline" onClick={() => refresh(true)}>
+            Retry loading plans
+          </Button>
+        </motion.div>
+      );
+    }
+
+    if (!selectedPlan) {
+      return (
+        <motion.div
+          key="empty"
+          initial={{ opacity: 0, y: 20, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -20, scale: 0.95 }}
+          transition={{ duration: 0.3 }}
+          className="text-center"
+        >
+          <div className="text-lg text-muted-foreground">
+            VIP plans will appear here as soon as they are published in Supabase.
+          </div>
+        </motion.div>
+      );
+    }
+
+    return (
+      <motion.div
+        key={selectedPlan.id}
+        initial={{ opacity: 0, y: 20, scale: 0.9 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        exit={{ opacity: 0, y: -20, scale: 0.9 }}
+        transition={{ duration: 0.3, type: "spring", stiffness: 300 }}
+        className="text-center"
+      >
+        <div className="text-sm uppercase tracking-[0.3em] text-muted-foreground mb-3">
+          {selectedPlan.name}
+        </div>
+        <div className="text-5xl sm:text-6xl md:text-7xl font-black bg-gradient-to-r from-primary via-dc-accent to-primary bg-clip-text text-transparent mb-2">
+          {formatPrice(selectedPlan.price, selectedPlan.currency)}
+        </div>
+        <div className="text-lg sm:text-xl text-muted-foreground font-medium">
+          {describePlanFrequency(selectedPlan)}
+        </div>
+        {savings ? (
+          <div className="text-sm text-accent-green font-semibold mt-2">
+            Save {savings.percent}% ({formatPrice(savings.amountSaved, selectedPlan.currency)}) compared to monthly billing
+          </div>
+        ) : selectedPlan.is_lifetime ? (
+          <div className="text-sm text-primary font-semibold mt-2">
+            One payment. Permanent VIP desk access.
+          </div>
+        ) : null}
+      </motion.div>
+    );
+  };
 
   return (
     <section className="py-16 bg-gradient-to-b from-transparent via-card/10 to-transparent">
       <div className="container mx-auto px-4 sm:px-6">
-        <motion.div 
+        <motion.div
           className="text-center mb-12"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -21,66 +189,60 @@ const VipPriceSwitcher = () => {
             VIP Membership Plans
           </h2>
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Choose the perfect plan for your trading journey
+            Choose the perfect plan for your trading journey. Pricing updates automatically from the Supabase subscription plans table shared with the Telegram bot.
           </p>
         </motion.div>
 
-        <motion.div
-          className="flex flex-col items-center justify-center gap-4 sm:flex-row mb-8"
-          initial={{ opacity: 0, scale: 0.9 }}
-          whileInView={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          viewport={{ once: true }}
-        >
-          <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-2 shadow-lg">
-            <div className="flex flex-col sm:flex-row gap-2">
-              <motion.button
-                className={`px-6 sm:px-8 py-3 sm:py-4 rounded-xl font-semibold transition-all duration-300 relative overflow-hidden ${
-                  billing === 'monthly'
-                    ? 'bg-gradient-to-r from-primary to-dc-accent text-white shadow-lg shadow-primary/30'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-                onClick={() => setBilling('monthly')}
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-              >
-                {billing === 'monthly' && (
-                  <motion.div
-                    className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent"
-                    animate={{ x: ['-100%', '100%'] }}
-                    transition={{ duration: 1.5, repeat: Infinity, ease: "linear" }}
-                  />
-                )}
-                Monthly
-              </motion.button>
-              
-              <motion.button
-                className={`px-6 sm:px-8 py-3 sm:py-4 rounded-xl font-semibold transition-all duration-300 relative overflow-hidden ${
-                  billing === 'annual'
-                    ? 'bg-gradient-to-r from-primary to-dc-accent text-white shadow-lg shadow-primary/30'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-                onClick={() => setBilling('annual')}
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-              >
-                {billing === 'annual' && (
-                  <motion.div
-                    className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent"
-                    animate={{ x: ['-100%', '100%'] }}
-                    transition={{ duration: 1.5, repeat: Infinity, ease: "linear" }}
-                  />
-                )}
-                Annual
-                <span className="ml-2 text-xs bg-accent-green/20 text-accent-green px-2 py-1 rounded-full">
-                  Save 18%
-                </span>
-              </motion.button>
+        {!error && (loading || orderedPlans.length > 0) ? (
+          <motion.div
+            className="flex flex-col items-center justify-center gap-4 sm:flex-row mb-8"
+            initial={{ opacity: 0, scale: 0.9 }}
+            whileInView={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+            viewport={{ once: true }}
+          >
+            <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-2 shadow-lg">
+              <div className="flex flex-col sm:flex-row gap-2">
+                {orderedPlans.length === 0
+                  ? (
+                    <div className="px-6 sm:px-8 py-3 sm:py-4 rounded-xl font-semibold text-muted-foreground">
+                      Loading options…
+                    </div>
+                  )
+                  : orderedPlans.map((plan) => {
+                      const isActive = plan.id === selectedPlanId;
+                      return (
+                        <motion.button
+                          key={plan.id}
+                          className={`px-6 sm:px-8 py-3 sm:py-4 rounded-xl font-semibold transition-all duration-300 relative overflow-hidden ${
+                            isActive
+                              ? "bg-gradient-to-r from-primary to-dc-accent text-white shadow-lg shadow-primary/30"
+                              : "text-muted-foreground hover:text-foreground"
+                          }`}
+                          onClick={() => setSelectedPlanId(plan.id)}
+                          whileHover={{ scale: 1.02 }}
+                          whileTap={{ scale: 0.98 }}
+                          aria-pressed={isActive}
+                        >
+                          {isActive && (
+                            <motion.div
+                              className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent"
+                              animate={{ x: ["-100%", "100%"] }}
+                              transition={{ duration: 1.5, repeat: Infinity, ease: "linear" }}
+                            />
+                          )}
+                          <span className="relative z-10">
+                            {getPlanLabel(plan)}
+                          </span>
+                        </motion.button>
+                      );
+                    })}
+              </div>
             </div>
-          </div>
-        </motion.div>
+          </motion.div>
+        ) : null}
 
-        <motion.div 
+        <motion.div
           className="text-center"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -88,46 +250,19 @@ const VipPriceSwitcher = () => {
           viewport={{ once: true }}
         >
           <div className="relative">
-            <AnimatePresence mode="wait">
-              {billing === 'monthly' ? (
-                <motion.div
-                  key="monthly"
-                  initial={{ opacity: 0, y: 20, scale: 0.9 }}
-                  animate={{ opacity: 1, y: 0, scale: 1 }}
-                  exit={{ opacity: 0, y: -20, scale: 0.9 }}
-                  transition={{ duration: 0.3, type: "spring", stiffness: 300 }}
-                  className="text-center"
-                >
-                  <div className="text-5xl sm:text-6xl md:text-7xl font-black bg-gradient-to-r from-primary via-dc-accent to-primary bg-clip-text text-transparent mb-2">
-                    $49
-                  </div>
-                  <div className="text-lg sm:text-xl text-muted-foreground font-medium">
-                    per month
-                  </div>
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="annual"
-                  initial={{ opacity: 0, y: 20, scale: 0.9 }}
-                  animate={{ opacity: 1, y: 0, scale: 1 }}
-                  exit={{ opacity: 0, y: -20, scale: 0.9 }}
-                  transition={{ duration: 0.3, type: "spring", stiffness: 300 }}
-                  className="text-center"
-                >
-                  <div className="text-5xl sm:text-6xl md:text-7xl font-black bg-gradient-to-r from-primary via-dc-accent to-primary bg-clip-text text-transparent mb-2">
-                    $480
-                  </div>
-                  <div className="text-lg sm:text-xl text-muted-foreground font-medium">
-                    per year
-                  </div>
-                  <div className="text-sm text-accent-green font-semibold mt-2">
-                    Save $108 annually
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
+            <AnimatePresence mode="wait">{renderPricingContent()}</AnimatePresence>
           </div>
         </motion.div>
+
+        {hasData ? (
+          <div className="mt-10 flex justify-center">
+            <Button variant="ghost" size="lg" className="rounded-full" asChild>
+              <a href="#vip-packages" className="flex items-center gap-2">
+                View detailed VIP packages
+              </a>
+            </Button>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/web/hooks/useSubscriptionPlans.ts
+++ b/apps/web/hooks/useSubscriptionPlans.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Plan } from "@/types/plan";
+import {
+  fetchSubscriptionPlans,
+  getCachedSubscriptionPlans,
+  getCachedSubscriptionPlansError,
+  isFetchingSubscriptionPlans,
+} from "@/services/plans";
+
+interface UseSubscriptionPlansOptions {
+  enabled?: boolean;
+}
+
+interface UseSubscriptionPlansResult {
+  plans: Plan[];
+  loading: boolean;
+  error: string | null;
+  hasData: boolean;
+  refresh: (force?: boolean) => Promise<Plan[]>;
+}
+
+export function useSubscriptionPlans(
+  options: UseSubscriptionPlansOptions = {},
+): UseSubscriptionPlansResult {
+  const { enabled = true } = options;
+  const [plans, setPlans] = useState<Plan[]>(() =>
+    enabled ? getCachedSubscriptionPlans() : [],
+  );
+  const [loading, setLoading] = useState(() =>
+    enabled
+      ? getCachedSubscriptionPlans().length === 0 &&
+        !getCachedSubscriptionPlansError() &&
+        !isFetchingSubscriptionPlans()
+      : false,
+  );
+  const [error, setError] = useState<string | null>(() =>
+    enabled ? getCachedSubscriptionPlansError() : null,
+  );
+
+  const loadPlans = useCallback(
+    async (force?: boolean) => {
+      if (!enabled) {
+        return [];
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const result = await fetchSubscriptionPlans({ force });
+        setPlans(result);
+        return result;
+      } catch (err) {
+        const message =
+          err instanceof Error
+            ? err.message
+            : "Failed to load subscription plans.";
+        setError(message);
+        setPlans([]);
+        return [];
+      } finally {
+        setLoading(false);
+      }
+    },
+    [enabled],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const cached = getCachedSubscriptionPlans();
+    const cachedErr = getCachedSubscriptionPlansError();
+
+    if (cached.length > 0) {
+      setPlans(cached);
+      return;
+    }
+
+    if (cachedErr) {
+      setError(cachedErr);
+      return;
+    }
+
+    if (isFetchingSubscriptionPlans()) {
+      setLoading(true);
+      return;
+    }
+
+    void loadPlans();
+  }, [enabled, loadPlans]);
+
+  const refresh = useCallback(
+    (force = false) => loadPlans(force),
+    [loadPlans],
+  );
+
+  return {
+    plans,
+    loading,
+    error,
+    hasData: plans.length > 0,
+    refresh,
+  };
+}

--- a/apps/web/services/plans.ts
+++ b/apps/web/services/plans.ts
@@ -1,0 +1,93 @@
+import type { Plan } from "@/types/plan";
+import { callEdgeFunction } from "@/config/supabase";
+
+interface PlansResponse {
+  plans?: Plan[] | null;
+  ok?: boolean;
+}
+
+let cachedPlans: Plan[] | null = null;
+let cachedError: string | null = null;
+let pendingRequest: Promise<Plan[]> | null = null;
+
+function normalizePlans(plans: PlansResponse["plans"]): Plan[] {
+  if (!Array.isArray(plans)) {
+    return [];
+  }
+
+  return plans.filter((plan): plan is Plan => {
+    return (
+      !!plan &&
+      typeof plan.id === "string" &&
+      typeof plan.name === "string" &&
+      typeof plan.price === "number" &&
+      typeof plan.currency === "string" &&
+      typeof plan.duration_months === "number" &&
+      typeof plan.is_lifetime === "boolean"
+    );
+  });
+}
+
+export async function fetchSubscriptionPlans(options: { force?: boolean } = {}): Promise<Plan[]> {
+  const { force = false } = options;
+
+  if (force) {
+    cachedPlans = null;
+    cachedError = null;
+  } else {
+    if (cachedPlans) {
+      return cachedPlans;
+    }
+
+    if (pendingRequest) {
+      return pendingRequest;
+    }
+  }
+
+  const request = callEdgeFunction<PlansResponse>("PLANS");
+
+  pendingRequest = request
+    .then(({ data, error }) => {
+      if (error) {
+        throw new Error(error.message || "Unable to load subscription plans");
+      }
+
+      const normalized = normalizePlans(data?.plans ?? null);
+      cachedPlans = normalized;
+      cachedError = null;
+      return normalized;
+    })
+    .catch((err) => {
+      const message = err instanceof Error
+        ? err.message
+        : "Unable to load subscription plans";
+
+      cachedPlans = [];
+      cachedError = message;
+
+      throw err instanceof Error ? err : new Error(message);
+    })
+    .finally(() => {
+      pendingRequest = null;
+    });
+
+  return pendingRequest;
+}
+
+export function getCachedSubscriptionPlans(): Plan[] {
+  return cachedPlans ?? [];
+}
+
+export function getCachedSubscriptionPlansError(): string | null {
+  return cachedError;
+}
+
+export function resetSubscriptionPlansCache() {
+  cachedPlans = null;
+  cachedError = null;
+  pendingRequest = null;
+}
+
+export function isFetchingSubscriptionPlans(): boolean {
+  return pendingRequest !== null;
+}


### PR DESCRIPTION
## Summary
- add a cached subscription plan service and hook so clients share Supabase plan data without hardcoded fallbacks
- wire the VIP packages section to the shared hook with retry, empty, and checkout states driven by Supabase data
- refresh the VIP price switcher to render live Supabase plans, dynamic savings messaging, and a deep-link to full packages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cec2a644948322a15eb0d66e856fb1