### PR TITLE
Rename Once UI system to Dynamic UI

### DIFF
--- a/docs/legal/THIRD_PARTY_LICENSES.md
+++ b/docs/legal/THIRD_PARTY_LICENSES.md
@@ -5,31 +5,31 @@ component remains the property of its respective authors and is distributed
 under the licenses indicated below. Follow the linked license texts when
 reviewing obligations such as copyright notices or attribution requirements.
 
-| Package / Component | Usage | License | Reference |
-| --- | --- | --- | --- |
-| Next.js | Core web application framework | MIT License | https://github.com/vercel/next.js/blob/canary/license.md |
-| React | UI library powering the web and mini app clients | MIT License | https://github.com/facebook/react/blob/main/LICENSE |
-| Supabase JS SDK & Supabase CLI | Database, authentication, and local development tooling | Apache License 2.0 | https://github.com/supabase/supabase/blob/master/LICENSE |
-| Once UI System | Design system tokens and components for the marketing site | MIT License | https://github.com/once-ui/once-ui/blob/main/LICENSE |
-| Tailwind CSS | Utility-first styling used across the landing and dashboard experiences | MIT License | https://github.com/tailwindlabs/tailwindcss/blob/master/LICENSE |
-| Lucide React | Icon set used in the dashboard and mini app | ISC License | https://github.com/lucide-icons/lucide/blob/main/LICENSE |
-| Framer Motion | Animation primitives for interactive UI elements | MIT License | https://github.com/framer/motion/blob/main/LICENSE |
-| TanStack Query | Client-side data fetching and caching | MIT License | https://github.com/TanStack/query/blob/main/LICENSE |
-| Inngest | Background job orchestration for queue and worker processes | Apache License 2.0 | https://github.com/inngest/inngest-js/blob/main/LICENSE |
-| AWS SDK for JavaScript v3 | DigitalOcean Spaces and S3-compatible uploads | Apache License 2.0 | https://github.com/aws/aws-sdk-js-v3/blob/main/LICENSE |
-| PostHog JS | Product analytics instrumentation | MIT License | https://github.com/PostHog/posthog-js/blob/master/LICENSE |
-| Sonner | Toast notifications within the dashboard | MIT License | https://github.com/emilkowalski/sonner/blob/main/LICENSE |
-| Auth.js (NextAuth.js) | End-user authentication and session management | ISC License | https://github.com/nextauthjs/next-auth/blob/main/LICENSE |
-| Supabase Auth Helpers & SSR | Seamless Supabase session handling for React and Next.js | MIT License | https://github.com/supabase/auth-helpers/blob/main/LICENSE |
-| grammY Telegram Framework | Telegram bot orchestration including conversations and throttling | MIT License | https://github.com/grammyjs/grammY/blob/main/LICENSE |
-| Radix UI Primitives | Accessible headless components underpinning the dashboard UI | MIT License | https://github.com/radix-ui/primitives/blob/main/LICENSE |
-| Sentry Next.js SDK | Application monitoring and error tracing | MIT License | https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE |
-| Drizzle ORM | Type-safe database access layer for Supabase Postgres | Apache License 2.0 | https://github.com/drizzle-team/drizzle-orm/blob/main/LICENSE |
-| Zod | Runtime validation for API payloads and forms | MIT License | https://github.com/colinhacks/zod/blob/master/LICENSE |
-| Tesseract.js | Optical character recognition used in receipt processing | Apache License 2.0 | https://github.com/naptha/tesseract.js/blob/master/LICENSE |
-| React Hook Form | Form state management for onboarding and admin flows | MIT License | https://github.com/react-hook-form/react-hook-form/blob/master/LICENSE |
-| React Three Fiber & Drei | 3D scene rendering helpers for marketing visualizations | MIT License | https://github.com/pmndrs/react-three-fiber/blob/master/LICENSE |
-| @vercel/otel | OpenTelemetry instrumentation for server-side observability | MIT License | https://github.com/vercel/otel/blob/main/LICENSE |
+| Package / Component            | Usage                                                                   | License            | Reference                                                              |
+| ------------------------------ | ----------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------- |
+| Next.js                        | Core web application framework                                          | MIT License        | https://github.com/vercel/next.js/blob/canary/license.md               |
+| React                          | UI library powering the web and mini app clients                        | MIT License        | https://github.com/facebook/react/blob/main/LICENSE                    |
+| Supabase JS SDK & Supabase CLI | Database, authentication, and local development tooling                 | Apache License 2.0 | https://github.com/supabase/supabase/blob/master/LICENSE               |
+| Dynamic UI                     | Design system tokens and components for the marketing site              | MIT License        | https://github.com/once-ui/once-ui/blob/main/LICENSE                   |
+| Tailwind CSS                   | Utility-first styling used across the landing and dashboard experiences | MIT License        | https://github.com/tailwindlabs/tailwindcss/blob/master/LICENSE        |
+| Lucide React                   | Icon set used in the dashboard and mini app                             | ISC License        | https://github.com/lucide-icons/lucide/blob/main/LICENSE               |
+| Framer Motion                  | Animation primitives for interactive UI elements                        | MIT License        | https://github.com/framer/motion/blob/main/LICENSE                     |
+| TanStack Query                 | Client-side data fetching and caching                                   | MIT License        | https://github.com/TanStack/query/blob/main/LICENSE                    |
+| Inngest                        | Background job orchestration for queue and worker processes             | Apache License 2.0 | https://github.com/inngest/inngest-js/blob/main/LICENSE                |
+| AWS SDK for JavaScript v3      | DigitalOcean Spaces and S3-compatible uploads                           | Apache License 2.0 | https://github.com/aws/aws-sdk-js-v3/blob/main/LICENSE                 |
+| PostHog JS                     | Product analytics instrumentation                                       | MIT License        | https://github.com/PostHog/posthog-js/blob/master/LICENSE              |
+| Sonner                         | Toast notifications within the dashboard                                | MIT License        | https://github.com/emilkowalski/sonner/blob/main/LICENSE               |
+| Auth.js (NextAuth.js)          | End-user authentication and session management                          | ISC License        | https://github.com/nextauthjs/next-auth/blob/main/LICENSE              |
+| Supabase Auth Helpers & SSR    | Seamless Supabase session handling for React and Next.js                | MIT License        | https://github.com/supabase/auth-helpers/blob/main/LICENSE             |
+| grammY Telegram Framework      | Telegram bot orchestration including conversations and throttling       | MIT License        | https://github.com/grammyjs/grammY/blob/main/LICENSE                   |
+| Radix UI Primitives            | Accessible headless components underpinning the dashboard UI            | MIT License        | https://github.com/radix-ui/primitives/blob/main/LICENSE               |
+| Sentry Next.js SDK             | Application monitoring and error tracing                                | MIT License        | https://github.com/getsentry/sentry-javascript/blob/develop/LICENSE    |
+| Drizzle ORM                    | Type-safe database access layer for Supabase Postgres                   | Apache License 2.0 | https://github.com/drizzle-team/drizzle-orm/blob/main/LICENSE          |
+| Zod                            | Runtime validation for API payloads and forms                           | MIT License        | https://github.com/colinhacks/zod/blob/master/LICENSE                  |
+| Tesseract.js                   | Optical character recognition used in receipt processing                | Apache License 2.0 | https://github.com/naptha/tesseract.js/blob/master/LICENSE             |
+| React Hook Form                | Form state management for onboarding and admin flows                    | MIT License        | https://github.com/react-hook-form/react-hook-form/blob/master/LICENSE |
+| React Three Fiber & Drei       | 3D scene rendering helpers for marketing visualizations                 | MIT License        | https://github.com/pmndrs/react-three-fiber/blob/master/LICENSE        |
+| @vercel/otel                   | OpenTelemetry instrumentation for server-side observability             | MIT License        | https://github.com/vercel/otel/blob/main/LICENSE                       |
 
 For transitive dependencies bundled through npm or Deno, consult the package
 manager manifests (`package-lock.json`, `deno.lock`) or run the relevant license

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-// Removed Once UI system dependencies
+// Removed Dynamic UI dependencies
 import { MotionConfigProvider } from "@/components/ui/motion-config";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";


### PR DESCRIPTION
## Summary
- update the note in `src/App.tsx` to reference the Dynamic UI dependencies
- rename the "Once UI System" entry in the third-party licenses table to "Dynamic UI"

## Testing
- $(bash scripts/deno_bin.sh) fmt src/App.tsx docs/legal/THIRD_PARTY_LICENSES.md

------
https://chatgpt.com/codex/tasks/task_e_68d476e89f488322b4de26bb3e57f725