### PR TITLE
refactor: align web ui resources with dynamic branding

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -24,7 +24,7 @@ import {
   RouteGuard,
   ScrollToHash,
 } from "@/components/magic-portfolio";
-import { dyamicUI } from "@/resources";
+import { dynamicUI } from "@/resources";
 
 const SITE_URL = process.env.SITE_URL || "http://localhost:8080";
 const DEFAULT_THEME = "dark" as const;
@@ -34,7 +34,7 @@ const {
   basics: basicsConfig,
   dataViz: dataVizConfig,
   effects: effectsConfig,
-} = dyamicUI;
+} = dynamicUI;
 const { fonts, style } = basicsConfig;
 const { dataStyle } = dataVizConfig;
 const backgroundEffects = effectsConfig.background;
@@ -58,7 +58,7 @@ const themeAttributeDefaults = Object.fromEntries(
   ) => [key.replace(/^data-/, ""), value]),
 );
 
-const onceThemeScript = `(function () {
+const dynamicThemeScript = `(function () {
   try {
     var root = document.documentElement;
     var defaultTheme = '${style.theme}';
@@ -97,14 +97,14 @@ const onceThemeScript = `(function () {
 
 function ensureThemeScript(markup: string): string {
   if (!markup) {
-    return `<script id="${THEME_SCRIPT_ID}">${onceThemeScript}</script>`;
+    return `<script id="${THEME_SCRIPT_ID}">${dynamicThemeScript}</script>`;
   }
 
   if (markup.includes(`id="${THEME_SCRIPT_ID}"`)) {
     return markup;
   }
 
-  return `${markup}\n<script id="${THEME_SCRIPT_ID}">${onceThemeScript}</script>`;
+  return `${markup}\n<script id="${THEME_SCRIPT_ID}">${dynamicThemeScript}</script>`;
 }
 
 function resolveMetadataBase(url: string) {
@@ -195,7 +195,7 @@ export default async function RootLayout(
         <script
           id={THEME_SCRIPT_ID}
           suppressHydrationWarning
-          dangerouslySetInnerHTML={{ __html: onceThemeScript }}
+          dangerouslySetInnerHTML={{ __html: dynamicThemeScript }}
         />
       </head>
       <body>

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -24,14 +24,14 @@ import {
 import { AuthProvider } from "@/hooks/useAuth";
 import { SupabaseProvider } from "@/context/SupabaseProvider";
 import { MotionConfigProvider } from "@/components/ui/motion-config";
-import { dyamicUI } from "@/resources";
+import { dynamicUI } from "@/resources";
 import { iconLibrary } from "@/resources/icons";
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from "@/config/supabase-runtime";
 
 const {
   basics: basicsConfig,
   dataViz: dataVizConfig,
-} = dyamicUI;
+} = dynamicUI;
 const { style } = basicsConfig;
 const { dataStyle } = dataVizConfig;
 

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -5,7 +5,7 @@ import { Background, Column, RevealFx } from "@once-ui-system/core";
 import { opacity, SpacingToken } from "@once-ui-system/core";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
-import { dyamicUI } from "@/resources";
+import { dynamicUI } from "@/resources";
 import { DynamicCapitalLandingPage } from "@/components/magic-portfolio/DynamicCapitalLandingPage";
 import type {
   ChromaBackgroundProps,
@@ -42,7 +42,7 @@ export function LandingPageShell({
   assistantClassName,
   chromaBackgroundVariant = null,
 }: LandingPageShellProps) {
-  const backgroundEffects = dyamicUI.effects.background;
+  const backgroundEffects = dynamicUI.effects.background;
 
   return (
     <Column

--- a/apps/web/components/magic-portfolio/Mailchimp.tsx
+++ b/apps/web/components/magic-portfolio/Mailchimp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { dyamicUI, newsletter } from "@/resources";
+import { dynamicUI, newsletter } from "@/resources";
 import {
   Background,
   Button,
@@ -16,7 +16,7 @@ import { useState } from "react";
 const {
   formControls: { newsletter: newsletterFormConfig },
   effects: { newsletter: newsletterEffects },
-} = dyamicUI;
+} = dynamicUI;
 
 function debounce<T extends (...args: any[]) => void>(
   func: T,

--- a/apps/web/resources/dynamic-ui.config.ts
+++ b/apps/web/resources/dynamic-ui.config.ts
@@ -213,7 +213,7 @@ const socialSharing: SocialSharingConfig = {
   },
 };
 
-const dyamicUI = {
+const dynamicUI = {
   basics: {
     baseURL,
     display,
@@ -251,7 +251,7 @@ export {
   baseURL,
   dataStyle,
   display,
-  dyamicUI,
+  dynamicUI,
   effects,
   fonts,
   mailchimp,

--- a/apps/web/resources/index.ts
+++ b/apps/web/resources/index.ts
@@ -14,7 +14,7 @@ export {
   baseURL,
   dataStyle,
   display,
-  dyamicUI,
+  dynamicUI,
   effects,
   fonts,
   mailchimp,
@@ -24,7 +24,7 @@ export {
   schema,
   socialSharing,
   style,
-} from "./once-ui.config";
+} from "./dynamic-ui.config";
 
 export {
   magicPortfolioBucketBaseUrl,

--- a/apps/web/resources/routes.ts
+++ b/apps/web/resources/routes.ts
@@ -1,5 +1,8 @@
-import type { NormalizedRouteDefinition, RouteConfigValue } from "@/resources/types";
-import { routes } from "./once-ui.config";
+import type {
+  NormalizedRouteDefinition,
+  RouteConfigValue,
+} from "@/resources/types";
+import { routes } from "./dynamic-ui.config";
 
 const normalizeRoutePath = (path: string): `/${string}` => {
   if (!path) {
@@ -29,18 +32,19 @@ const normalizeRouteConfig = (value: RouteConfigValue) => {
   };
 };
 
-const routeDefinitions: NormalizedRouteDefinition[] = Object.entries(routes).map(
-  ([path, value]) => {
-    const normalizedPath = normalizeRoutePath(path);
-    const { enabled, includeChildren } = normalizeRouteConfig(value);
+const routeDefinitions: NormalizedRouteDefinition[] = Object.entries(routes)
+  .map(
+    ([path, value]) => {
+      const normalizedPath = normalizeRoutePath(path);
+      const { enabled, includeChildren } = normalizeRouteConfig(value);
 
-    return {
-      path: normalizedPath,
-      enabled,
-      includeChildren,
-    } satisfies NormalizedRouteDefinition;
-  },
-);
+      return {
+        path: normalizedPath,
+        enabled,
+        includeChildren,
+      } satisfies NormalizedRouteDefinition;
+    },
+  );
 
 const routePrefix = (path: `/${string}`) => {
   if (path === "/") {
@@ -50,7 +54,10 @@ const routePrefix = (path: `/${string}`) => {
   return `${path}/` as const;
 };
 
-const matchesRoute = (target: `/${string}`, route: NormalizedRouteDefinition) => {
+const matchesRoute = (
+  target: `/${string}`,
+  route: NormalizedRouteDefinition,
+) => {
   if (!route.enabled) {
     return false;
   }
@@ -70,10 +77,13 @@ const matchesRoute = (target: `/${string}`, route: NormalizedRouteDefinition) =>
   return target.startsWith(routePrefix(route.path));
 };
 
-export const getRouteDefinitions = (): NormalizedRouteDefinition[] => [...routeDefinitions];
+export const getRouteDefinitions =
+  (): NormalizedRouteDefinition[] => [...routeDefinitions];
 
 export const isRouteEnabled = (path: string): boolean => {
   const normalized = normalizeRoutePath(path);
 
-  return routeDefinitions.some((definition) => matchesRoute(normalized, definition));
+  return routeDefinitions.some((definition) =>
+    matchesRoute(normalized, definition)
+  );
 };

--- a/apps/web/resources/types/config.types.ts
+++ b/apps/web/resources/types/config.types.ts
@@ -259,9 +259,9 @@ export type SystemUIConfig = {
 };
 
 /**
- * Top-level config types for once-ui.config.js
+ * Top-level config types for dynamic-ui.config.ts
  */
-export type OnceUIConfig = {
+export type DynamicUIConfig = {
   display: DisplayConfig;
   mailchimp: MailchimpConfig;
   routes: RoutesConfig;


### PR DESCRIPTION
## Summary
- rename the Once UI configuration to `dynamic-ui.config.ts` and export a `dynamicUI` bundle for Dynamic Capital
- update layout, providers, landing shell, and Mailchimp components to consume the new dynamic configuration naming
- refresh theme initialization script naming to `dynamicThemeScript` for consistent branding

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d487e7c6348322990bebf0dd1c392c