### PR TITLE
docs: add investing.com signal integration checklist

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -31,6 +31,7 @@ Follow the numbered order below when coordinating large efforts. Each entry link
 | 10 | [`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding for the TradingView webhook to MT5 flow | Coordinate roadmap execution across teams | — |
 | 11 | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md) | Merging Dynamic Codex into this monorepo | Completed — dashboard now lives at `/telegram` in the Next.js app | — |
 | 12 | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md) | Align Git branches with deployable services and domains | Rework branching strategy to support independent deployments | — |
+| 13 | [`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md) | Bringing Investing.com pattern data into Supabase, queue, and Mini App surfaces | Plan and track the signal ingestion + alert rollout | — |
 
 ## Project delivery (priorities 1–3)
 
@@ -53,6 +54,7 @@ Follow the numbered order below when coordinating large efforts. Each entry link
 - **[`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md)** – mirrors the onboarding roadmap so TradingView, webhook, Supabase, and MT5 teams can work in parallel with clear hand-offs.
 - **[`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)** – archived after Dynamic Codex was merged into the main `/telegram` route; keep for historical context.
 - **[`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)** – guides the restructuring of branches so each deployable service can map to its own domain and load-balanced release flow.
+- **[`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md)** – governs the new Investing.com signal ingestion pipeline, Telegram broadcasts, and Mini App surfacing workstream.
 
 ## Keep documentation in sync
 

--- a/docs/investing-com-candlestick-checklist.md
+++ b/docs/investing-com-candlestick-checklist.md
@@ -1,0 +1,88 @@
+# Investing.com Candlestick Signal Integration Checklist
+
+Use this checklist when building the Investing.com candlestick signal pipeline
+so the data ingestion, alerting, and Mini App surfaces stay aligned with Dynamic
+Capital's existing automation stack.
+
+## 1. Source ingestion & normalization
+
+- [ ] Confirm legal/ToS compliance for polling Investing.com data and record
+      retention limits.
+- [ ] Document the exact API or scraping strategy (URL patterns, query params,
+      rate limits, auth requirements).
+- [ ] Build a fetcher (cron job, Supabase Edge Function, or queue worker) that
+      downloads the latest candlestick pattern payloads per symbol/timeframe.
+- [ ] Normalize raw fields (symbol, timeframe, reliability score, detection
+      timestamps) into consistent enums and UTC timestamps.
+- [ ] Implement retries, exponential backoff, and failure logging so transient
+      network issues do not drop signals.
+- [ ] Write unit tests covering parser edge cases (missing fields, new pattern
+      names, malformed timestamps).
+
+## 2. Supabase schema & data retention
+
+- [ ] Design/extend a Supabase table (e.g., `public.candlestick_signals`) with
+      indexes on symbol, timeframe, detected_at.
+- [ ] Define enum or lookup tables for pattern names and reliability tiers to
+      avoid typos.
+- [ ] Add RLS policies or service-role usage notes documenting how ingestion
+      writes bypass end-user restrictions.
+- [ ] Create a data retention strategy (e.g., automatic pruning or archival
+      after N days) to manage table growth.
+- [ ] Expose a Supabase view or RPC that joins signals with relevant pricing
+      metadata for downstream consumers.
+- [ ] Verify ingestion writes via local Supabase tests and record migrations in
+      `supabase/migrations`.
+
+## 3. Queue processing & alert curation
+
+- [ ] Register a queue job that reacts to newly stored signals and applies
+      internal risk filters (reliability score, overlapping patterns, price
+      context).
+- [ ] Deduplicate signals (symbol + timeframe + pattern) within a configurable
+      window to avoid double alerts.
+- [ ] Implement escalation logic that tags VIP or depositor segments using
+      existing queue helpers.
+- [ ] Add feature flags/config toggles so ops can pause or adjust alert cadence
+      without redeploying code.
+- [ ] Log outcomes (skipped, queued, broadcast) with sufficient metadata for
+      audit trails.
+
+## 4. Telegram broadcast workflow
+
+- [ ] Map curated signals into the Telegram broadcast planner payload (title,
+      body, CTA, segmentation tags).
+- [ ] Blend market context with deposit messaging (e.g., highlight funding
+      windows or risk reminders).
+- [ ] Respect Telegram rate limits using the existing chunking helper and queue
+      retries.
+- [ ] Provide localized or templated message variants if multilingual support is
+      required.
+- [ ] Update runbooks documenting how to enable/disable the new signal campaign.
+
+## 5. Mini App market pulse module
+
+- [ ] Define UX for displaying latest/high-confidence patterns within the
+      Next.js Mini App dashboard.
+- [ ] Implement a Supabase query hook or realtime subscription that surfaces
+      fresh signals with timestamps and reliability badges.
+- [ ] Add UI states for "no recent signals" and loading/error conditions to
+      prevent empty panels.
+- [ ] Ensure formatting matches Once UI/Tailwind conventions (spacing,
+      typography, color usage).
+- [ ] Write integration tests or Storybook stories to validate rendering against
+      mock signal data.
+
+## 6. Analytics, monitoring & QA
+
+- [ ] Track ingestion counts, queue throughput, and Telegram delivery metrics
+      via existing observability stack (logs, Supabase metrics, Telegram
+      response codes).
+- [ ] Configure alerts for sustained ingestion failures or queue backlogs.
+- [ ] Set up a QA playbook covering end-to-end verification (force-ingest sample
+      data, confirm queue job execution, validate Telegram preview, and Mini App
+      rendering).
+- [ ] Schedule periodic audits to reassess pattern reliability and adjust
+      filters accordingly.
+- [ ] Document manual rollback steps (disable feature flags, purge recent
+      signals, halt queue jobs) for operational incidents.


### PR DESCRIPTION
## Summary
- create an Investing.com candlestick signal integration checklist covering ingestion, storage, alerts, mini app UX, and monitoring tasks
- register the new checklist inside `docs/CHECKLISTS.md` so contributors can find it in the prioritized roadmap

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d471d6f5a883228ee7b85d4bdbe877