### PR TITLE
Fix VIP plan fetching fallback

### DIFF
--- a/apps/web/services/plans.ts
+++ b/apps/web/services/plans.ts
@@ -1,31 +1,107 @@
+import type { SupabaseClient } from "@/integrations/supabase/client";
+import { createClient } from "@/integrations/supabase/client";
 import type { Plan } from "@/types/plan";
 import { callEdgeFunction } from "@/config/supabase";
 
 interface PlansResponse {
-  plans?: Plan[] | null;
+  plans?: RawPlan[] | null;
   ok?: boolean;
 }
+
+type RawPlan = {
+  id?: string | null;
+  name?: string | null;
+  price?: number | string | null;
+  currency?: string | null;
+  duration_months?: number | string | null;
+  is_lifetime?: boolean | null;
+  features?: unknown;
+  created_at?: string | null;
+};
 
 let cachedPlans: Plan[] | null = null;
 let cachedError: string | null = null;
 let pendingRequest: Promise<Plan[]> | null = null;
+
+let fallbackClient: SupabaseClient | null = null;
+
+function getFallbackClient() {
+  if (!fallbackClient) {
+    fallbackClient = createClient();
+  }
+  return fallbackClient;
+}
+
+function coerceNumber(value: number | string | null | undefined) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function normalizePlan(plan: RawPlan | null | undefined): Plan | null {
+  if (!plan || typeof plan.id !== "string" || plan.id.trim() === "") {
+    return null;
+  }
+
+  if (typeof plan.name !== "string" || plan.name.trim() === "") {
+    return null;
+  }
+
+  const price = coerceNumber(plan.price);
+  if (price === null) {
+    return null;
+  }
+
+  const isLifetime = plan.is_lifetime === true;
+  const duration = coerceNumber(plan.duration_months);
+
+  const features = Array.isArray(plan.features)
+    ? plan.features.filter((feature): feature is string =>
+        typeof feature === "string" && feature.trim().length > 0,
+      )
+    : [];
+
+  return {
+    id: plan.id,
+    name: plan.name,
+    price,
+    currency:
+      typeof plan.currency === "string" && plan.currency.trim().length > 0
+        ? plan.currency
+        : "USD",
+    duration_months: isLifetime ? 0 : duration ?? 0,
+    is_lifetime: isLifetime,
+    features,
+  };
+}
 
 function normalizePlans(plans: PlansResponse["plans"]): Plan[] {
   if (!Array.isArray(plans)) {
     return [];
   }
 
-  return plans.filter((plan): plan is Plan => {
-    return (
-      !!plan &&
-      typeof plan.id === "string" &&
-      typeof plan.name === "string" &&
-      typeof plan.price === "number" &&
-      typeof plan.currency === "string" &&
-      typeof plan.duration_months === "number" &&
-      typeof plan.is_lifetime === "boolean"
-    );
-  });
+  return plans
+    .map((plan) => normalizePlan(plan))
+    .filter((plan): plan is Plan => plan !== null);
+}
+
+async function fetchPlansFromSupabase(): Promise<Plan[]> {
+  const client = getFallbackClient();
+  const { data, error } = await client
+    .from("subscription_plans")
+    .select(
+      "id,name,price,currency,duration_months,is_lifetime,features,created_at",
+    )
+    .order("price", { ascending: true });
+
+  if (error) {
+    throw new Error(error.message || "Unable to load subscription plans");
+  }
+
+  return normalizePlans(data as RawPlan[] | null);
 }
 
 export async function fetchSubscriptionPlans(options: { force?: boolean } = {}): Promise<Plan[]> {
@@ -44,18 +120,35 @@ export async function fetchSubscriptionPlans(options: { force?: boolean } = {}):
     }
   }
 
-  const request = callEdgeFunction<PlansResponse>("PLANS");
-
-  pendingRequest = request
-    .then(({ data, error }) => {
+  const request = (async () => {
+    try {
+      const { data, error } = await callEdgeFunction<PlansResponse>("PLANS");
       if (error) {
         throw new Error(error.message || "Unable to load subscription plans");
       }
 
       const normalized = normalizePlans(data?.plans ?? null);
-      cachedPlans = normalized;
+      if (normalized.length > 0) {
+        return normalized;
+      }
+
+      // If we received an empty result, fall back to a direct query to ensure
+      // live plans still render for admins and the landing page.
+      return await fetchPlansFromSupabase();
+    } catch (edgeError) {
+      console.warn(
+        "Edge function `plans` failed, falling back to direct Supabase query",
+        edgeError,
+      );
+      return await fetchPlansFromSupabase();
+    }
+  })();
+
+  pendingRequest = request
+    .then((plans) => {
+      cachedPlans = plans;
       cachedError = null;
-      return normalized;
+      return plans;
     })
     .catch((err) => {
       const message = err instanceof Error


### PR DESCRIPTION
## Summary
- normalize subscription plan data returned from the Edge function so price, duration, and features are always usable
- fall back to a direct Supabase query when the `plans` edge function fails or returns an empty payload to keep VIP packages rendering
- reuse the sanitized results in the plan caching service to clear previous errors

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d039e937ac8322a8a654e0b58d2314