### PR TITLE
feat: add commit-aware health endpoints

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,26 @@
+import { corsHeaders, jsonResponse, methodNotAllowed } from '@/utils/http.ts';
+import { healthPayload } from '@/utils/commit.ts';
+
+export const dynamic = 'force-static';
+
+const payload = healthPayload();
+
+export function GET(req: Request) {
+  return jsonResponse(payload, {}, req);
+}
+
+export function HEAD() {
+  return new Response(null, { status: 204 });
+}
+
+export function OPTIONS(req: Request) {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(req, 'GET'),
+  });
+}
+
+export const POST = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const DELETE = methodNotAllowed;

--- a/apps/web/utils/commit.ts
+++ b/apps/web/utils/commit.ts
@@ -1,0 +1,63 @@
+const nodeProcess = (globalThis as any).process as
+  | { env?: Record<string, string | undefined> }
+  | undefined;
+
+const denoEnv = 'Deno' in globalThis
+  ? ((globalThis as any).Deno?.env as { get?: (key: string) => string | undefined })
+  : undefined;
+
+const commitEnvOrder = [
+  'COMMIT_SHA',
+  'NEXT_PUBLIC_COMMIT_SHA',
+  'GIT_COMMIT_SHA',
+  'GIT_COMMIT',
+  'VERCEL_GIT_COMMIT_SHA',
+  'SOURCE_VERSION',
+  'DIGITALOCEAN_GIT_COMMIT_SHA',
+  'DIGITALOCEAN_DEPLOYMENT_ID',
+  'DIGITALOCEAN_APP_DEPLOYMENT_SHA',
+  'RENDER_GIT_COMMIT',
+  'HEROKU_SLUG_COMMIT',
+];
+
+function readEnv(key: string): string | undefined {
+  const fromDeno = denoEnv?.get?.(key);
+  if (fromDeno && fromDeno.trim()) {
+    return fromDeno;
+  }
+  const fromNode = nodeProcess?.env?.[key];
+  if (fromNode && `${fromNode}`.trim()) {
+    return fromNode;
+  }
+  return undefined;
+}
+
+function normalizeCommit(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const value = raw.trim();
+  if (!value || value === 'undefined' || value === 'null') {
+    return undefined;
+  }
+  return value;
+}
+
+let cachedCommit: string | undefined;
+
+export function getCommitSha(): string {
+  if (cachedCommit) return cachedCommit;
+
+  for (const key of commitEnvOrder) {
+    const candidate = normalizeCommit(readEnv(key));
+    if (candidate) {
+      cachedCommit = candidate;
+      return candidate;
+    }
+  }
+
+  cachedCommit = 'unknown';
+  return cachedCommit;
+}
+
+export function healthPayload() {
+  return { status: 'ok', commit: getCommitSha() } as const;
+}

--- a/go-service/main.go
+++ b/go-service/main.go
@@ -4,16 +4,47 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
+
+func commitSHA() string {
+	keys := []string{
+		"COMMIT_SHA",
+		"GIT_COMMIT_SHA",
+		"GIT_COMMIT",
+		"SOURCE_VERSION",
+		"VERCEL_GIT_COMMIT_SHA",
+		"DIGITALOCEAN_GIT_COMMIT_SHA",
+		"DIGITALOCEAN_DEPLOYMENT_ID",
+		"DIGITALOCEAN_APP_DEPLOYMENT_SHA",
+		"RENDER_GIT_COMMIT",
+		"HEROKU_SLUG_COMMIT",
+	}
+
+	for _, key := range keys {
+		if value, ok := os.LookupEnv(key); ok {
+			trimmed := strings.TrimSpace(value)
+			lower := strings.ToLower(trimmed)
+			if trimmed != "" && lower != "undefined" && lower != "null" {
+				return trimmed
+			}
+		}
+	}
+
+	return "unknown"
+}
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
+	commit := commitSHA()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		logger.Info("healthz", "method", r.Method, "remote", r.RemoteAddr)
-		w.Write([]byte("ok"))
+		logger.Info("healthz", "method", r.Method, "remote", r.RemoteAddr, "commit", commit)
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Write([]byte("ok " + commit))
 	})
 
 	srv := &http.Server{

--- a/supabase/functions/_shared/commit.ts
+++ b/supabase/functions/_shared/commit.ts
@@ -1,0 +1,1 @@
+export * from "../../../apps/web/utils/commit.ts";

--- a/supabase/functions/_tests/health.test.ts
+++ b/supabase/functions/_tests/health.test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+Deno.test("health function responds with commit", async () => {
+  const commit = "test-health-sha";
+  Deno.env.set("COMMIT_SHA", commit);
+  const g = globalThis as { process?: { env: Record<string, string> } };
+  if (!g.process) g.process = { env: {} };
+  g.process.env.COMMIT_SHA = commit;
+
+  const { handler } = await import(
+    `../health/index.ts?cache=${crypto.randomUUID()}`
+  );
+
+  const res = await handler(new Request("http://localhost/functions/v1/health"));
+  assertEquals(res.status, 200);
+  const body = await res.json() as { status: string; commit: string };
+  assertEquals(body.status, "ok");
+  assertEquals(body.commit, commit);
+
+  Deno.env.delete("COMMIT_SHA");
+  delete g.process.env.COMMIT_SHA;
+});

--- a/supabase/functions/health/index.ts
+++ b/supabase/functions/health/index.ts
@@ -1,0 +1,13 @@
+import { guardHealthRequest } from "../_shared/health.ts";
+import { jsonResponse } from "../_shared/http.ts";
+import { healthPayload } from "../_shared/commit.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+export const handler = registerHandler((req) => {
+  const guard = guardHealthRequest(req, ["GET"]);
+  if (guard) return guard;
+
+  return jsonResponse(healthPayload(), {}, req);
+});
+
+export default handler;


### PR DESCRIPTION
## Summary
- add a shared commit resolver and expose `/api/health` with the deployment SHA
- return the commit from marketing and bridge `/health` probes to satisfy go-live checks
- ship a Supabase `health` edge function (plus tests) that surfaces the commit for readiness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4146bc92c832297bfc0e8bc98b959