### PR TITLE
feat: add web api health endpoint

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,41 @@
+import { corsHeaders, jsonResponse, methodNotAllowed } from '@/utils/http.ts';
+import { getEnvVar } from '@/utils/env.ts';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const COMMIT_ENV_KEYS = [
+  'NEXT_PUBLIC_COMMIT_SHA',
+  'COMMIT_SHA',
+  'VERCEL_GIT_COMMIT_SHA',
+  'GITHUB_SHA',
+] as const;
+
+function resolveCommitSha(): string {
+  const [primary, ...aliases] = COMMIT_ENV_KEYS;
+  return getEnvVar(primary, aliases) ?? 'dev';
+}
+
+export function GET(req: Request) {
+  const body = {
+    status: 'ok' as const,
+    commit: resolveCommitSha(),
+  };
+
+  return jsonResponse(
+    body,
+    { headers: { 'cache-control': 'no-store' } },
+    req,
+  );
+}
+
+export function OPTIONS(req: Request) {
+  const headers = corsHeaders(req, 'GET');
+  return new Response(null, { status: 204, headers });
+}
+
+export const POST = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const DELETE = methodNotAllowed;
+export const HEAD = methodNotAllowed;

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+
+const modulePath = '../../apps/web/app/api/health/route.ts';
+const COMMIT_ENV_KEYS = [
+  'NEXT_PUBLIC_COMMIT_SHA',
+  'COMMIT_SHA',
+  'VERCEL_GIT_COMMIT_SHA',
+  'GITHUB_SHA',
+] as const;
+
+const nodeProcess =
+  typeof globalThis.process !== 'undefined'
+    ? (globalThis.process as { env?: Record<string, string | undefined> })
+    : undefined;
+
+const denoEnv =
+  typeof globalThis.Deno !== 'undefined' &&
+  typeof globalThis.Deno.env === 'object'
+    ? (globalThis.Deno.env as {
+        get?(key: string): string | undefined;
+        set?(key: string, value: string): void;
+        delete?(key: string): void;
+      })
+    : undefined;
+
+type EnvSnapshot = Record<string, string | undefined>;
+
+function captureEnv(): EnvSnapshot {
+  const snapshot: EnvSnapshot = {};
+  for (const key of COMMIT_ENV_KEYS) {
+    snapshot[key] = readEnv(key);
+  }
+  return snapshot;
+}
+
+function restoreEnv(snapshot: EnvSnapshot) {
+  for (const key of COMMIT_ENV_KEYS) {
+    const value = snapshot[key];
+    setEnv(key, value);
+  }
+}
+
+function readEnv(key: string): string | undefined {
+  if (denoEnv && typeof denoEnv.get === 'function') {
+    try {
+      const value = denoEnv.get(key);
+      if (typeof value === 'string') {
+        return value;
+      }
+    } catch {
+      // ignore permission errors
+    }
+  }
+
+  if (nodeProcess?.env && typeof nodeProcess.env[key] === 'string') {
+    return nodeProcess.env[key];
+  }
+
+  return undefined;
+}
+
+function setEnv(key: string, value: string | undefined) {
+  if (denoEnv) {
+    try {
+      if (value === undefined) {
+        if (typeof denoEnv.delete === 'function') {
+          denoEnv.delete(key);
+        } else if (typeof denoEnv.set === 'function') {
+          denoEnv.set(key, '');
+        }
+      } else if (typeof denoEnv.set === 'function') {
+        denoEnv.set(key, value);
+      }
+    } catch {
+      // ignore permission errors
+    }
+  }
+
+  if (nodeProcess?.env) {
+    if (value === undefined) {
+      delete nodeProcess.env[key];
+    } else {
+      nodeProcess.env[key] = value;
+    }
+  }
+}
+
+async function loadHandlers() {
+  return import(/* @vite-ignore */ modulePath);
+}
+
+async function runWithCommit() {
+  const snapshot = captureEnv();
+  setEnv('NEXT_PUBLIC_COMMIT_SHA', 'test-sha');
+  for (const key of COMMIT_ENV_KEYS) {
+    if (key !== 'NEXT_PUBLIC_COMMIT_SHA') {
+      setEnv(key, undefined);
+    }
+  }
+
+  try {
+    const { GET } = await loadHandlers();
+    const res = await GET(new Request('http://localhost/api/health'));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    const data = await res.json();
+    assert.deepEqual(data, { status: 'ok', commit: 'test-sha' });
+  } finally {
+    restoreEnv(snapshot);
+  }
+}
+
+async function runWithFallback() {
+  const snapshot = captureEnv();
+  for (const key of COMMIT_ENV_KEYS) {
+    setEnv(key, undefined);
+  }
+
+  try {
+    const { GET } = await loadHandlers();
+    const res = await GET(new Request('http://localhost/api/health'));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    const data = await res.json();
+    assert.deepEqual(data, { status: 'ok', commit: 'dev' });
+  } finally {
+    restoreEnv(snapshot);
+  }
+}
+
+if (typeof Deno !== 'undefined') {
+  Deno.test('GET /api/health returns commit when configured', runWithCommit);
+  Deno.test('GET /api/health falls back to dev when commit missing', runWithFallback);
+} else {
+  const { default: test } = await import(/* @vite-ignore */ 'node:test');
+  test('GET /api/health returns commit when configured', runWithCommit);
+  test('GET /api/health falls back to dev when commit missing', runWithFallback);
+}


### PR DESCRIPTION
## Problem
- Ops defaults expect a `/api/health` endpoint that exposes the running commit SHA.
- The web app only exposed `/healthz`, so platform health probes could not retrieve commit metadata.

## Root Cause
- The Next.js API routes omitted a dedicated health handler aligned with the shared infrastructure contract.

## Solution
- Add `/api/health` route that reports `{ status: 'ok', commit }`, resolves the commit from several env keys, and disables caching.
- Provide CORS-friendly OPTIONS handling and method guards to keep the endpoint consistent with other API routes.
- Add regression tests covering commit resolution from env vars and fallback behaviour.

## Risks & Rollback
- Low risk; new route is additive and isolated. Roll back by reverting the commit if issues arise.

## Tests
- `npm test`

## Migrations
- None

## Flags
- None

------
https://chatgpt.com/codex/tasks/task_e_68d4155551688322bcef7a5186be0e55