### PR TITLE
Add Unicorn Studio chroma background for landing page

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -8,5 +8,5 @@ export default function HomePage() {
     return <StaticLandingPage />;
   }
 
-  return <LandingPageShell />;
+  return <LandingPageShell chromaBackgroundVariant="liquid" />;
 }

--- a/apps/web/components/landing/ChromaBackground.tsx
+++ b/apps/web/components/landing/ChromaBackground.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+
+import { cn } from "@/utils";
+
+const SCRIPT_SRC = "https://cdn.unicorn.studio/v1.2.3/unicornStudio.umd.js";
+
+type UnicornStudioController = {
+  init: () => Promise<unknown>;
+  destroy: () => void;
+};
+
+declare global {
+  interface Window {
+    UnicornStudio?: UnicornStudioController;
+  }
+}
+
+let unicornStudioScriptPromise: Promise<void> | null = null;
+
+async function loadUnicornStudioScript(): Promise<void> {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (unicornStudioScriptPromise) {
+    return unicornStudioScriptPromise;
+  }
+
+  unicornStudioScriptPromise = new Promise((resolve, reject) => {
+    const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${SCRIPT_SRC}"]`);
+
+    if (existingScript) {
+      if (existingScript.dataset.loaded === "true") {
+        resolve();
+        return;
+      }
+
+      existingScript.addEventListener(
+        "load",
+        () => {
+          existingScript.dataset.loaded = "true";
+          resolve();
+        },
+        { once: true }
+      );
+
+      existingScript.addEventListener(
+        "error",
+        () => {
+          unicornStudioScriptPromise = null;
+          reject(new Error("Failed to load the Unicorn Studio script."));
+        },
+        { once: true }
+      );
+
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+
+    const handleLoad = () => {
+      script.dataset.loaded = "true";
+      resolve();
+    };
+
+    const handleError = () => {
+      script.removeEventListener("load", handleLoad);
+      script.removeEventListener("error", handleError);
+      unicornStudioScriptPromise = null;
+      reject(new Error("Failed to load the Unicorn Studio script."));
+    };
+
+    script.addEventListener("load", handleLoad, { once: true });
+    script.addEventListener("error", handleError, { once: true });
+
+    document.head.appendChild(script);
+  });
+
+  return unicornStudioScriptPromise;
+}
+
+const PROJECT_IDS = {
+  liquid: "lHlDvoJDIXCxxXVqTNOC",
+  folds: "YnADGzDD7LGB9cUocyyN",
+  smoke: "ezEDNzFtrAgm8yCUWUeX",
+  flow: "wYI4YirTR5lrja86ArSY",
+  pixel: "rJ39y9Nnyz3cJooDtmNM",
+  ascii: "HJKVa10sftexJ7OgsOnU",
+} as const satisfies Record<string, string>;
+
+export type ChromaBackgroundStyle = keyof typeof PROJECT_IDS;
+
+export interface ChromaBackgroundProps {
+  variant?: ChromaBackgroundStyle;
+  className?: string;
+  /**
+   * Optional attribute overrides for Unicorn Studio embeds.
+   */
+  fps?: number;
+  scale?: number;
+  dpi?: number;
+}
+
+export function ChromaBackground({
+  variant = "liquid",
+  className,
+  fps = 60,
+  scale = 1,
+  dpi = 1,
+}: ChromaBackgroundProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const projectId = useMemo(() => PROJECT_IDS[variant] ?? PROJECT_IDS.liquid, [variant]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const initialize = async () => {
+      if (!containerRef.current || !projectId) {
+        return;
+      }
+
+      try {
+        await loadUnicornStudioScript();
+
+        if (cancelled || !containerRef.current) {
+          return;
+        }
+
+        containerRef.current.setAttribute("data-us-project", projectId);
+
+        const unicornStudio = window.UnicornStudio;
+
+        if (!unicornStudio) {
+          return;
+        }
+
+        unicornStudio.destroy();
+        await unicornStudio.init();
+      } catch (error) {
+        console.error("Failed to initialise Unicorn Studio background", error);
+      }
+    };
+
+    initialize();
+
+    return () => {
+      cancelled = true;
+      try {
+        window.UnicornStudio?.destroy();
+      } catch (error) {
+        console.error("Failed to tear down Unicorn Studio background", error);
+      }
+    };
+  }, [projectId]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-us-dpi={dpi}
+      data-us-scale={scale}
+      data-us-fps={fps}
+      aria-hidden
+      className={cn("h-full w-full", className)}
+    />
+  );
+}
+
+export default ChromaBackground;

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -1,9 +1,19 @@
+import dynamic from "next/dynamic";
 import { Background, Column, RevealFx } from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
 import { systemUI } from "@/resources";
 import { MagicLandingPage } from "@/components/magic-portfolio/MagicLandingPage";
+import type {
+  ChromaBackgroundProps,
+  ChromaBackgroundStyle,
+} from "@/components/landing/ChromaBackground";
+
+const DynamicChromaBackground = dynamic<ChromaBackgroundProps>(
+  () => import("@/components/landing/ChromaBackground"),
+  { ssr: false }
+);
 
 export interface LandingPageShellProps {
   /**
@@ -18,12 +28,17 @@ export interface LandingPageShellProps {
    * Additional className passed to the chat assistant widget when rendered.
    */
   assistantClassName?: string;
+  /**
+   * Optional dynamic Unicorn Studio background variant.
+   */
+  chromaBackgroundVariant?: ChromaBackgroundStyle | null;
 }
 
 export function LandingPageShell({
   className,
   showAssistant = true,
   assistantClassName,
+  chromaBackgroundVariant = null,
 }: LandingPageShellProps) {
   const backgroundEffects = systemUI.effects.background;
 
@@ -80,6 +95,12 @@ export function LandingPageShell({
           }}
         />
       </RevealFx>
+      {chromaBackgroundVariant ? (
+        <DynamicChromaBackground
+          variant={chromaBackgroundVariant}
+          className="pointer-events-none absolute inset-0 z-0"
+        />
+      ) : null}
       <Column
         zIndex={1}
         fillWidth

--- a/apps/web/components/miniapp/AppShell.tsx
+++ b/apps/web/components/miniapp/AppShell.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, type Transition } from "framer-motion";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
-const transition = {
+const transition: Transition = {
   type: "spring",
   stiffness: 200,
   damping: 30,


### PR DESCRIPTION
## Summary
- add a reusable Unicorn Studio chroma background component that lazily loads the embed script and exposes the pre-defined scene variants
- integrate the dynamic background option into the landing page shell and enable the liquid variant on the home page
- tighten the mini app shell transition typing so TypeScript passes type checking

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d461165520832297388bd540372904