### PR TITLE
Add value proposition section to landing page

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -5,6 +5,7 @@ import { ComplianceCertificates } from "@/components/magic-portfolio/home/Compli
 import { EconomicCalendarSection } from "@/components/magic-portfolio/home/EconomicCalendarSection";
 import { FundamentalAnalysisSection } from "@/components/magic-portfolio/home/FundamentalAnalysisSection";
 import { HeroExperience } from "@/components/magic-portfolio/home/HeroExperience";
+import { ValuePropositionSection } from "@/components/magic-portfolio/home/ValuePropositionSection";
 import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchlist";
 import { MentorshipProgramsSection } from "@/components/magic-portfolio/home/MentorshipProgramsSection";
@@ -29,6 +30,9 @@ export function DynamicCapitalLandingPage() {
         }}
       />
       <HeroExperience />
+      <RevealFx translateY="20" delay={0.6}>
+        <ValuePropositionSection />
+      </RevealFx>
       <RevealFx translateY="20" delay={0.65}>
         <MarketWatchlist />
       </RevealFx>

--- a/apps/web/components/magic-portfolio/home/HeroExperience.tsx
+++ b/apps/web/components/magic-portfolio/home/HeroExperience.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Column,
   Heading,
+  Icon,
   Row,
   Text,
 } from "@once-ui-system/core";
@@ -70,6 +71,24 @@ const PREVIEW_CARDS = [
     description: "Daily guardrail locks if hit",
     gradient:
       "linear-gradient(135deg, rgba(252, 211, 77, 0.9) 0%, rgba(249, 115, 22, 0.85) 55%, rgba(88, 28, 135, 0.8) 100%)",
+  },
+] as const;
+
+const SOCIAL_PROOF = [
+  {
+    icon: "users",
+    value: "8,500+",
+    label: "members trade with the desk",
+  },
+  {
+    icon: "timer",
+    value: "14 days",
+    label: "median time to pass readiness",
+  },
+  {
+    icon: "shield",
+    value: "92%",
+    label: "renew for another quarter",
   },
 ] as const;
 
@@ -303,6 +322,41 @@ export function HeroExperience() {
           >
             Beginner friendly · Cancel anytime · Real humans on standby
           </Text>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{
+            delay: 0.58,
+            type: "spring",
+            stiffness: 150,
+            damping: 26,
+          }}
+        >
+          <Row gap="16" wrap horizontal="center">
+            {SOCIAL_PROOF.map((stat) => (
+              <Column
+                key={stat.label}
+                gap="8"
+                background="surface"
+                border="neutral-alpha-weak"
+                radius="l"
+                paddingX="16"
+                paddingY="12"
+                minWidth={14}
+              >
+                <Row gap="12" vertical="center">
+                  <Icon name={stat.icon} onBackground="brand-medium" />
+                  <Column gap="4">
+                    <Text variant="heading-strong-m">{stat.value}</Text>
+                    <Text variant="label-default-s" onBackground="neutral-weak">
+                      {stat.label}
+                    </Text>
+                  </Column>
+                </Row>
+              </Column>
+            ))}
+          </Row>
         </motion.div>
       </Column>
 

--- a/apps/web/components/magic-portfolio/home/ValuePropositionSection.tsx
+++ b/apps/web/components/magic-portfolio/home/ValuePropositionSection.tsx
@@ -1,0 +1,198 @@
+import { Fragment } from "react";
+
+import {
+  Badge,
+  Column,
+  Heading,
+  Icon,
+  Line,
+  Row,
+  Tag,
+  Text,
+} from "@once-ui-system/core";
+
+type ValuePillar = {
+  id: string;
+  eyebrow: string;
+  icon: string;
+  title: string;
+  description: string;
+  highlights: string[];
+};
+
+type ProofPoint = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+};
+
+const VALUE_PILLARS: ValuePillar[] = [
+  {
+    id: "clarity",
+    eyebrow: "Get oriented fast",
+    icon: "sparkles",
+    title: "Clarity from day one",
+    description:
+      "Launch with a 60-second intake that maps your asset focus, schedule, and risk limits to a ready-to-run workspace.",
+    highlights: [
+      "Daily prep flows with the exact catalysts to watch",
+      "Automation toggles that respect your risk dial",
+      "Mentor nudges so you never guess at the next action",
+    ],
+  },
+  {
+    id: "execution",
+    eyebrow: "Trade with structure",
+    icon: "target",
+    title: "Institutional execution",
+    description:
+      "Pair live desk signals with guardrails that keep you inside plan—from simulated drills to funded account readiness.",
+    highlights: [
+      "Signal room alerts with precise entry and exit levels",
+      "Auto-journaling and readiness scoring after every session",
+      "Risk locks that pause allocation when guardrails are hit",
+    ],
+  },
+  {
+    id: "support",
+    eyebrow: "Stay accountable",
+    icon: "users",
+    title: "Support when it matters",
+    description:
+      "Access mentors, desk analysts, and a focused trading community so questions are answered before capital is at risk.",
+    highlights: [
+      "24/7 desk chat with escalation to human mentors",
+      "Weekly performance reviews with action items",
+      "Private cohorts for founders, funds, and operators",
+    ],
+  },
+];
+
+const PROOF_POINTS: ProofPoint[] = [
+  {
+    id: "readiness",
+    label: "Members pass readiness in",
+    value: "14 days",
+    detail: "median time to unlock live alerts",
+  },
+  {
+    id: "discipline",
+    label: "Weekly playbook adherence",
+    value: "87%",
+    detail: "average across funded traders",
+  },
+  {
+    id: "retention",
+    label: "Members renewing each quarter",
+    value: "92%",
+    detail: "choose to stay on the desk",
+  },
+];
+
+export function ValuePropositionSection() {
+  return (
+    <Column
+      id="value-proposition"
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="32"
+      shadow="l"
+    >
+      <Column gap="12" maxWidth={32}>
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="shield">
+          Why traders choose Dynamic Capital
+        </Tag>
+        <Heading variant="display-strong-xs">
+          Signal clarity, execution guardrails, and human accountability in one
+          lane
+        </Heading>
+        <Text variant="body-default-l" onBackground="neutral-weak">
+          Everything we ship is built to remove hesitation—so you focus on
+          taking the next high-quality trade while the desk handles prep,
+          context, and risk.
+        </Text>
+      </Column>
+
+      <Column gap="24">
+        {VALUE_PILLARS.map((pillar, index) => (
+          <Fragment key={pillar.id}>
+            <Row
+              background="page"
+              border="neutral-alpha-weak"
+              radius="l"
+              padding="l"
+              gap="20"
+              s={{ direction: "column" }}
+            >
+              <Row
+                gap="12"
+                vertical="center"
+                s={{ direction: "column", align: "start" }}
+              >
+                <Badge
+                  background="neutral-alpha-weak"
+                  onBackground="neutral-strong"
+                  paddingX="12"
+                  paddingY="4"
+                  textVariant="label-default-s"
+                >
+                  {pillar.eyebrow}
+                </Badge>
+                <Row gap="12" vertical="center">
+                  <Icon name={pillar.icon} onBackground="brand-medium" />
+                  <Heading variant="heading-strong-l">{pillar.title}</Heading>
+                </Row>
+              </Row>
+              <Column gap="16">
+                <Text variant="body-default-m" onBackground="neutral-weak">
+                  {pillar.description}
+                </Text>
+                <Column as="ul" gap="8">
+                  {pillar.highlights.map((highlight) => (
+                    <Row key={highlight} gap="8" vertical="center">
+                      <Icon name="check" onBackground="brand-medium" />
+                      <Text as="li" variant="body-default-m">
+                        {highlight}
+                      </Text>
+                    </Row>
+                  ))}
+                </Column>
+              </Column>
+            </Row>
+            {index < VALUE_PILLARS.length - 1
+              ? <Line background="neutral-alpha-weak" />
+              : null}
+          </Fragment>
+        ))}
+      </Column>
+
+      <Column
+        background="page"
+        border="neutral-alpha-weak"
+        radius="l"
+        padding="l"
+        gap="16"
+      >
+        <Row gap="16" wrap>
+          {PROOF_POINTS.map((point) => (
+            <Column key={point.id} gap="8" minWidth={12}>
+              <Text variant="label-default-m" onBackground="brand-medium">
+                {point.label}
+              </Text>
+              <Heading variant="display-strong-xs">{point.value}</Heading>
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                {point.detail}
+              </Text>
+            </Column>
+          ))}
+        </Row>
+      </Column>
+    </Column>
+  );
+}
+
+export default ValuePropositionSection;


### PR DESCRIPTION
## Summary
- introduce a ValuePropositionSection component that highlights core benefits and proof points for the Dynamic Capital desk
- surface the new section within the landing page flow directly after the hero for stronger early messaging
- expand the hero experience with social proof metrics to reinforce trust and readiness timelines

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d483cb2af48322b71824f1524458ce