### PR TITLE
Enhance Once UI motion system and red theme

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -48,20 +48,20 @@
   --card-foreground: 224 71.4% 4.1%;
   --popover: 0 0% 100%;
   --popover-foreground: 224 71.4% 4.1%;
-  --primary: 14 100% 57%;
+  --primary: 0 84% 58%;
   --primary-foreground: 0 0% 100%;
   --secondary: 0 68% 95%;
   --secondary-foreground: 0 45% 20%;
   --muted: 0 5% 96%;
   --muted-foreground: 0 5% 45%;
   --elevated: 0 72% 10%;
-  --accent: 340 75% 55%;
+  --accent: 350 88% 60%;
   --accent-foreground: 0 0% 100%;
-  --destructive: 0 72% 51%;
+  --destructive: 0 72% 50%;
   --destructive-foreground: 0 0% 98%;
   --border: 0 10% 89%;
   --input: 0 10% 89%;
-  --ring: 14 100% 57%;
+  --ring: 0 84% 58%;
   --radius: 0.5rem;
   --chart-1: 14 100% 57%;
   --chart-2: 200 100% 50%;
@@ -78,11 +78,11 @@
   --motion-ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Dynamic Capital Red Brand Colors */
-  --dc-brand: 14 100% 57%;
-  --dc-brand-light: 14 100% 67%;
-  --dc-brand-dark: 14 100% 47%;
-  --dc-secondary: 200 100% 50%;
-  --dc-accent: 340 75% 55%;
+  --dc-brand: 0 84% 58%;
+  --dc-brand-light: 0 92% 68%;
+  --dc-brand-dark: 0 76% 48%;
+  --dc-secondary: 200 96% 52%;
+  --dc-accent: 350 88% 60%;
 
   /* Motion-Enhanced Red Gradients */
   --gradient-motion-primary: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--dc-brand-light)) 50%, hsl(var(--dc-accent)) 100%);
@@ -118,20 +118,20 @@
   --card-foreground: 0 5% 98%;
   --popover: 0 8% 8%;
   --popover-foreground: 0 5% 98%;
-  --primary: 14 100% 57%;
+  --primary: 0 84% 58%;
   --primary-foreground: 0 0% 100%;
   --secondary: 0 10% 15%;
   --secondary-foreground: 0 5% 98%;
   --muted: 0 10% 15%;
   --muted-foreground: 0 5% 65%;
   --elevated: 0 5% 95%;
-  --accent: 340 75% 55%;
+  --accent: 350 88% 60%;
   --accent-foreground: 0 0% 100%;
-  --destructive: 0 65% 45%;
+  --destructive: 0 68% 46%;
   --destructive-foreground: 0 5% 98%;
   --border: 0 15% 18%;
   --input: 0 15% 18%;
-  --ring: 14 100% 57%;
+  --ring: 0 84% 58%;
 
   /* Dark mode motion effects */
   --glass-motion-bg: hsl(var(--dc-brand) / 0.15);

--- a/apps/web/components/once-ui/index.ts
+++ b/apps/web/components/once-ui/index.ts
@@ -1,2 +1,15 @@
 export { OnceButton, type OnceButtonProps } from "./once-button";
 export { OnceContainer, type OnceContainerProps } from "./once-container";
+export {
+  OnceMotionColumn,
+  OnceMotionFlex,
+  OnceMotionRow,
+  OnceMotionStack,
+  OnceMotionStackItem,
+  type OnceMotionColumnProps,
+  type OnceMotionFlexProps,
+  type OnceMotionRowProps,
+  type OnceMotionStackProps,
+  type OnceMotionStackItemProps,
+  type OnceMotionStackDensity,
+} from "./once-motion";

--- a/apps/web/components/once-ui/once-motion.tsx
+++ b/apps/web/components/once-ui/once-motion.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+import { Column, Flex, Row } from "@once-ui-system/core";
+
+import {
+  onceMotionVariants,
+  type OnceMotionVariantKey,
+} from "@/lib/motion-variants";
+
+const MotionFlexBase = motion(Flex, { forwardMotionProps: true });
+const MotionColumnBase = motion(Column, { forwardMotionProps: true });
+const MotionRowBase = motion(Row, { forwardMotionProps: true });
+
+type MotionBaseProps = React.ComponentPropsWithoutRef<typeof MotionFlexBase>;
+
+type MotionPresetShape = Pick<
+  MotionBaseProps,
+  "animate" | "variants" | "viewport" | "initial" | "whileInView"
+>;
+
+interface MotionPresetInput extends MotionPresetShape {
+  animateIn: boolean;
+  variant?: OnceMotionVariantKey | null;
+  once: boolean;
+  viewportAmount: number;
+}
+
+function resolveMotionPreset({
+  animateIn,
+  variant,
+  once,
+  viewportAmount,
+  animate,
+  variants,
+  viewport,
+  initial,
+  whileInView,
+}: MotionPresetInput) {
+  const shouldUsePreset = animateIn && variant !== null;
+  const resolvedVariants =
+    variants ?? (shouldUsePreset && variant ? onceMotionVariants[variant] : undefined);
+
+  const shouldAutoInView = shouldUsePreset && animate === undefined;
+
+  return {
+    variants: resolvedVariants,
+    initial: shouldAutoInView && resolvedVariants ? initial ?? "hidden" : initial,
+    whileInView:
+      shouldAutoInView && resolvedVariants ? whileInView ?? "visible" : whileInView,
+    viewport:
+      shouldAutoInView && resolvedVariants
+        ? viewport ?? { once, amount: viewportAmount }
+        : viewport,
+  } as const;
+}
+
+export interface OnceMotionFlexProps extends MotionBaseProps {
+  variant?: OnceMotionVariantKey | null;
+  animateIn?: boolean;
+  once?: boolean;
+  viewportAmount?: number;
+}
+
+export const OnceMotionFlex = React.forwardRef<HTMLDivElement, OnceMotionFlexProps>(
+  (
+    {
+      variant = "slideUp",
+      animateIn = true,
+      once = true,
+      viewport,
+      viewportAmount = 0.2,
+      variants: variantsProp,
+      initial: initialProp,
+      whileInView: whileInViewProp,
+      animate: animateProp,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { variants, initial, whileInView, viewport: resolvedViewport } = resolveMotionPreset({
+      animateIn,
+      variant,
+      once,
+      viewportAmount,
+      animate: animateProp,
+      variants: variantsProp,
+      viewport,
+      initial: initialProp,
+      whileInView: whileInViewProp,
+    });
+
+    return (
+      <MotionFlexBase
+        ref={ref}
+        variants={variants}
+        initial={initial}
+        animate={animateProp}
+        whileInView={whileInView}
+        viewport={resolvedViewport}
+        {...rest}
+      />
+    );
+  },
+);
+OnceMotionFlex.displayName = "OnceMotionFlex";
+
+export interface OnceMotionColumnProps
+  extends React.ComponentPropsWithoutRef<typeof MotionColumnBase> {
+  variant?: OnceMotionVariantKey | null;
+  animateIn?: boolean;
+  once?: boolean;
+  viewportAmount?: number;
+}
+
+export const OnceMotionColumn = React.forwardRef<HTMLDivElement, OnceMotionColumnProps>(
+  (
+    {
+      variant = "slideUp",
+      animateIn = true,
+      once = true,
+      viewport,
+      viewportAmount = 0.2,
+      variants: variantsProp,
+      initial: initialProp,
+      whileInView: whileInViewProp,
+      animate: animateProp,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { variants, initial, whileInView, viewport: resolvedViewport } = resolveMotionPreset({
+      animateIn,
+      variant,
+      once,
+      viewportAmount,
+      animate: animateProp,
+      variants: variantsProp,
+      viewport,
+      initial: initialProp,
+      whileInView: whileInViewProp,
+    });
+
+    return (
+      <MotionColumnBase
+        ref={ref}
+        variants={variants}
+        initial={initial}
+        animate={animateProp}
+        whileInView={whileInView}
+        viewport={resolvedViewport}
+        {...rest}
+      />
+    );
+  },
+);
+OnceMotionColumn.displayName = "OnceMotionColumn";
+
+export interface OnceMotionRowProps
+  extends React.ComponentPropsWithoutRef<typeof MotionRowBase> {
+  variant?: OnceMotionVariantKey | null;
+  animateIn?: boolean;
+  once?: boolean;
+  viewportAmount?: number;
+}
+
+export const OnceMotionRow = React.forwardRef<HTMLDivElement, OnceMotionRowProps>(
+  (
+    {
+      variant = "slideUp",
+      animateIn = true,
+      once = true,
+      viewport,
+      viewportAmount = 0.2,
+      variants: variantsProp,
+      initial: initialProp,
+      whileInView: whileInViewProp,
+      animate: animateProp,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { variants, initial, whileInView, viewport: resolvedViewport } = resolveMotionPreset({
+      animateIn,
+      variant,
+      once,
+      viewportAmount,
+      animate: animateProp,
+      variants: variantsProp,
+      viewport,
+      initial: initialProp,
+      whileInView: whileInViewProp,
+    });
+
+    return (
+      <MotionRowBase
+        ref={ref}
+        variants={variants}
+        initial={initial}
+        animate={animateProp}
+        whileInView={whileInView}
+        viewport={resolvedViewport}
+        {...rest}
+      />
+    );
+  },
+);
+OnceMotionRow.displayName = "OnceMotionRow";
+
+type OnceMotionStackDensity = "base" | "soft" | "slow";
+
+const densityToVariant: Record<OnceMotionStackDensity, OnceMotionVariantKey> = {
+  base: "stackItem",
+  soft: "stackItemSoft",
+  slow: "stackItemSlow",
+};
+
+export type OnceMotionStackProps = OnceMotionColumnProps;
+
+export const OnceMotionStack = React.forwardRef<HTMLDivElement, OnceMotionStackProps>(
+  ({ variant, ...rest }, ref) => (
+    <OnceMotionColumn ref={ref} variant={variant ?? "stack"} {...rest} />
+  ),
+);
+OnceMotionStack.displayName = "OnceMotionStack";
+
+export interface OnceMotionStackItemProps extends OnceMotionColumnProps {
+  density?: OnceMotionStackDensity;
+}
+
+export const OnceMotionStackItem = React.forwardRef<
+  HTMLDivElement,
+  OnceMotionStackItemProps
+>(({ density = "base", variant, ...rest }, ref) => {
+  const resolvedVariant = variant ?? densityToVariant[density];
+  return <OnceMotionColumn ref={ref} variant={resolvedVariant} {...rest} />;
+});
+OnceMotionStackItem.displayName = "OnceMotionStackItem";
+
+export type { OnceMotionStackDensity };

--- a/apps/web/components/shared/ChatAssistantWidget.tsx
+++ b/apps/web/components/shared/ChatAssistantWidget.tsx
@@ -22,7 +22,12 @@ import {
   X,
 } from "lucide-react";
 
-import { OnceButton, OnceContainer } from "@/components/once-ui";
+import {
+  OnceButton,
+  OnceContainer,
+  OnceMotionRow,
+  OnceMotionStackItem,
+} from "@/components/once-ui";
 import {
   Badge,
   Button,
@@ -35,6 +40,7 @@ import {
 import { useToast } from "@/hooks/useToast";
 import { supabase } from "@/integrations/supabase/client";
 import { logChatMessage } from "@/integrations/supabase/queries";
+import { ONCE_MOTION_SPRINGS } from "@/lib/motion-variants";
 import { cn } from "@/utils";
 
 export interface TelegramAuthData {
@@ -510,7 +516,12 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
                     </Row>
                   </Row>
 
-                  <Row
+                  <OnceMotionRow
+                    layout
+                    variant="slideUp"
+                    initial="hidden"
+                    animate="visible"
+                    transition={{ ...ONCE_MOTION_SPRINGS.soft, delay: 0.1 }}
                     gap="12"
                     vertical="center"
                     background="surface"
@@ -530,9 +541,22 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
                       </Text>
                     </Column>
                     <Badge {...statusMeta.badgeProps}>{statusMeta.badge}</Badge>
-                  </Row>
+                  </OnceMotionRow>
 
-                  <Row wrap gap="8">
+                  <OnceMotionRow
+                    layout
+                    variant="stackItemSoft"
+                    initial="hidden"
+                    animate="visible"
+                    transition={{
+                      ...ONCE_MOTION_SPRINGS.soft,
+                      stiffness: 280,
+                      damping: 24,
+                      delay: 0.15,
+                    }}
+                    wrap
+                    gap="8"
+                  >
                     {quickSuggestions.map((suggestion) => (
                       <Button
                         key={suggestion}
@@ -546,7 +570,7 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
                         {suggestion}
                       </Button>
                     ))}
-                  </Row>
+                  </OnceMotionRow>
 
                   <div
                     ref={messageContainerRef}
@@ -555,69 +579,85 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
                     aria-busy={isLoading}
                     className="flex max-h-72 flex-col gap-3 overflow-y-auto pr-1"
                   >
-                    {messages.length === 0 ? (
-                      <Column
-                        radius="l"
-                        padding="m"
-                        gap="8"
-                        className="border border-dashed border-border/60 bg-background/90 text-left"
-                      >
-                        <Text variant="body-default-m">
-                          Welcome! Ask how to join the VIP desk, what’s inside the admin dashboard, or how to automate risk.
-                        </Text>
-                        <Text variant="body-default-s" onBackground="neutral-weak">
-                          Responses stay synced with ChatGPT so you can ask follow-up questions in the same thread.
-                        </Text>
-                      </Column>
-                    ) : (
-                      messages.map((message, index) => (
-                        <Column
-                          key={`${message.role}-${index}`}
+                    <AnimatePresence initial={false}>
+                      {messages.length === 0 ? (
+                        <OnceMotionStackItem
+                          key="empty-state"
+                          density="soft"
+                          variant="messageBubble"
+                          initial="hidden"
+                          animate="visible"
+                          exit="exit"
+                          transition={{ ...ONCE_MOTION_SPRINGS.soft, damping: 24 }}
                           radius="l"
                           padding="m"
                           gap="8"
-                          className={cn(
-                            "relative overflow-hidden border text-left shadow-[0_20px_40px_-28px_rgba(15,23,42,0.55)]",
-                            message.role === "assistant"
-                              ? "border-primary/40 bg-gradient-to-br from-primary/15 via-background/85 to-background/95"
-                              : "border-border/60 bg-background/90",
-                          )}
+                          className="border border-dashed border-border/60 bg-background/90 text-left"
                         >
-                          {message.role === "assistant" ? (
-                            <div
-                              className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-dc-accent/10"
-                              aria-hidden="true"
-                            />
-                          ) : null}
-                          <Row gap="8" vertical="center" className="relative z-[1] text-muted-foreground">
-                            <div
-                              className={cn(
-                                "flex h-7 w-7 items-center justify-center rounded-full",
-                                message.role === "assistant"
-                                  ? "bg-primary/15 text-primary"
-                                  : "bg-muted/40 text-muted-foreground",
-                              )}
-                            >
-                              {message.role === "assistant" ? (
-                                <Bot className="h-4 w-4" />
-                              ) : (
-                                <User className="h-4 w-4" />
-                              )}
-                            </div>
-                            <Text variant="body-default-s" onBackground="neutral-weak">
-                              {message.role === "assistant" ? "Desk" : "You"}
-                            </Text>
-                          </Row>
-                          <Text
-                            variant="body-default-m"
-                            style={{ whiteSpace: "pre-wrap" }}
-                            className="relative z-[1] text-foreground"
-                          >
-                            {message.content}
+                          <Text variant="body-default-m">
+                            Welcome! Ask how to join the VIP desk, what’s inside the admin dashboard, or how to automate risk.
                           </Text>
-                        </Column>
-                      ))
-                    )}
+                          <Text variant="body-default-s" onBackground="neutral-weak">
+                            Responses stay synced with ChatGPT so you can ask follow-up questions in the same thread.
+                          </Text>
+                        </OnceMotionStackItem>
+                      ) : (
+                        messages.map((message, index) => (
+                          <OnceMotionStackItem
+                            key={`${message.role}-${index}`}
+                            layout
+                            density="soft"
+                            variant="messageBubble"
+                            initial="hidden"
+                            animate="visible"
+                            exit="exit"
+                            transition={{ ...ONCE_MOTION_SPRINGS.soft, damping: 24 }}
+                            radius="l"
+                            padding="m"
+                            gap="8"
+                            className={cn(
+                              "relative overflow-hidden border text-left shadow-[0_20px_40px_-28px_rgba(15,23,42,0.55)]",
+                              message.role === "assistant"
+                                ? "border-primary/40 bg-gradient-to-br from-primary/15 via-background/85 to-background/95"
+                                : "border-border/60 bg-background/90",
+                            )}
+                          >
+                            {message.role === "assistant" ? (
+                              <div
+                                className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-transparent to-dc-accent/10"
+                                aria-hidden="true"
+                              />
+                            ) : null}
+                            <Row gap="8" vertical="center" className="relative z-[1] text-muted-foreground">
+                              <div
+                                className={cn(
+                                  "flex h-7 w-7 items-center justify-center rounded-full",
+                                  message.role === "assistant"
+                                    ? "bg-primary/15 text-primary"
+                                    : "bg-muted/40 text-muted-foreground",
+                                )}
+                              >
+                                {message.role === "assistant" ? (
+                                  <Bot className="h-4 w-4" />
+                                ) : (
+                                  <User className="h-4 w-4" />
+                                )}
+                              </div>
+                              <Text variant="body-default-s" onBackground="neutral-weak">
+                                {message.role === "assistant" ? "Desk" : "You"}
+                              </Text>
+                            </Row>
+                            <Text
+                              variant="body-default-m"
+                              style={{ whiteSpace: "pre-wrap" }}
+                              className="relative z-[1] text-foreground"
+                            >
+                              {message.content}
+                            </Text>
+                          </OnceMotionStackItem>
+                        ))
+                      )}
+                    </AnimatePresence>
                   </div>
 
                   <form onSubmit={handleSubmit} className="space-y-3">

--- a/apps/web/components/ui/motion-config.tsx
+++ b/apps/web/components/ui/motion-config.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { MotionConfig, LazyMotion, domAnimation } from "framer-motion";
-import { useReducedMotion } from "framer-motion";
+import { MotionConfig, LazyMotion, domAnimation, useReducedMotion } from "framer-motion";
+
+import { ONCE_MOTION_SPRINGS } from "@/lib/motion-variants";
 
 interface MotionConfigProviderProps {
   children: React.ReactNode;
@@ -14,11 +15,7 @@ export const MotionConfigProvider: React.FC<MotionConfigProviderProps> = ({ chil
   return (
     <LazyMotion features={domAnimation}>
       <MotionConfig
-        transition={{
-          type: "spring",
-          stiffness: 320,
-          damping: 28,
-        }}
+        transition={ONCE_MOTION_SPRINGS.base}
         reducedMotion={shouldReduceMotion ? "always" : "user"}
       >
         {children}

--- a/apps/web/lib/motion-variants.ts
+++ b/apps/web/lib/motion-variants.ts
@@ -268,6 +268,31 @@ const stackItemSlow: Variants = {
   },
 };
 
+const messageBubble: Variants = {
+  hidden: { opacity: 0, y: 18, scale: 0.96, filter: "blur(10px)" },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    filter: "blur(0px)",
+    transition: {
+      ...ONCE_MOTION_SPRINGS.soft,
+      damping: 26,
+      mass: 0.95,
+    },
+  },
+  exit: {
+    opacity: 0,
+    y: -18,
+    scale: 0.96,
+    filter: "blur(6px)",
+    transition: {
+      duration: ONCE_MOTION_DURATIONS.quick,
+      ease: ONCE_MOTION_EASING.exit,
+    },
+  },
+};
+
 const button: Variants = {
   initial: { scale: 1 },
   hover: {
@@ -536,6 +561,7 @@ export const onceMotionVariants = {
   stackItem,
   stackItemSoft,
   stackItemSlow,
+  messageBubble,
   button,
   primaryButton,
   ghostButton,
@@ -567,6 +593,7 @@ export const pageVariants = page;
 export const buttonVariants = button;
 export const primaryButtonVariants = primaryButton;
 export const ghostButtonVariants = ghostButton;
+export const messageBubbleVariants = messageBubble;
 export const staggerContainerVariants = staggerContainer;
 export const staggerItemVariants = staggerItem;
 export const modalVariants = modal;
@@ -629,6 +656,7 @@ export default {
   cardVariants,
   pageVariants,
   buttonVariants,
+  messageBubbleVariants,
   staggerContainerVariants,
   staggerItemVariants,
   modalVariants,

--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -73,7 +73,7 @@ const fonts: FontsConfig = {
 const style: StyleConfig = {
   theme: "system",
   neutral: "gray",
-  brand: "cyan",
+  brand: "red",
   accent: "magenta",
   solid: "contrast",
   solidStyle: "flat",


### PR DESCRIPTION
## Summary
- add motion-enabled Once UI wrappers along with a message bubble variant to improve Framer Motion compatibility
- refresh the chat assistant widget to use the new primitives and richer animations while updating the design tokens to a red theme
- align the shared motion config with Once UI spring presets for consistent transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6519b6148322814a4b2cbfbadb6f