### PR TITLE
Fix chat assistant spacing tokens

### DIFF
--- a/apps/web/components/shared/ChatAssistantWidget.tsx
+++ b/apps/web/components/shared/ChatAssistantWidget.tsx
@@ -435,7 +435,7 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
               />
               {isMinimized ? (
                 <Row horizontal="between" vertical="center" className="relative z-[1]">
-                  <Row gap="10" vertical="center">
+                  <Row gap="12" vertical="center">
                     <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                       <Bot className="h-5 w-5" />
                     </div>
@@ -470,7 +470,7 @@ export function ChatAssistantWidget({ telegramData, className }: ChatAssistantWi
               ) : (
                 <Column gap="16" className="relative z-[1]">
                   <Row horizontal="between" vertical="center">
-                    <Row gap="10" vertical="center">
+                    <Row gap="12" vertical="center">
                       <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                         <Bot className="h-5 w-5" />
                       </div>


### PR DESCRIPTION
## Summary
- replace invalid spacing tokens in chat assistant rows with supported values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf907fd03c8322b8709d6b1846e3f1