### PR TITLE
fix: serve miniapp version payload

### DIFF
--- a/supabase/functions/miniapp/index.ts
+++ b/supabase/functions/miniapp/index.ts
@@ -285,7 +285,7 @@ export async function handler(req: Request): Promise<Response> {
   console.log(`[miniapp] ${req.method} ${logPath}`);
   
   // Handle version endpoint for health checks and deployment verification
-  if (path === "/version" || path === "/miniapp/version") {
+  if (path === "/version") {
     return withSecurity(new Response(JSON.stringify({
       version: "1.0.0",
       timestamp: new Date().toISOString(),
@@ -301,7 +301,8 @@ export async function handler(req: Request): Promise<Response> {
     path === "/" ||
     (path.startsWith("/miniapp") &&
       !path.startsWith("/miniapp/api") &&
-      !path.startsWith("/miniapp/assets"))
+      !path.startsWith("/miniapp/assets") &&
+      !path.startsWith("/miniapp/version"))
   ) {
     try {
       const staticOpts: StaticOpts = {

--- a/tests/miniapp-version-endpoint.test.ts
+++ b/tests/miniapp-version-endpoint.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import { equal as assertEquals, ok as assert } from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { freshImport } from './utils/freshImport.ts';
+
+const globalAny = globalThis as any;
+const supaState: any = { tables: {} };
+globalAny.__SUPA_MOCK__ = supaState;
+
+type TestEnvMap = Record<string, string>;
+let previousTestEnv: TestEnvMap | undefined;
+let lastEnvKeys: string[] = [];
+
+function setupEnv(extra: Record<string, string> = {}): TestEnvMap {
+  const values: TestEnvMap = {
+    SUPABASE_URL: 'http://localhost',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role',
+    SUPABASE_ANON_KEY: 'anon-key',
+    ...extra,
+  };
+
+  lastEnvKeys = Object.keys(values);
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+
+  previousTestEnv = globalAny.__TEST_ENV__ as TestEnvMap | undefined;
+  globalAny.__TEST_ENV__ = { ...(previousTestEnv ?? {}), ...values };
+
+  return values;
+}
+
+function cleanupEnv() {
+  for (const key of lastEnvKeys) {
+    delete process.env[key];
+  }
+  supaState.tables = {};
+  if (previousTestEnv === undefined) {
+    delete globalAny.__TEST_ENV__;
+  } else {
+    globalAny.__TEST_ENV__ = previousTestEnv;
+  }
+  previousTestEnv = undefined;
+  lastEnvKeys = [];
+}
+
+test('miniapp version endpoint returns expected fields', async () => {
+  const envValues = setupEnv();
+  const originalDeno = globalAny.Deno;
+  const createdDeno = originalDeno === undefined;
+  const denoRef = createdDeno ? {} : originalDeno;
+  const originalEnv = denoRef?.env;
+  const originalReadTextFile = denoRef?.readTextFile;
+  const originalReadFile = denoRef?.readFile;
+  const baseGet = typeof originalEnv?.get === 'function'
+    ? originalEnv.get.bind(originalEnv)
+    : undefined;
+
+  if (createdDeno) {
+    globalAny.Deno = denoRef;
+  }
+
+  denoRef.env = {
+    ...(originalEnv ?? {}),
+    get: (name: string) => {
+      if (name in envValues) return envValues[name];
+      return baseGet ? baseGet(name) ?? '' : '';
+    },
+  };
+  denoRef.readTextFile = (path: string) => readFile(path, 'utf8');
+  denoRef.readFile = readFile;
+
+  try {
+    const mod = await freshImport(new URL('../supabase/functions/miniapp/index.ts', import.meta.url));
+    const handler: (req: Request) => Promise<Response> | Response = mod.default;
+    const res = await handler(new Request('https://example.com/miniapp/version'));
+    assertEquals(res.status, 200);
+    const body = await res.json();
+    assert(typeof body === 'object' && body);
+    assertEquals(body.name, 'miniapp');
+    assert(typeof body.ts === 'string' && body.ts.length > 0);
+    assert('serveFromStorage' in body);
+    assert('htmlCompressionDisabled' in body);
+  } finally {
+    if (createdDeno) {
+      delete globalAny.Deno;
+    } else {
+      if (originalEnv === undefined) {
+        delete denoRef.env;
+      } else {
+        denoRef.env = originalEnv;
+      }
+      if (originalReadTextFile === undefined) {
+        delete denoRef.readTextFile;
+      } else {
+        denoRef.readTextFile = originalReadTextFile;
+      }
+      if (originalReadFile === undefined) {
+        delete denoRef.readFile;
+      } else {
+        denoRef.readFile = originalReadFile;
+      }
+    }
+    cleanupEnv();
+  }
+});
+


### PR DESCRIPTION
## Summary
- stop the mini app handler from treating `/miniapp/version` like static content so that the JSON endpoint executes
- keep the existing version endpoint focused on `/version` and add a node test that verifies the payload contains the expected fields

## Problem
- the embedded mini app UI expects the `/miniapp/version` endpoint to respond with `name`/`ts`, but the handler returned `version`/`timestamp` and static middleware short-circuited the request.

## Root Cause
- the version handler intercepted both `/version` and `/miniapp/version`, bypassing the updated JSON payload, and the static serving branch also captured `/miniapp/version` before the JSON handler could run.

## Solution
- narrow the version handler to `/version`, exclude `/miniapp/version` from the static serving branch, and add a regression test to assert the version payload includes the expected metadata.

## Risks & Rollback
- Low risk: changes are limited to the mini app function and a new unit test. Roll back by reverting this commit if unexpected behavior appears.

## Tests
- `npm test`

## Migrations
- n/a

## Feature Flags
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d4122117e48322b7b45ebf3d67771d