### PR TITLE
Refactor system UI config into grouped categories

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -12,11 +12,20 @@ import { Background, Column, Flex, RevealFx, opacity, SpacingToken } from "@once
 import Providers from "./providers";
 import { getStaticLandingDocument } from "@/lib/staticLanding";
 import { Footer, Header, RouteGuard, ScrollToHash } from "@/components/magic-portfolio";
-import { dataStyle, effects, fonts, style } from "@/resources";
+import { systemUI } from "@/resources";
 
 const SITE_URL = process.env.SITE_URL || "http://localhost:8080";
 const DEFAULT_THEME = "dark" as const;
 const THEME_SCRIPT_ID = "theme-init";
+
+const {
+  basics: basicsConfig,
+  dataViz: dataVizConfig,
+  effects: effectsConfig,
+} = systemUI;
+const { fonts, style } = basicsConfig;
+const { dataStyle } = dataVizConfig;
+const backgroundEffects = effectsConfig.background;
 
 const htmlAttributeDefaults: Record<string, string> = {
   "data-neutral": style.neutral,
@@ -184,42 +193,42 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             <RevealFx fill position="absolute">
               <Background
                 mask={{
-                  x: effects.mask.x,
-                  y: effects.mask.y,
-                  radius: effects.mask.radius,
-                  cursor: effects.mask.cursor,
+                  x: backgroundEffects.mask.x,
+                  y: backgroundEffects.mask.y,
+                  radius: backgroundEffects.mask.radius,
+                  cursor: backgroundEffects.mask.cursor,
                 }}
                 gradient={{
-                  display: effects.gradient.display,
-                  opacity: effects.gradient.opacity as opacity,
-                  x: effects.gradient.x,
-                  y: effects.gradient.y,
-                  width: effects.gradient.width,
-                  height: effects.gradient.height,
-                  tilt: effects.gradient.tilt,
-                  colorStart: effects.gradient.colorStart,
-                  colorEnd: effects.gradient.colorEnd,
+                  display: backgroundEffects.gradient.display,
+                  opacity: backgroundEffects.gradient.opacity as opacity,
+                  x: backgroundEffects.gradient.x,
+                  y: backgroundEffects.gradient.y,
+                  width: backgroundEffects.gradient.width,
+                  height: backgroundEffects.gradient.height,
+                  tilt: backgroundEffects.gradient.tilt,
+                  colorStart: backgroundEffects.gradient.colorStart,
+                  colorEnd: backgroundEffects.gradient.colorEnd,
                 }}
                 dots={{
-                  display: effects.dots.display,
-                  opacity: effects.dots.opacity as opacity,
-                  size: effects.dots.size as SpacingToken,
-                  color: effects.dots.color,
+                  display: backgroundEffects.dots.display,
+                  opacity: backgroundEffects.dots.opacity as opacity,
+                  size: backgroundEffects.dots.size as SpacingToken,
+                  color: backgroundEffects.dots.color,
                 }}
                 grid={{
-                  display: effects.grid.display,
-                  opacity: effects.grid.opacity as opacity,
-                  color: effects.grid.color,
-                  width: effects.grid.width,
-                  height: effects.grid.height,
+                  display: backgroundEffects.grid.display,
+                  opacity: backgroundEffects.grid.opacity as opacity,
+                  color: backgroundEffects.grid.color,
+                  width: backgroundEffects.grid.width,
+                  height: backgroundEffects.grid.height,
                 }}
                 lines={{
-                  display: effects.lines.display,
-                  opacity: effects.lines.opacity as opacity,
-                  size: effects.lines.size as SpacingToken,
-                  thickness: effects.lines.thickness,
-                  angle: effects.lines.angle,
-                  color: effects.lines.color,
+                  display: backgroundEffects.lines.display,
+                  opacity: backgroundEffects.lines.opacity as opacity,
+                  size: backgroundEffects.lines.size as SpacingToken,
+                  thickness: backgroundEffects.lines.thickness,
+                  angle: backgroundEffects.lines.angle,
+                  color: backgroundEffects.lines.color,
                 }}
               />
             </RevealFx>

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -24,8 +24,15 @@ import {
 import { AuthProvider } from '@/hooks/useAuth';
 import { SupabaseProvider } from '@/context/SupabaseProvider';
 import { MotionConfigProvider } from '@/components/ui/motion-config';
-import { dataStyle, style } from '@/resources';
+import { systemUI } from '@/resources';
 import { iconLibrary } from '@/resources/icons';
+
+const {
+  basics: basicsConfig,
+  dataViz: dataVizConfig,
+} = systemUI;
+const { style } = basicsConfig;
+const { dataStyle } = dataVizConfig;
 
 const SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
 const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -2,7 +2,7 @@ import { Background, Column, RevealFx } from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
-import { effects } from "@/resources";
+import { systemUI } from "@/resources";
 import { MagicLandingPage } from "@/components/magic-portfolio/MagicLandingPage";
 
 export interface LandingPageShellProps {
@@ -25,6 +25,8 @@ export function LandingPageShell({
   showAssistant = true,
   assistantClassName,
 }: LandingPageShellProps) {
+  const backgroundEffects = systemUI.effects.background;
+
   return (
     <Column
       fillWidth
@@ -39,42 +41,42 @@ export function LandingPageShell({
       <RevealFx fill position="absolute">
         <Background
           mask={{
-            x: effects.mask.x,
-            y: effects.mask.y,
-            radius: effects.mask.radius,
-            cursor: effects.mask.cursor,
+            x: backgroundEffects.mask.x,
+            y: backgroundEffects.mask.y,
+            radius: backgroundEffects.mask.radius,
+            cursor: backgroundEffects.mask.cursor,
           }}
           gradient={{
-            display: effects.gradient.display,
-            opacity: effects.gradient.opacity as opacity,
-            x: effects.gradient.x,
-            y: effects.gradient.y,
-            width: effects.gradient.width,
-            height: effects.gradient.height,
-            tilt: effects.gradient.tilt,
-            colorStart: effects.gradient.colorStart,
-            colorEnd: effects.gradient.colorEnd,
+            display: backgroundEffects.gradient.display,
+            opacity: backgroundEffects.gradient.opacity as opacity,
+            x: backgroundEffects.gradient.x,
+            y: backgroundEffects.gradient.y,
+            width: backgroundEffects.gradient.width,
+            height: backgroundEffects.gradient.height,
+            tilt: backgroundEffects.gradient.tilt,
+            colorStart: backgroundEffects.gradient.colorStart,
+            colorEnd: backgroundEffects.gradient.colorEnd,
           }}
           dots={{
-            display: effects.dots.display,
-            opacity: effects.dots.opacity as opacity,
-            size: effects.dots.size as SpacingToken,
-            color: effects.dots.color,
+            display: backgroundEffects.dots.display,
+            opacity: backgroundEffects.dots.opacity as opacity,
+            size: backgroundEffects.dots.size as SpacingToken,
+            color: backgroundEffects.dots.color,
           }}
           grid={{
-            display: effects.grid.display,
-            opacity: effects.grid.opacity as opacity,
-            color: effects.grid.color,
-            width: effects.grid.width,
-            height: effects.grid.height,
+            display: backgroundEffects.grid.display,
+            opacity: backgroundEffects.grid.opacity as opacity,
+            color: backgroundEffects.grid.color,
+            width: backgroundEffects.grid.width,
+            height: backgroundEffects.grid.height,
           }}
           lines={{
-            display: effects.lines.display,
-            opacity: effects.lines.opacity as opacity,
-            size: effects.lines.size as SpacingToken,
-            thickness: effects.lines.thickness,
-            angle: effects.lines.angle,
-            color: effects.lines.color,
+            display: backgroundEffects.lines.display,
+            opacity: backgroundEffects.lines.opacity as opacity,
+            size: backgroundEffects.lines.size as SpacingToken,
+            thickness: backgroundEffects.lines.thickness,
+            angle: backgroundEffects.lines.angle,
+            color: backgroundEffects.lines.color,
           }}
         />
       </RevealFx>

--- a/apps/web/components/magic-portfolio/Mailchimp.tsx
+++ b/apps/web/components/magic-portfolio/Mailchimp.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { mailchimp, newsletter } from "@/resources";
+import { newsletter, systemUI } from "@/resources";
 import { Button, Heading, Input, Text, Background, Column, Row } from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { useState } from "react";
+
+const {
+  formControls: { newsletter: newsletterFormConfig },
+  effects: { newsletter: newsletterEffects },
+} = systemUI;
 
 function debounce<T extends (...args: any[]) => void>(func: T, delay: number): T {
   let timeout: ReturnType<typeof setTimeout>;
@@ -66,42 +71,42 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
         top="0"
         position="absolute"
         mask={{
-          x: mailchimp.effects.mask.x,
-          y: mailchimp.effects.mask.y,
-          radius: mailchimp.effects.mask.radius,
-          cursor: mailchimp.effects.mask.cursor,
+          x: newsletterEffects.mask.x,
+          y: newsletterEffects.mask.y,
+          radius: newsletterEffects.mask.radius,
+          cursor: newsletterEffects.mask.cursor,
         }}
         gradient={{
-          display: mailchimp.effects.gradient.display,
-          opacity: mailchimp.effects.gradient.opacity as opacity,
-          x: mailchimp.effects.gradient.x,
-          y: mailchimp.effects.gradient.y,
-          width: mailchimp.effects.gradient.width,
-          height: mailchimp.effects.gradient.height,
-          tilt: mailchimp.effects.gradient.tilt,
-          colorStart: mailchimp.effects.gradient.colorStart,
-          colorEnd: mailchimp.effects.gradient.colorEnd,
+          display: newsletterEffects.gradient.display,
+          opacity: newsletterEffects.gradient.opacity as opacity,
+          x: newsletterEffects.gradient.x,
+          y: newsletterEffects.gradient.y,
+          width: newsletterEffects.gradient.width,
+          height: newsletterEffects.gradient.height,
+          tilt: newsletterEffects.gradient.tilt,
+          colorStart: newsletterEffects.gradient.colorStart,
+          colorEnd: newsletterEffects.gradient.colorEnd,
         }}
         dots={{
-          display: mailchimp.effects.dots.display,
-          opacity: mailchimp.effects.dots.opacity as opacity,
-          size: mailchimp.effects.dots.size as SpacingToken,
-          color: mailchimp.effects.dots.color,
+          display: newsletterEffects.dots.display,
+          opacity: newsletterEffects.dots.opacity as opacity,
+          size: newsletterEffects.dots.size as SpacingToken,
+          color: newsletterEffects.dots.color,
         }}
         grid={{
-          display: mailchimp.effects.grid.display,
-          opacity: mailchimp.effects.grid.opacity as opacity,
-          color: mailchimp.effects.grid.color,
-          width: mailchimp.effects.grid.width,
-          height: mailchimp.effects.grid.height,
+          display: newsletterEffects.grid.display,
+          opacity: newsletterEffects.grid.opacity as opacity,
+          color: newsletterEffects.grid.color,
+          width: newsletterEffects.grid.width,
+          height: newsletterEffects.grid.height,
         }}
         lines={{
-          display: mailchimp.effects.lines.display,
-          opacity: mailchimp.effects.lines.opacity as opacity,
-          size: mailchimp.effects.lines.size as SpacingToken,
-          thickness: mailchimp.effects.lines.thickness,
-          angle: mailchimp.effects.lines.angle,
-          color: mailchimp.effects.lines.color,
+          display: newsletterEffects.lines.display,
+          opacity: newsletterEffects.lines.opacity as opacity,
+          size: newsletterEffects.lines.size as SpacingToken,
+          thickness: newsletterEffects.lines.thickness,
+          angle: newsletterEffects.lines.angle,
+          color: newsletterEffects.lines.color,
         }}
       />
       <Column maxWidth="xs" horizontal="center">
@@ -118,7 +123,7 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
           display: "flex",
           justifyContent: "center",
         }}
-        action={mailchimp.action}
+        action={newsletterFormConfig.action}
         method="post"
         id="mc-embedded-subscribe-form"
         name="mc-embedded-subscribe-form"

--- a/apps/web/resources/index.ts
+++ b/apps/web/resources/index.ts
@@ -23,6 +23,7 @@ export {
   socialSharing,
   effects,
   dataStyle,
+  systemUI,
 } from "./once-ui.config";
 
 export {

--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -10,6 +10,7 @@ import {
   SchemaConfig,
   SocialSharingConfig,
   StyleConfig,
+  SystemUIConfig,
 } from "@/resources/types";
 import { home } from "./content";
 
@@ -211,6 +212,40 @@ const socialSharing: SocialSharingConfig = {
   },
 };
 
+const systemUI = {
+  basics: {
+    baseURL,
+    display,
+    fonts,
+    style,
+  },
+  contexts: {
+    routes,
+    protectedRoutes,
+    schema,
+    sameAs,
+    socialSharing,
+  },
+  modules: {
+    mailchimp,
+  },
+  formControls: {
+    newsletter: mailchimp,
+  },
+  components: {
+    display,
+    fonts,
+    style,
+  },
+  dataViz: {
+    dataStyle,
+  },
+  effects: {
+    background: effects,
+    newsletter: mailchimp.effects,
+  },
+} satisfies SystemUIConfig;
+
 export {
   display,
   mailchimp,
@@ -224,4 +259,5 @@ export {
   socialSharing,
   effects,
   dataStyle,
+  systemUI,
 };

--- a/apps/web/resources/types/config.types.ts
+++ b/apps/web/resources/types/config.types.ts
@@ -187,6 +187,78 @@ export type SocialSharingConfig = {
 };
 
 /**
+ * High-level Once UI primitives used to configure global surfaces.
+ */
+export type SystemUIBasicsConfig = {
+  baseURL: string;
+  display: DisplayConfig;
+  fonts: FontsConfig;
+  style: StyleConfig;
+};
+
+/**
+ * Routing, schema, and metadata contexts required by the UI system.
+ */
+export type SystemUIContextsConfig = {
+  routes: RoutesConfig;
+  protectedRoutes: ProtectedRoutesConfig;
+  schema: SchemaConfig;
+  sameAs: SameAsConfig;
+  socialSharing: SocialSharingConfig;
+};
+
+/**
+ * Modular feature blocks that can be toggled independently.
+ */
+export type SystemUIModulesConfig = {
+  mailchimp: MailchimpConfig;
+};
+
+/**
+ * Form-oriented configuration shared across newsletter and lead capture flows.
+ */
+export type SystemUIFormControlsConfig = {
+  newsletter: MailchimpConfig;
+};
+
+/**
+ * Core component tokens exposed to consuming surfaces.
+ */
+export type SystemUIComponentsConfig = {
+  display: DisplayConfig;
+  fonts: FontsConfig;
+  style: StyleConfig;
+};
+
+/**
+ * Data visualisation primitives for charts and analytics widgets.
+ */
+export type SystemUIDataVizConfig = {
+  dataStyle: DataStyleConfig;
+};
+
+/**
+ * Effect layers used across hero backgrounds and form modules.
+ */
+export type SystemUIEffectsConfig = {
+  background: EffectsConfig;
+  newsletter: EffectsConfig;
+};
+
+/**
+ * Aggregate view of the system UI building blocks.
+ */
+export type SystemUIConfig = {
+  basics: SystemUIBasicsConfig;
+  contexts: SystemUIContextsConfig;
+  modules: SystemUIModulesConfig;
+  formControls: SystemUIFormControlsConfig;
+  components: SystemUIComponentsConfig;
+  dataViz: SystemUIDataVizConfig;
+  effects: SystemUIEffectsConfig;
+};
+
+/**
  * Top-level config types for once-ui.config.js
  */
 export type OnceUIConfig = {


### PR DESCRIPTION
## Summary
- add typed groupings for Once UI basics, contexts, modules, forms, components, data-viz, and effects
- export a consolidated `systemUI` helper and update layout, providers, landing shell, and newsletter form to consume the grouped settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf8a946b6c8322996d3f7e2257a787