### PR TITLE
Add reviewer nudge workflow

### DIFF
--- a/.github/workflows/reviewer-nudge.yml
+++ b/.github/workflows/reviewer-nudge.yml
@@ -10,6 +10,7 @@ jobs:
   nudge:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Ping stale PRs with awaiting-review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a scheduled reviewer nudge workflow that pings stale awaiting-review pull requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d43c1cf4a883229d84249bc88f66fd