### PR TITLE
Add setup automation for Supabase and CI parity

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -20,33 +20,35 @@ Follow the numbered order below when coordinating large efforts. Each entry link
 | Priority | Checklist | Primary focus | Typical use | Automation key |
 | --- | --- | --- | --- | --- |
 | 1 | [`Dynamic Capital Checklist`](./dynamic-capital-checklist.md) | Aggregated repo status and cross-checks | Kick off large initiatives or review overall progress | `dynamic-capital` |
-| 2 | [`Coding Efficiency Checklist`](./coding-efficiency-checklist.md) | Day-to-day development hygiene | Scope and deliver individual features or maintenance updates | `coding-efficiency` |
-| 3 | [`Once UI Development Checklist`](./once-ui-development-checklist.md) | Frontend/back-end surfaces using Once UI | Build or refactor any Once UI-powered surface (landing, dashboard, mini app shell) | `once-ui` |
-| 4 | [`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md) | Environment variables and outbound link audits | Confirm production configuration before toggling features | `variables-and-links` |
-| 5 | [`Go Live Checklist`](./GO_LIVE_CHECKLIST.md) | Manual production readiness smoke tests | Validate Telegram webhook flows before launch | `go-live` |
-| 6 | [`Launch Checklist`](./LAUNCH_CHECKLIST.md) | Secrets and keeper setup | Harden Supabase edge functions ahead of launch | — |
-| 7 | [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md) | Well-architected review for hosted frontends | Audit Vercel deployments for operational readiness | — |
-| 8 | [`Automated Trading System Build Checklist`](./automated-trading-checklist.md) | TradingView → Vercel → Supabase → MetaTrader 5 pipeline | Stand up or extend the automated trading stack | — |
-| 9 | [`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding for the TradingView webhook to MT5 flow | Coordinate roadmap execution across teams | — |
-| 10 | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md) | Merging Dynamic Codex into this monorepo | Completed — dashboard now lives at `/telegram` in the Next.js app | — |
-| 11 | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md) | Align Git branches with deployable services and domains | Rework branching strategy to support independent deployments | — |
+| 2 | [`Setup Follow-Ups`](./dynamic-capital-checklist.md#setup-follow-ups) | Supabase CLI workflow and CI parity tasks | Complete onboarding and align local runs with CI | `setup-followups` |
+| 3 | [`Coding Efficiency Checklist`](./coding-efficiency-checklist.md) | Day-to-day development hygiene | Scope and deliver individual features or maintenance updates | `coding-efficiency` |
+| 4 | [`Once UI Development Checklist`](./once-ui-development-checklist.md) | Frontend/back-end surfaces using Once UI | Build or refactor any Once UI-powered surface (landing, dashboard, mini app shell) | `once-ui` |
+| 5 | [`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md) | Environment variables and outbound link audits | Confirm production configuration before toggling features | `variables-and-links` |
+| 6 | [`Go Live Checklist`](./GO_LIVE_CHECKLIST.md) | Manual production readiness smoke tests | Validate Telegram webhook flows before launch | `go-live` |
+| 7 | [`Launch Checklist`](./LAUNCH_CHECKLIST.md) | Secrets and keeper setup | Harden Supabase edge functions ahead of launch | — |
+| 8 | [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md) | Well-architected review for hosted frontends | Audit Vercel deployments for operational readiness | — |
+| 9 | [`Automated Trading System Build Checklist`](./automated-trading-checklist.md) | TradingView → Vercel → Supabase → MetaTrader 5 pipeline | Stand up or extend the automated trading stack | — |
+| 10 | [`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding for the TradingView webhook to MT5 flow | Coordinate roadmap execution across teams | — |
+| 11 | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md) | Merging Dynamic Codex into this monorepo | Completed — dashboard now lives at `/telegram` in the Next.js app | — |
+| 12 | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md) | Align Git branches with deployable services and domains | Rework branching strategy to support independent deployments | — |
 
 ## Project delivery (priorities 1–3)
 
 ### Aggregate & iteration checklists
 - **[`Dynamic Capital Checklist`](./dynamic-capital-checklist.md)** – the umbrella tracker that collects repo-level action items and links to every specialized list. Use it for weekly reviews or when coordinating cross-functional workstreams.
+- **[`Setup Follow-Ups`](./dynamic-capital-checklist.md#setup-follow-ups)** – orchestrates the Supabase CLI workflow alongside the CI parity checks flagged in onboarding. Use the `setup-followups` automation key to run the scripted sequence end-to-end.
 - **[`Coding Efficiency Checklist`](./coding-efficiency-checklist.md)** – a reusable template for feature branches. Copy it into issues or PRs to make sure implementation, testing, and documentation steps land together.
 
 ### UI & shared tooling
 - **[`Once UI Development Checklist`](./once-ui-development-checklist.md)** – ensures surfaces built on the Once UI design system follow linting, testing, and build expectations. Includes optional automation for production builds and mini app packaging.
 
-## Launch & production hardening (priorities 4–7)
+## Launch & production hardening (priorities 5–8)
 - **[`Go Live Checklist`](./GO_LIVE_CHECKLIST.md)** – quick Telegram webhook and Mini App validation steps. Use alongside the `go-live` automation key for repeatable smoke tests.
 - **[`Launch Checklist`](./LAUNCH_CHECKLIST.md)** – enumerates Supabase secrets and keeper tasks required before exposing the bot to end users.
 - **[`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md)** – covers outbound URLs, hostnames, and environment variable drift. Pair it with the automation key `variables-and-links` to run scripted audits.
 - **[`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)** – applies the Vercel Well-Architected review to the hosted frontend. Ideal before handoffs or compliance reviews.
 
-## Specialized projects & integrations (priorities 8–10)
+## Specialized projects & integrations (priorities 9–12)
 - **[`Automated Trading System Build Checklist`](./automated-trading-checklist.md)** – sequences the deliverables for the TradingView → Supabase → MetaTrader 5 automation project, from Pine Script alerts to VPS hardening.
 - **[`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md)** – mirrors the onboarding roadmap so TradingView, webhook, Supabase, and MT5 teams can work in parallel with clear hand-offs.
 - **[`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)** – archived after Dynamic Codex was merged into the main `/telegram` route; keep for historical context.

--- a/docs/SETUP_SUMMARY.md
+++ b/docs/SETUP_SUMMARY.md
@@ -29,7 +29,7 @@
 - Future contributors have a clear checklist.
 
 ## What’s Left
-- If not already: `npx supabase login && supabase link && supabase db push`.
+- If not already: run `npx supabase login && supabase link && supabase db push` (or `bash scripts/supabase-cli-workflow.sh`).
 - Open/refresh the PR with the add-only files; ensure checks (`typecheck`, `test`, `audit`, `test-and-pr`) pass.
 - Enable auto-merge and add branch protection (mark those checks as required).
 - Quick production sanity: `/start`, `/plans`, approve a test payment → confirm `current_vip.is_vip = true`.

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -34,8 +34,10 @@ Use the automation helper (or run commands directly) to complete the recurring r
 
 ## Setup Follow-Ups
 
-1. [ ] Complete the Supabase CLI workflow (`npx supabase login && supabase link && supabase db push`).
-2. [ ] Refresh or open the pending PR ensuring CI checks pass.
+> [!TIP] Run `npm run checklists -- --checklist setup-followups` to execute the Supabase CLI automation and CI parity checks captured in this section.
+
+1. [ ] Complete the Supabase CLI workflow (`npx supabase login && supabase link && supabase db push`) or run `bash scripts/supabase-cli-workflow.sh` with the required credentials exported.
+2. [ ] Refresh or open the pending PR ensuring CI checks pass (`deno task typecheck`, `npm run test`, `npm run audit`, `deno task ci`).
 3. [ ] Enable auto-merge with the required branch protections.
 4. [ ] Run the production sanity test (`/start`, `/plans`, approve test payment) to confirm `current_vip.is_vip`.
 

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -100,6 +100,40 @@ const TASK_LIBRARY = {
     docs: ['docs/dynamic-capital-checklist.md'],
     notes: ['Executes scripted flows that mirror the production sanity checklist for the Telegram mini app.'],
   },
+  'supabase-cli-workflow': {
+    id: 'supabase-cli-workflow',
+    label: 'Run Supabase CLI workflow (bash scripts/supabase-cli-workflow.sh)',
+    command: 'bash scripts/supabase-cli-workflow.sh',
+    optional: false,
+    docs: ['docs/dynamic-capital-checklist.md', 'docs/SETUP_SUMMARY.md'],
+    notes: [
+      'Logs in with SUPABASE_ACCESS_TOKEN, links the configured project, and pushes pending migrations.',
+    ],
+  },
+  'deno-typecheck': {
+    id: 'deno-typecheck',
+    label: 'Run Deno typecheck (deno task typecheck)',
+    command: 'deno task typecheck',
+    optional: false,
+    docs: ['docs/SETUP_SUMMARY.md', 'docs/coding-efficiency-checklist.md'],
+    notes: ['Matches the standalone typecheck executed in CI (test-and-pr job).'],
+  },
+  'npm-audit': {
+    id: 'npm-audit',
+    label: 'Run npm dependency audit (npm run audit)',
+    command: 'npm run audit',
+    optional: false,
+    docs: ['docs/SETUP_SUMMARY.md'],
+    notes: ['Surfaces vulnerable packages to keep parity with the GitHub Actions audit step.'],
+  },
+  'ci-test-and-pr': {
+    id: 'ci-test-and-pr',
+    label: 'Run CI parity checks (deno task ci)',
+    command: 'deno task ci',
+    optional: false,
+    docs: ['docs/SETUP_SUMMARY.md'],
+    notes: ['Executes the aggregated formatting, linting, and test routine used by the test-and-pr workflow.'],
+  },
 };
 
 const CHECKLISTS = {
@@ -136,6 +170,18 @@ const CHECKLISTS = {
     tasks: [
       'check-webhook',
       { task: 'smoke-miniapp', optional: true, note: 'Complements manual go-live validation with scripted coverage.' },
+    ],
+  },
+  'setup-followups': {
+    name: 'Setup Follow-Ups',
+    doc: 'docs/dynamic-capital-checklist.md#setup-follow-ups',
+    description: 'Supabase CLI linking and CI parity checks referenced after initial onboarding.',
+    tasks: [
+      'supabase-cli-workflow',
+      'deno-typecheck',
+      'repo-test',
+      'npm-audit',
+      'ci-test-and-pr',
     ],
   },
   'dynamic-capital': {

--- a/scripts/supabase-cli-workflow.sh
+++ b/scripts/supabase-cli-workflow.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Orchestrate the Supabase CLI workflow referenced in the setup checklist.
+# Requires SUPABASE_ACCESS_TOKEN, SUPABASE_DB_PASSWORD, and optionally
+# SUPABASE_PROJECT_REF. Falls back to supabase/config.toml when the ref
+# is not provided via environment variable.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_REF="${SUPABASE_PROJECT_REF:-}"
+ACCESS_TOKEN="${SUPABASE_ACCESS_TOKEN:-}"
+DB_PASSWORD="${SUPABASE_DB_PASSWORD:-}"
+
+if [[ -z "${ACCESS_TOKEN}" ]]; then
+  echo "SUPABASE_ACCESS_TOKEN is required to run the Supabase CLI workflow." >&2
+  echo "Generate a personal access token from the Supabase dashboard and export it" >&2
+  echo "before invoking this script." >&2
+  exit 1
+fi
+
+if [[ -z "${PROJECT_REF}" ]]; then
+  if [[ -f "${ROOT_DIR}/supabase/config.toml" ]]; then
+    PROJECT_REF="$(sed -n 's/^project_id = "\(.*\)"/\1/p' "${ROOT_DIR}/supabase/config.toml" | head -n 1)"
+  fi
+fi
+
+if [[ -z "${PROJECT_REF}" ]]; then
+  echo "Unable to determine Supabase project ref. Set SUPABASE_PROJECT_REF or" >&2
+  echo "ensure supabase/config.toml includes a project_id." >&2
+  exit 1
+fi
+
+if [[ -z "${DB_PASSWORD}" ]]; then
+  echo "SUPABASE_DB_PASSWORD is required to link and push migrations." >&2
+  echo "Export the database password used for the remote project before running" >&2
+  echo "this workflow." >&2
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+run_supabase() {
+  local description="$1"
+  shift
+  echo "== ${description} =="
+  npx supabase --workdir "${ROOT_DIR}" "$@"
+}
+
+run_supabase "Logging in to Supabase CLI" login --token "${ACCESS_TOKEN}" --no-browser --yes
+run_supabase "Linking project ${PROJECT_REF}" link --project-ref "${PROJECT_REF}" --password "${DB_PASSWORD}" --yes
+run_supabase "Pushing database migrations" db push --linked --password "${DB_PASSWORD}" --yes
+
+echo "Supabase CLI workflow completed for project ${PROJECT_REF}."


### PR DESCRIPTION
## Summary
- add a Supabase CLI workflow script that logs in, links the project, and pushes migrations with exported credentials
- extend the checklist runner with setup-followups automation tasks for Supabase and CI parity commands
- document the new automation key across the dynamic capital checklist, setup summary, and checklist directory

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf93d0636c83228ce1271b7f88f541