### PR TITLE
feat: add economic calendar and fundamental insights

### DIFF
--- a/apps/web/components/magic-portfolio/MagicLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/MagicLandingPage.tsx
@@ -8,6 +8,8 @@ import { MentorshipProgramsSection } from "@/components/magic-portfolio/home/Men
 import { PoolTradingSection } from "@/components/magic-portfolio/home/PoolTradingSection";
 import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchlist";
 import { ComplianceCertificates } from "@/components/magic-portfolio/home/ComplianceCertificates";
+import { EconomicCalendarSection } from "@/components/magic-portfolio/home/EconomicCalendarSection";
+import { FundamentalAnalysisSection } from "@/components/magic-portfolio/home/FundamentalAnalysisSection";
 
 export function MagicLandingPage() {
   return (
@@ -89,21 +91,27 @@ export function MagicLandingPage() {
         <MarketWatchlist />
       </RevealFx>
       <RevealFx translateY="20" delay={0.7}>
-        <AboutShowcase />
+        <EconomicCalendarSection />
       </RevealFx>
       <RevealFx translateY="20" delay={0.75}>
-        <ComplianceCertificates />
+        <FundamentalAnalysisSection />
       </RevealFx>
       <RevealFx translateY="20" delay={0.8}>
-        <MentorshipProgramsSection />
+        <AboutShowcase />
       </RevealFx>
       <RevealFx translateY="20" delay={0.84}>
-        <PoolTradingSection />
+        <ComplianceCertificates />
       </RevealFx>
       <RevealFx translateY="20" delay={0.88}>
-        <VipPackagesSection />
+        <MentorshipProgramsSection />
       </RevealFx>
       <RevealFx translateY="20" delay={0.92}>
+        <PoolTradingSection />
+      </RevealFx>
+      <RevealFx translateY="20" delay={0.96}>
+        <VipPackagesSection />
+      </RevealFx>
+      <RevealFx translateY="20" delay={1}>
         <CheckoutCallout />
       </RevealFx>
       <Mailchimp />

--- a/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
+++ b/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
@@ -1,0 +1,160 @@
+import { Fragment } from "react";
+
+import { Column, Heading, Icon, Line, Row, Tag, Text } from "@once-ui-system/core";
+
+type ImpactLevel = "High" | "Medium" | "Low";
+
+type EconomicEvent = {
+  id: string;
+  day: string;
+  time: string;
+  title: string;
+  impact: ImpactLevel;
+  marketFocus: string[];
+  commentary: string;
+  deskPlan: string[];
+};
+
+const IMPACT_STYLES: Record<ImpactLevel, { label: string; background: string; icon: string }> = {
+  High: { label: "High impact", background: "danger-alpha-weak", icon: "alert-triangle" },
+  Medium: { label: "Medium impact", background: "brand-alpha-weak", icon: "activity" },
+  Low: { label: "Low impact", background: "neutral-alpha-weak", icon: "info" },
+};
+
+const ECONOMIC_EVENTS: EconomicEvent[] = [
+  {
+    id: "fomc",
+    day: "Wed · 19 Mar",
+    time: "18:00 GMT",
+    title: "FOMC rate decision & Powell press conference",
+    impact: "High",
+    marketFocus: ["USD", "Rates", "US Indices"],
+    commentary:
+      "We expect the statement to keep optionality for mid-year cuts while Powell leans against premature easing. Volatility will spike across USD pairs and equity index futures.",
+    deskPlan: [
+      "Pause USD scalps 30 minutes before the statement and re-open only after the press conference tone is clear.",
+      "Automation primed to fade S&P strength if dot plot shifts hawkish and 5,200 fails to hold on retests.",
+    ],
+  },
+  {
+    id: "uk-cpi",
+    day: "Wed · 19 Mar",
+    time: "07:00 GMT",
+    title: "UK CPI (Feb)",
+    impact: "Medium",
+    marketFocus: ["GBP", "UK Rates"],
+    commentary:
+      "Sticky services inflation keeps the Bank of England boxed in. Consensus looks too light on core readings after energy base effects faded.",
+    deskPlan: [
+      "Short bias stays in place for GBP/USD below 1.28 with automation trimming risk if core prints under 5.0%.",
+      "Gilts desk watching 2Y yields for a break above 4.50% to add to short-duration hedges.",
+    ],
+  },
+  {
+    id: "ecb-speeches",
+    day: "Thu · 20 Mar",
+    time: "09:30 GMT",
+    title: "ECB speakers rotation",
+    impact: "Low",
+    marketFocus: ["EUR", "European Banks"],
+    commentary:
+      "Lagarde, Villeroy, and Schnabel hit the wires across the session. Guidance around June easing path will steer EUR crosses.",
+    deskPlan: [
+      "Maintain light EUR/USD short starter with adds only if commentary dismisses back-to-back cuts.",
+      "Financials desk monitoring EuroStoxx banks for continuation above 130 to keep overweight exposure on.",
+    ],
+  },
+  {
+    id: "us-pmi",
+    day: "Fri · 21 Mar",
+    time: "13:45 GMT",
+    title: "US S&P Global PMIs (Mar flash)",
+    impact: "Medium",
+    marketFocus: ["USD", "Commodities"],
+    commentary:
+      "Manufacturing prints are the swing factor for cyclical trades. A beat keeps the soft-landing narrative alive and supports metals demand.",
+    deskPlan: [
+      "Gold overlay hedges stay live while manufacturing PMI holds above 50; unwind if the composite slips under 49.5.",
+      "Energy team watching WTI for acceptance above $80 to re-enter trend longs on solid services demand signals.",
+    ],
+  },
+];
+
+export function EconomicCalendarSection() {
+  return (
+    <Column
+      id="economic-calendar"
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="32"
+      shadow="l"
+    >
+      <Column gap="12" maxWidth={32}>
+        <Heading variant="display-strong-xs">Upcoming economic catalysts</Heading>
+        <Text variant="body-default-l" onBackground="neutral-weak">
+          The desk tracks macro releases that can reprice risk within minutes. Each listing includes the positioning gameplan so you know how we manage exposure into and out of the data.
+        </Text>
+      </Column>
+      <Column gap="24">
+        {ECONOMIC_EVENTS.map((event, index) => {
+          const impactDetails = IMPACT_STYLES[event.impact];
+
+          return (
+            <Fragment key={event.id}>
+              <Column
+                background="page"
+                border="neutral-alpha-weak"
+                radius="l"
+                padding="l"
+                gap="16"
+              >
+                <Row horizontal="between" vertical="center" gap="16" s={{ direction: "column", align: "start" }}>
+                  <Column gap="8">
+                    <Row gap="8" wrap>
+                      <Tag size="s" background="neutral-alpha-weak" prefixIcon="calendar">
+                        {event.day}
+                      </Tag>
+                      <Tag size="s" background="neutral-alpha-weak" prefixIcon="clock">
+                        {event.time}
+                      </Tag>
+                    </Row>
+                    <Heading variant="heading-strong-m">{event.title}</Heading>
+                  </Column>
+                  <Tag size="s" background={impactDetails.background} prefixIcon={impactDetails.icon}>
+                    {impactDetails.label}
+                  </Tag>
+                </Row>
+                <Text variant="body-default-m" onBackground="neutral-weak">
+                  {event.commentary}
+                </Text>
+                <Row gap="8" wrap>
+                  {event.marketFocus.map((focus) => (
+                    <Tag key={focus} size="s" background="brand-alpha-weak" prefixIcon="target">
+                      {focus}
+                    </Tag>
+                  ))}
+                </Row>
+                <Column as="ul" gap="8">
+                  {event.deskPlan.map((plan, planIndex) => (
+                    <Row key={planIndex} gap="8" vertical="start">
+                      <Icon name="sparkles" onBackground="brand-medium" />
+                      <Text as="li" variant="body-default-m">
+                        {plan}
+                      </Text>
+                    </Row>
+                  ))}
+                </Column>
+              </Column>
+              {index < ECONOMIC_EVENTS.length - 1 ? <Line background="neutral-alpha-weak" /> : null}
+            </Fragment>
+          );
+        })}
+      </Column>
+    </Column>
+  );
+}
+
+export default EconomicCalendarSection;

--- a/apps/web/components/magic-portfolio/home/FundamentalAnalysisSection.tsx
+++ b/apps/web/components/magic-portfolio/home/FundamentalAnalysisSection.tsx
@@ -1,0 +1,169 @@
+import { Fragment } from "react";
+
+import { Column, Heading, Icon, Line, Row, Tag, Text } from "@once-ui-system/core";
+
+type Positioning = "Overweight" | "Market weight" | "Underweight";
+
+type FundamentalInsight = {
+  id: string;
+  asset: string;
+  sector: string;
+  positioning: Positioning;
+  summary: string;
+  catalysts: string[];
+  riskControls: string;
+  metrics: { label: string; value: string }[];
+};
+
+const POSITIONING_STYLES: Record<Positioning, { background: string; icon: string }> = {
+  Overweight: { background: "brand-alpha-weak", icon: "trending-up" },
+  "Market weight": { background: "neutral-alpha-weak", icon: "bar-chart" },
+  Underweight: { background: "danger-alpha-weak", icon: "trending-down" },
+};
+
+const FUNDAMENTAL_INSIGHTS: FundamentalInsight[] = [
+  {
+    id: "nvda",
+    asset: "NVDA",
+    sector: "Semiconductors",
+    positioning: "Overweight",
+    summary:
+      "Data-center backlog and H200 ramp keep revenue visibility high through FY25. Demand from hyperscalers and sovereign AI funds still exceeds supply.",
+    catalysts: [
+      "May earnings update with fresh visibility on Blackwell shipments",
+      "Potential incremental capex commitments from top-three hyperscalers",
+    ],
+    riskControls:
+      "Scaling entries on pullbacks toward $820 with invalidation under $780 weekly support. Hedged via SOXX puts into earnings window.",
+    metrics: [
+      { label: "YoY revenue", value: "+262%" },
+      { label: "Gross margin", value: "74%" },
+      { label: "Forward P/E", value: "33x" },
+    ],
+  },
+  {
+    id: "cldx",
+    asset: "CLDX",
+    sector: "Biotech",
+    positioning: "Market weight",
+    summary:
+      "Pipeline milestones in Q2 keep optionality alive, but valuation already prices in a successful Phase 2b readout. We stay balanced while waiting on data.",
+    catalysts: [
+      "Phase 2b results for CDX-0159 chronic urticaria study",
+      "Partnership chatter with large-cap pharma for commercialization support",
+    ],
+    riskControls:
+      "Hold core starter size with a stop under $30. Leverage covered calls to finance protection ahead of binary data catalysts.",
+    metrics: [
+      { label: "Cash runway", value: "8 quarters" },
+      { label: "EV / Sales", value: "6.2x" },
+      { label: "Short interest", value: "7%" },
+    ],
+  },
+  {
+    id: "xom",
+    asset: "XOM",
+    sector: "Energy",
+    positioning: "Underweight",
+    summary:
+      "Crude supply discipline supports cash flows, but valuation no longer compensates for slowing downstream margins and energy transition capex needs.",
+    catalysts: [
+      "Next OPEC+ meeting commentary on summer production targets",
+      "US Gulf Coast margin data for indications of refining softness",
+    ],
+    riskControls:
+      "Running a reduced core position with tight stop above $125. Pair trade expressed through long CVX / short XOM to keep sector beta neutral.",
+    metrics: [
+      { label: "Dividend yield", value: "3.1%" },
+      { label: "Net debt / EBITDA", value: "0.7x" },
+      { label: "Implied Brent", value: "$83" },
+    ],
+  },
+];
+
+export function FundamentalAnalysisSection() {
+  return (
+    <Column
+      id="fundamental-analysis"
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="32"
+      shadow="l"
+    >
+      <Column gap="12" maxWidth={32}>
+        <Heading variant="display-strong-xs">Fundamental positioning highlights</Heading>
+        <Text variant="body-default-l" onBackground="neutral-weak">
+          Snapshot of the desk's highest conviction fundamental calls this week, including catalysts on the radar and the risk controls backing each stance.
+        </Text>
+      </Column>
+      <Column gap="24">
+        {FUNDAMENTAL_INSIGHTS.map((insight, index) => {
+          const positioningStyles = POSITIONING_STYLES[insight.positioning];
+
+          return (
+            <Fragment key={insight.id}>
+              <Column
+                background="page"
+                border="neutral-alpha-weak"
+                radius="l"
+                padding="l"
+                gap="20"
+              >
+                <Row horizontal="between" vertical="center" gap="12" s={{ direction: "column", align: "start" }}>
+                  <Column gap="4">
+                    <Heading variant="heading-strong-m">
+                      {insight.asset}
+                    </Heading>
+                    <Text variant="body-default-s" onBackground="neutral-medium">
+                      {insight.sector}
+                    </Text>
+                  </Column>
+                  <Tag size="s" background={positioningStyles.background} prefixIcon={positioningStyles.icon}>
+                    {insight.positioning}
+                  </Tag>
+                </Row>
+                <Text variant="body-default-m" onBackground="neutral-weak">
+                  {insight.summary}
+                </Text>
+                <Column gap="12">
+                  <Heading as="h3" variant="label-default-m" onBackground="neutral-medium">
+                    Key catalysts
+                  </Heading>
+                  <Column as="ul" gap="8">
+                    {insight.catalysts.map((catalyst, catalystIndex) => (
+                      <Row key={catalystIndex} gap="8" vertical="start">
+                        <Icon name="sparkles" onBackground="brand-medium" />
+                        <Text as="li" variant="body-default-m">
+                          {catalyst}
+                        </Text>
+                      </Row>
+                    ))}
+                  </Column>
+                </Column>
+                <Column gap="12">
+                  <Heading as="h3" variant="label-default-m" onBackground="neutral-medium">
+                    Risk controls
+                  </Heading>
+                  <Text variant="body-default-m">{insight.riskControls}</Text>
+                </Column>
+                <Row gap="8" wrap>
+                  {insight.metrics.map((metric) => (
+                    <Tag key={metric.label} size="s" background="neutral-alpha-weak">
+                      {metric.label}: {metric.value}
+                    </Tag>
+                  ))}
+                </Row>
+              </Column>
+              {index < FUNDAMENTAL_INSIGHTS.length - 1 ? <Line background="neutral-alpha-weak" /> : null}
+            </Fragment>
+          );
+        })}
+      </Column>
+    </Column>
+  );
+}
+
+export default FundamentalAnalysisSection;


### PR DESCRIPTION
## Summary
- add an economic calendar section that highlights upcoming macro catalysts and desk playbooks
- introduce a fundamental analysis module with positioning, catalysts, and risk controls
- wire the new sections into the landing page flow alongside existing trading content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d47067ee148322ad96993f6ec2496c