### PR TITLE
Fix pip conversions in MQL5 risk management helpers

### DIFF
--- a/mql5/risk_management.mqh
+++ b/mql5/risk_management.mqh
@@ -11,6 +11,19 @@ input double BreakEvenPips    = 10;    // Pips in profit before moving SL to bre
 CTrade rm_trade;                       // trade object used for modifications
 
 //+------------------------------------------------------------------+
+//| Helper: return pip size for the current symbol                   |
+//+------------------------------------------------------------------+
+double GetPipSize()
+{
+   double pipSize = _Point;
+
+   if(_Digits == 3 || _Digits == 5)
+      pipSize *= 10.0;
+
+   return pipSize;
+}
+
+//+------------------------------------------------------------------+
 //| Calculate lot size based on account balance and SL distance      |
 //+------------------------------------------------------------------+
 double CalculateLotSize(double stopLossPips)
@@ -21,12 +34,38 @@ double CalculateLotSize(double stopLossPips)
    double riskMoney  = balance * RiskPercent / 100.0;
    double tickValue  = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_VALUE);
    double tickSize   = SymbolInfoDouble(_Symbol, SYMBOL_TRADE_TICK_SIZE);
-   double pipValue   = tickValue / tickSize * _Point * 10.0; // approximate pip value
+   double pipSize    = GetPipSize();
+   if(pipSize <= 0.0)
+   {
+      Print("CalculateLotSize: invalid pip size for symbol ", _Symbol);
+      return 0.0;
+   }
+   if(tickSize <= 0.0 || tickValue <= 0.0)
+   {
+      Print("CalculateLotSize: invalid tick data for symbol ", _Symbol);
+      return 0.0;
+   }
+   double pipValue   = (tickValue / tickSize) * pipSize;
+   if(pipValue <= 0.0)
+   {
+      Print("CalculateLotSize: invalid pip value for symbol ", _Symbol);
+      return 0.0;
+   }
    double lot        = riskMoney / (stopLossPips * pipValue);
    double lotStep    = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_STEP);
    double minLot     = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MIN);
    double maxLot     = SymbolInfoDouble(_Symbol, SYMBOL_VOLUME_MAX);
+   if(lotStep <= 0.0)
+   {
+      Print("CalculateLotSize: invalid lot step for symbol ", _Symbol);
+      return 0.0;
+   }
    lot = MathMax(minLot, MathMin(maxLot, MathFloor(lot/lotStep)*lotStep));
+   if(lot <= 0.0)
+   {
+      Print("CalculateLotSize: resulting lot size is zero for symbol ", _Symbol);
+      return 0.0;
+   }
    lot = NormalizeDouble(lot, 2);
    double margin;
    if(!OrderCalcMargin(ORDER_TYPE_BUY, _Symbol, lot, SymbolInfoDouble(_Symbol, SYMBOL_ASK), margin))
@@ -52,18 +91,24 @@ void SetStopLossAndTakeProfit(ulong ticket, double slPips, double tpPips)
       Print("SetStopLossAndTakeProfit: position not found");
       return;
    }
+   double pipSize = GetPipSize();
+   if(pipSize <= 0.0)
+   {
+      Print("SetStopLossAndTakeProfit: invalid pip size for symbol ", _Symbol);
+      return;
+   }
    double openPrice = PositionGetDouble(POSITION_PRICE_OPEN);
    long   type      = PositionGetInteger(POSITION_TYPE);
    double sl, tp;
    if(type == POSITION_TYPE_BUY)
    {
-      sl = openPrice - slPips * _Point;
-      tp = openPrice + tpPips * _Point;
+      sl = openPrice - slPips * pipSize;
+      tp = openPrice + tpPips * pipSize;
    }
    else
    {
-      sl = openPrice + slPips * _Point;
-      tp = openPrice - tpPips * _Point;
+      sl = openPrice + slPips * pipSize;
+      tp = openPrice - tpPips * pipSize;
    }
    if(!rm_trade.PositionModify(ticket, NormalizeDouble(sl, _Digits), NormalizeDouble(tp, _Digits)))
       Print("Failed to modify position: ", rm_trade.ResultRetcode());
@@ -76,17 +121,20 @@ void MoveToBreakEven(ulong ticket, double entryPrice)
 {
    if(!PositionSelectByTicket(ticket))
       return;
+   double pipSize = GetPipSize();
+   if(pipSize <= 0.0)
+      return;
    long type = PositionGetInteger(POSITION_TYPE);
    double price = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_BID)
                                               : SymbolInfoDouble(_Symbol, SYMBOL_ASK);
    if(type == POSITION_TYPE_BUY)
    {
-      if(price - entryPrice >= BreakEvenPips * _Point && PositionGetDouble(POSITION_SL) < entryPrice)
+      if(price - entryPrice >= BreakEvenPips * pipSize && PositionGetDouble(POSITION_SL) < entryPrice)
          rm_trade.PositionModify(ticket, NormalizeDouble(entryPrice, _Digits), PositionGetDouble(POSITION_TP));
    }
    else
    {
-      if(entryPrice - price >= BreakEvenPips * _Point && (PositionGetDouble(POSITION_SL) > entryPrice || PositionGetDouble(POSITION_SL) == 0))
+      if(entryPrice - price >= BreakEvenPips * pipSize && (PositionGetDouble(POSITION_SL) > entryPrice || PositionGetDouble(POSITION_SL) == 0))
          rm_trade.PositionModify(ticket, NormalizeDouble(entryPrice, _Digits), PositionGetDouble(POSITION_TP));
    }
 }
@@ -98,6 +146,9 @@ void ApplyTrailingStop(ulong ticket, double trailStartPips, double trailStepPips
 {
    if(!PositionSelectByTicket(ticket))
       return;
+   double pipSize = GetPipSize();
+   if(pipSize <= 0.0)
+      return;
    long type     = PositionGetInteger(POSITION_TYPE);
    double open   = PositionGetDouble(POSITION_PRICE_OPEN);
    double price  = (type == POSITION_TYPE_BUY) ? SymbolInfoDouble(_Symbol, SYMBOL_BID)
@@ -107,20 +158,20 @@ void ApplyTrailingStop(ulong ticket, double trailStartPips, double trailStepPips
 
    if(type == POSITION_TYPE_BUY)
    {
-      double start = open + trailStartPips * _Point;
+      double start = open + trailStartPips * pipSize;
       if(price > start)
       {
-         double desired = price - trailStepPips * _Point;
+         double desired = price - trailStepPips * pipSize;
          if(desired > sl)
             newSL = desired;
       }
    }
    else
    {
-      double start = open - trailStartPips * _Point;
+      double start = open - trailStartPips * pipSize;
       if(price < start)
       {
-         double desired = price + trailStepPips * _Point;
+         double desired = price + trailStepPips * pipSize;
          if(desired < sl || sl == 0)
             newSL = desired;
       }


### PR DESCRIPTION
## Summary
- add a pip size helper so stop loss, take profit, breakeven and trailing calculations honor true pip distances across different symbols
- recalculate lot sizing with symbol-aware pip values and guard against invalid tick/volume metadata
- fail fast when conversions are unavailable instead of silently applying incorrect risk parameters

## Testing
- Not run (MetaTrader tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ced4071c188322b7854fdba569ea90