### PR TITLE
Configure Next.js i18n locales

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -181,6 +181,10 @@ const nextConfig = {
     DEFAULT_LOCALE,
     NEXT_PUBLIC_DEFAULT_LOCALE: DEFAULT_LOCALE,
   },
+  i18n: {
+    locales: LOCALES,
+    defaultLocale: DEFAULT_LOCALE,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- configure the Next.js app to surface locales from `config/locales.json` via the built-in `i18n` setting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d36af8291483229df74413f6c70d0c