### PR TITLE
fix: ensure health commit defaults to dev

### DIFF
--- a/apps/web/utils/commit.ts
+++ b/apps/web/utils/commit.ts
@@ -6,9 +6,9 @@ const denoEnv = 'Deno' in globalThis
   ? ((globalThis as any).Deno?.env as { get?: (key: string) => string | undefined })
   : undefined;
 
-const commitEnvOrder = [
-  'COMMIT_SHA',
+export const COMMIT_ENV_KEYS = [
   'NEXT_PUBLIC_COMMIT_SHA',
+  'COMMIT_SHA',
   'GIT_COMMIT_SHA',
   'GIT_COMMIT',
   'VERCEL_GIT_COMMIT_SHA',
@@ -18,7 +18,7 @@ const commitEnvOrder = [
   'DIGITALOCEAN_APP_DEPLOYMENT_SHA',
   'RENDER_GIT_COMMIT',
   'HEROKU_SLUG_COMMIT',
-];
+] as const;
 
 function readEnv(key: string): string | undefined {
   const fromDeno = denoEnv?.get?.(key);
@@ -46,7 +46,7 @@ let cachedCommit: string | undefined;
 export function getCommitSha(): string {
   if (cachedCommit) return cachedCommit;
 
-  for (const key of commitEnvOrder) {
+  for (const key of COMMIT_ENV_KEYS) {
     const candidate = normalizeCommit(readEnv(key));
     if (candidate) {
       cachedCommit = candidate;
@@ -54,7 +54,7 @@ export function getCommitSha(): string {
     }
   }
 
-  cachedCommit = 'unknown';
+  cachedCommit = 'dev';
   return cachedCommit;
 }
 

--- a/tests/health-commit.test.ts
+++ b/tests/health-commit.test.ts
@@ -1,0 +1,99 @@
+if (typeof Deno !== 'undefined') {
+  const { assertEquals } = await import('https://deno.land/std@0.224.0/assert/mod.ts');
+  const { COMMIT_ENV_KEYS } = await import('../apps/web/utils/commit.ts');
+
+  type CommitEnvKey = (typeof COMMIT_ENV_KEYS)[number];
+
+  function ensureProcessEnv() {
+    const g = globalThis as { process?: { env?: Record<string, string | undefined> } };
+    if (!g.process) {
+      g.process = { env: {} };
+    }
+    if (!g.process.env) {
+      g.process.env = {};
+    }
+    return g.process.env as Record<string, string | undefined>;
+  }
+
+  async function withCommitEnvCleared(run: () => Promise<void>) {
+    const processEnv = ensureProcessEnv();
+    const originalNode = new Map<CommitEnvKey, string | undefined>();
+    const originalDeno = new Map<CommitEnvKey, string | undefined>();
+
+    for (const key of COMMIT_ENV_KEYS) {
+      originalNode.set(key, processEnv[key]);
+      delete processEnv[key];
+
+      let denoValue: string | undefined;
+      try {
+        denoValue = Deno.env.get(key) ?? undefined;
+      } catch {
+        denoValue = undefined;
+      }
+      originalDeno.set(key, denoValue);
+
+      try {
+        Deno.env.delete(key);
+      } catch {
+        // ignore keys that were not set
+      }
+    }
+
+    try {
+      await run();
+    } finally {
+      const restoredEnv = ensureProcessEnv();
+      for (const [key, value] of originalNode) {
+        if (value === undefined) {
+          delete restoredEnv[key];
+        } else {
+          restoredEnv[key] = value;
+        }
+      }
+
+      for (const [key, value] of originalDeno) {
+        if (value === undefined) {
+          try {
+            Deno.env.delete(key);
+          } catch {
+            // ignore
+          }
+        } else {
+          Deno.env.set(key, value);
+        }
+      }
+    }
+  }
+
+  Deno.test('health payload defaults commit to dev when env missing', async () => {
+    await withCommitEnvCleared(async () => {
+      const { healthPayload } = await import(
+        `../apps/web/utils/commit.ts?cache=${crypto.randomUUID()}`
+      );
+      const payload = healthPayload();
+      assertEquals(payload.status, 'ok');
+      assertEquals(payload.commit, 'dev');
+    });
+  });
+
+  Deno.test('health payload prefers NEXT_PUBLIC_COMMIT_SHA when present', async () => {
+    await withCommitEnvCleared(async () => {
+      const processEnv = ensureProcessEnv();
+      Deno.env.set('COMMIT_SHA', 'commit-sha');
+      processEnv.COMMIT_SHA = 'commit-sha';
+      Deno.env.set('NEXT_PUBLIC_COMMIT_SHA', 'public-sha');
+      processEnv.NEXT_PUBLIC_COMMIT_SHA = 'public-sha';
+
+      const { healthPayload } = await import(
+        `../apps/web/utils/commit.ts?cache=${crypto.randomUUID()}`
+      );
+      const payload = healthPayload();
+      assertEquals(payload.status, 'ok');
+      assertEquals(payload.commit, 'public-sha');
+    });
+  });
+} else {
+  const { default: test } = await import('node:test');
+  test.skip('health payload defaults commit to dev when env missing (Deno only)', () => {});
+  test.skip('health payload prefers NEXT_PUBLIC_COMMIT_SHA when present (Deno only)', () => {});
+}


### PR DESCRIPTION
## Summary
- default the shared health payload helper to prefer NEXT_PUBLIC_COMMIT_SHA and fall back to "dev"
- export the commit env key list for reuse and keep the payload stable across Next.js and Edge runtimes
- add regression tests covering the dev fallback and NEXT_PUBLIC_COMMIT_SHA precedence

## Testing
- npm test

## Risks & Mitigations
- Low risk: touches commit metadata helper only; covered by new automated tests.

## Rollback
- Revert this PR.

## Dependencies
- None.

## Migration
- None.

## Feature Flags
- None.

------
https://chatgpt.com/codex/tasks/task_e_68d418f7dc8483228594f7607735ed14