### PR TITLE
Rename system UI export to dyamic UI

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,12 +7,24 @@ import "./globals.css";
 import "@/lib/env";
 
 import classNames from "classnames";
-import { Background, Column, Flex, RevealFx, opacity, SpacingToken } from "@once-ui-system/core";
+import {
+  Background,
+  Column,
+  Flex,
+  opacity,
+  RevealFx,
+  SpacingToken,
+} from "@once-ui-system/core";
 
 import Providers from "./providers";
 import { getStaticLandingDocument } from "@/lib/staticLanding";
-import { Footer, Header, RouteGuard, ScrollToHash } from "@/components/magic-portfolio";
-import { systemUI } from "@/resources";
+import {
+  Footer,
+  Header,
+  RouteGuard,
+  ScrollToHash,
+} from "@/components/magic-portfolio";
+import { dyamicUI } from "@/resources";
 
 const SITE_URL = process.env.SITE_URL || "http://localhost:8080";
 const DEFAULT_THEME = "dark" as const;
@@ -22,7 +34,7 @@ const {
   basics: basicsConfig,
   dataViz: dataVizConfig,
   effects: effectsConfig,
-} = systemUI;
+} = dyamicUI;
 const { fonts, style } = basicsConfig;
 const { dataStyle } = dataVizConfig;
 const backgroundEffects = effectsConfig.background;
@@ -41,7 +53,9 @@ const htmlAttributeDefaults: Record<string, string> = {
 };
 
 const themeAttributeDefaults = Object.fromEntries(
-  Object.entries(htmlAttributeDefaults).map(([key, value]) => [key.replace(/^data-/, ""), value]),
+  Object.entries(htmlAttributeDefaults).map((
+    [key, value],
+  ) => [key.replace(/^data-/, ""), value]),
 );
 
 const onceThemeScript = `(function () {
@@ -138,8 +152,11 @@ const fontClassName = classNames(
   fonts.code.variable,
 );
 
-export default async function RootLayout({ children }: { children: ReactNode }) {
-  const isStaticSnapshot = globalThis?.process?.env?.["STATIC_SNAPSHOT"] === "true";
+export default async function RootLayout(
+  { children }: { children: ReactNode },
+) {
+  const isStaticSnapshot =
+    globalThis?.process?.env?.["STATIC_SNAPSHOT"] === "true";
 
   if (isStaticSnapshot) {
     const { head, body, lang } = await getStaticLandingDocument();
@@ -152,7 +169,10 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
         data-theme={DEFAULT_THEME}
       >
         <head dangerouslySetInnerHTML={{ __html: ensureThemeScript(head) }} />
-        <body suppressHydrationWarning dangerouslySetInnerHTML={{ __html: body }} />
+        <body
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: body }}
+        />
       </html>
     );
   }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ReactNode, useState } from 'react';
-import { createBrowserClient } from '@supabase/ssr';
-import { SessionContextProvider } from '@supabase/auth-helpers-react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode, useState } from "react";
+import { createBrowserClient } from "@supabase/ssr";
+import { SessionContextProvider } from "@supabase/auth-helpers-react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   BorderStyle,
   ChartMode,
@@ -20,18 +20,18 @@ import {
   ThemeProvider,
   ToastProvider as OnceToastProvider,
   TransitionStyle,
-} from '@once-ui-system/core';
-import { AuthProvider } from '@/hooks/useAuth';
-import { SupabaseProvider } from '@/context/SupabaseProvider';
-import { MotionConfigProvider } from '@/components/ui/motion-config';
-import { systemUI } from '@/resources';
-import { iconLibrary } from '@/resources/icons';
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from '@/config/supabase-runtime';
+} from "@once-ui-system/core";
+import { AuthProvider } from "@/hooks/useAuth";
+import { SupabaseProvider } from "@/context/SupabaseProvider";
+import { MotionConfigProvider } from "@/components/ui/motion-config";
+import { dyamicUI } from "@/resources";
+import { iconLibrary } from "@/resources/icons";
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "@/config/supabase-runtime";
 
 const {
   basics: basicsConfig,
   dataViz: dataVizConfig,
-} = systemUI;
+} = dyamicUI;
 const { style } = basicsConfig;
 const { dataStyle } = dataVizConfig;
 

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -1,11 +1,11 @@
-'use client';
+"use client";
 
 import dynamic from "next/dynamic";
 import { Background, Column, RevealFx } from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
-import { systemUI } from "@/resources";
+import { dyamicUI } from "@/resources";
 import { MagicLandingPage } from "@/components/magic-portfolio/MagicLandingPage";
 import type {
   ChromaBackgroundProps,
@@ -14,7 +14,7 @@ import type {
 
 const DynamicChromaBackground = dynamic<ChromaBackgroundProps>(
   () => import("@/components/landing/ChromaBackground"),
-  { ssr: false }
+  { ssr: false },
 );
 
 export interface LandingPageShellProps {
@@ -42,7 +42,7 @@ export function LandingPageShell({
   assistantClassName,
   chromaBackgroundVariant = null,
 }: LandingPageShellProps) {
-  const backgroundEffects = systemUI.effects.background;
+  const backgroundEffects = dyamicUI.effects.background;
 
   return (
     <Column
@@ -97,12 +97,14 @@ export function LandingPageShell({
           }}
         />
       </RevealFx>
-      {chromaBackgroundVariant ? (
-        <DynamicChromaBackground
-          variant={chromaBackgroundVariant}
-          className="pointer-events-none absolute inset-0 z-0"
-        />
-      ) : null}
+      {chromaBackgroundVariant
+        ? (
+          <DynamicChromaBackground
+            variant={chromaBackgroundVariant}
+            className="pointer-events-none absolute inset-0 z-0"
+          />
+        )
+        : null}
       <Column
         zIndex={1}
         fillWidth
@@ -113,12 +115,13 @@ export function LandingPageShell({
       >
         <MagicLandingPage />
       </Column>
-      {showAssistant ? (
-        <Column zIndex={1} paddingX="16">
-          <ChatAssistantWidget className={assistantClassName} />
-        </Column>
-      ) : null}
+      {showAssistant
+        ? (
+          <Column zIndex={1} paddingX="16">
+            <ChatAssistantWidget className={assistantClassName} />
+          </Column>
+        )
+        : null}
     </Column>
   );
 }
-

--- a/apps/web/components/magic-portfolio/Mailchimp.tsx
+++ b/apps/web/components/magic-portfolio/Mailchimp.tsx
@@ -1,16 +1,27 @@
 "use client";
 
-import { newsletter, systemUI } from "@/resources";
-import { Button, Heading, Input, Text, Background, Column, Row } from "@once-ui-system/core";
+import { dyamicUI, newsletter } from "@/resources";
+import {
+  Background,
+  Button,
+  Column,
+  Heading,
+  Input,
+  Row,
+  Text,
+} from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { useState } from "react";
 
 const {
   formControls: { newsletter: newsletterFormConfig },
   effects: { newsletter: newsletterEffects },
-} = systemUI;
+} = dyamicUI;
 
-function debounce<T extends (...args: any[]) => void>(func: T, delay: number): T {
+function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  delay: number,
+): T {
   let timeout: ReturnType<typeof setTimeout>;
   return ((...args: Parameters<T>) => {
     clearTimeout(timeout);
@@ -18,7 +29,9 @@ function debounce<T extends (...args: any[]) => void>(func: T, delay: number): T
   }) as T;
 }
 
-export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...flex }) => {
+export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = (
+  { ...flex },
+) => {
   const [email, setEmail] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [touched, setTouched] = useState<boolean>(false);
@@ -113,7 +126,12 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
         <Heading marginBottom="s" variant="display-strong-xs">
           {newsletter.title}
         </Heading>
-        <Text wrap="balance" marginBottom="l" variant="body-default-l" onBackground="neutral-weak">
+        <Text
+          wrap="balance"
+          marginBottom="l"
+          variant="body-default-l"
+          onBackground="neutral-weak"
+        >
           {newsletter.description}
         </Text>
       </Column>
@@ -163,10 +181,23 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
             />
           </div>
           <div id="mce-responses" className="clearfalse">
-            <div className="response" id="mce-error-response" style={{ display: "none" }}></div>
-            <div className="response" id="mce-success-response" style={{ display: "none" }}></div>
+            <div
+              className="response"
+              id="mce-error-response"
+              style={{ display: "none" }}
+            >
+            </div>
+            <div
+              className="response"
+              id="mce-success-response"
+              style={{ display: "none" }}
+            >
+            </div>
           </div>
-          <div aria-hidden="true" style={{ position: "absolute", left: "-5000px" }}>
+          <div
+            aria-hidden="true"
+            style={{ position: "absolute", left: "-5000px" }}
+          >
             <input
               type="text"
               readOnly
@@ -177,7 +208,12 @@ export const Mailchimp: React.FC<React.ComponentProps<typeof Column>> = ({ ...fl
           </div>
           <div className="clear">
             <Row height="48" vertical="center">
-              <Button id="mc-embedded-subscribe" value="Subscribe" size="m" fillWidth>
+              <Button
+                id="mc-embedded-subscribe"
+                value="Subscribe"
+                size="m"
+                fillWidth
+              >
                 Subscribe
               </Button>
             </Row>

--- a/apps/web/resources/index.ts
+++ b/apps/web/resources/index.ts
@@ -1,36 +1,36 @@
 // import a pre-defined template for config and content options
 export {
-  person,
-  social,
-  newsletter,
-  home,
   about,
   blog,
-  work,
   gallery,
+  home,
+  newsletter,
+  person,
+  social,
+  work,
 } from "./content";
 
 export {
-  display,
-  mailchimp,
-  routes,
-  protectedRoutes,
   baseURL,
-  fonts,
-  style,
-  schema,
-  sameAs,
-  socialSharing,
-  effects,
   dataStyle,
-  systemUI,
+  display,
+  dyamicUI,
+  effects,
+  fonts,
+  mailchimp,
+  protectedRoutes,
+  routes,
+  sameAs,
+  schema,
+  socialSharing,
+  style,
 } from "./once-ui.config";
 
 export {
-  supabaseAsset,
-  toAbsoluteUrl,
   magicPortfolioBucketBaseUrl,
   magicPortfolioBucketName,
+  supabaseAsset,
+  toAbsoluteUrl,
 } from "./assets";
 
 export { getRouteDefinitions, isRouteEnabled } from "./routes";

--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -140,7 +140,8 @@ const effects: EffectsConfig = {
 };
 
 const mailchimp: MailchimpConfig = {
-  action: "https://dynamiccapital.us21.list-manage.com/subscribe/post?u=c1a5a210340eb6c7bff33b2ba&id=0462d244aa",
+  action:
+    "https://dynamiccapital.us21.list-manage.com/subscribe/post?u=c1a5a210340eb6c7bff33b2ba&id=0462d244aa",
   effects: {
     mask: {
       cursor: true,
@@ -212,7 +213,7 @@ const socialSharing: SocialSharingConfig = {
   },
 };
 
-const systemUI = {
+const dyamicUI = {
   basics: {
     baseURL,
     display,
@@ -247,17 +248,17 @@ const systemUI = {
 } satisfies SystemUIConfig;
 
 export {
-  display,
-  mailchimp,
-  routes,
-  protectedRoutes,
   baseURL,
-  fonts,
-  style,
-  schema,
-  sameAs,
-  socialSharing,
-  effects,
   dataStyle,
-  systemUI,
+  display,
+  dyamicUI,
+  effects,
+  fonts,
+  mailchimp,
+  protectedRoutes,
+  routes,
+  sameAs,
+  schema,
+  socialSharing,
+  style,
 };


### PR DESCRIPTION
## Summary
- rename the exported system UI configuration object to `dyamicUI` and update its re-export map
- update all UI components and providers to consume the renamed `dyamicUI` configuration

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d474cd1860832286cb6b73dfcb6052