### PR TITLE
feat(miniapp): nextjs app-shell + lucide icons + theme bridge + tabs + haptics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ supabase/functions/**/vendor/
 # Mini app build outputs
 apps/mini/dist/
 miniapp/
+# Allow Next.js mini app source under apps/web
+!apps/web/components/miniapp/
+!apps/web/components/miniapp/**
+!apps/web/app/(miniapp)/
+!apps/web/app/(miniapp)/**
 
 # Keep miniapp static assets (explicit allow)
 !supabase/functions/miniapp/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ Supabase access, authentication, and other server-side features.
 The Telegram Mini App is built with Next.js/React, hosted on DigitalOcean, and
 backed by Supabase.
 
+## Telegram Mini App — Next.js + React + Icons
+- Built with **Next.js (App Router)** + **React 18**
+- Uses **lucide-react** icons (swap to `react-icons` if preferred)
+- Telegram theme drives CSS vars (auto updates on theme change)
+- App shell with safe areas, bottom tabs, icons
+- MainButton/BackButton + haptics helpers in `lib/telegram.ts`
+
+### Install
+```bash
+pnpm add lucide-react # or: npm i lucide-react
+```
+
+### Swap icon library (optional)
+
+If you prefer `react-icons`, remove `lucide-react` imports and:
+
+```bash
+pnpm add react-icons
+```
+
+Then in `BottomNav.tsx`:
+
+```ts
+import { FiHome, FiActivity, FiUser } from 'react-icons/fi';
+// ...use <FiHome/>, <FiActivity/>, <FiUser/>
+```
+
 ## Features
 
 - Telegram webhook (200-fast), OCR on images only

--- a/apps/web/app/(miniapp)/miniapp/(tabs)/account/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/(tabs)/account/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { BadgeCheck, CreditCard, Settings } from "lucide-react";
+import { Sheet } from "@/components/miniapp/Sheet";
+import { haptic } from "@/lib/telegram";
+import { track } from "@/lib/metrics";
+
+export default function AccountTab() {
+  const [showSheet, setShowSheet] = useState(false);
+
+  return (
+    <>
+      <section className="card" style={{ display: "grid", gap: 16 }}>
+        <header style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 16,
+              display: "grid",
+              placeItems: "center",
+              background: "rgba(48, 194, 242, 0.12)",
+              color: "var(--tg-accent)",
+            }}
+          >
+            <BadgeCheck size={20} />
+          </div>
+          <div>
+            <h2 style={{ margin: 0 }}>Your VIP status</h2>
+            <p className="muted" style={{ margin: 0 }}>Active — renews automatically every 30 days.</p>
+          </div>
+        </header>
+
+        <div style={{
+          display: "grid",
+          gap: 12,
+          fontSize: 14,
+        }}>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <span className="muted">Plan</span>
+            <strong>VIP Momentum</strong>
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <span className="muted">Next renewal</span>
+            <strong>June 24</strong>
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between" }}>
+            <span className="muted">Referral boost</span>
+            <strong>+2% lifetime</strong>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <button
+            className="btn"
+            onClick={() => {
+              haptic("medium");
+              void track("account_manage_billing");
+              setShowSheet(true);
+            }}
+          >
+            <CreditCard size={18} /> Manage billing
+          </button>
+          <button
+            className="btn"
+            style={{ background: "transparent", color: "var(--brand-text)", border: "1px solid rgba(255,255,255,0.12)" }}
+            onClick={() => {
+              haptic("light");
+              void track("account_preferences");
+              setShowSheet(true);
+            }}
+          >
+            <Settings size={18} /> Preferences
+          </button>
+        </div>
+      </section>
+
+      <Sheet
+        open={showSheet}
+        onClose={() => setShowSheet(false)}
+        title="Coming soon"
+      >
+        <p style={{ margin: 0 }}>
+          We're finalizing direct billing management inside Telegram. In the meantime, support can adjust your cycle instantly.
+        </p>
+        <p style={{ margin: 0 }}>
+          Tap the Main Button to ping concierge support for high-touch requests.
+        </p>
+      </Sheet>
+    </>
+  );
+}

--- a/apps/web/app/(miniapp)/miniapp/(tabs)/home/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/(tabs)/home/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sparkles, TrendingUp } from "lucide-react";
+import { Skeleton } from "@/components/miniapp/Skeleton";
+import { Toast } from "@/components/miniapp/Toast";
+import { haptic } from "@/lib/telegram";
+import { track } from "@/lib/metrics";
+
+interface Insight {
+  label: string;
+  value: string;
+  delta: string;
+}
+
+const placeholders: Insight[] = [
+  { label: "Daily ROI", value: "--", delta: "--" },
+  { label: "Signal Accuracy", value: "--", delta: "--" },
+  { label: "VIP Retention", value: "--", delta: "--" },
+];
+
+const readyData: Insight[] = [
+  { label: "Daily ROI", value: "+8.4%", delta: "▲ 1.2% vs yesterday" },
+  { label: "Signal Accuracy", value: "92%", delta: "▲ 4% vs 7d avg" },
+  { label: "VIP Retention", value: "87%", delta: "▲ 2% this month" },
+];
+
+export default function HomeTab() {
+  const [loading, setLoading] = useState(true);
+  const [showToast, setShowToast] = useState(false);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setLoading(false), 900);
+    return () => window.clearTimeout(timeout);
+  }, []);
+
+  const data = loading ? placeholders : readyData;
+
+  return (
+    <>
+      <section className="card" style={{ display: "grid", gap: 16 }}>
+        <header style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div style={{
+            width: 40,
+            height: 40,
+            borderRadius: 16,
+            display: "grid",
+            placeItems: "center",
+            background: "rgba(48, 194, 242, 0.12)",
+            color: "var(--tg-accent)",
+          }}>
+            <Sparkles size={20} />
+          </div>
+          <div>
+            <h2 style={{ margin: 0 }}>Welcome back</h2>
+            <p className="muted" style={{ margin: 0 }}>
+              Your trading pulse syncs with Telegram in real-time.
+            </p>
+          </div>
+        </header>
+
+        <div style={{ display: "grid", gap: 12 }}>
+          {data.map((insight) => (
+            <div
+              key={insight.label}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "12px 0",
+                borderBottom: "1px solid rgba(255,255,255,0.06)",
+              }}
+            >
+              <div>
+                <div style={{ fontWeight: 600 }}>{insight.label}</div>
+                <p className="muted" style={{ margin: 0, fontSize: 12 }}>
+                  {loading ? <Skeleton h={12} w={120} /> : insight.delta}
+                </p>
+              </div>
+              <div style={{ fontSize: 18, fontWeight: 600 }}>
+                {loading ? <Skeleton h={18} w={72} /> : insight.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <button
+          className="btn"
+          onClick={() => {
+            haptic("medium");
+            void track("home_refresh");
+            setShowToast(true);
+            setLoading(true);
+            window.setTimeout(() => setLoading(false), 750);
+          }}
+        >
+          <TrendingUp size={18} /> Refresh insights
+        </button>
+      </section>
+      <Toast text="Insights refreshed" show={showToast} onDismiss={() => setShowToast(false)} />
+    </>
+  );
+}

--- a/apps/web/app/(miniapp)/miniapp/(tabs)/signals/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/(tabs)/signals/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUpRight, RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Skeleton } from "@/components/miniapp/Skeleton";
+import { Toast } from "@/components/miniapp/Toast";
+import {
+  haptic,
+  hideMainButton,
+  setMainButton,
+} from "@/lib/telegram";
+import { track } from "@/lib/metrics";
+
+const placeholders = new Array(3).fill({
+  pair: "--",
+  confidence: "--",
+  text: "Signal loading...",
+});
+
+const signals = [
+  {
+    pair: "BTC/USDT",
+    confidence: "High",
+    text: "Breakout above $68.5k. Consider scaling long with tight stop.",
+  },
+  {
+    pair: "ETH/USDT",
+    confidence: "Medium",
+    text: "Momentum cooling. Watch support at $3.5k before re-entry.",
+  },
+  {
+    pair: "SOL/USDT",
+    confidence: "High",
+    text: "On-chain flows heating up. Ladder entries between $185-$189.",
+  },
+];
+
+export default function SignalsTab() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [showToast, setShowToast] = useState(false);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setLoading(false), 600);
+    return () => window.clearTimeout(timeout);
+  }, []);
+
+  useEffect(() => {
+    setMainButton("Open VIP", () => {
+      haptic("medium");
+      void track("main_button_open_vip");
+      router.push("/miniapp/account");
+    });
+    return () => hideMainButton();
+  }, [router]);
+
+  const data = loading ? placeholders : signals;
+
+  return (
+    <>
+      <section className="card" style={{ display: "grid", gap: 16 }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <h2 style={{ margin: 0 }}>Signals</h2>
+            <p className="muted" style={{ margin: 0 }}>Live insights synced from the trading desk.</p>
+          </div>
+          <button
+            className="btn"
+            style={{ background: "transparent", color: "var(--brand-text)", border: "1px solid rgba(255,255,255,0.12)" }}
+            onClick={() => {
+              haptic("light");
+              void track("signals_refresh");
+              setLoading(true);
+              setShowToast(true);
+              window.setTimeout(() => setLoading(false), 560);
+            }}
+          >
+            <RefreshCw size={16} />
+            Refresh
+          </button>
+        </header>
+
+        <div style={{ display: "grid", gap: 12 }}>
+          {data.map((signal, index) => (
+            <article
+              key={`${signal.pair}-${index}`}
+              style={{
+                padding: "16px",
+                borderRadius: 16,
+                background: "rgba(255,255,255,0.04)",
+                border: "1px solid rgba(255,255,255,0.05)",
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <strong>{loading ? <Skeleton h={16} w={80} /> : signal.pair}</strong>
+                <span className="muted" style={{ fontSize: 12 }}>
+                  {loading ? <Skeleton h={12} w={56} /> : `Confidence: ${signal.confidence}`}
+                </span>
+              </div>
+              <p style={{ margin: 0, color: "var(--brand-text)" }}>
+                {loading ? <Skeleton h={14} w="100%" /> : signal.text}
+              </p>
+            </article>
+          ))}
+        </div>
+
+        <button
+          className="btn"
+          onClick={() => {
+            haptic("medium");
+            void track("signals_open_vip");
+            router.push("/miniapp/account");
+          }}
+        >
+          <ArrowUpRight size={18} />
+          Upgrade to VIP
+        </button>
+      </section>
+      <Toast text="Signals updated" show={showToast} onDismiss={() => setShowToast(false)} />
+    </>
+  );
+}

--- a/apps/web/app/(miniapp)/miniapp/layout.tsx
+++ b/apps/web/app/(miniapp)/miniapp/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { AppShell } from "@/components/miniapp/AppShell";
+import { BottomNav } from "@/components/miniapp/BottomNav";
+import MiniAppProviders from "./providers";
+import "@/styles/theme.css";
+
+export const metadata: Metadata = {
+  title: "Dynamic Capital Mini App",
+  description: "Native-feel Telegram experience with tabs, haptics, and telemetry.",
+};
+
+export default function MiniAppLayout({ children }: { children: ReactNode }) {
+  return (
+    <MiniAppProviders>
+      <AppShell footer={<BottomNav />}>{children}</AppShell>
+    </MiniAppProviders>
+  );
+}

--- a/apps/web/app/(miniapp)/miniapp/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MiniAppIndex() {
+  redirect("/miniapp/home");
+}

--- a/apps/web/app/(miniapp)/miniapp/providers.tsx
+++ b/apps/web/app/(miniapp)/miniapp/providers.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  applyThemeVars,
+  hideBackButton,
+  hideMainButton,
+  initTelegram,
+  showBackButton,
+} from "@/lib/telegram";
+
+export default function MiniAppProviders({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    initTelegram();
+    applyThemeVars();
+    const webApp: any = (window as any)?.Telegram?.WebApp;
+    const onTheme = () => applyThemeVars();
+    webApp?.onEvent?.("themeChanged", onTheme);
+    return () => webApp?.offEvent?.("themeChanged", onTheme);
+  }, []);
+
+  useEffect(() => {
+    if (!pathname) return;
+    let cleanupBack: (() => void) | undefined;
+    if (pathname === "/miniapp" || pathname === "/miniapp/home") {
+      hideBackButton();
+    } else {
+      cleanupBack = showBackButton(() => router.back());
+    }
+    hideMainButton();
+    return () => {
+      cleanupBack?.();
+      hideBackButton();
+    };
+  }, [pathname, router]);
+
+  return <>{children}</>;
+}

--- a/apps/web/components/miniapp/AppShell.tsx
+++ b/apps/web/components/miniapp/AppShell.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+const transition = {
+  type: "spring",
+  stiffness: 200,
+  damping: 30,
+  mass: 0.8,
+};
+
+export function AppShell({
+  children,
+  footer,
+}: {
+  children: ReactNode;
+  footer: ReactNode;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <div className="app-shell">
+      <AnimatePresence initial={false} mode="wait">
+        <motion.main
+          key={pathname}
+          initial={{ y: 24, opacity: 0.4 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -12, opacity: 0 }}
+          transition={transition}
+          style={{
+            padding: "16px",
+            paddingTop: "calc(var(--safe-top) + 8px)",
+            display: "grid",
+            alignContent: "start",
+            gap: "16px",
+          }}
+        >
+          {children}
+        </motion.main>
+      </AnimatePresence>
+      {footer}
+    </div>
+  );
+}

--- a/apps/web/components/miniapp/BottomNav.tsx
+++ b/apps/web/components/miniapp/BottomNav.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Activity, Home, User } from "lucide-react";
+import { haptic } from "@/lib/telegram";
+import { track } from "@/lib/metrics";
+
+const tabs = [
+  { href: "/miniapp/home", label: "Home", Icon: Home, event: "nav_home" },
+  { href: "/miniapp/signals", label: "Signals", Icon: Activity, event: "nav_signals" },
+  { href: "/miniapp/account", label: "Account", Icon: User, event: "nav_account" },
+] as const;
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="bottom-nav" role="navigation" aria-label="Mini app primary">
+      {tabs.map(({ href, label, Icon, event }) => {
+        const active = pathname?.startsWith(href);
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`bottom-btn ${active ? "active" : ""}`}
+            aria-current={active ? "page" : undefined}
+            onClick={() => {
+              haptic(active ? "light" : "medium");
+              void track(event);
+            }}
+          >
+            <Icon size={20} strokeWidth={active ? 2.4 : 2} />
+            <span>{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/components/miniapp/Sheet.tsx
+++ b/apps/web/components/miniapp/Sheet.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { haptic } from "@/lib/telegram";
+
+interface SheetProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+}
+
+export function Sheet({ open, onClose, title, children }: SheetProps) {
+  useEffect(() => {
+    if (open) {
+      haptic("light");
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <AnimatePresence>
+      {open ? (
+        <>
+          <motion.div
+            key="sheet-backdrop"
+            className="fixed inset-0 z-40"
+            style={{ background: "rgba(3, 5, 7, 0.65)" }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={onClose}
+          />
+          <motion.div
+            key="sheet-content"
+            className="fixed left-0 right-0 bottom-0 z-50"
+            style={{
+              borderTopLeftRadius: 24,
+              borderTopRightRadius: 24,
+              background: "var(--brand-surface)",
+              padding: "24px 20px",
+              boxShadow: "0 -12px 40px rgba(0,0,0,0.45)",
+            }}
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ type: "spring", stiffness: 240, damping: 28 }}
+          >
+            {title ? (
+              <div style={{ marginBottom: 16, fontWeight: 600 }}>{title}</div>
+            ) : null}
+            <div style={{ color: "var(--brand-text)", display: "grid", gap: 12 }}>{children}</div>
+            <button className="btn" style={{ marginTop: 24 }} onClick={onClose}>
+              Close
+            </button>
+          </motion.div>
+        </>
+      ) : null}
+    </AnimatePresence>,
+    document.body
+  );
+}

--- a/apps/web/components/miniapp/Skeleton.tsx
+++ b/apps/web/components/miniapp/Skeleton.tsx
@@ -1,0 +1,24 @@
+import type { CSSProperties } from "react";
+
+interface SkeletonProps {
+  h?: number;
+  w?: number | string;
+  r?: number;
+  style?: CSSProperties;
+}
+
+export function Skeleton({ h = 16, w = "100%", r = 12, style }: SkeletonProps) {
+  return (
+    <div
+      style={{
+        height: h,
+        width: w,
+        borderRadius: r,
+        background:
+          "linear-gradient(90deg, rgba(255,255,255,.06), rgba(255,255,255,.12), rgba(255,255,255,.06))",
+        animation: "pulse 1.2s ease-in-out infinite",
+        ...style,
+      }}
+    />
+  );
+}

--- a/apps/web/components/miniapp/Toast.tsx
+++ b/apps/web/components/miniapp/Toast.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ToastProps {
+  text: string;
+  show: boolean;
+  duration?: number;
+  onDismiss?: () => void;
+}
+
+export function Toast({ text, show, duration = 2400, onDismiss }: ToastProps) {
+  const [visible, setVisible] = useState(show);
+
+  useEffect(() => {
+    setVisible(show);
+  }, [show]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const timeout = window.setTimeout(() => {
+      setVisible(false);
+      onDismiss?.();
+    }, duration);
+    return () => window.clearTimeout(timeout);
+  }, [duration, onDismiss, visible]);
+
+  return (
+    <AnimatePresence>
+      {visible ? (
+        <motion.div
+          initial={{ y: 32, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 32, opacity: 0 }}
+          transition={{ type: "spring", stiffness: 300, damping: 32 }}
+          style={{
+            position: "fixed",
+            left: 12,
+            right: 12,
+            bottom: `calc(72px + var(--safe-bottom))`,
+            background: "var(--brand-surface)",
+            color: "var(--brand-text)",
+            padding: "12px 16px",
+            borderRadius: 12,
+            boxShadow: "var(--shadow)",
+            textAlign: "center",
+            pointerEvents: "auto",
+            zIndex: 50,
+          }}
+        >
+          {text}
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/apps/web/lib/metrics.ts
+++ b/apps/web/lib/metrics.ts
@@ -1,0 +1,47 @@
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+interface MetricPayload {
+  event: string;
+  props: Record<string, unknown>;
+  at: string;
+}
+
+async function sendToSupabase(payload: MetricPayload) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY || typeof fetch === "undefined") return;
+  try {
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/miniapp_metrics`, {
+      method: "POST",
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+    });
+
+    if (!response.ok && process.env.NODE_ENV !== "production") {
+      console.debug("[metric] supabase noop", response.status, response.statusText);
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[metric] supabase error", error);
+    }
+  }
+}
+
+export async function track(event: string, props: Record<string, unknown> = {}) {
+  const payload: MetricPayload = {
+    event,
+    props,
+    at: new Date().toISOString(),
+  };
+
+  if (process.env.NODE_ENV !== "production") {
+    console.debug("[metric]", payload);
+  }
+
+  await sendToSupabase(payload);
+}

--- a/apps/web/lib/telegram.ts
+++ b/apps/web/lib/telegram.ts
@@ -1,0 +1,110 @@
+// Minimal helpers for Telegram WebApp API
+const globalAny: any = typeof window !== "undefined" ? window : undefined;
+export const tg = globalAny?.Telegram?.WebApp as
+  | undefined
+  | (typeof globalAny.Telegram.WebApp & {
+      __dcMainHandler?: () => void;
+      __dcBackHandler?: () => void;
+    });
+
+export function initTelegram() {
+  if (!tg) return;
+  tg.ready();
+  try {
+    tg.expand();
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[tg] expand skipped", error);
+    }
+  }
+  try {
+    tg.disableVerticalSwipes && tg.disableVerticalSwipes();
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[tg] disableVerticalSwipes skipped", error);
+    }
+  }
+}
+
+export function applyThemeVars() {
+  if (!tg) return;
+  const params = tg.themeParams || {};
+  const set = (key: string, value?: string) => {
+    if (!value) return;
+    document.documentElement.style.setProperty(key, value);
+  };
+  set("--tg-bg", params.bg_color);
+  set("--tg-text", params.text_color);
+  set("--tg-muted", params.hint_color);
+  set("--tg-accent", params.button_color);
+  set("--tg-button", params.button_color);
+  try {
+    tg.setHeaderColor?.(params.bg_color || "#0b0d12");
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[tg] setHeaderColor skipped", error);
+    }
+  }
+}
+
+export function setMainButton(text: string, onClick?: () => void) {
+  if (!tg) return;
+  const button = tg.MainButton;
+  button.setText(text);
+  button.show();
+  if (onClick) {
+    const handler = () => onClick();
+    if (tg.__dcMainHandler) {
+      tg.offEvent?.("mainButtonClicked", tg.__dcMainHandler);
+    }
+    tg.__dcMainHandler = handler;
+    tg.onEvent?.("mainButtonClicked", handler);
+  }
+}
+
+export function hideMainButton() {
+  if (!tg) return;
+  if (tg.__dcMainHandler) {
+    tg.offEvent?.("mainButtonClicked", tg.__dcMainHandler);
+    tg.__dcMainHandler = undefined;
+  }
+  tg.MainButton?.hide();
+}
+
+export function showBackButton(cb?: () => void) {
+  if (!tg) return () => {};
+  const backButton = tg.BackButton;
+  backButton.show();
+  if (!cb) return () => {};
+  const handler = () => cb();
+  if (tg.__dcBackHandler) {
+    tg.offEvent?.("backButtonClicked", tg.__dcBackHandler);
+  }
+  tg.__dcBackHandler = handler;
+  tg.onEvent?.("backButtonClicked", handler);
+  return () => {
+    if (tg.__dcBackHandler) {
+      tg.offEvent?.("backButtonClicked", tg.__dcBackHandler);
+      tg.__dcBackHandler = undefined;
+    }
+  };
+}
+
+export function hideBackButton() {
+  if (!tg) return;
+  if (tg.__dcBackHandler) {
+    tg.offEvent?.("backButtonClicked", tg.__dcBackHandler);
+    tg.__dcBackHandler = undefined;
+  }
+  tg.BackButton?.hide();
+}
+
+export function haptic(type: "light" | "medium" | "heavy" = "light") {
+  try {
+    tg?.HapticFeedback?.impactOccurred(type);
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[tg] haptic skipped", error);
+    }
+  }
+}

--- a/apps/web/styles/theme.css
+++ b/apps/web/styles/theme.css
@@ -1,0 +1,52 @@
+:root {
+  /* Brand tokens – replace values to match marketing site */
+  --brand-bg: #0b0d12;
+  --brand-surface: #11141a;
+  --brand-text: #f7f9fc;
+  --brand-muted: #a6b0c3;
+  --brand-accent: #30C2F2; /* update to your brand */
+  --radius: 16px;
+  --shadow: 0 6px 24px rgba(0,0,0,.25);
+
+  /* Layout */
+  --safe-bottom: env(safe-area-inset-bottom);
+  --safe-top: env(safe-area-inset-top);
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px; --space-5: 24px; --space-6: 32px;
+  --tap: 44px; /* min target */
+
+  /* Telegram theme vars (set dynamically via TelegramProvider) */
+  --tg-bg: var(--brand-bg);
+  --tg-text: var(--brand-text);
+  --tg-muted: var(--brand-muted);
+  --tg-accent: var(--brand-accent);
+  --tg-button: var(--brand-accent);
+}
+
+html, body { height: 100%; background: var(--tg-bg); color: var(--tg-text); }
+* { box-sizing: border-box; }
+
+.app-shell {
+  min-height: 100dvh; display: grid; grid-template-rows: 1fr auto; background: var(--tg-bg);
+}
+
+.bottom-nav {
+  position: sticky; bottom: 0; left: 0; right: 0; height: calc(56px + var(--safe-bottom));
+  padding-bottom: var(--safe-bottom); display: grid; grid-template-columns: repeat(3,1fr);
+  background: var(--brand-surface); box-shadow: var(--shadow); border-top: 1px solid rgba(255,255,255,.06);
+}
+
+.bottom-btn { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:6px; padding:6px 8px; font-size:12px; opacity:.9; text-decoration:none; color: inherit; }
+.bottom-btn.active { color: var(--tg-accent); opacity: 1; }
+
+.card { background: var(--brand-surface); border-radius: var(--radius); padding: var(--space-5); box-shadow: var(--shadow); }
+.btn { height: var(--tap); padding: 0 16px; border-radius: 999px; background: var(--tg-button); color:#030507; border:none; display:inline-flex; align-items:center; justify-content:center; gap:8px; font-weight:600; cursor:pointer; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.muted { color: var(--brand-muted); }
+
+.safe-area-pb { padding-bottom: var(--safe-bottom); }
+
+@keyframes pulse {
+  0% { opacity: 0.6; }
+  50% { opacity: 1; }
+  100% { opacity: 0.6; }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Telegram mini app layout with providers that sync theme variables, back button state, and safe-area shell chrome
- introduce reusable mini app UI primitives (app shell, bottom tabs, toast, skeleton, sheet) plus lucide-driven tab screens with haptics, metrics, and Telegram main button orchestration
- bridge Telegram theme params into CSS tokens, add lightweight metrics helper, and document setup details for icons and theming

## Testing
- npm run lint

Labels: codex, ui, miniapp

------
https://chatgpt.com/codex/tasks/task_e_68d455290a64832282320c1d16323ee2