### PR TITLE
Use ISO 8601 formatting for timestamps

### DIFF
--- a/apps/web/components/admin/AdminBans.tsx
+++ b/apps/web/components/admin/AdminBans.tsx
@@ -11,6 +11,7 @@ import { Shield, UserX, Plus, Calendar, RefreshCw } from "lucide-react";
 import { useToast } from "@/hooks/useToast";
 import { useTelegramAuth } from "@/hooks/useTelegramAuth";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 
 interface AbuseBan {
   id: string;
@@ -173,7 +174,7 @@ export function AdminBans() {
   }, [loadBans]);
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString();
+    return formatIsoDateTime(dateString);
   };
 
   const isExpired = (expiresAt?: string) => {

--- a/apps/web/components/admin/AdminDashboard.tsx
+++ b/apps/web/components/admin/AdminDashboard.tsx
@@ -23,6 +23,7 @@ import { AdminBans } from "./AdminBans";
 import { BroadcastManager } from "./BroadcastManager";
 import { BotDiagnostics } from "./BotDiagnostics";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 import { OnceButton, OnceContainer } from "@/components/once-ui";
 
 interface AdminStats {
@@ -255,7 +256,7 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
 
   const adminName = telegramUser?.first_name || "Admin";
   const formattedLastUpdated = stats?.last_updated
-    ? new Date(stats.last_updated).toLocaleString()
+    ? formatIsoDateTime(stats.last_updated)
     : "Awaiting sync";
   const overviewItems = stats
     ? [
@@ -433,7 +434,7 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
                               User {payment.telegram_user_id}
                             </span>
                             <span className="rounded-full border border-border/60 bg-card/60 px-3 py-1">
-                              {new Date(payment.created_at).toLocaleString()}
+                              {formatIsoDateTime(payment.created_at)}
                             </span>
                             <span className="rounded-full border border-border/60 bg-card/60 px-3 py-1">
                               Status: {payment.status}

--- a/apps/web/components/admin/AdminLogs.tsx
+++ b/apps/web/components/admin/AdminLogs.tsx
@@ -10,6 +10,7 @@ import { FileText, Search, RefreshCw, Calendar } from "lucide-react";
 import { useToast } from "@/hooks/useToast";
 import { useTelegramAuth } from "@/hooks/useTelegramAuth";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 
 interface AdminLog {
   id: string;
@@ -94,7 +95,7 @@ export function AdminLogs() {
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString();
+    return formatIsoDateTime(dateString);
   };
 
   return (

--- a/apps/web/components/admin/BotDebugger.tsx
+++ b/apps/web/components/admin/BotDebugger.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/useToast";
 import { Badge } from "@/components/ui/badge";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 
 interface BotStatusResponse {
   bot_status: string;
@@ -152,7 +153,7 @@ export const BotDebugger = () => {
                 <div className="mt-4 p-3 bg-muted rounded">
                   <p className="text-sm text-muted-foreground">
                     Last checked:{" "}
-                    {new Date(botStatus.timestamp).toLocaleString()}
+                    {formatIsoDateTime(botStatus.timestamp)}
                   </p>
                 </div>
               </div>

--- a/apps/web/components/admin/BotDiagnostics.tsx
+++ b/apps/web/components/admin/BotDiagnostics.tsx
@@ -9,6 +9,7 @@ import { Bot, Shield, RefreshCw, AlertTriangle, CheckCircle, Settings } from "lu
 import { useToast } from "@/hooks/useToast";
 import { useTelegramAuth } from "@/hooks/useTelegramAuth";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 
 interface BotStatus {
   bot_status: string;
@@ -251,7 +252,7 @@ export function BotDiagnostics() {
               )}
 
               <div className="text-xs text-muted-foreground">
-                Last checked: {new Date(botStatus.last_update).toLocaleString()}
+                Last checked: {formatIsoDateTime(botStatus.last_update)}
               </div>
             </div>
           ) : (

--- a/apps/web/components/admin/BroadcastManager.tsx
+++ b/apps/web/components/admin/BroadcastManager.tsx
@@ -12,6 +12,7 @@ import { MessageSquare, Send, Calendar, Users, RefreshCw } from "lucide-react";
 import { useToast } from "@/hooks/useToast";
 import { useTelegramAuth } from "@/hooks/useTelegramAuth";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 
 interface BroadcastMessage {
   id: string;
@@ -139,7 +140,7 @@ export function BroadcastManager() {
   }, [loadBroadcasts]);
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString();
+    return formatIsoDateTime(dateString);
   };
 
   const getStatusColor = (status: string) => {

--- a/apps/web/components/admin/PaymentReview.tsx
+++ b/apps/web/components/admin/PaymentReview.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDate, formatIsoTime } from "@/utils/isoFormat";
 
 interface Payment {
   id: string;
@@ -264,10 +265,10 @@ export function PaymentReview() {
                       <p className="text-muted-foreground">Date</p>
                       <div className="flex items-center gap-1">
                         <Calendar className="h-3 w-3" />
-                        <span>{new Date(payment.created_at).toLocaleDateString()}</span>
+                        <span>{formatIsoDate(payment.created_at)}</span>
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        {new Date(payment.created_at).toLocaleTimeString()}
+                        {formatIsoTime(payment.created_at)}
                       </p>
                     </div>
                   </div>

--- a/apps/web/components/admin/SystemResetButton.tsx
+++ b/apps/web/components/admin/SystemResetButton.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { AlertTriangle, RefreshCw, CheckCircle2, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 
 interface ResetResults {
   payments_cleared: number;
@@ -108,7 +109,7 @@ export function SystemResetButton() {
               Last Reset: {lastReset.success ? "Success" : "Failed"}
             </CardTitle>
             <CardDescription>
-              {lastReset.timestamp && `Executed at: ${new Date(lastReset.timestamp).toLocaleString()}`}
+              {lastReset.timestamp && `Executed at: ${formatIsoDateTime(lastReset.timestamp)}`}
             </CardDescription>
           </CardHeader>
           {lastReset.results && (

--- a/apps/web/components/admin/SystemStatus.tsx
+++ b/apps/web/components/admin/SystemStatus.tsx
@@ -20,6 +20,7 @@ import { formatSupabaseError } from '@/utils/supabaseError';
 import { useToast } from "@/hooks/useToast";
 import { getCached } from "@/utils/cache";
 import { getTimezones } from "@/utils/timezones";
+import { formatIsoDate, formatIsoTime } from "@/utils/isoFormat";
 import {
   Activity,
   AlertTriangle,
@@ -398,7 +399,7 @@ export const SystemStatus = () => {
                         {getStatusBadge(func.status)}
                         {func.lastChecked && (
                           <span className="text-xs text-muted-foreground">
-                            {new Date(func.lastChecked).toLocaleTimeString()}
+                            {formatIsoTime(func.lastChecked)}
                           </span>
                         )}
                       </div>
@@ -449,7 +450,7 @@ export const SystemStatus = () => {
                           {table.lastUpdated && (
                             <p className="text-xs text-muted-foreground">
                               Last updated:{" "}
-                              {new Date(table.lastUpdated).toLocaleDateString()}
+                              {formatIsoDate(table.lastUpdated)}
                             </p>
                           )}
                         </div>

--- a/apps/web/components/admin/UserManagement.tsx
+++ b/apps/web/components/admin/UserManagement.tsx
@@ -35,6 +35,7 @@ import { useToast } from "@/hooks/useToast";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
 import { Loader2, Package, Plus, Search, Users } from "lucide-react";
+import { formatIsoDate } from "@/utils/isoFormat";
 
 interface Profile {
   id: string;
@@ -668,7 +669,7 @@ export function UserManagement() {
                             </Badge>
                           </TableCell>
                           <TableCell>
-                            {new Date(user.created_at).toLocaleDateString()}
+                            {formatIsoDate(user.created_at)}
                           </TableCell>
                           <TableCell>
                             <div className="flex gap-2">
@@ -722,13 +723,11 @@ export function UserManagement() {
                             {assignment.package_id.substring(0, 8)}...
                           </TableCell>
                           <TableCell>
-                            {new Date(assignment.assigned_at)
-                              .toLocaleDateString()}
+                            {formatIsoDate(assignment.assigned_at)}
                           </TableCell>
                           <TableCell>
                             {assignment.expires_at
-                              ? new Date(assignment.expires_at)
-                                .toLocaleDateString()
+                              ? formatIsoDate(assignment.expires_at)
                               : "Never"}
                           </TableCell>
                           <TableCell>
@@ -798,7 +797,7 @@ export function UserManagement() {
                             </Badge>
                           </TableCell>
                           <TableCell>
-                            {new Date(payment.created_at).toLocaleDateString()}
+                            {formatIsoDate(payment.created_at)}
                           </TableCell>
                           <TableCell>
                             {payment.receipt_telegram_file_id

--- a/apps/web/components/admin/WelcomeMessageEditor.tsx
+++ b/apps/web/components/admin/WelcomeMessageEditor.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/useToast";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 import {
   Eye,
   Info,
@@ -359,7 +360,7 @@ Choose an option below:`,
                     <div className="text-xs text-muted-foreground space-y-1">
                       <p>
                         <strong>Last updated:</strong>{" "}
-                        {new Date(welcomeMessage.updated_at).toLocaleString()}
+                        {formatIsoDateTime(welcomeMessage.updated_at)}
                       </p>
                       <p>
                         <strong>Modified by:</strong>{" "}

--- a/apps/web/components/magic-portfolio/home/MarketWatchlist.tsx
+++ b/apps/web/components/magic-portfolio/home/MarketWatchlist.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Column, Heading, Line, Row, Tag, Text } from "@once-ui-system/core";
 import type { IconName } from "@/resources/icons";
+import { formatIsoTime } from "@/utils/isoFormat";
 
 interface MarketWatchlistItem {
   symbol: string;
@@ -374,11 +375,7 @@ const getStatusLabel = (updatedAt: Date | null, isFetching: boolean) => {
     return "Syncing live prices…";
   }
   if (updatedAt) {
-    return `Synced ${updatedAt.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    })}`;
+    return `Synced ${formatIsoTime(updatedAt)}`;
   }
   return "Waiting for live feed…";
 };

--- a/apps/web/components/receipts/PaymentStatus.tsx
+++ b/apps/web/components/receipts/PaymentStatus.tsx
@@ -17,6 +17,7 @@ import {
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import ReceiptUploader from "./ReceiptUploader";
+import { formatIsoDate } from "@/utils/isoFormat";
 
 interface PaymentStatusProps {
   paymentId?: string;
@@ -186,7 +187,7 @@ export const PaymentStatus: React.FC<PaymentStatusProps> = ({ paymentId }) => {
             <div>
               <div className="text-sm font-medium text-muted-foreground">Created</div>
               <div className="font-medium">
-                {new Date(payment.created_at).toLocaleDateString()}
+                {formatIsoDate(payment.created_at)}
               </div>
             </div>
           </div>

--- a/apps/web/components/shared/SubscriptionStatusCard.tsx
+++ b/apps/web/components/shared/SubscriptionStatusCard.tsx
@@ -9,6 +9,7 @@ import { Crown, Calendar, Clock, CheckCircle, XCircle } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/hooks/useToast";
 import { callEdgeFunction } from "@/config/supabase";
+import { formatIsoDate } from "@/utils/isoFormat";
 
 interface SubscriptionStatus {
   is_vip: boolean;
@@ -73,11 +74,7 @@ export const SubscriptionStatusCard = ({
   }, [getUserId, fetchSubscriptionStatus]);
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
+    return formatIsoDate(dateString);
   };
 
   const getStatusBadge = () => {

--- a/apps/web/components/telegram/dashboard/AnalyticsView.tsx
+++ b/apps/web/components/telegram/dashboard/AnalyticsView.tsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { formatIsoDateTime } from "@/utils/isoFormat";
 import type { AnalyticsData } from "./types";
 import { ViewHeader } from "./ViewHeader";
 
@@ -211,7 +212,7 @@ export function AnalyticsView({ onBack }: AnalyticsViewProps) {
               <div className="space-y-2">
                 <h3 className="text-lg font-semibold">Audience overview</h3>
                 <p className="text-sm text-muted-foreground">
-                  Snapshot generated at {new Date(analytics.generated_at).toLocaleString()}
+                  Snapshot generated at {formatIsoDateTime(analytics.generated_at ?? new Date())}
                 </p>
               </div>
               <div className="flex flex-wrap gap-4">

--- a/apps/web/components/ui/system-health.tsx
+++ b/apps/web/components/ui/system-health.tsx
@@ -26,6 +26,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/utils';
+import { formatIsoTime } from '@/utils/isoFormat';
 import {
   type SystemHealthCheck,
   type SystemHealthCheckKey,
@@ -463,7 +464,7 @@ export function SystemHealth({
         </div>
         {lastChecked && (
           <CardDescription className="text-xs">
-            Last checked: {lastChecked.toLocaleTimeString()}
+            Last checked: {formatIsoTime(lastChecked)}
           </CardDescription>
         )}
       </CardHeader>

--- a/apps/web/utils/isoFormat.ts
+++ b/apps/web/utils/isoFormat.ts
@@ -1,0 +1,48 @@
+export type IsoDateInput = string | number | Date;
+
+function toDate(value: IsoDateInput): Date | null {
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatWithPrecision(date: Date, includeMilliseconds: boolean): string {
+  const iso = date.toISOString();
+  if (includeMilliseconds) {
+    return iso;
+  }
+  return iso.replace(/\.\d{3}Z$/, "Z");
+}
+
+export function formatIsoDateTime(
+  value: IsoDateInput,
+  { includeMilliseconds = false }: { includeMilliseconds?: boolean } = {},
+): string {
+  const date = toDate(value);
+  if (!date) {
+    return "Invalid Date";
+  }
+  return formatWithPrecision(date, includeMilliseconds);
+}
+
+export function formatIsoDate(value: IsoDateInput): string {
+  const isoDateTime = formatIsoDateTime(value);
+  if (isoDateTime === "Invalid Date") {
+    return isoDateTime;
+  }
+  return isoDateTime.split("T")[0];
+}
+
+export function formatIsoTime(
+  value: IsoDateInput,
+  { includeMilliseconds = false }: { includeMilliseconds?: boolean } = {},
+): string {
+  const isoDateTime = formatIsoDateTime(value, { includeMilliseconds });
+  if (isoDateTime === "Invalid Date") {
+    return isoDateTime;
+  }
+  return isoDateTime.split("T")[1];
+}

--- a/apps/web/utils/magic-portfolio/formatDate.ts
+++ b/apps/web/utils/magic-portfolio/formatDate.ts
@@ -1,3 +1,5 @@
+import { formatIsoDate } from "@/utils/isoFormat";
+
 export function formatDate(date: string, includeRelative = false) {
   const currentDate = new Date();
 
@@ -22,11 +24,7 @@ export function formatDate(date: string, includeRelative = false) {
     formattedDate = "Today";
   }
 
-  const fullDate = targetDate.toLocaleString("en-us", {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
+  const fullDate = formatIsoDate(targetDate);
 
   if (!includeRelative) {
     return fullDate;

--- a/scripts/codex-workflow.js
+++ b/scripts/codex-workflow.js
@@ -822,7 +822,7 @@ function formatTimestamp(iso) {
     return iso;
   }
 
-  return date.toLocaleString();
+  return date.toISOString();
 }
 
 function printTroubleshootingTips(task, options = {}) {


### PR DESCRIPTION
## Summary
- add shared utilities to render timestamps and dates in ISO 8601 format
- update admin and analytics UI components to rely on the new helpers for consistent ISO output
- switch codex workflow tooling to emit ISO-formatted timestamps

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cfa66ff55c83229695c916b478e2f5