### PR TITLE
Replace broken marketing links and mini-app preview fallback

### DIFF
--- a/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
+++ b/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
@@ -119,15 +119,17 @@ export function MentorshipProgramsSection() {
                 >
                   {program.primaryCtaLabel}
                 </Button>
-                <Button
-                  size="m"
-                  variant="secondary"
-                  data-border="rounded"
-                  prefixIcon="calendar"
-                  href={about.calendar.link}
-                >
-                  {program.secondaryCtaLabel}
-                </Button>
+                {about.calendar.display && about.calendar.link ? (
+                  <Button
+                    size="m"
+                    variant="secondary"
+                    data-border="rounded"
+                    prefixIcon="calendar"
+                    href={about.calendar.link}
+                  >
+                    {program.secondaryCtaLabel}
+                  </Button>
+                ) : null}
               </Row>
             </Column>
             {index < PROGRAMS.length - 1 ? <Line background="neutral-alpha-weak" /> : null}

--- a/apps/web/components/magic-portfolio/home/PoolTradingSection.tsx
+++ b/apps/web/components/magic-portfolio/home/PoolTradingSection.tsx
@@ -95,15 +95,17 @@ export function PoolTradingSection() {
         >
           Start allocation checkout
         </Button>
-        <Button
-          size="m"
-          variant="secondary"
-          data-border="rounded"
-          prefixIcon="calendar"
-          href={about.calendar.link}
-        >
-          Schedule a pool strategy call
-        </Button>
+        {about.calendar.display && about.calendar.link ? (
+          <Button
+            size="m"
+            variant="secondary"
+            data-border="rounded"
+            prefixIcon="calendar"
+            href={about.calendar.link}
+          >
+            Schedule a pool strategy call
+          </Button>
+        ) : null}
       </Row>
     </Column>
   );

--- a/apps/web/components/telegram/MiniAppPreview.tsx
+++ b/apps/web/components/telegram/MiniAppPreview.tsx
@@ -15,7 +15,7 @@ export default function MiniAppPreview({ className }: MiniAppPreviewProps) {
   const [activeTab, setActiveTab] = useState("home");
   const [viewMode, setViewMode] = useState<"deployed" | "inline">("deployed");
 
-  const miniAppUrl = "https://chatty-telly-bot.lovable.app/miniapp/";
+  const miniAppUrl = "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/";
 
   const tabs = [
     { id: "home", label: "Home", icon: Star },

--- a/apps/web/resources/content.tsx
+++ b/apps/web/resources/content.tsx
@@ -87,8 +87,8 @@ const about: About = {
     display: true,
   },
   calendar: {
-    display: true,
-    link: "https://cal.com/dynamiccapital/strategy",
+    display: false,
+    link: "",
   },
   intro: {
     display: true,

--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -140,7 +140,7 @@ const effects: EffectsConfig = {
 };
 
 const mailchimp: MailchimpConfig = {
-  action: "https://dynamiccapital.us21.list-manage.com/subscribe/post?u=demo&id=desk",
+  action: "https://dynamiccapital.us21.list-manage.com/subscribe/post?u=c1a5a210340eb6c7bff33b2ba&id=0462d244aa",
   effects: {
     mask: {
       cursor: true,

--- a/supabase/functions/setup-lovable-miniapp/index.ts
+++ b/supabase/functions/setup-lovable-miniapp/index.ts
@@ -31,7 +31,7 @@ export const handler = registerHandler(async (req) => {
     }
 
     const lovableMiniAppUrl =
-      Deno.env.get('MINI_APP_URL') ?? 'https://chatty-telly-bot.lovable.app/miniapp/';
+      Deno.env.get('MINI_APP_URL') ?? 'https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/';
     
     console.log('Setting up Lovable Mini App with URL:', lovableMiniAppUrl);
 


### PR DESCRIPTION
## Summary
- disable the about/mentorship calendar CTAs when no booking link is configured
- point the marketing newsletter form at the live Mailchimp subscribe endpoint
- update the mini app preview and setup script to use the deployed Supabase mini-app URL

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d421e5f8a083229cb861067d06e3e0