### PR TITLE
Add test verifying route config matches Next routes

### DIFF
--- a/apps/web/resources/once-ui.config.ts
+++ b/apps/web/resources/once-ui.config.ts
@@ -5,7 +5,6 @@ import {
   FontsConfig,
   MailchimpConfig,
   ProtectedRoutesConfig,
-  RoutesConfig,
   SameAsConfig,
   SchemaConfig,
   SocialSharingConfig,
@@ -13,21 +12,9 @@ import {
   SystemUIConfig,
 } from "@/resources/types";
 import { home } from "./content";
+import { routes } from "./routes.config";
 
 const baseURL: string = "https://dynamic.capital";
-
-const routes: RoutesConfig = {
-  "/": true,
-  "/about": true,
-  "/plans": true,
-  "/checkout": true,
-  "/login": true,
-  "/admin": true,
-  "/work": false,
-  "/blog": false,
-  "/gallery": false,
-  "/telegram": true,
-};
 
 const display: DisplayConfig = {
   location: true,

--- a/apps/web/resources/routes.config.ts
+++ b/apps/web/resources/routes.config.ts
@@ -1,0 +1,14 @@
+import type { RoutesConfig } from "@/resources/types";
+
+export const routes: RoutesConfig = {
+  "/": true,
+  "/about": true,
+  "/plans": true,
+  "/checkout": true,
+  "/login": true,
+  "/admin": true,
+  "/work": false,
+  "/blog": false,
+  "/gallery": false,
+  "/telegram": true,
+};

--- a/tests/routes-config.test.ts
+++ b/tests/routes-config.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import { deepStrictEqual } from "node:assert/strict";
+
+import { getAppRoutes, getPageRoutes } from "../apps/web/utils/routes.ts";
+import { routes } from "../apps/web/resources/routes.config.ts";
+
+const toRouteSet = () => {
+  const appRoutes = getAppRoutes();
+  const pageRoutes = getPageRoutes();
+  const entries = [...appRoutes, ...pageRoutes];
+  return new Set(entries.map((entry) => entry.route));
+};
+
+test("route config paths map to existing Next.js routes", () => {
+  const availableRoutes = toRouteSet();
+  const configuredRoutes = Object.keys(routes);
+
+  const missing = configuredRoutes.filter((route) =>
+    !availableRoutes.has(route)
+  );
+
+  deepStrictEqual(
+    missing,
+    [],
+    missing.length === 0
+      ? undefined
+      : `Configured routes are missing Next.js entries: ${missing.join(", ")}`,
+  );
+});


### PR DESCRIPTION
## Summary
- extract the Once UI routes map into its own module so it can be imported without Next-specific dependencies
- add a regression test that asserts each configured route has a corresponding App or Pages directory entry

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d47b242654832284ff5099af29c71d