### PR TITLE
feat: sync dashboard data with Supabase

### DIFF
--- a/apps/web/components/telegram/BotDashboard.tsx
+++ b/apps/web/components/telegram/BotDashboard.tsx
@@ -35,15 +35,18 @@ const BotDashboard = () => {
   const fetchBotStats = async () => {
     try {
       setLoading(true);
-      const { data, error } = await supabase.functions.invoke("analytics-data");
+      const { data, error } = await supabase.functions.invoke(
+        "analytics-data",
+        { body: { timeframe: "month" } },
+      );
 
       if (error) throw error;
 
       setStats({
-        totalUsers: data?.total_users || 0,
-        vipMembers: data?.vip_users || 0,
-        totalRevenue: data?.total_revenue || 0,
-        pendingPayments: data?.pending_payments || 0,
+        totalUsers: data?.total_users ?? 0,
+        vipMembers: data?.vip_users ?? 0,
+        totalRevenue: data?.total_revenue ?? 0,
+        pendingPayments: data?.pending_payments ?? 0,
         lastUpdated: new Date().toISOString(),
       });
     } catch (error) {
@@ -55,8 +58,15 @@ const BotDashboard = () => {
 
   const checkBotStatus = async () => {
     try {
-      const { data, error } = await supabase.functions.invoke("test-bot-status");
-      setIsConnected(!error && data?.bot_status?.includes("✅"));
+      const { data, error } = await supabase.functions.invoke(
+        "bot-status-check",
+      );
+      const connected =
+        !error &&
+        Boolean(data?.ok) &&
+        Boolean(data?.bot_info?.success) &&
+        Boolean(data?.webhook_info?.data?.url);
+      setIsConnected(connected);
     } catch (error) {
       console.error("Error checking bot status:", error);
       setIsConnected(false);

--- a/apps/web/components/telegram/dashboard/AnalyticsView.tsx
+++ b/apps/web/components/telegram/dashboard/AnalyticsView.tsx
@@ -1,80 +1,303 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  BarChart3,
+  Package,
+  RefreshCw,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { AnalyticsData } from "./types";
 import { ViewHeader } from "./ViewHeader";
-import { BarChart3, MessageSquare, Package, Users } from "lucide-react";
 
 interface AnalyticsViewProps {
   onBack: () => void;
 }
 
+const formatCurrency = (value: number, currency: string) =>
+  new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency || "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const timeframeOptions = [
+  { value: "today", label: "Today" },
+  { value: "week", label: "This Week" },
+  { value: "14days", label: "Last 14 Days" },
+  { value: "month", label: "This Month" },
+] as const;
+
+type Timeframe = (typeof timeframeOptions)[number]["value"];
+
 export function AnalyticsView({ onBack }: AnalyticsViewProps) {
+  const [timeframe, setTimeframe] = useState<Timeframe>("month");
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchAnalytics = async () => {
+      try {
+        setLoading(true);
+        const { data, error: fnError } = await supabase.functions.invoke(
+          "analytics-data",
+          { body: { timeframe } },
+        );
+
+        if (fnError) {
+          throw fnError;
+        }
+
+        if (!isMounted) return;
+        setAnalytics(data as AnalyticsData);
+        setError(null);
+      } catch (err) {
+        if (!isMounted) return;
+        console.error("Error loading analytics data:", err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load analytics data",
+        );
+        setAnalytics(null);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    fetchAnalytics();
+    return () => {
+      isMounted = false;
+    };
+  }, [timeframe]);
+
+  const packageStats = useMemo(() => {
+    if (!analytics) {
+      return { totalSales: 0, totalRevenue: 0, avgRevenue: 0 };
+    }
+    const totalSales = analytics.package_performance.reduce(
+      (sum, pkg) => sum + (pkg.sales ?? 0),
+      0,
+    );
+    const totalRevenue = analytics.total_revenue ?? 0;
+    return {
+      totalSales,
+      totalRevenue,
+      avgRevenue: totalSales > 0 ? totalRevenue / totalSales : 0,
+    };
+  }, [analytics]);
+
+  const handleRefresh = () => {
+    // Trigger re-fetch by setting same timeframe (force state update)
+    setTimeframe((prev) => prev);
+  };
+
+  const renderSkeleton = () => (
+    <>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card
+            key={`analytics-skeleton-${index}`}
+            className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg"
+          >
+            <Skeleton className="h-6 w-1/3" />
+            <Skeleton className="h-10 w-1/2 mt-4" />
+            <Skeleton className="h-4 w-1/3 mt-2" />
+          </Card>
+        ))}
+      </div>
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+        <Skeleton className="h-64 w-full" />
+      </Card>
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+        <Skeleton className="h-32 w-full" />
+      </Card>
+    </>
+  );
+
   return (
     <div className="space-y-6">
       <ViewHeader
         title="Revenue Analytics"
         description="Track revenue performance and package analytics"
         onBack={onBack}
+        actions={
+          <div className="flex items-center gap-2">
+            {timeframeOptions.map((option) => (
+              <Button
+                key={option.value}
+                variant={option.value === timeframe ? "default" : "outline"}
+                size="sm"
+                onClick={() => setTimeframe(option.value)}
+              >
+                {option.label}
+              </Button>
+            ))}
+            <Button
+              variant="outline"
+              size="icon"
+              aria-label="Refresh analytics"
+              onClick={handleRefresh}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </div>
+        }
       />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-2">
-            <p className="text-sm text-muted-foreground">Today</p>
-            <p className="text-2xl font-bold text-green-500">$1,240</p>
-            <p className="text-xs text-muted-foreground">+12% vs yesterday</p>
-          </div>
-        </Card>
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-2">
-            <p className="text-sm text-muted-foreground">This Week</p>
-            <p className="text-2xl font-bold text-blue-500">$8,650</p>
-            <p className="text-xs text-muted-foreground">+8% vs last week</p>
-          </div>
-        </Card>
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-2">
-            <p className="text-sm text-muted-foreground">This Month</p>
-            <p className="text-2xl font-bold text-purple-500">$32,420</p>
-            <p className="text-xs text-muted-foreground">+5% vs last month</p>
-          </div>
-        </Card>
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-2">
-            <p className="text-sm text-muted-foreground">Active Subscriptions</p>
-            <p className="text-2xl font-bold text-telegram">1,248</p>
-            <p className="text-xs text-muted-foreground">+42 new this week</p>
-          </div>
-        </Card>
-      </div>
+      {error && (
+        <Alert variant="destructive" className="flex items-start gap-2">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
 
-      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-        <h3 className="text-lg font-semibold mb-4">Revenue Trend (Last 30 Days)</h3>
-        <div className="h-64 bg-background/30 rounded-lg flex items-center justify-center">
-          <p className="text-muted-foreground">Chart visualization would go here</p>
-        </div>
-      </Card>
+      {loading ? (
+        renderSkeleton()
+      ) : analytics ? (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+              <div className="space-y-2 text-center">
+                <p className="text-sm text-muted-foreground">Total revenue</p>
+                <p className="text-2xl font-bold text-green-500">
+                  {formatCurrency(packageStats.totalRevenue, analytics.currency)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Timeframe: {timeframeOptions.find((t) => t.value === timeframe)?.label}
+                </p>
+              </div>
+            </Card>
+            <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+              <div className="space-y-2 text-center">
+                <p className="text-sm text-muted-foreground">Packages sold</p>
+                <p className="text-2xl font-bold text-blue-500">
+                  {packageStats.totalSales}
+                </p>
+                <p className="text-xs text-muted-foreground">Across active plans</p>
+              </div>
+            </Card>
+            <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+              <div className="space-y-2 text-center">
+                <p className="text-sm text-muted-foreground">Avg revenue per sale</p>
+                <p className="text-2xl font-bold text-purple-500">
+                  {formatCurrency(packageStats.avgRevenue, analytics.currency)}
+                </p>
+                <p className="text-xs text-muted-foreground">Based on completed sales</p>
+              </div>
+            </Card>
+            <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+              <div className="space-y-2 text-center">
+                <p className="text-sm text-muted-foreground">Pending payments</p>
+                <p className="text-2xl font-bold text-telegram">
+                  {analytics.pending_payments ?? 0}
+                </p>
+                <p className="text-xs text-muted-foreground">Awaiting completion</p>
+              </div>
+            </Card>
+          </div>
 
-      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-        <h3 className="text-lg font-semibold mb-4">Analytics Actions</h3>
-        <div className="flex flex-wrap gap-3">
-          <Button variant="outline" size="sm" className="gap-2">
-            <BarChart3 className="w-4 h-4" />
-            Export Revenue Report
-          </Button>
-          <Button variant="outline" size="sm" className="gap-2">
-            <Package className="w-4 h-4" />
-            Package Performance Report
-          </Button>
-          <Button variant="outline" size="sm" className="gap-2">
-            <Users className="w-4 h-4" />
-            User Analytics
-          </Button>
-          <Button variant="default" size="sm" className="gap-2">
-            <MessageSquare className="w-4 h-4" />
-            Edit via Telegram
-          </Button>
-        </div>
-      </Card>
+          <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold">Audience overview</h3>
+                <p className="text-sm text-muted-foreground">
+                  Snapshot generated at {new Date(analytics.generated_at).toLocaleString()}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-4">
+                <div className="flex items-center gap-2">
+                  <Users className="w-4 h-4 text-blue-500" />
+                  <span className="text-sm font-medium">
+                    {analytics.total_users ?? 0} total users
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <TrendingUp className="w-4 h-4 text-green-500" />
+                  <span className="text-sm font-medium">
+                    {analytics.vip_users ?? 0} VIP members
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Package className="w-4 h-4 text-purple-500" />
+                  <span className="text-sm font-medium">
+                    {analytics.package_performance.length} active plans
+                  </span>
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+            <h3 className="text-lg font-semibold mb-4">Package performance</h3>
+            <div className="space-y-4">
+              {analytics.package_performance.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No package performance data available for this timeframe.
+                </p>
+              ) : (
+                analytics.package_performance.map((pkg) => (
+                  <div
+                    key={pkg.id}
+                    className="flex flex-col gap-2 rounded-lg border border-border/40 bg-background/40 p-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <h4 className="font-semibold">{pkg.name}</h4>
+                      <p className="text-sm text-muted-foreground">
+                        {pkg.sales} sale{pkg.sales === 1 ? "" : "s"}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+                      <span>
+                        Revenue: {formatCurrency(pkg.revenue, pkg.currency)}
+                      </span>
+                      <span>
+                        Avg sale: {formatCurrency(
+                          pkg.sales > 0 ? pkg.revenue / pkg.sales : 0,
+                          pkg.currency,
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </Card>
+
+          <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+            <h3 className="text-lg font-semibold mb-4">Analytics actions</h3>
+            <div className="flex flex-wrap gap-3">
+              <Button variant="outline" size="sm" className="gap-2">
+                <BarChart3 className="w-4 h-4" />
+                Export revenue report
+              </Button>
+              <Button variant="outline" size="sm" className="gap-2">
+                <Package className="w-4 h-4" />
+                Package performance report
+              </Button>
+              <Button variant="default" size="sm" className="gap-2">
+                <TrendingUp className="w-4 h-4" />
+                Share with team
+              </Button>
+            </div>
+          </Card>
+        </>
+      ) : (
+        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg text-center">
+          <p className="text-muted-foreground">
+            No analytics data available for the selected timeframe.
+          </p>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/components/telegram/dashboard/PackagesView.tsx
+++ b/apps/web/components/telegram/dashboard/PackagesView.tsx
@@ -1,20 +1,212 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { SubscriptionPlan } from "./types";
 import { ViewHeader } from "./ViewHeader";
 
 interface PackagesViewProps {
   onBack: () => void;
 }
 
-const PLANS = [
-  { name: "1 Month VIP", price: "$9.99", duration: "1 month", popular: false },
-  { name: "3 Month VIP", price: "$24.99", duration: "3 months", popular: true },
-  { name: "6 Month VIP", price: "$44.99", duration: "6 months", popular: false },
-  { name: "Lifetime VIP", price: "$99.99", duration: "Lifetime", popular: false },
+const DEFAULT_FEATURES = [
+  "Premium trading signals",
+  "VIP chat access",
+  "Priority mentor support",
+  "Market analysis briefs",
 ];
 
+const toCurrency = (value: number, currency: string) =>
+  new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency || "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const normalizePlan = (plan: SubscriptionPlan): SubscriptionPlan => ({
+  ...plan,
+  price: typeof plan.price === "number" ? plan.price : Number(plan.price ?? 0),
+  currency: plan.currency || "USD",
+  duration_months:
+    plan.duration_months !== null && plan.duration_months !== undefined
+      ? plan.duration_months
+      : plan.is_lifetime
+      ? 0
+      : null,
+  features: Array.isArray(plan.features)
+    ? plan.features.filter(
+        (feature): feature is string =>
+          typeof feature === "string" && feature.trim().length > 0,
+      )
+    : null,
+});
+
+const formatDuration = (plan: SubscriptionPlan) => {
+  if (plan.is_lifetime) return "Lifetime access";
+  if (!plan.duration_months) return "Flexible duration";
+  if (plan.duration_months === 1) return "1 month";
+  return `${plan.duration_months} months`;
+};
+
+const monthlyPrice = (plan: SubscriptionPlan) => {
+  if (plan.is_lifetime) return null;
+  if (!plan.duration_months || plan.duration_months <= 0) return null;
+  if (!plan.price) return null;
+  return plan.price / plan.duration_months;
+};
+
 export function PackagesView({ onBack }: PackagesViewProps) {
+  const [plans, setPlans] = useState<SubscriptionPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadPlans = async () => {
+      try {
+        setLoading(true);
+        const { data, error: fnError } = await supabase.functions.invoke(
+          "plans",
+          { method: "GET" },
+        );
+
+        if (fnError) {
+          throw fnError;
+        }
+
+        const fetchedPlans = Array.isArray(data?.plans)
+          ? (data?.plans as SubscriptionPlan[])
+          : [];
+
+        if (!isMounted) return;
+        setPlans(fetchedPlans.map(normalizePlan));
+        setError(null);
+      } catch (err) {
+        if (!isMounted) return;
+        console.error("Error loading subscription plans:", err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load subscription plans",
+        );
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    loadPlans();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const bestValuePlanId = useMemo(() => {
+    let bestId: string | undefined;
+    let bestMonthly = Number.POSITIVE_INFINITY;
+
+    plans.forEach((plan) => {
+      const monthly = monthlyPrice(plan);
+      if (monthly !== null && monthly < bestMonthly) {
+        bestMonthly = monthly;
+        bestId = plan.id;
+      }
+    });
+
+    return bestId;
+  }, [plans]);
+
+  const renderSkeletons = () => (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Card
+          key={`plan-skeleton-${index}`}
+          className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg"
+        >
+          <div className="space-y-4">
+            <Skeleton className="h-6 w-24 mx-auto" />
+            <Skeleton className="h-10 w-32 mx-auto" />
+            <Skeleton className="h-4 w-28 mx-auto" />
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((__, idx) => (
+                <Skeleton key={idx} className="h-3 w-3/4 mx-auto" />
+              ))}
+            </div>
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+
+  const renderPlans = () => {
+    if (plans.length === 0) {
+      return (
+        <Card className="p-8 bg-gradient-to-br from-background to-muted border-0 shadow-lg text-center">
+          <h3 className="text-xl font-semibold mb-2">No subscription plans</h3>
+          <p className="text-muted-foreground">
+            Create a plan in Supabase to have it appear here and in the Telegram bot menu.
+          </p>
+        </Card>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {plans.map((plan) => {
+          const features = plan.features && plan.features.length > 0
+            ? plan.features
+            : DEFAULT_FEATURES;
+          const monthly = monthlyPrice(plan);
+          return (
+            <Card
+              key={plan.id}
+              className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg relative"
+            >
+              {plan.is_lifetime ? (
+                <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
+                  <Badge className="bg-purple-600 text-white">Lifetime</Badge>
+                </div>
+              ) : plan.id === bestValuePlanId ? (
+                <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
+                  <Badge className="bg-blue-600 text-white">Best Value</Badge>
+                </div>
+              ) : null}
+
+              <div className="text-center space-y-4">
+                <div>
+                  <h3 className="text-xl font-semibold">{plan.name}</h3>
+                  <p className="text-3xl font-bold text-blue-600">
+                    {toCurrency(plan.price, plan.currency)}
+                  </p>
+                  <p className="text-muted-foreground">{formatDuration(plan)}</p>
+                  {monthly !== null && (
+                    <p className="text-xs text-muted-foreground">
+                      ≈ {toCurrency(monthly, plan.currency)} per month
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2 text-sm text-muted-foreground text-left">
+                  {features.map((feature) => (
+                    <p key={`${plan.id}-${feature}`}>✓ {feature}</p>
+                  ))}
+                </div>
+                <Button variant="default" className="w-full">
+                  Edit Plan
+                </Button>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    );
+  };
+
   return (
     <div className="space-y-6">
       <ViewHeader
@@ -23,33 +215,16 @@ export function PackagesView({ onBack }: PackagesViewProps) {
         onBack={onBack}
       />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {PLANS.map((plan) => (
-          <Card key={plan.name} className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg relative">
-            {plan.popular && (
-              <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
-                <Badge className="bg-blue-600 text-white">Most Popular</Badge>
-              </div>
-            )}
-            <div className="text-center space-y-4">
-              <div>
-                <h3 className="text-xl font-semibold">{plan.name}</h3>
-                <p className="text-3xl font-bold text-blue-600">{plan.price}</p>
-                <p className="text-muted-foreground">{plan.duration}</p>
-              </div>
-              <div className="space-y-2 text-sm text-muted-foreground">
-                <p>✓ Premium signals</p>
-                <p>✓ VIP chat access</p>
-                <p>✓ Priority support</p>
-                <p>✓ Market analysis</p>
-              </div>
-              <Button variant="default" className="w-full">
-                Edit Plan
-              </Button>
-            </div>
-          </Card>
-        ))}
-      </div>
+      {error && (
+        <Alert variant="destructive" className="flex items-start gap-2">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            {error}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {loading ? renderSkeletons() : renderPlans()}
     </div>
   );
 }

--- a/apps/web/components/telegram/dashboard/PromosView.tsx
+++ b/apps/web/components/telegram/dashboard/PromosView.tsx
@@ -1,45 +1,355 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, CalendarClock, Copy, Gift, Timer } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Promotion } from "./types";
 import { ViewHeader } from "./ViewHeader";
-import { Copy, Gift } from "lucide-react";
 
 interface PromosViewProps {
   onBack: () => void;
   onCopyPromo: (code: string) => void;
 }
 
-const PROMOS = [
-  {
-    code: "VIPBOTLAUNCH50",
-    description: "VIP Bot Launch - 50% OFF Lifetime",
-    discount: "50%",
-    type: "Percentage",
-    uses: "0/100",
-    status: "Active",
-    expires: "30 days",
-  },
-  {
-    code: "WELCOME20",
-    description: "Welcome discount for new users",
-    discount: "20%",
-    type: "Percentage",
-    uses: "45/500",
-    status: "Disabled",
-    expires: "60 days",
-  },
-  {
-    code: "SUMMER25",
-    description: "Summer special offer",
-    discount: "$25",
-    type: "Fixed",
-    uses: "123/200",
-    status: "Disabled",
-    expires: "Expired",
-  },
-];
+const toCurrency = (value: number) =>
+  new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const parseDate = (value?: string | null) =>
+  value ? new Date(value) : null;
+
+const normalizePromo = (promo: Promotion): Promotion => ({
+  ...promo,
+  discount_type: promo.discount_type?.toLowerCase() ?? null,
+  discount_value:
+    typeof promo.discount_value === "number"
+      ? promo.discount_value
+      : Number(promo.discount_value ?? 0),
+  max_uses:
+    promo.max_uses !== null && promo.max_uses !== undefined
+      ? Number(promo.max_uses)
+      : null,
+  usage_count:
+    promo.usage_count !== null && promo.usage_count !== undefined
+      ? Number(promo.usage_count)
+      : null,
+});
+
+const formatDiscount = (promo: Promotion) => {
+  if (promo.discount_type === "percentage") {
+    return `${promo.discount_value ?? 0}%`;
+  }
+  if (promo.discount_type === "fixed") {
+    return toCurrency(promo.discount_value ?? 0);
+  }
+  return promo.discount_value ? `${promo.discount_value}` : "—";
+};
+
+const daysUntil = (promo: Promotion) => {
+  const expiresAt = parseDate(promo.valid_until);
+  if (!expiresAt) return null;
+  const diff = expiresAt.getTime() - Date.now();
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
+};
 
 export function PromosView({ onBack, onCopyPromo }: PromosViewProps) {
+  const [promos, setPromos] = useState<Promotion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadPromos = async () => {
+      try {
+        setLoading(true);
+        const { data, error: fnError } = await supabase.functions.invoke(
+          "active-promos",
+          { method: "GET" },
+        );
+
+        if (fnError) {
+          throw fnError;
+        }
+
+        const fetchedPromos = Array.isArray(data?.promotions)
+          ? (data?.promotions as Promotion[])
+          : [];
+
+        if (!isMounted) return;
+        setPromos(fetchedPromos.map(normalizePromo));
+        setError(null);
+      } catch (err) {
+        if (!isMounted) return;
+        console.error("Error loading promotions:", err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load promotions",
+        );
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    loadPromos();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const highlightPromo = useMemo(() => {
+    if (promos.length === 0) return null;
+    return [...promos].sort((a, b) => {
+      const aDate = parseDate(a.valid_until)?.getTime() ?? Infinity;
+      const bDate = parseDate(b.valid_until)?.getTime() ?? Infinity;
+      return aDate - bDate;
+    })[0];
+  }, [promos]);
+
+  const stats = useMemo(() => {
+    if (promos.length === 0) {
+      return {
+        active: 0,
+        expiringSoon: 0,
+        highestDiscount: "—",
+      };
+    }
+
+    const expiringSoon = promos.filter((promo) => {
+      const days = daysUntil(promo);
+      return days !== null && days <= 7 && days >= 0;
+    }).length;
+
+    const highest = promos.reduce<Promotion | null>((best, current) => {
+      if (!best) return current;
+      if ((current.discount_value ?? 0) > (best.discount_value ?? 0)) {
+        return current;
+      }
+      return best;
+    }, null);
+
+    return {
+      active: promos.length,
+      expiringSoon,
+      highestDiscount: highest ? formatDiscount(highest) : "—",
+    };
+  }, [promos]);
+
+  const handleCopy = async (code: string) => {
+    try {
+      if (typeof navigator !== "undefined" && navigator.clipboard) {
+        await navigator.clipboard.writeText(code);
+      }
+    } catch (copyError) {
+      console.error("Failed to copy promo code:", copyError);
+    } finally {
+      onCopyPromo(code);
+    }
+  };
+
+  const renderSkeleton = () => (
+    <>
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg border-l-4 border-l-green-500">
+        <div className="flex items-center gap-4">
+          <Skeleton className="h-12 w-12 rounded-lg" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-6 w-1/2" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/3" />
+          </div>
+        </div>
+      </Card>
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`promo-skeleton-${index}`} className="flex items-center gap-4">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-1/2" />
+                <Skeleton className="h-3 w-3/4" />
+              </div>
+              <Skeleton className="h-8 w-24" />
+            </div>
+          ))}
+        </div>
+      </Card>
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={`promo-stat-${index}`} className="h-24 w-full rounded-lg" />
+          ))}
+        </div>
+      </Card>
+    </>
+  );
+
+  const renderPromos = () => {
+    if (promos.length === 0) {
+      return (
+        <Card className="p-8 bg-gradient-to-br from-background to-muted border-0 shadow-lg text-center">
+          <h3 className="text-xl font-semibold mb-2">No active promotions</h3>
+          <p className="text-muted-foreground">
+            Create a promo code in Supabase to make it available here and through the Telegram bot.
+          </p>
+        </Card>
+      );
+    }
+
+    return (
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+        <div className="flex items-center justify-between mb-6">
+          <h3 className="text-lg font-semibold">All Promo Codes</h3>
+        </div>
+        <div className="space-y-4">
+          {promos.map((promo) => {
+            const days = daysUntil(promo);
+            const expiresLabel = promo.valid_until
+              ? new Intl.DateTimeFormat(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                }).format(parseDate(promo.valid_until)!)
+              : "No expiry";
+            const statusLabel =
+              days === null
+                ? "Active"
+                : days < 0
+                ? "Expired"
+                : days <= 7
+                ? "Expiring Soon"
+                : "Active";
+            return (
+              <div
+                key={promo.code}
+                className="flex items-center justify-between p-4 rounded-lg bg-muted/50"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="p-2 bg-orange-500/10 rounded-lg">
+                    <Gift className="w-5 h-5 text-orange-500" />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <p className="font-mono font-semibold">{promo.code}</p>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6"
+                        aria-label={`Copy promo code ${promo.code}`}
+                        title="Copy code"
+                        onClick={() => handleCopy(promo.code)}
+                      >
+                        <Copy className="h-4 w-4" />
+                      </Button>
+                      <Badge
+                        variant="outline"
+                        className={
+                          statusLabel === "Active"
+                            ? "border-green-500 text-green-600"
+                            : statusLabel === "Expiring Soon"
+                            ? "border-orange-500 text-orange-600"
+                            : "border-destructive text-destructive"
+                        }
+                      >
+                        {statusLabel}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {promo.description || "No description provided."}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-4 mt-1 text-xs text-muted-foreground">
+                      <span>Discount: {formatDiscount(promo)}</span>
+                      <span>Expires: {expiresLabel}</span>
+                      {promo.max_uses !== null && promo.usage_count !== null && (
+                        <span>
+                          Usage: {promo.usage_count}/{promo.max_uses}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="sm">
+                    Manage
+                  </Button>
+                  <Button variant="outline" size="sm">
+                    Edit
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-dc-brand-dark hover:text-dc-brand-dark"
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+    );
+  };
+
+  const renderHighlight = () => {
+    if (!highlightPromo) return null;
+    const days = daysUntil(highlightPromo);
+    const expiresLabel = highlightPromo.valid_until
+      ? new Intl.DateTimeFormat(undefined, {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        }).format(parseDate(highlightPromo.valid_until)!)
+      : "No expiry";
+    return (
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg border-l-4 border-l-green-500">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-4">
+            <div className="p-3 bg-green-500/10 rounded-lg">
+              <Gift className="w-6 h-6 text-green-500" />
+            </div>
+            <div>
+              <h3 className="text-xl font-semibold text-green-600">{highlightPromo.code}</h3>
+              <p className="text-muted-foreground">
+                {highlightPromo.description || "Active promotion"}
+              </p>
+              <div className="flex flex-wrap items-center gap-4 mt-2 text-sm text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Badge className="bg-green-500 text-white">ACTIVE</Badge>
+                </span>
+                <span className="flex items-center gap-1">
+                  <Timer className="w-4 h-4" />
+                  {days !== null && days >= 0
+                    ? `Expires in ${days} day${days === 1 ? "" : "s"}`
+                    : "Expires soon"}
+                </span>
+                <span className="flex items-center gap-1">
+                  <CalendarClock className="w-4 h-4" />
+                  {expiresLabel}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm">
+              Edit
+            </Button>
+            <Button variant="destructive" size="sm">
+              Disable
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  };
+
   return (
     <div className="space-y-6">
       <ViewHeader
@@ -54,122 +364,38 @@ export function PromosView({ onBack, onCopyPromo }: PromosViewProps) {
         }
       />
 
-      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg border-l-4 border-l-green-500">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-green-500/10 rounded-lg">
-              <Gift className="w-6 h-6 text-green-500" />
-            </div>
-            <div>
-              <h3 className="text-xl font-semibold text-green-600">🚀 VIP Bot Launch Special!</h3>
-              <p className="text-muted-foreground">VIPBOTLAUNCH50 - 50% OFF Lifetime Access</p>
-              <div className="flex items-center gap-4 mt-2">
-                <Badge className="bg-green-500 text-white">ACTIVE</Badge>
-                <span className="text-sm text-muted-foreground">Valid for 30 days • 0/100 uses</span>
-              </div>
-            </div>
-          </div>
-          <div className="text-right">
-            <Button variant="outline" size="sm" className="mr-2">
-              Edit
-            </Button>
-            <Button variant="destructive" size="sm">
-              Disable
-            </Button>
-          </div>
-        </div>
-      </Card>
+      {error && (
+        <Alert variant="destructive" className="flex items-start gap-2">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
 
-      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-        <div className="flex items-center justify-between mb-6">
-          <h3 className="text-lg font-semibold">All Promo Codes</h3>
-        </div>
-        <div className="space-y-4">
-          {PROMOS.map((promo) => (
-            <div
-              key={promo.code}
-              className="flex items-center justify-between p-4 rounded-lg bg-muted/50"
-            >
-              <div className="flex items-center gap-4">
-                <div className="p-2 bg-orange-500/10 rounded-lg">
-                  <Gift className="w-5 h-5 text-orange-500" />
-                </div>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <p className="font-mono font-semibold">{promo.code}</p>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6"
-                      aria-label={`Copy promo code ${promo.code}`}
-                      title="Copy code"
-                      onClick={async () => {
-                        await navigator.clipboard.writeText(promo.code);
-                        onCopyPromo(promo.code);
-                      }}
-                    >
-                      <Copy className="h-4 w-4" />
-                    </Button>
-                    <Badge
-                      variant="outline"
-                      className={
-                        promo.status === "Active"
-                          ? "border-green-500 text-green-600"
-                          : promo.status === "Disabled"
-                          ? "border-orange-500 text-orange-600"
-                          : "border-dc-brand text-dc-brand-dark"
-                      }
-                    >
-                      {promo.status}
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-muted-foreground">{promo.description}</p>
-                  <div className="flex items-center gap-4 mt-1 text-xs text-muted-foreground">
-                    <span>
-                      {promo.discount} {promo.type}
-                    </span>
-                    <span>Uses: {promo.uses}</span>
-                    <span>Expires: {promo.expires}</span>
-                  </div>
-                </div>
+      {loading ? (
+        renderSkeleton()
+      ) : (
+        <>
+          {renderHighlight()}
+          {renderPromos()}
+          <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+            <h3 className="text-lg font-semibold mb-4">Promo Performance</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="text-center p-4 bg-background/50 rounded-lg">
+                <p className="text-2xl font-bold text-green-500">{stats.active}</p>
+                <p className="text-sm text-muted-foreground">Active codes</p>
               </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm">
-                  {promo.status === "Active" ? "Disable" : "Enable"}
-                </Button>
-                <Button variant="outline" size="sm">
-                  Edit
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="text-dc-brand-dark hover:text-dc-brand-dark"
-                >
-                  Delete
-                </Button>
+              <div className="text-center p-4 bg-background/50 rounded-lg">
+                <p className="text-2xl font-bold text-blue-500">{stats.expiringSoon}</p>
+                <p className="text-sm text-muted-foreground">Expiring within 7 days</p>
+              </div>
+              <div className="text-center p-4 bg-background/50 rounded-lg">
+                <p className="text-2xl font-bold text-orange-500">{stats.highestDiscount}</p>
+                <p className="text-sm text-muted-foreground">Top discount available</p>
               </div>
             </div>
-          ))}
-        </div>
-      </Card>
-
-      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-        <h3 className="text-lg font-semibold mb-4">Promo Performance</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="text-center p-4 bg-background/50 rounded-lg">
-            <p className="text-2xl font-bold text-green-500">$2,450</p>
-            <p className="text-sm text-muted-foreground">Revenue from promos</p>
-          </div>
-          <div className="text-center p-4 bg-background/50 rounded-lg">
-            <p className="text-2xl font-bold text-blue-500">168</p>
-            <p className="text-sm text-muted-foreground">Total redemptions</p>
-          </div>
-          <div className="text-center p-4 bg-background/50 rounded-lg">
-            <p className="text-2xl font-bold text-red-500">23%</p>
-            <p className="text-sm text-muted-foreground">Conversion rate</p>
-          </div>
-        </div>
-      </Card>
+          </Card>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/components/telegram/dashboard/SupportView.tsx
+++ b/apps/web/components/telegram/dashboard/SupportView.tsx
@@ -1,99 +1,205 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertCircle, HeadphonesIcon, MessageSquare, PhoneCall } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ContactLink } from "./types";
 import { ViewHeader } from "./ViewHeader";
-import { MessageSquare } from "lucide-react";
 
 interface SupportViewProps {
   onBack: () => void;
 }
 
-const TICKETS = [
-  { user: "John Doe", issue: "Payment not processed", status: "Open", time: "2 min ago" },
-  { user: "Jane Smith", issue: "VIP access expired", status: "Pending", time: "15 min ago" },
-  { user: "Mike Johnson", issue: "Cannot access premium signals", status: "Resolved", time: "1 hour ago" },
-];
+const formatLinkHref = (url: string) => {
+  if (!url) return "#";
+  if (url.startsWith("http")) return url;
+  if (url.startsWith("@")) return `https://t.me/${url.slice(1)}`;
+  if (url.startsWith("mailto:")) return url;
+  if (url.includes("@")) return `mailto:${url}`;
+  return url;
+};
 
 export function SupportView({ onBack }: SupportViewProps) {
-  return (
-    <div className="space-y-6">
-      <ViewHeader
-        title="Customer Support"
-        description="Manage user inquiries and support tickets"
-        onBack={onBack}
-      />
+  const [links, setLinks] = useState<ContactLink[]>([]);
+  const [supportMessage, setSupportMessage] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-4">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-dc-brand/10 rounded-lg">
-              <MessageSquare className="w-6 h-6 text-dc-brand" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold">12</p>
-              <p className="text-sm text-muted-foreground">Open Tickets</p>
-            </div>
-          </div>
-        </Card>
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-4">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-yellow-500/10 rounded-lg">
-              <MessageSquare className="w-6 h-6 text-yellow-500" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold">8</p>
-              <p className="text-sm text-muted-foreground">Pending</p>
-            </div>
-          </div>
-        </Card>
-        <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-          <div className="text-center space-y-4">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-green-500/10 rounded-lg">
-              <MessageSquare className="w-6 h-6 text-green-500" />
-            </div>
-            <div>
-              <p className="text-2xl font-bold">156</p>
-              <p className="text-sm text-muted-foreground">Resolved Today</p>
-            </div>
-          </div>
-        </Card>
-      </div>
+  useEffect(() => {
+    let isMounted = true;
 
+    const loadSupportData = async () => {
+      try {
+        setLoading(true);
+        const [linksResponse, contentResponse] = await Promise.all([
+          supabase.functions.invoke("contact-links", { method: "GET" }),
+          supabase.functions.invoke("content-batch", {
+            body: { keys: ["support_message"] },
+          }),
+        ]);
+
+        if (linksResponse.error) {
+          throw linksResponse.error;
+        }
+        if (contentResponse.error) {
+          throw contentResponse.error;
+        }
+
+        if (!isMounted) return;
+
+        const fetchedLinks = Array.isArray(linksResponse.data?.data)
+          ? (linksResponse.data?.data as ContactLink[])
+          : [];
+
+        const supportContent = Array.isArray(contentResponse.data?.contents)
+          ? (contentResponse.data?.contents as {
+              content_key?: string;
+              content_value?: string;
+            }[]).find((item) => item.content_key === "support_message")
+          : undefined;
+
+        setLinks(fetchedLinks);
+        setSupportMessage(
+          supportContent?.content_value ??
+            "Our support team is here to help. Contact us anytime!",
+        );
+        setError(null);
+      } catch (err) {
+        if (!isMounted) return;
+        console.error("Error loading support data:", err);
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load support information",
+        );
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    loadSupportData();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const renderSkeleton = () => (
+    <>
       <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
-        <h3 className="text-lg font-semibold mb-4">Recent Support Requests</h3>
+        <Skeleton className="h-5 w-1/3 mb-4" />
+        <Skeleton className="h-20 w-full" />
+      </Card>
+      <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+        <Skeleton className="h-6 w-1/4 mb-4" />
         <div className="space-y-4">
-          {TICKETS.map((ticket) => (
-            <div
-              key={`${ticket.user}-${ticket.time}`}
-              className="flex items-center justify-between p-4 rounded-lg bg-muted/50"
-            >
-              <div className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center text-white text-sm font-medium">
-                  {ticket.user.split(" ").map((n) => n[0]).join("")}
-                </div>
-                <div>
-                  <p className="font-medium">{ticket.user}</p>
-                  <p className="text-sm text-muted-foreground">{ticket.issue}</p>
-                </div>
-              </div>
-              <div className="text-right">
-                <Badge
-                  variant="outline"
-                  className={
-                    ticket.status === "Open"
-                      ? "border-dc-brand text-dc-brand-dark"
-                      : ticket.status === "Pending"
-                      ? "border-yellow-500 text-yellow-600"
-                      : "border-green-500 text-green-600"
-                  }
-                >
-                  {ticket.status}
-                </Badge>
-                <p className="text-sm text-muted-foreground mt-1">{ticket.time}</p>
-              </div>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`support-skeleton-${index}`} className="flex items-center gap-4">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <Skeleton className="h-4 w-1/2" />
             </div>
           ))}
         </div>
       </Card>
+    </>
+  );
+
+  return (
+    <div className="space-y-6">
+      <ViewHeader
+        title="Customer Support"
+        description="Manage user inquiries and support channels"
+        onBack={onBack}
+      />
+
+      {error && (
+        <Alert variant="destructive" className="flex items-start gap-2">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {loading ? (
+        renderSkeleton()
+      ) : (
+        <>
+          <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="space-y-3">
+                <div className="inline-flex items-center gap-2 rounded-lg bg-dc-brand/10 px-3 py-1 text-sm font-medium text-dc-brand">
+                  <HeadphonesIcon className="h-4 w-4" />
+                  24/7 support desk
+                </div>
+                <div className="prose prose-sm max-w-none text-muted-foreground">
+                  {supportMessage
+                    .split("\n")
+                    .filter((line) => line.trim().length > 0)
+                    .map((line, index) => (
+                      <p key={`support-line-${index}`}>{line}</p>
+                    ))}
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Badge variant="outline" className="flex items-center gap-2">
+                  <MessageSquare className="h-4 w-4" />
+                  Tickets sync with Telegram bot
+                </Badge>
+                <Badge variant="outline" className="flex items-center gap-2">
+                  <PhoneCall className="h-4 w-4" />
+                  Escalations monitored hourly
+                </Badge>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="p-6 bg-gradient-to-br from-background to-muted border-0 shadow-lg">
+            <h3 className="text-lg font-semibold mb-4">
+              Contact channels ({links.length})
+            </h3>
+            {links.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No contact links configured. Add channels in Supabase to make them available here and in the Telegram bot.
+              </p>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {links.map((link) => (
+                  <div
+                    key={`${link.display_name}-${link.url}`}
+                    className="rounded-lg border border-border/40 bg-background/40 p-4"
+                  >
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-2">
+                        <span className="text-2xl">{link.icon_emoji ?? "💬"}</span>
+                        <div>
+                          <p className="font-semibold">{link.display_name}</p>
+                          {link.platform && (
+                            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                              {link.platform}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <Badge variant="outline">Active</Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground break-all mb-3">
+                      {link.url}
+                    </p>
+                    <Button asChild variant="outline" size="sm">
+                      <a href={formatLinkHref(link.url)} target="_blank" rel="noreferrer">
+                        Open channel
+                      </a>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/components/telegram/dashboard/types.ts
+++ b/apps/web/components/telegram/dashboard/types.ts
@@ -16,3 +16,56 @@ export interface DashboardStats {
 }
 
 export type NavigateToView = (view: DashboardViewKey) => void;
+
+export interface SubscriptionPlan {
+  id: string;
+  name: string;
+  price: number;
+  currency: string;
+  duration_months: number | null;
+  is_lifetime: boolean | null;
+  features: string[] | null;
+  created_at?: string;
+}
+
+export interface Promotion {
+  code: string;
+  description?: string | null;
+  discount_type?: string | null;
+  discount_value?: number | null;
+  valid_until?: string | null;
+  max_uses?: number | null;
+  usage_count?: number | null;
+}
+
+export interface ContactLink {
+  id?: string;
+  display_name: string;
+  url: string;
+  icon_emoji?: string | null;
+  platform?: string | null;
+}
+
+export interface PackagePerformanceEntry {
+  id: string;
+  name: string;
+  sales: number;
+  revenue: number;
+  currency: string;
+}
+
+export interface AnalyticsData {
+  timeframe: string;
+  total_revenue: number;
+  currency: string;
+  comparison?: {
+    revenue_change?: number;
+    sales_change?: number;
+  };
+  package_performance: PackagePerformanceEntry[];
+  generated_at: string;
+  total_users?: number;
+  vip_users?: number;
+  pending_payments?: number;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- load Telegram dashboard cards from Supabase instead of hardcoded placeholders
- hydrate promo/support views with live promotions and contact links from the database
- extend the analytics edge function to expose user, VIP, and payment totals for the dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ced90a96bc8322aea95f2e2160dfd2