### PR TITLE
Make magic portfolio branding dynamic

### DIFF
--- a/apps/web/components/magic-portfolio/Footer.tsx
+++ b/apps/web/components/magic-portfolio/Footer.tsx
@@ -1,12 +1,19 @@
-import { Row, IconButton, Text } from "@once-ui-system/core";
-import { person, social } from "@/resources";
+import { IconButton, Row, Text } from "@once-ui-system/core";
+import { schema, social } from "@/resources";
 import styles from "./Footer.module.scss";
 
 export const Footer = () => {
   const currentYear = new Date().getFullYear();
+  const organizationName = schema.name;
 
   return (
-    <Row as="footer" fillWidth padding="8" horizontal="center" s={{ direction: "column" }}>
+    <Row
+      as="footer"
+      fillWidth
+      padding="8"
+      horizontal="center"
+      s={{ direction: "column" }}
+    >
       <Row
         className={styles.mobile}
         maxWidth="m"
@@ -23,7 +30,7 @@ export const Footer = () => {
       >
         <Text variant="body-default-s" onBackground="neutral-strong">
           <Text onBackground="neutral-weak">© {currentYear} /</Text>
-          <Text paddingX="4">Dynamic Capital</Text>
+          <Text paddingX="4">{organizationName}</Text>
         </Text>
         <Row gap="16">
           {social.map(

--- a/apps/web/components/magic-portfolio/home/ComplianceCertificates.tsx
+++ b/apps/web/components/magic-portfolio/home/ComplianceCertificates.tsx
@@ -1,4 +1,5 @@
 import { Column, Heading, Icon, Row, Tag, Text } from "@once-ui-system/core";
+import { schema } from "@/resources";
 
 interface Certificate {
   name: string;
@@ -47,6 +48,8 @@ const CERTIFICATES: Certificate[] = [
 ];
 
 export function ComplianceCertificates() {
+  const organizationName = schema.name;
+
   return (
     <Column
       id="compliance"
@@ -63,9 +66,10 @@ export function ComplianceCertificates() {
           Independent security &amp; privacy certifications
         </Heading>
         <Text variant="body-default-l" onBackground="neutral-weak">
-          Dynamic Capital operates under audited controls for security, privacy,
-          and data residency. Each certificate below is issued by an independent
-          assessor and mapped to our evidence library for rapid vendor reviews.
+          {organizationName}{" "}
+          operates under audited controls for security, privacy, and data
+          residency. Each certificate below is issued by an independent assessor
+          and mapped to our evidence library for rapid vendor reviews.
         </Text>
       </Column>
       <Row gap="16" wrap>

--- a/apps/web/components/magic-portfolio/home/ValuePropositionSection.tsx
+++ b/apps/web/components/magic-portfolio/home/ValuePropositionSection.tsx
@@ -10,6 +10,7 @@ import {
   Tag,
   Text,
 } from "@once-ui-system/core";
+import { schema } from "@/resources";
 
 type ValuePillar = {
   id: string;
@@ -91,6 +92,8 @@ const PROOF_POINTS: ProofPoint[] = [
 ];
 
 export function ValuePropositionSection() {
+  const organizationName = schema.name;
+
   return (
     <Column
       id="value-proposition"
@@ -104,7 +107,7 @@ export function ValuePropositionSection() {
     >
       <Column gap="12" maxWidth={32}>
         <Tag size="s" background="brand-alpha-weak" prefixIcon="shield">
-          Why traders choose Dynamic Capital
+          Why traders choose {organizationName}
         </Tag>
         <Heading variant="display-strong-xs">
           Signal clarity, execution guardrails, and human accountability in one


### PR DESCRIPTION
## Summary
- read the organization name from the shared schema config in the magic portfolio footer and key marketing sections
- ensure compliance copy and value-proposition tag automatically reflect branding updates

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d48b6df7408322a9bbfdfbd72e3f58