### PR TITLE
Optimize indicator calculations

### DIFF
--- a/algorithms/python/data_pipeline.py
+++ b/algorithms/python/data_pipeline.py
@@ -39,26 +39,38 @@ def _rolling_mean(values: Sequence[float]) -> float:
 def _compute_rsi(closes: Sequence[float], period: int) -> List[Optional[float]]:
     if period <= 0:
         raise ValueError("RSI period must be positive")
-    rsis: List[Optional[float]] = [None] * len(closes)
-    gains: List[float] = [0.0]
-    losses: List[float] = [0.0]
-    for idx in range(1, len(closes)):
+    total = len(closes)
+    rsis: List[Optional[float]] = [None] * total
+    if total <= period:
+        return rsis
+
+    gain_sum = 0.0
+    loss_sum = 0.0
+    for idx in range(1, period + 1):
         change = closes[idx] - closes[idx - 1]
-        gains.append(max(change, 0.0))
-        losses.append(abs(min(change, 0.0)))
-    for idx in range(period, len(closes)):
-        if idx == period:
-            avg_gain = _rolling_mean(gains[1 : period + 1])
-            avg_loss = _rolling_mean(losses[1 : period + 1])
+        if change >= 0:
+            gain_sum += change
         else:
-            avg_gain = (avg_gain * (period - 1) + gains[idx]) / period  # type: ignore[name-defined]
-            avg_loss = (avg_loss * (period - 1) + losses[idx]) / period  # type: ignore[name-defined]
+            loss_sum -= change
+    avg_gain = gain_sum / period
+    avg_loss = loss_sum / period
+
+    def _rsi_from_averages(avg_gain: float, avg_loss: float) -> float:
         if avg_loss == 0:
             rs = math.inf
         else:
             rs = avg_gain / avg_loss
-        rsi = 100 - (100 / (1 + rs))
-        rsis[idx] = rsi
+        return 100 - (100 / (1 + rs))
+
+    rsis[period] = _rsi_from_averages(avg_gain, avg_loss)
+
+    for idx in range(period + 1, total):
+        change = closes[idx] - closes[idx - 1]
+        gain = change if change > 0 else 0.0
+        loss = -change if change < 0 else 0.0
+        avg_gain = (avg_gain * (period - 1) + gain) / period
+        avg_loss = (avg_loss * (period - 1) + loss) / period
+        rsis[idx] = _rsi_from_averages(avg_gain, avg_loss)
     return rsis
 
 
@@ -70,42 +82,62 @@ def _compute_adx(
 ) -> List[Optional[float]]:
     if period <= 0:
         raise ValueError("ADX period must be positive")
-    adx_values: List[Optional[float]] = [None] * len(closes)
-    tr_values: List[float] = [0.0]
-    plus_dm: List[float] = [0.0]
-    minus_dm: List[float] = [0.0]
-    for idx in range(1, len(closes)):
+    if not (len(highs) == len(lows) == len(closes)):
+        raise ValueError("High, low, and close series must share the same length")
+    total = len(closes)
+    adx_values: List[Optional[float]] = [None] * total
+    if total <= period:
+        return adx_values
+
+    tr_sum = 0.0
+    plus_dm_sum = 0.0
+    minus_dm_sum = 0.0
+
+    def _true_range(idx: int, prev_close: float) -> float:
         high = highs[idx]
         low = lows[idx]
-        prev_close = closes[idx - 1]
-        up_move = high - highs[idx - 1]
-        down_move = lows[idx - 1] - low
-        plus_dm.append(up_move if up_move > down_move and up_move > 0 else 0.0)
-        minus_dm.append(down_move if down_move > up_move and down_move > 0 else 0.0)
-        true_range = max(high - low, abs(high - prev_close), abs(low - prev_close))
-        tr_values.append(true_range)
-    for idx in range(period, len(closes)):
-        if idx == period:
-            tr_sum = sum(tr_values[1 : period + 1])
-            plus_dm_sum = sum(plus_dm[1 : period + 1])
-            minus_dm_sum = sum(minus_dm[1 : period + 1])
-        else:
-            tr_sum = tr_sum - (tr_sum / period) + tr_values[idx]  # type: ignore[name-defined]
-            plus_dm_sum = plus_dm_sum - (plus_dm_sum / period) + plus_dm[idx]  # type: ignore[name-defined]
-            minus_dm_sum = minus_dm_sum - (minus_dm_sum / period) + minus_dm[idx]  # type: ignore[name-defined]
+        return max(high - low, abs(high - prev_close), abs(low - prev_close))
+
+    for idx in range(1, period + 1):
+        up_move = highs[idx] - highs[idx - 1]
+        down_move = lows[idx - 1] - lows[idx]
+        plus_dm = up_move if up_move > down_move and up_move > 0 else 0.0
+        minus_dm = down_move if down_move > up_move and down_move > 0 else 0.0
+        tr = _true_range(idx, closes[idx - 1])
+        plus_dm_sum += plus_dm
+        minus_dm_sum += minus_dm
+        tr_sum += tr
+
+    def _di_values(tr_sum: float, plus_dm_sum: float, minus_dm_sum: float) -> tuple[float, float]:
         if tr_sum == 0:
-            plus_di = 0.0
-            minus_di = 0.0
-        else:
-            plus_di = 100 * (plus_dm_sum / tr_sum)
-            minus_di = 100 * (minus_dm_sum / tr_sum)
+            return 0.0, 0.0
+        plus_di = 100 * (plus_dm_sum / tr_sum)
+        minus_di = 100 * (minus_dm_sum / tr_sum)
+        return plus_di, minus_di
+
+    plus_di, minus_di = _di_values(tr_sum, plus_dm_sum, minus_dm_sum)
+    di_diff = abs(plus_di - minus_di)
+    di_sum = plus_di + minus_di
+    dx = 0.0 if di_sum == 0 else (di_diff / di_sum) * 100
+    adx = dx
+    adx_values[period] = adx
+
+    for idx in range(period + 1, total):
+        up_move = highs[idx] - highs[idx - 1]
+        down_move = lows[idx - 1] - lows[idx]
+        plus_dm = up_move if up_move > down_move and up_move > 0 else 0.0
+        minus_dm = down_move if down_move > up_move and down_move > 0 else 0.0
+        tr = _true_range(idx, closes[idx - 1])
+
+        plus_dm_sum = plus_dm_sum - (plus_dm_sum / period) + plus_dm
+        minus_dm_sum = minus_dm_sum - (minus_dm_sum / period) + minus_dm
+        tr_sum = tr_sum - (tr_sum / period) + tr
+
+        plus_di, minus_di = _di_values(tr_sum, plus_dm_sum, minus_dm_sum)
         di_diff = abs(plus_di - minus_di)
         di_sum = plus_di + minus_di
         dx = 0.0 if di_sum == 0 else (di_diff / di_sum) * 100
-        if idx == period:
-            adx = _rolling_mean([dx] * period)
-        else:
-            adx = (adx * (period - 1) + dx) / period  # type: ignore[name-defined]
+        adx = (adx * (period - 1) + dx) / period
         adx_values[idx] = adx
     return adx_values
 

--- a/algorithms/python/tests/test_indicators.py
+++ b/algorithms/python/tests/test_indicators.py
@@ -1,0 +1,300 @@
+"""Unit tests for technical indicator helpers used by the data pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from algorithms.python.data_pipeline import _compute_adx, _compute_rsi
+
+
+@pytest.mark.parametrize(
+    "period, closes, expected",
+    [
+        (
+            14,
+            [
+                1.2345,
+                1.2350,
+                1.2330,
+                1.2380,
+                1.2400,
+                1.2375,
+                1.2390,
+                1.2410,
+                1.2450,
+                1.2440,
+                1.2460,
+                1.2475,
+                1.2490,
+                1.2510,
+                1.2500,
+                1.2480,
+                1.2520,
+                1.2530,
+                1.2545,
+                1.2550,
+                1.2565,
+                1.2580,
+                1.2570,
+                1.2595,
+                1.2600,
+                1.2615,
+                1.2630,
+                1.2620,
+                1.2610,
+                1.2640,
+                1.2660,
+                1.2650,
+                1.2675,
+                1.2690,
+                1.2680,
+                1.2705,
+                1.2720,
+            ],
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                77.1929824561,
+                71.7691342535,
+                75.4799228770,
+                76.3180020552,
+                77.5571337964,
+                77.9709040317,
+                79.2092904365,
+                80.3961144950,
+                77.2309111727,
+                79.4130539879,
+                79.8294155981,
+                81.0665434895,
+                82.2396370156,
+                78.7371553056,
+                75.2842588586,
+                78.3514360428,
+                80.1224482102,
+                76.7419555197,
+                79.1144067718,
+                80.4058810885,
+                76.9880115189,
+                79.3511454074,
+                80.6360310924,
+            ],
+        ),
+    ],
+)
+def test_compute_rsi_matches_reference(period: int, closes: list[float], expected: list[float | None]) -> None:
+    result = _compute_rsi(closes, period)
+    assert len(result) == len(expected)
+    for idx, (value, expected_value) in enumerate(zip(result, expected)):
+        if expected_value is None:
+            assert value is None, f"Expected None at index {idx}, got {value}"
+            continue
+        assert value is not None
+        assert value == pytest.approx(expected_value, rel=1e-6)
+
+
+def test_compute_rsi_rejects_non_positive_period() -> None:
+    with pytest.raises(ValueError):
+        _compute_rsi([1.0, 1.1], 0)
+
+
+@pytest.mark.parametrize(
+    "period, highs, lows, closes, expected",
+    [
+        (
+            14,
+            [c + 0.0015 for c in [
+                1.2345,
+                1.2350,
+                1.2330,
+                1.2380,
+                1.2400,
+                1.2375,
+                1.2390,
+                1.2410,
+                1.2450,
+                1.2440,
+                1.2460,
+                1.2475,
+                1.2490,
+                1.2510,
+                1.2500,
+                1.2480,
+                1.2520,
+                1.2530,
+                1.2545,
+                1.2550,
+                1.2565,
+                1.2580,
+                1.2570,
+                1.2595,
+                1.2600,
+                1.2615,
+                1.2630,
+                1.2620,
+                1.2610,
+                1.2640,
+                1.2660,
+                1.2650,
+                1.2675,
+                1.2690,
+                1.2680,
+                1.2705,
+                1.2720,
+            ]],
+            [c - 0.0012 for c in [
+                1.2345,
+                1.2350,
+                1.2330,
+                1.2380,
+                1.2400,
+                1.2375,
+                1.2390,
+                1.2410,
+                1.2450,
+                1.2440,
+                1.2460,
+                1.2475,
+                1.2490,
+                1.2510,
+                1.2500,
+                1.2480,
+                1.2520,
+                1.2530,
+                1.2545,
+                1.2550,
+                1.2565,
+                1.2580,
+                1.2570,
+                1.2595,
+                1.2600,
+                1.2615,
+                1.2630,
+                1.2620,
+                1.2610,
+                1.2640,
+                1.2660,
+                1.2650,
+                1.2675,
+                1.2690,
+                1.2680,
+                1.2705,
+                1.2720,
+            ]],
+            [
+                1.2345,
+                1.2350,
+                1.2330,
+                1.2380,
+                1.2400,
+                1.2375,
+                1.2390,
+                1.2410,
+                1.2450,
+                1.2440,
+                1.2460,
+                1.2475,
+                1.2490,
+                1.2510,
+                1.2500,
+                1.2480,
+                1.2520,
+                1.2530,
+                1.2545,
+                1.2550,
+                1.2565,
+                1.2580,
+                1.2570,
+                1.2595,
+                1.2600,
+                1.2615,
+                1.2630,
+                1.2620,
+                1.2610,
+                1.2640,
+                1.2660,
+                1.2650,
+                1.2675,
+                1.2690,
+                1.2680,
+                1.2705,
+                1.2720,
+            ],
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                54.3859649123,
+                53.6111294548,
+                53.4217520476,
+                53.3656271949,
+                53.4905300805,
+                53.6656213650,
+                54.0051184727,
+                54.4899120811,
+                54.4879056714,
+                54.7977772645,
+                55.1449954025,
+                55.6441448008,
+                56.2752254602,
+                56.3608743995,
+                55.9471346365,
+                56.0011158829,
+                56.3042430641,
+                56.1027907766,
+                56.2546495457,
+                56.5801575908,
+                56.3941479799,
+                56.5590153252,
+                56.8956615295,
+            ],
+        ),
+    ],
+)
+def test_compute_adx_matches_reference(
+    period: int,
+    highs: list[float],
+    lows: list[float],
+    closes: list[float],
+    expected: list[float | None],
+) -> None:
+    result = _compute_adx(highs, lows, closes, period)
+    assert len(result) == len(expected)
+    for idx, (value, expected_value) in enumerate(zip(result, expected)):
+        if expected_value is None:
+            assert value is None, f"Expected None at index {idx}, got {value}"
+            continue
+        assert value is not None
+        assert value == pytest.approx(expected_value, rel=1e-6)
+
+
+def test_compute_adx_validates_lengths() -> None:
+    with pytest.raises(ValueError):
+        _compute_adx([1.0, 1.1], [0.9], [1.0, 1.1], 14)
+
+
+def test_compute_adx_rejects_non_positive_period() -> None:
+    with pytest.raises(ValueError):
+        _compute_adx([1.0, 1.1], [0.9, 1.0], [1.0, 1.1], 0)


### PR DESCRIPTION
## Summary
- rewrite the RSI and ADX helpers in the data ingestion job to use single-pass rolling updates and stricter input validation
- return early for short inputs and avoid allocating large intermediate arrays for the indicator computations
- add regression tests that lock in the RSI/ADX outputs and validate error handling

## Testing
- python -m pytest algorithms/python/tests/test_indicators.py

------
https://chatgpt.com/codex/tasks/task_e_68d47018ae9c83228e654ca03e038118