### PR TITLE
Refine system health UI integration with Supabase

### DIFF
--- a/apps/web/components/ui/system-health.tsx
+++ b/apps/web/components/ui/system-health.tsx
@@ -1,220 +1,492 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { motion } from "framer-motion";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { 
-  CheckCircle,
-  AlertCircle,
-  Clock,
-  RefreshCw,
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
   Activity,
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle,
   Database,
-  Zap,
+  RefreshCw,
   Shield,
-  TrendingUp
-} from "lucide-react";
-import { toast } from "sonner";
-import { callEdgeFunction } from "@/config/supabase";
+  TrendingUp,
+  Zap,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/utils';
+import {
+  type SystemHealthCheck,
+  type SystemHealthCheckKey,
+  type SystemHealthCheckStatus,
+  type SystemHealthOverallStatus,
+  type SystemHealthPerformance,
+  type SystemHealthResponse,
+} from '@/types/system-health';
+import { useSystemHealth } from '@/hooks/useSystemHealth';
 
-interface HealthCheck {
-  status: "ok" | "error" | "warning";
-  error?: string;
-  response_time: number;
-  active_count?: number;
-}
-
-interface HealthStatus {
-  overall_status: "healthy" | "degraded" | "error";
-  timestamp: string;
-  checks: {
-    database: HealthCheck;
-    bot_content: HealthCheck;
-    promotions: HealthCheck;
-    rpc_functions: HealthCheck;
-  };
-  performance: {
-    average_response_time: number;
-    total_checks: number;
-    failed_checks: number;
-  };
-  recommendations: string[];
-}
+export type SystemHealthDisplayStatus =
+  | SystemHealthOverallStatus
+  | 'loading'
+  | 'unknown';
 
 interface SystemHealthProps {
   className?: string;
   showDetails?: boolean;
 }
 
-export function SystemHealth({ className, showDetails = false }: SystemHealthProps) {
-  const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [lastCheck, setLastCheck] = useState<Date | null>(null);
+interface StatusMeta {
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  iconClass: string;
+  badgeClass: string;
+  badgeVariant?: 'outline' | 'default';
+}
 
-  const checkHealth = async () => {
-    setLoading(true);
-    try {
-      const { data, error } = await callEdgeFunction<HealthStatus>('WEB_APP_HEALTH');
+const STATUS_META: Record<SystemHealthDisplayStatus, StatusMeta> = {
+  healthy: {
+    label: 'Healthy',
+    description: 'All systems are operating within expected thresholds.',
+    icon: CheckCircle,
+    iconClass: 'text-success',
+    badgeClass: 'bg-success/10 text-success border-success/30',
+  },
+  degraded: {
+    label: 'Degraded',
+    description: 'Some checks require attention. Review the affected components.',
+    icon: AlertTriangle,
+    iconClass: 'text-warning',
+    badgeClass: 'bg-warning/10 text-warning border-warning/30',
+  },
+  error: {
+    label: 'Error',
+    description: 'Critical issues detected. Immediate action recommended.',
+    icon: AlertCircle,
+    iconClass: 'text-dc-brand',
+    badgeClass: 'bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30',
+  },
+  loading: {
+    label: 'Checking',
+    description: 'Fetching the latest system health status.',
+    icon: RefreshCw,
+    iconClass: 'text-muted-foreground',
+    badgeClass: 'border-dashed border text-muted-foreground',
+    badgeVariant: 'outline',
+  },
+  unknown: {
+    label: 'Unknown',
+    description: 'System health could not be determined. Try refreshing.',
+    icon: Activity,
+    iconClass: 'text-muted-foreground',
+    badgeClass: 'border-dashed border text-muted-foreground',
+    badgeVariant: 'outline',
+  },
+};
 
-      if (error || !data) {
-        throw new Error(error?.message || 'Health check failed');
-      }
+export const SYSTEM_HEALTH_STATUS_META = STATUS_META;
 
-      setHealthStatus(data);
-      setLastCheck(new Date());
+interface CheckMeta {
+  label: string;
+  description: string;
+  icon: LucideIcon;
+}
 
-      if (data.overall_status === 'degraded') {
-        toast.warning('Some systems are experiencing issues');
-      } else if (data.overall_status === 'error') {
-        toast.error('System health check failed');
-      }
-    } catch (error) {
-      console.error('Health check error:', error);
-      toast.error('Unable to check system health');
-    } finally {
-      setLoading(false);
-    }
-  };
+const CHECK_META: Record<SystemHealthCheckKey, CheckMeta> = {
+  database: {
+    label: 'Database',
+    description: 'Primary Supabase cluster availability',
+    icon: Database,
+  },
+  bot_content: {
+    label: 'Bot Content',
+    description: 'Content freshness and publishing pipeline',
+    icon: Activity,
+  },
+  promotions: {
+    label: 'Promotions',
+    description: 'Active promo codes and campaigns',
+    icon: Zap,
+  },
+  rpc_functions: {
+    label: 'Edge Functions',
+    description: 'Critical RPC and edge function endpoints',
+    icon: Shield,
+  },
+};
+
+const CHECK_STATUS_META: Record<
+  SystemHealthCheckStatus,
+  { label: string; icon: LucideIcon; className: string }
+> = {
+  ok: {
+    label: 'Operational',
+    icon: CheckCircle,
+    className: 'bg-success/10 text-success border-success/30',
+  },
+  warning: {
+    label: 'Warning',
+    icon: AlertTriangle,
+    className: 'bg-warning/10 text-warning border-warning/30',
+  },
+  error: {
+    label: 'Error',
+    icon: AlertCircle,
+    className: 'bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30',
+  },
+};
+
+export function SystemHealthStatusBadge({
+  status,
+  className,
+  children,
+}: {
+  status: SystemHealthDisplayStatus;
+  className?: string;
+  children?: ReactNode;
+}) {
+  const meta = STATUS_META[status] ?? STATUS_META.unknown;
+
+  return (
+    <Badge
+      variant={meta.badgeVariant}
+      className={cn('gap-1 px-2 py-1 text-xs', meta.badgeClass, className)}
+    >
+      {children ?? meta.label}
+    </Badge>
+  );
+}
+
+export function SystemHealthStatusIcon({
+  status,
+  isRefreshing = false,
+  className,
+}: {
+  status: SystemHealthDisplayStatus;
+  isRefreshing?: boolean;
+  className?: string;
+}) {
+  const meta = STATUS_META[status] ?? STATUS_META.unknown;
+  const Icon = meta.icon;
+  return (
+    <Icon
+      className={cn(
+        'h-4 w-4',
+        meta.iconClass,
+        (status === 'loading' || isRefreshing) && 'animate-spin',
+        className,
+      )}
+    />
+  );
+}
+
+export function SystemHealthCheckStatusBadge({
+  status,
+  className,
+}: {
+  status: SystemHealthCheckStatus;
+  className?: string;
+}) {
+  const meta = CHECK_STATUS_META[status];
+  const Icon = meta.icon;
+
+  return (
+    <Badge className={cn('gap-1 px-2 py-1 text-xs', meta.className, className)}>
+      <Icon className="h-3 w-3" />
+      {meta.label}
+    </Badge>
+  );
+}
+
+export function SystemHealthMetric({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string | number | ReactNode;
+  tone?: 'default' | 'positive' | 'negative';
+}) {
+  return (
+    <div className="space-y-1 rounded-lg border border-border/40 bg-muted/30 p-3 text-center">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p
+        className={cn('text-sm font-semibold', {
+          'text-success': tone === 'positive',
+          'text-dc-brand': tone === 'negative',
+        })}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function SystemHealthMetrics({
+  performance,
+}: {
+  performance: SystemHealthPerformance;
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      <SystemHealthMetric
+        label="Average response"
+        value={`${performance.average_response_time}ms`}
+      />
+      <SystemHealthMetric
+        label="Total checks"
+        value={performance.total_checks}
+      />
+      <SystemHealthMetric
+        label="Failed checks"
+        value={performance.failed_checks}
+        tone={performance.failed_checks > 0 ? 'negative' : 'positive'}
+      />
+    </div>
+  );
+}
+
+export function SystemHealthCheckItem({
+  checkKey,
+  check,
+}: {
+  checkKey: SystemHealthCheckKey;
+  check: SystemHealthCheck;
+}) {
+  const meta = CHECK_META[checkKey];
+  const Icon = meta.icon;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border/40 bg-muted/20 p-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-start gap-3">
+        <Icon className="mt-0.5 h-4 w-4 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium">{meta.label}</p>
+          <p className="text-xs text-muted-foreground">{meta.description}</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <span>{check.response_time}ms</span>
+        {typeof check.active_count === 'number' && (
+          <span>{check.active_count} active</span>
+        )}
+        <SystemHealthCheckStatusBadge status={check.status} />
+      </div>
+    </div>
+  );
+}
+
+export function SystemHealthRecommendations({
+  recommendations,
+}: {
+  recommendations: string[];
+}) {
+  if (!recommendations.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Recommendations</p>
+      <div className="space-y-2">
+        {recommendations.map((rec, index) => (
+          <Alert key={`${index}-${rec}`} className="border-warning/20 bg-warning/10">
+            <TrendingUp className="h-4 w-4 text-warning" />
+            <AlertDescription className="text-sm text-warning">
+              {rec}
+            </AlertDescription>
+          </Alert>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function SystemHealthSkeleton({
+  showDetails,
+}: {
+  showDetails: boolean;
+}) {
+  if (showDetails) {
+    return (
+      <div className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-20" />
+          ))}
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-16" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-4 w-32" />
+      <div className="grid gap-3 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Skeleton key={index} className="h-16" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SystemHealthSummary({ data }: { data: SystemHealthResponse }) {
+  return (
+    <div className="space-y-4">
+      <SystemHealthMetrics performance={data.performance} />
+      <SystemHealthRecommendations recommendations={data.recommendations} />
+    </div>
+  );
+}
+
+function SystemHealthDetails({ data }: { data: SystemHealthResponse }) {
+  const checkEntries = useMemo(
+    () => Object.entries(data.checks) as [SystemHealthCheckKey, SystemHealthCheck][],
+    [data.checks],
+  );
+
+  return (
+    <div className="space-y-4">
+      <SystemHealthMetrics performance={data.performance} />
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Component status</p>
+        <div className="space-y-2">
+          {checkEntries.map(([key, check]) => (
+            <SystemHealthCheckItem key={key} checkKey={key} check={check} />
+          ))}
+        </div>
+      </div>
+      <SystemHealthRecommendations recommendations={data.recommendations} />
+    </div>
+  );
+}
+
+export function SystemHealth({
+  className,
+  showDetails = false,
+}: SystemHealthProps) {
+  const {
+    data,
+    error,
+    isError,
+    isLoading,
+    isFetching,
+    refetch,
+    dataUpdatedAt,
+  } = useSystemHealth({
+    autoRefresh: showDetails,
+  });
+  const previousStatusRef = useRef<SystemHealthOverallStatus | null>(null);
+
+  const status: SystemHealthDisplayStatus = data
+    ? data.overall_status
+    : isLoading
+    ? 'loading'
+    : isError
+    ? 'unknown'
+    : 'loading';
+
+  const lastChecked = data?.timestamp
+    ? new Date(data.timestamp)
+    : dataUpdatedAt
+    ? new Date(dataUpdatedAt)
+    : undefined;
 
   useEffect(() => {
-    checkHealth();
-    
-    // Auto-refresh every 5 minutes
-    const interval = setInterval(checkHealth, 5 * 60 * 1000);
-    return () => clearInterval(interval);
-  }, []);
+    if (!data) return;
+    if (previousStatusRef.current === data.overall_status) return;
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'healthy': return <CheckCircle className="h-4 w-4 text-success" />;
-      case 'degraded': return <AlertCircle className="h-4 w-4 text-warning" />;
-      case 'error': return <AlertCircle className="h-4 w-4 text-dc-brand" />;
-      default: return <Clock className="h-4 w-4 text-muted-foreground" />;
+    previousStatusRef.current = data.overall_status;
+
+    if (data.overall_status === 'degraded') {
+      toast.warning('Some systems are experiencing issues');
+    } else if (data.overall_status === 'error') {
+      toast.error('System health check failed');
     }
-  };
+  }, [data]);
 
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case 'healthy':
-        return <Badge className="bg-success/10 text-success border-success/30">Healthy</Badge>;
-      case 'degraded':
-        return <Badge className="bg-warning/10 text-warning border-warning/30">Degraded</Badge>;
-      case 'error':
-        return <Badge className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30">Error</Badge>;
-      default:
-        return <Badge variant="outline">Unknown</Badge>;
-    }
-  };
-
-  const getCheckIcon = (checkName: string) => {
-    switch (checkName) {
-      case 'database': return <Database className="h-4 w-4" />;
-      case 'bot_content': return <Activity className="h-4 w-4" />;
-      case 'promotions': return <Zap className="h-4 w-4" />;
-      case 'rpc_functions': return <Shield className="h-4 w-4" />;
-      default: return <Activity className="h-4 w-4" />;
-    }
-  };
-
-  if (!showDetails && healthStatus?.overall_status === 'healthy') {
-    return null; // Don't show anything when healthy and details not requested
+  if (!showDetails && !isLoading && !isError && data?.overall_status === 'healthy') {
+    return null;
   }
+
+  const meta = STATUS_META[status];
 
   return (
     <Card className={className}>
       <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {healthStatus ? getStatusIcon(healthStatus.overall_status) : <Activity className="h-4 w-4" />}
-            <CardTitle className="text-base">System Health</CardTitle>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-2 sm:items-center">
+            <SystemHealthStatusIcon
+              status={status}
+              isRefreshing={isFetching && !!data}
+              className="mt-0.5"
+            />
+            <div>
+              <CardTitle className="text-base">System Health</CardTitle>
+              <CardDescription className="text-xs">
+                {meta.description}
+              </CardDescription>
+            </div>
           </div>
           <div className="flex items-center gap-2">
-            {healthStatus && getStatusBadge(healthStatus.overall_status)}
+            <SystemHealthStatusBadge status={status} />
             <Button
               variant="ghost"
               size="sm"
-              onClick={checkHealth}
-              disabled={loading}
+              onClick={() => refetch()}
+              disabled={isFetching}
             >
-              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              <RefreshCw
+                className={cn('h-4 w-4', isFetching && 'animate-spin')}
+              />
             </Button>
           </div>
         </div>
-        {lastCheck && (
+        {lastChecked && (
           <CardDescription className="text-xs">
-            Last checked: {lastCheck.toLocaleTimeString()}
+            Last checked: {lastChecked.toLocaleTimeString()}
           </CardDescription>
         )}
       </CardHeader>
+      <CardContent className="space-y-4">
+        {isError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="text-sm">
+              {error?.message || 'Failed to load system health'}
+            </AlertDescription>
+          </Alert>
+        )}
 
-      {showDetails && healthStatus && (
-        <CardContent className="space-y-4">
-          {/* Performance Metrics */}
-          <div className="grid grid-cols-3 gap-4 text-center">
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">Avg Response</p>
-              <p className="text-sm font-medium">
-                {healthStatus.performance.average_response_time}ms
-              </p>
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">Total Checks</p>
-              <p className="text-sm font-medium">
-                {healthStatus.performance.total_checks}
-              </p>
-            </div>
-            <div className="space-y-1">
-              <p className="text-xs text-muted-foreground">Failed</p>
-              <p className="text-sm font-medium text-dc-brand">
-                {healthStatus.performance.failed_checks}
-              </p>
-            </div>
-          </div>
-
-          {/* Individual Checks */}
-          <div className="space-y-2">
-            <p className="text-sm font-medium">Component Status</p>
-            {Object.entries(healthStatus.checks).map(([name, check]) => (
-              <div key={name} className="flex items-center justify-between p-2 bg-muted/30 rounded">
-                <div className="flex items-center gap-2">
-                  {getCheckIcon(name)}
-                  <span className="text-sm capitalize">
-                    {name.replace('_', ' ')}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-muted-foreground">
-                    {check.response_time}ms
-                  </span>
-                  {check.status === 'ok' ? (
-                    <CheckCircle className="h-4 w-4 text-success" />
-                  ) : (
-                    <AlertCircle className="h-4 w-4 text-dc-brand" />
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Recommendations */}
-          {healthStatus.recommendations.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-sm font-medium">Recommendations</p>
-              {healthStatus.recommendations.map((rec, index) => (
-                <Alert key={index} className="border-warning/20 bg-warning/10">
-                  <TrendingUp className="h-4 w-4" />
-                  <AlertDescription className="text-warning text-sm">
-                    {rec}
-                  </AlertDescription>
-                </Alert>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      )}
+        {isLoading && !data ? (
+          <SystemHealthSkeleton showDetails={showDetails} />
+        ) : data ? (
+          showDetails ? (
+            <SystemHealthDetails data={data} />
+          ) : (
+            <SystemHealthSummary data={data} />
+          )
+        ) : null}
+      </CardContent>
     </Card>
   );
 }

--- a/apps/web/hooks/useSystemHealth.ts
+++ b/apps/web/hooks/useSystemHealth.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEdgeFunction } from '@/hooks/useEdgeFunction';
+import { SUPABASE_ENV_ERROR } from '@/config/supabase';
+import type { SystemHealthResponse } from '@/types/system-health';
+
+const SYSTEM_HEALTH_QUERY_KEY = ['system-health'];
+const DEFAULT_REFRESH_INTERVAL = 5 * 60 * 1000;
+
+interface UseSystemHealthOptions {
+  /**
+   * Automatically refetch the health status on an interval.
+   * Defaults to 5 minutes when enabled.
+   */
+  autoRefresh?: boolean;
+  /**
+   * Custom refresh interval in milliseconds. Only used when `autoRefresh` is true.
+   */
+  refreshInterval?: number;
+  /**
+   * Enable or disable the query entirely. Enabled by default.
+   */
+  enabled?: boolean;
+}
+
+export function useSystemHealth({
+  autoRefresh = false,
+  refreshInterval,
+  enabled = true,
+}: UseSystemHealthOptions = {}) {
+  const callEdgeFunction = useEdgeFunction();
+
+  const fetchSystemHealth = useCallback(async () => {
+    if (SUPABASE_ENV_ERROR) {
+      throw new Error(SUPABASE_ENV_ERROR);
+    }
+
+    const { data, error } = await callEdgeFunction<SystemHealthResponse>('WEB_APP_HEALTH');
+
+    if (error || !data) {
+      throw new Error(error?.message || 'Unable to load system health');
+    }
+
+    return data;
+  }, [callEdgeFunction]);
+
+  return useQuery<SystemHealthResponse, Error>({
+    queryKey: SYSTEM_HEALTH_QUERY_KEY,
+    queryFn: fetchSystemHealth,
+    staleTime: DEFAULT_REFRESH_INTERVAL,
+    gcTime: DEFAULT_REFRESH_INTERVAL * 2,
+    retry: 1,
+    refetchOnWindowFocus: false,
+    refetchInterval: autoRefresh
+      ? refreshInterval ?? DEFAULT_REFRESH_INTERVAL
+      : false,
+    enabled,
+  });
+}
+
+export function useSystemHealthRefetch() {
+  const queryClient = useQueryClient();
+
+  return useCallback(() => {
+    return queryClient.invalidateQueries({ queryKey: SYSTEM_HEALTH_QUERY_KEY });
+  }, [queryClient]);
+}

--- a/apps/web/types/system-health.ts
+++ b/apps/web/types/system-health.ts
@@ -1,0 +1,30 @@
+export type SystemHealthOverallStatus = "healthy" | "degraded" | "error";
+
+export type SystemHealthCheckStatus = "ok" | "warning" | "error";
+
+export interface SystemHealthCheck {
+  status: SystemHealthCheckStatus;
+  error?: string;
+  response_time: number;
+  active_count?: number;
+}
+
+export type SystemHealthCheckKey =
+  | "database"
+  | "bot_content"
+  | "promotions"
+  | "rpc_functions";
+
+export interface SystemHealthPerformance {
+  average_response_time: number;
+  total_checks: number;
+  failed_checks: number;
+}
+
+export interface SystemHealthResponse {
+  overall_status: SystemHealthOverallStatus;
+  timestamp: string;
+  checks: Record<SystemHealthCheckKey, SystemHealthCheck>;
+  performance: SystemHealthPerformance;
+  recommendations: string[];
+}


### PR DESCRIPTION
## Summary
- add shared system health types and a reusable `useSystemHealth` hook for calling the Supabase health edge function
- refactor the system health UI to consume the shared hook, expose reusable status components, and improve loading/error handling
- update the edge function status badge to reuse the centralized health status

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf9bc8969c832289eff1a0641b327b