### PR TITLE
docs: document branch naming plan

### DIFF
--- a/docs/BRANCH_NAMING_GUIDE.md
+++ b/docs/BRANCH_NAMING_GUIDE.md
@@ -1,0 +1,45 @@
+# Branch Naming Guide
+
+## Overview
+
+Dynamic Capital uses service-scoped branches so each deployable surface can be
+prepared, validated, and promoted independently before landing in `main`.
+Reference this guide when cutting new branches, wiring CI filters, or auditing
+deployment triggers.
+
+## Long-lived service branches
+
+| Branch            | Purpose                                                                                          | Owned directories & focus areas                                                                                                      | Deployment target                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `main`            | Integration trunk that aggregates the latest production-ready commits from every service branch. | Cross-cutting changes that span multiple services and shared packages.                                                               | Acts as the source of truth for staging and production promotions.   |
+| `web/main`        | Baseline for the Next.js marketing site and admin dashboard.                                     | `apps/web/`, `_static/`, `docs/`, frontend-specific config (`tailwind.config.ts`, `postcss.config.js`, `vite.config.ts`).            | Vercel and DigitalOcean App Platform deployments serving the web UI. |
+| `bot/main`        | Source of truth for Supabase Edge Functions powering the Telegram bot.                           | `supabase/functions/`, `scripts/telegram-*`, server-side shared libs under `supabase/functions/_shared/`.                            | Supabase functions deployments and BotFather webhook updates.        |
+| `miniapp/main`    | Anchors the Telegram Mini App shell and supporting tooling.                                      | Mini App build scripts (`scripts/*miniapp*`), Mini App smoke tests under `tests/`, `_static/` assets exported for the Mini App host. | Supabase-hosted Mini App bundle and CDN snapshot refreshes.          |
+| `broadcast/main`  | Coordinates broadcast workers that fan out notifications.                                        | `broadcast/`, relevant Supabase functions (`broadcast-*`), queue configuration that feeds broadcast events.                          | Scheduled broadcasts and cron-triggered deliveries.                  |
+| `queue/main`      | Manages asynchronous job runners and queue health checks.                                        | `queue/`, queue-specific scripts under `scripts/queue*`, monitoring utilities in `scripts/verify/`.                                  | Worker containers and monitors that process queued jobs.             |
+| `go-service/main` | Stabilizes the standalone Go HTTP service.                                                       | `go-service/`, shared Go modules, Docker artifacts for the Go runtime.                                                               | Deployed Go binaries or containers (e.g., health check endpoints).   |
+
+> [!NOTE]
+> Service branches always fork from the latest `main` commit. Promote validated
+> changes by fast-forwarding the service branch, then open an integration PR
+> from the service branch back into `main`.
+
+## Short-lived branch patterns
+
+| Pattern                         | When to use                                                                                                      | Example                                 |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `<service>/feature/<slug>`      | Net-new functionality or UI surfaced by a single service.                                                        | `web/feature/multi-language-onboarding` |
+| `<service>/fix/<slug>`          | Bug fixes that stay scoped to one service branch.                                                                | `bot/fix/receipt-validation`            |
+| `<service>/chore/<slug>`        | Maintenance work, dependency upgrades, or automation tweaks.                                                     | `queue/chore/bump-worker-timeouts`      |
+| `hotfix/<slug>`                 | Urgent fixes that need to bypass normal release cadence. Merge into the affected service branch and then `main`. | `hotfix/reset-webhook-secret`           |
+| `integration/<service>-to-main` | Coordinated promotion from a service branch back into `main`. Use when multiple commits need a combined review.  | `integration/web-to-main`               |
+
+### Additional guidelines
+
+- Keep feature branches rebased on their target service branch to simplify
+  fast-forward merges.
+- Prefer descriptive slugs using lowercase letters and hyphens.
+- Archive temporary investigative branches locally or under a personal fork;
+  only push branches that follow these conventions to the canonical remote.
+- Update automation filters (`web/*`, `bot/*`, etc.) and branch protections when
+  introducing a new long-lived service branch.

--- a/docs/git-branch-organization-checklist.md
+++ b/docs/git-branch-organization-checklist.md
@@ -1,40 +1,80 @@
 # Git Branch Organization Checklist
 
-Align the repository's branching strategy with deployable services so each domain can target an isolated branch and traffic can be balanced deliberately. Work through the sections in order and record evidence (command output, screenshots, change logs) for audits and onboarding.
+Align the repository's branching strategy with deployable services so each
+domain can target an isolated branch and traffic can be balanced deliberately.
+Work through the sections in order and record evidence (command output,
+screenshots, change logs) for audits and onboarding.
 
-> [!TIP] Keep [`docs/DEVELOPMENT_WORKFLOW.md`](./DEVELOPMENT_WORKFLOW.md) and related runbooks nearby. Update them as you finalize the branch topology so future contributors inherit the new process.
+> [!TIP] Keep [`docs/DEVELOPMENT_WORKFLOW.md`](./DEVELOPMENT_WORKFLOW.md) and
+> related runbooks nearby. Update them as you finalize the branch topology so
+> future contributors inherit the new process.
 
 ## Prerequisites & Alignment
-- [ ] Confirm the current production state of `main` and freeze non-essential merges until the branch plan is in place.
-- [ ] Inventory every deployable surface (Next.js app, Supabase Edge functions, broadcast/queue workers, Go service) and the directories/files they own.
-- [ ] Document desired branch naming conventions (e.g., `web/main`, `bot/main`, `broadcast/main`) and the relationship between service branches and `main`.
-- [ ] Review CI/CD pipelines and hosting integrations to understand which branches trigger builds, deployments, or domain updates today.
-- [ ] Socialize the upcoming change with stakeholders (engineering, ops, compliance) and collect sign-off on the timeline.
+
+- [ ] Confirm the current production state of `main` and freeze non-essential
+      merges until the branch plan is in place.
+- [ ] Inventory every deployable surface (Next.js app, Supabase Edge functions,
+      broadcast/queue workers, Go service) and the directories/files they own.
+- [ ] Document desired branch naming conventions (e.g., `web/main`, `bot/main`,
+      `broadcast/main`) and the relationship between service branches and
+      `main`. Capture the canonical matrix in
+      [`docs/BRANCH_NAMING_GUIDE.md`](./BRANCH_NAMING_GUIDE.md).
+- [ ] Review CI/CD pipelines and hosting integrations to understand which
+      branches trigger builds, deployments, or domain updates today.
+- [ ] Socialize the upcoming change with stakeholders (engineering, ops,
+      compliance) and collect sign-off on the timeline.
 
 ## Establish Service Baselines
-- [ ] Cut long-lived service branches from the latest `main` commit (`git switch -c web/main`, `bot/main`, `miniapp/main`, `broadcast/main`, `queue/main`, `go-service/main`, etc.).
-- [ ] Push each service branch to the remote and configure protections to require review, CI, and fast-forward merges from feature branches.
-- [ ] Update code owners or review assignment rules so service experts are automatically requested on their branch PRs.
-- [ ] Create README snippets or `docs/` notes describing which directories belong to which service branch for future reference.
-- [ ] Validate that `main` remains protected as the integration trunk and record the expected merge direction (service branch → `main`).
+
+- [ ] Cut long-lived service branches from the latest `main` commit
+      (`git switch -c web/main`, `bot/main`, `miniapp/main`, `broadcast/main`,
+      `queue/main`, `go-service/main`, etc.).
+- [ ] Push each service branch to the remote and configure protections to
+      require review, CI, and fast-forward merges from feature branches.
+- [ ] Update code owners or review assignment rules so service experts are
+      automatically requested on their branch PRs.
+- [ ] Create README snippets or `docs/` notes describing which directories
+      belong to which service branch for future reference.
+- [ ] Validate that `main` remains protected as the integration trunk and record
+      the expected merge direction (service branch → `main`).
 
 ## Update Automation & CI/CD
-- [ ] Adjust CI workflows to scope tests/builds to the relevant service when a branch with the matching prefix is pushed (e.g., `web/*` runs Next.js build, `bot/*` runs Deno checks).
-- [ ] Ensure deployment pipelines or infrastructure-as-code reflect the new branch triggers and environment variables.
-- [ ] Add or update status checks that must pass before merging into each service branch and before promoting into `main`.
-- [ ] If using automation helpers (e.g., `npm run checklists`), add tasks or keys that reference the new branch-specific routines.
-- [ ] Run dry-run builds or deployments from each service branch in a staging environment to validate the pipeline updates.
+
+- [ ] Adjust CI workflows to scope tests/builds to the relevant service when a
+      branch with the matching prefix is pushed (e.g., `web/*` runs Next.js
+      build, `bot/*` runs Deno checks).
+- [ ] Ensure deployment pipelines or infrastructure-as-code reflect the new
+      branch triggers and environment variables.
+- [ ] Add or update status checks that must pass before merging into each
+      service branch and before promoting into `main`.
+- [ ] If using automation helpers (e.g., `npm run checklists`), add tasks or
+      keys that reference the new branch-specific routines.
+- [ ] Run dry-run builds or deployments from each service branch in a staging
+      environment to validate the pipeline updates.
 
 ## Configure Domain Routing & Load Balancing
-- [ ] Map long-lived service branches to their target domains/subdomains (e.g., `web/main` → `app.example.com`, `bot/main` → `bot.example.com`).
-- [ ] For services requiring blue/green or canary releases, create auxiliary branches (`web/canary`, `bot/blue`) and document how traffic will shift between them.
-- [ ] Update CDN, DNS, or load balancer configurations to recognize the new branch endpoints and set initial traffic weights.
-- [ ] Verify branch-specific deployments with health checks (including the Go service) before exposing traffic.
-- [ ] Capture rollback procedures for each branch/domain pair so you can revert quickly if load tests surface issues.
+
+- [ ] Map long-lived service branches to their target domains/subdomains (e.g.,
+      `web/main` → `app.example.com`, `bot/main` → `bot.example.com`).
+- [ ] For services requiring blue/green or canary releases, create auxiliary
+      branches (`web/canary`, `bot/blue`) and document how traffic will shift
+      between them.
+- [ ] Update CDN, DNS, or load balancer configurations to recognize the new
+      branch endpoints and set initial traffic weights.
+- [ ] Verify branch-specific deployments with health checks (including the Go
+      service) before exposing traffic.
+- [ ] Capture rollback procedures for each branch/domain pair so you can revert
+      quickly if load tests surface issues.
 
 ## Communicate & Train
-- [ ] Update onboarding materials (`docs/SETUP_SUMMARY.md`, team handbooks, runbooks) with the branch workflow and naming conventions.
-- [ ] Schedule walkthroughs or pair sessions so contributors practice branching from service baselines and promoting back to `main`.
-- [ ] Define expectations for integration cadence (e.g., weekly merges from service branches into `main`) and document how conflicts will be resolved.
-- [ ] Publish a changelog entry or internal announcement summarizing the new branch structure, domain mappings, and load balancing strategy.
-- [ ] Reassess after the first release cycle and iterate on the checklist to capture lessons learned or automation opportunities.
+
+- [ ] Update onboarding materials (`docs/SETUP_SUMMARY.md`, team handbooks,
+      runbooks) with the branch workflow and naming conventions.
+- [ ] Schedule walkthroughs or pair sessions so contributors practice branching
+      from service baselines and promoting back to `main`.
+- [ ] Define expectations for integration cadence (e.g., weekly merges from
+      service branches into `main`) and document how conflicts will be resolved.
+- [ ] Publish a changelog entry or internal announcement summarizing the new
+      branch structure, domain mappings, and load balancing strategy.
+- [ ] Reassess after the first release cycle and iterate on the checklist to
+      capture lessons learned or automation opportunities.


### PR DESCRIPTION
## Summary
- add a branch naming guide that maps long-lived service branches to their responsibilities and deployment targets
- document feature and maintenance branch naming patterns for day-to-day work
- link the git branch organization checklist to the new canonical matrix

## Testing
- npm run format
- npx deno fmt docs/BRANCH_NAMING_GUIDE.md docs/git-branch-organization-checklist.md

------
https://chatgpt.com/codex/tasks/task_e_68d47c838524832296547ef5851536bf