### PR TITLE
refactor: reuse formatPrice in analytics view

### DIFF
--- a/apps/web/components/telegram/dashboard/AnalyticsView.tsx
+++ b/apps/web/components/telegram/dashboard/AnalyticsView.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatIsoDateTime } from "@/utils/isoFormat";
+import { formatPrice } from "@/utils/format-price";
+import { DEFAULT_LOCALE } from "@/config/localization";
 import type { AnalyticsData } from "./types";
 import { ViewHeader } from "./ViewHeader";
 
@@ -22,12 +24,15 @@ interface AnalyticsViewProps {
   onBack: () => void;
 }
 
-const formatCurrency = (value: number, currency: string) =>
-  new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: currency || "USD",
-    maximumFractionDigits: 2,
-  }).format(value);
+const DEFAULT_CURRENCY = "USD";
+
+const formatCurrency = (value: number, currency: string | null | undefined) =>
+  formatPrice(
+    value,
+    currency && currency.trim() ? currency : DEFAULT_CURRENCY,
+    DEFAULT_LOCALE,
+    { minimumFractionDigits: 2, maximumFractionDigits: 2 },
+  );
 
 const timeframeOptions = [
   { value: "today", label: "Today" },


### PR DESCRIPTION
## Context
- duplicated currency formatting in the analytics dashboard bypassed our shared formatter and locale defaults

## Approach
- import the shared `formatPrice` helper and default locale into the analytics view
- centralize the currency formatting logic so all KPI tiles run through the same helper with explicit precision

## Risks & Rollback
- Low risk: only affects number formatting in the dashboard. Roll back by reverting this commit if unexpected rendering occurs.

## Tests
- `npm test`

## Flags
- None

## Migration
- None

------
https://chatgpt.com/codex/tasks/task_e_68d4109615d88322a4a7d3886f82c875