### PR TITLE
fix: modernize deno config options

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -74,13 +74,15 @@
   // Telegram webhook keeper: every 15 minutes
   // supabase functions schedule create "*/15 * * * *" telegram-webhook-keeper
   "lock": false,
-  "nodeModulesDir": false,
+  "nodeModulesDir": "none",
   "compilerOptions": {
     "types": [
       "./apps/web/types/tesseract.d.ts",
-      "./apps/web/types/deno.d.ts"
-    ],
-    "typeRoots": ["./apps/web/types"]
+      "./apps/web/types/deno.d.ts",
+      "./apps/web/types/import-meta.d.ts",
+      "./apps/web/types/sentry-nextjs.d.ts",
+      "./apps/web/types/@types/node/index.d.ts"
+    ]
   },
   "importMap": "./supabase/functions/telegram-bot/vendor/import_map.json",
   "test": {


### PR DESCRIPTION
## Problem / Root Cause
- Deno 2 raised warnings during tests because `nodeModulesDir` was still configured as `false` and `typeRoots` was specified, which are no longer supported compiler options.

## Solution
- Switched the configuration to `nodeModulesDir: "none"` and replaced the `typeRoots` usage with explicit `types` entries so Deno continues to load our custom declarations without warnings.

## Dependencies / Scripts
- No dependency or script changes required.

## Testing
- npm test

## Risks / Rollback
- Low risk; revert `deno.json` to the previous configuration if new issues appear.

## Migrations
- None.

## Flags / Follow-Up
- None.


------
https://chatgpt.com/codex/tasks/task_e_68d4166822008322b1a1b5558021db08