### PR TITLE
Add tag guard workflow

### DIFF
--- a/.github/workflows/tag-guard.yml
+++ b/.github/workflows/tag-guard.yml
@@ -1,0 +1,40 @@
+name: Tag Guard
+on:
+  push:
+    tags: ["*"]
+permissions:
+  contents: write
+  issues: write
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Allowlist & patterns
+        id: check
+        env:
+          PUSHER: ${{ github.actor }}
+          REF: ${{ github.ref }}  # refs/tags/<tag>
+        run: |
+          TAG="${REF#refs/tags/}"
+          case "$TAG" in
+            v[0-9]*.[0-9]*.[0-9]*) OK_PATTERN=1 ;;
+            *) OK_PATTERN=0 ;;
+          esac
+          case "$PUSHER" in
+            github-actions[bot]|Dynamic-Capital|Dynamic-Capital-bot) OK_PUSHER=1 ;;
+            *) OK_PUSHER=0 ;;
+          esac
+          echo "ok=$((OK_PATTERN & OK_PUSHER))" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Revert unauthorized tag
+        if: steps.check.outputs.ok != '1'
+        env:
+          TAG: ${{ steps.check.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # delete the tag ref
+          gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/$TAG || true
+          # open a heads-up issue
+          gh issue create -t "Removed unauthorized tag: $TAG" \
+            -b "Tag \`$TAG\` created by @${{ github.actor }} was reverted by Tag Guard. Allowed: semver tags from release bot/admins."


### PR DESCRIPTION
## Summary
- add a Tag Guard workflow to enforce semver tags and allowed pushers
- automatically delete unauthorized tags and file an issue for awareness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d45201b54c8322b0b303198ee9021b