### PR TITLE
Enable baked-in Supabase config defaults

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -26,6 +26,7 @@ import { SupabaseProvider } from '@/context/SupabaseProvider';
 import { MotionConfigProvider } from '@/components/ui/motion-config';
 import { systemUI } from '@/resources';
 import { iconLibrary } from '@/resources/icons';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '@/config/supabase-runtime';
 
 const {
   basics: basicsConfig,
@@ -33,9 +34,6 @@ const {
 } = systemUI;
 const { style } = basicsConfig;
 const { dataStyle } = dataVizConfig;
-
-const SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [supabaseClient] = useState(() =>

--- a/apps/web/config/supabase-runtime.ts
+++ b/apps/web/config/supabase-runtime.ts
@@ -1,0 +1,41 @@
+import { getEnvVar } from "@/utils/env.ts";
+
+export const DEFAULT_SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
+export const DEFAULT_SUPABASE_ANON_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXRpOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+
+type ResolvedValue = {
+  value: string;
+  fromEnv: boolean;
+};
+
+function resolveValue(
+  primary: string,
+  aliases: string[],
+  fallback: string,
+): ResolvedValue {
+  const resolved = getEnvVar(primary, aliases);
+  if (resolved && resolved.length > 0) {
+    return { value: resolved, fromEnv: true };
+  }
+
+  return { value: fallback, fromEnv: false };
+}
+
+export const SUPABASE_URL_RESOLUTION = resolveValue(
+  "NEXT_PUBLIC_SUPABASE_URL",
+  ["SUPABASE_URL"],
+  DEFAULT_SUPABASE_URL,
+);
+
+export const SUPABASE_ANON_KEY_RESOLUTION = resolveValue(
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  ["SUPABASE_ANON_KEY"],
+  DEFAULT_SUPABASE_ANON_KEY,
+);
+
+export const SUPABASE_URL = SUPABASE_URL_RESOLUTION.value;
+export const SUPABASE_ANON_KEY = SUPABASE_ANON_KEY_RESOLUTION.value;
+
+export const SUPABASE_CONFIG_FROM_ENV =
+  SUPABASE_URL_RESOLUTION.fromEnv && SUPABASE_ANON_KEY_RESOLUTION.fromEnv;

--- a/apps/web/config/supabase.ts
+++ b/apps/web/config/supabase.ts
@@ -1,15 +1,15 @@
-import { getEnvVar } from "@/utils/env.ts";
+import {
+  SUPABASE_ANON_KEY,
+  SUPABASE_CONFIG_FROM_ENV,
+  SUPABASE_URL,
+} from "@/config/supabase-runtime";
 
-const SUPABASE_URL = getEnvVar("NEXT_PUBLIC_SUPABASE_URL", ["SUPABASE_URL"]) ??
-  "";
-const SUPABASE_ANON_KEY =
-  getEnvVar("NEXT_PUBLIC_SUPABASE_ANON_KEY", ["SUPABASE_ANON_KEY"]) ?? "";
+export const SUPABASE_ENV_ERROR = "";
 
-export let SUPABASE_ENV_ERROR = "";
-
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  SUPABASE_ENV_ERROR = "Missing required Supabase env vars";
-  console.warn("Configuration warning:", SUPABASE_ENV_ERROR);
+if (!SUPABASE_CONFIG_FROM_ENV) {
+  console.info(
+    "[Supabase] Using baked-in project credentials because env vars are not set.",
+  );
 }
 
 export const SUPABASE_CONFIG = {

--- a/apps/web/integrations/supabase/client.ts
+++ b/apps/web/integrations/supabase/client.ts
@@ -4,20 +4,18 @@ import {
   type SupabaseClientOptions,
 } from '@supabase/supabase-js';
 import { getEnvVar } from '@/utils/env.ts';
+import {
+  SUPABASE_ANON_KEY,
+  SUPABASE_CONFIG_FROM_ENV,
+  SUPABASE_URL,
+} from '@/config/supabase-runtime';
 
-const PLACEHOLDER_URL = 'https://example.supabase.co';
-const PLACEHOLDER_ANON_KEY = 'anon-key-placeholder';
+export const SUPABASE_ENV_ERROR = '';
 
-export const SUPABASE_URL =
-  getEnvVar('NEXT_PUBLIC_SUPABASE_URL', ['SUPABASE_URL']) ?? PLACEHOLDER_URL;
-export const SUPABASE_ANON_KEY =
-  getEnvVar('NEXT_PUBLIC_SUPABASE_ANON_KEY', ['SUPABASE_ANON_KEY']) ??
-  PLACEHOLDER_ANON_KEY;
-export let SUPABASE_ENV_ERROR = '';
-
-if (SUPABASE_URL === PLACEHOLDER_URL || SUPABASE_ANON_KEY === PLACEHOLDER_ANON_KEY) {
-  SUPABASE_ENV_ERROR = 'Missing required Supabase env vars';
-  console.warn('Configuration warning:', SUPABASE_ENV_ERROR);
+if (!SUPABASE_CONFIG_FROM_ENV) {
+  console.info(
+    '[Supabase] Using baked-in project credentials because env vars are not set.',
+  );
 }
 
 const queryCounts: Record<string, number> = {};
@@ -80,3 +78,5 @@ export const supabase: SupabaseClient =
 export function getQueryCounts() {
   return { ...queryCounts };
 }
+
+export { SUPABASE_URL, SUPABASE_ANON_KEY };

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,16 +1,76 @@
-// Consolidated Supabase client configuration
-import { createClient } from "@supabase/supabase-js";
+import {
+  createClient as createBrowserClient,
+  type SupabaseClientOptions,
+} from "@supabase/supabase-js";
+import { getEnvVar } from "@/utils/env.ts";
+import {
+  SUPABASE_ANON_KEY,
+  SUPABASE_URL,
+} from "@/config/supabase-runtime";
 
-const SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-const SUPABASE_ANON_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+type QueryCounts = Record<string, number>;
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    storage: typeof window !== "undefined" ? localStorage : undefined,
-    persistSession: true,
-    autoRefreshToken: true,
-  },
-});
+const queryCounts: QueryCounts = {};
+
+const loggingFetch: typeof fetch = async (input, init) => {
+  const start = Date.now();
+  const res = await fetch(input as RequestInfo, init);
+  const end = Date.now();
+  try {
+    let url: string;
+    if (typeof input === "string") {
+      url = input;
+    } else if (input instanceof Request) {
+      url = input.url;
+    } else {
+      url = input.toString();
+    }
+    const path = new URL(url).pathname;
+    queryCounts[path] = (queryCounts[path] || 0) + 1;
+    console.log(`[Supabase] ${path} - ${res.status} - ${end - start}ms`);
+  } catch {
+    // ignore logging errors
+  }
+  return res;
+};
+
+export type SupabaseCreateOptions = SupabaseClientOptions<"public">;
+
+export function createClient(
+  role: "anon" | "service" = "anon",
+  options: SupabaseCreateOptions = {},
+) {
+  const key =
+    role === "service"
+      ? getEnvVar("SUPABASE_SERVICE_ROLE_KEY")
+      : SUPABASE_ANON_KEY;
+
+  if (!key) {
+    throw new Error(
+      role === "service"
+        ? "Missing Supabase service role key"
+        : "Missing Supabase anon key",
+    );
+  }
+
+  const mergedGlobal = {
+    fetch: loggingFetch,
+    ...(options.global ?? {}),
+  };
+
+  return createBrowserClient(SUPABASE_URL, key, {
+    ...options,
+    global: mergedGlobal,
+  });
+}
+
+export type SupabaseClient = ReturnType<typeof createClient>;
+
+export const supabase: SupabaseClient =
+  typeof window !== "undefined" ? createClient() : ({} as SupabaseClient);
+
+export function getQueryCounts() {
+  return { ...queryCounts };
+}
 
 export { SUPABASE_ANON_KEY, SUPABASE_URL };

--- a/tests/missing-env-screen.test.ts
+++ b/tests/missing-env-screen.test.ts
@@ -1,14 +1,15 @@
 import test from 'node:test';
-import { ok as assert } from 'node:assert/strict';
+import { strictEqual } from 'node:assert/strict';
 import { freshImport } from './utils/freshImport.ts';
 
-test('missing Supabase env vars sets error flag', async () => {
+test('supabase config falls back to baked-in defaults', async () => {
   const prevUrl = process.env.SUPABASE_URL;
   const prevKey = process.env.SUPABASE_ANON_KEY;
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_ANON_KEY;
   const mod = await freshImport(new URL('../apps/web/config/supabase.ts', import.meta.url));
-  assert(mod.SUPABASE_ENV_ERROR);
+  strictEqual(mod.SUPABASE_ENV_ERROR, '');
+  strictEqual(mod.SUPABASE_CONFIG.URL, 'https://qeejuomcapbdlhnjqjcc.supabase.co');
   if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl;
   if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey;
 });


### PR DESCRIPTION
## Summary
- add a shared supabase-runtime helper that resolves env overrides and falls back to the production Supabase project
- wire Supabase clients, providers, and config helpers to consume the runtime defaults while gracefully disabling remote config when env vars are absent
- update the missing-env regression test to assert the baked-in defaults are surfaced instead of triggering the maintenance screen

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d41e4878cc832299cb60e3413c68d4