### PR TITLE
Fix chroma background dynamic import for server component

### DIFF
--- a/apps/web/components/landing/DynamicChromaBackground.tsx
+++ b/apps/web/components/landing/DynamicChromaBackground.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import type { ChromaBackgroundProps } from "@/components/landing/ChromaBackground";
+
+export const DynamicChromaBackground = dynamic<ChromaBackgroundProps>(
+  () => import("@/components/landing/ChromaBackground"),
+  { ssr: false }
+);

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -1,19 +1,11 @@
-import dynamic from "next/dynamic";
 import { Background, Column, RevealFx } from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
 import { systemUI } from "@/resources";
 import { MagicLandingPage } from "@/components/magic-portfolio/MagicLandingPage";
-import type {
-  ChromaBackgroundProps,
-  ChromaBackgroundStyle,
-} from "@/components/landing/ChromaBackground";
-
-const DynamicChromaBackground = dynamic<ChromaBackgroundProps>(
-  () => import("@/components/landing/ChromaBackground"),
-  { ssr: false }
-);
+import type { ChromaBackgroundStyle } from "@/components/landing/ChromaBackground";
+import { DynamicChromaBackground } from "@/components/landing/DynamicChromaBackground";
 
 export interface LandingPageShellProps {
   /**


### PR DESCRIPTION
## Summary
- move the dynamic Chroma background loader into a dedicated client component
- update the landing page shell to reference the client-safe dynamic loader

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4693347e48322a23a8449c6cad9fe