### PR TITLE
chore: align deno config with 2.x warnings

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -74,13 +74,15 @@
   // Telegram webhook keeper: every 15 minutes
   // supabase functions schedule create "*/15 * * * *" telegram-webhook-keeper
   "lock": false,
-  "nodeModulesDir": false,
+  "nodeModulesDir": "none",
   "compilerOptions": {
     "types": [
       "./apps/web/types/tesseract.d.ts",
-      "./apps/web/types/deno.d.ts"
-    ],
-    "typeRoots": ["./apps/web/types"]
+      "./apps/web/types/deno.d.ts",
+      "./apps/web/types/import-meta.d.ts",
+      "./apps/web/types/sentry-nextjs.d.ts",
+      "./apps/web/types/@types/node/index.d.ts"
+    ]
   },
   "importMap": "./supabase/functions/telegram-bot/vendor/import_map.json",
   "test": {


### PR DESCRIPTION
## Root Cause
- Deno 2.x treats the boolean `nodeModulesDir` flag and the `typeRoots` compiler option as deprecated or unsupported, which caused persistent warnings in every `deno test` run.

## Fix
- Switch the configuration to `"nodeModulesDir": "none"` and explicitly enumerate the custom declaration files in `compilerOptions.types`, allowing us to drop the unsupported `typeRoots` entry without losing type coverage.

## Tests
- `npm test`

## Risks / Rollback Plan
- Low risk configuration change; rollback by restoring the previous `deno.json` if new type resolutions fail.

## Migrations
- None.

## Flags
- None.


------
https://chatgpt.com/codex/tasks/task_e_68d4155551688322bcef7a5186be0e55