### PR TITLE
Add Once UI checkout route for web app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,8 @@ import { MotionConfigProvider } from '@/components/ui/motion-config';
 import { Toaster } from '@/components/ui/toaster';
 import { Toaster as Sonner } from '@/components/ui/sonner';
 import { LandingPageShell } from '@/components/landing/LandingPageShell';
-import Footer from '@/components/layout/Footer';
+import CheckoutPage from './pages/CheckoutPage';
+import { Footer } from '@/components/magic-portfolio/Footer';
 
 const queryClient = new QueryClient();
 
@@ -29,6 +30,7 @@ function App() {
             <main className="flex-1">
               <Routes>
                 <Route path="/" element={<HomePage />} />
+                <Route path="/checkout" element={<CheckoutPage />} />
               </Routes>
             </main>
             <Footer />

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Column, Heading, Text } from '@once-ui-system/core';
+import { WebCheckout } from '@/components/checkout/WebCheckout';
+
+function useCheckoutParams() {
+  const location = useLocation();
+
+  return useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    const plan = params.get('plan') || undefined;
+    const promo = params.get('promo') || undefined;
+
+    return { plan, promo };
+  }, [location.search]);
+}
+
+export function CheckoutPage() {
+  const { plan, promo } = useCheckoutParams();
+
+  return (
+    <Column gap="24" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={28} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Secure checkout
+        </Heading>
+        <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+          Review your plan, select a payment method, and submit proof if you’re joining via bank transfer or crypto.
+        </Text>
+      </Column>
+      <WebCheckout selectedPlanId={plan} promoCode={promo} />
+    </Column>
+  );
+}
+
+export default CheckoutPage;

--- a/src/stubs/next-font-google.ts
+++ b/src/stubs/next-font-google.ts
@@ -1,0 +1,38 @@
+export interface NextFontOptions {
+  subsets?: string[];
+  weight?: string | string[];
+  style?: string;
+  display?: string;
+  variable?: string;
+  preload?: boolean;
+  adjustFontFallback?: boolean;
+  fallback?: string[];
+}
+
+export interface NextFontResult {
+  className: string;
+  variable?: string;
+  style: Record<string, string>;
+}
+
+function createFont(name: string) {
+  const fontFamily = name.replace(/_/g, ' ');
+
+  return function loadFont(options: NextFontOptions = {}): NextFontResult {
+    const variable = options.variable;
+    const className = variable ? variable.replace(/^--/, '') : `font-${fontFamily.toLowerCase().replace(/\s+/g, '-')}`;
+
+    return {
+      className,
+      variable,
+      style: {
+        fontFamily,
+        fontDisplay: options.display ?? 'swap',
+      },
+    };
+  };
+}
+
+export const Geist = createFont('Geist');
+export const Geist_Mono = createFont('Geist_Mono');
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["apps/web/*"],
-      "~/*": ["src/*"]
+      "~/*": ["src/*"],
+      "next/font/google": ["src/stubs/next-font-google.ts"]
     },
     "types": ["vite/client"]
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,10 @@ export default defineConfig(({ mode }) => ({
         __dirname,
         'node_modules/@once-ui-system/core',
       ),
+      'next/font/google': path.resolve(
+        __dirname,
+        'src/stubs/next-font-google.ts',
+      ),
     }
   }
 }))


### PR DESCRIPTION
## Summary
- add a Vite checkout page that reuses the shared Once UI WebCheckout experience
- expose the new `/checkout` route in the React router and fix the footer import to the shared Magic footer
- stub the `next/font/google` module so the shared Once UI resources compile in the Vite build

## Testing
- npm run build:dev

------
https://chatgpt.com/codex/tasks/task_e_68ced1ccccac83229377cc552bb5e92c