### PR TITLE
docs: add codex CLI plaintext diff tip

### DIFF
--- a/docs/codex_cli_workflow.md
+++ b/docs/codex_cli_workflow.md
@@ -40,6 +40,9 @@ overwriting each other's reminders. When a task fails multiple times, the CLI
 surfaces targeted troubleshooting tips before the next run. Use `--reset-issues`
 if you want to discard that history and silence the reminders.
 
+> **ProTip!** Add `.patch` or `.diff` to the end of GitHub URLs when you need a
+> plaintext view of a change for the Codex CLI or other tooling.
+
 To speed up cooperative runs, the helper fingerprints `package-lock.json` and
 shares `npm install` successes between agents. Skip the shared cache with
 `--no-shared-cache` (or `CODEX_DISABLE_SHARED_CACHE=1`) whenever you need a


### PR DESCRIPTION
## Summary
- document how to append .patch or .diff to GitHub URLs to grab plaintext diffs when using the Codex CLI

## Testing
- npm run format
- npx deno fmt docs/codex_cli_workflow.md

------
https://chatgpt.com/codex/tasks/task_e_68d4787b17088322a1ffb4a7cf123cfc