### PR TITLE
Add dynamic branding config import/export utilities

### DIFF
--- a/apps/web/resources/dynamic-branding.config.ts
+++ b/apps/web/resources/dynamic-branding.config.ts
@@ -1,0 +1,343 @@
+import {
+  type BrandingGradients,
+  type BrandingMetadata,
+  type BrandingMotion,
+  type BrandingPalette,
+  type BrandingTokens,
+  type DynamicBrandingConfig,
+  type DynamicBrandingOverrides,
+} from "./types/branding.types";
+
+const palette: BrandingPalette = {
+  brand: {
+    base: "0 84% 58%",
+    light: "0 92% 68%",
+    dark: "0 76% 48%",
+    secondary: "200 96% 52%",
+    accent: "350 88% 60%",
+  },
+  light: {
+    background: "0 0% 100%",
+    foreground: "224 71.4% 4.1%",
+    card: "0 0% 100%",
+    cardForeground: "224 71.4% 4.1%",
+    popover: "0 0% 100%",
+    popoverForeground: "224 71.4% 4.1%",
+    primary: "0 84% 58%",
+    primaryForeground: "0 0% 100%",
+    secondary: "0 68% 95%",
+    secondaryForeground: "0 45% 20%",
+    muted: "0 5% 96%",
+    mutedForeground: "0 5% 45%",
+    elevated: "0 72% 10%",
+    accent: "350 88% 60%",
+    accentForeground: "0 0% 100%",
+    destructive: "0 72% 50%",
+    destructiveForeground: "0 0% 98%",
+    border: "0 10% 89%",
+    input: "0 10% 89%",
+    ring: "0 84% 58%",
+    radius: "0.5rem",
+    charts: [
+      "14 100% 57%",
+      "200 100% 50%",
+      "28 87% 67%",
+      "340 82% 62%",
+      "320 65% 55%",
+    ],
+  },
+  dark: {
+    background: "0 5% 6%",
+    foreground: "0 5% 98%",
+    card: "0 8% 8%",
+    cardForeground: "0 5% 98%",
+    popover: "0 8% 8%",
+    popoverForeground: "0 5% 98%",
+    primary: "0 84% 58%",
+    primaryForeground: "0 0% 100%",
+    secondary: "0 10% 15%",
+    secondaryForeground: "0 5% 98%",
+    muted: "0 10% 15%",
+    mutedForeground: "0 5% 65%",
+    elevated: "0 5% 95%",
+    accent: "350 88% 60%",
+    accentForeground: "0 0% 100%",
+    destructive: "0 68% 46%",
+    destructiveForeground: "0 5% 98%",
+    border: "0 15% 18%",
+    input: "0 15% 18%",
+    ring: "0 84% 58%",
+    radius: "0.5rem",
+    charts: [
+      "14 100% 57%",
+      "200 100% 50%",
+      "28 87% 67%",
+      "340 82% 62%",
+      "320 65% 55%",
+    ],
+  },
+};
+
+const gradients: BrandingGradients = {
+  brand:
+    "linear-gradient(135deg, hsl(var(--dc-brand)) 0%, hsl(var(--dc-brand-light)) 50%, hsl(var(--dc-brand-dark)) 100%)",
+  primary:
+    "linear-gradient(135deg, hsl(var(--dc-brand)) 0%, hsl(var(--dc-secondary)) 100%)",
+  card:
+    "linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--muted)/0.1) 100%)",
+  hero:
+    "linear-gradient(135deg, hsl(var(--background)) 0%, hsl(var(--dc-brand)/0.05) 50%, hsl(var(--background)) 100%)",
+  navigation:
+    "linear-gradient(135deg, hsl(var(--background)/0.95) 0%, hsl(var(--card)/0.95) 100%)",
+  motion: {
+    primary:
+      "linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--dc-brand-light)) 50%, hsl(var(--dc-accent)) 100%)",
+    card:
+      "linear-gradient(135deg, hsl(var(--card)) 0%, hsl(var(--primary)/0.08) 50%, hsl(var(--primary)/0.03) 100%)",
+    backgroundLight:
+      "radial-gradient(ellipse at top, hsl(var(--primary)/0.15) 0%, transparent 60%), radial-gradient(ellipse at bottom, hsl(var(--dc-brand-light)/0.12) 0%, transparent 60%), linear-gradient(to bottom, hsl(var(--background)), hsl(var(--background)))",
+    backgroundDark:
+      "radial-gradient(ellipse at top, hsl(var(--primary)/0.2) 0%, transparent 60%), radial-gradient(ellipse at bottom, hsl(var(--dc-brand-light)/0.15) 0%, transparent 60%), linear-gradient(to bottom, hsl(var(--background)), hsl(var(--background)))",
+  },
+  glass: {
+    base: "rgba(255, 255, 255, 0.1)",
+    border: "rgba(255, 255, 255, 0.2)",
+    shadow: "0 8px 32px rgba(31, 38, 135, 0.37)",
+    motionBackground: "hsl(var(--dc-brand) / 0.12)",
+    motionBorder: "hsl(var(--dc-brand-light) / 0.25)",
+    motionShadow: "0 12px 40px hsl(var(--dc-brand-dark) / 0.4)",
+    motionBlur: "blur(24px) saturate(1.8) brightness(1.1)",
+    motionBackgroundDark: "hsl(var(--dc-brand) / 0.15)",
+    motionBorderDark: "hsl(var(--dc-brand-light) / 0.2)",
+    motionShadowDark: "0 12px 40px hsl(var(--dc-brand-dark) / 0.6)",
+  },
+};
+
+const motion: BrandingMotion = {
+  durations: {
+    fast: "0.15s",
+    normal: "0.3s",
+    slow: "0.6s",
+  },
+  easings: {
+    spring: "cubic-bezier(0.16, 1, 0.3, 1)",
+    bounce: "cubic-bezier(0.68, -0.55, 0.265, 1.55)",
+    smooth: "cubic-bezier(0.4, 0, 0.2, 1)",
+  },
+  shadows: {
+    sm: "0 2px 8px rgba(0, 0, 0, 0.04)",
+    md: "0 4px 16px rgba(0, 0, 0, 0.08)",
+    lg: "0 8px 32px rgba(0, 0, 0, 0.12)",
+    xl: "0 16px 64px rgba(0, 0, 0, 0.16)",
+    glow: "0 0 32px hsl(var(--primary) / 0.4)",
+  },
+  scales: {
+    sm: "1.02",
+    md: "1.05",
+    lg: "1.08",
+    press: "0.96",
+  },
+};
+
+const metadata: BrandingMetadata = {
+  name: "Dynamic Capital",
+  tagline: "Institutional trading intelligence for ambitious operators.",
+  description:
+    "Dynamic Capital delivers institutional trading intelligence, mentorship, and automation for ambitious operators.",
+  keywords: [
+    "dynamic capital",
+    "algorithmic trading",
+    "mentorship",
+    "automation",
+    "portfolio intelligence",
+    "financial education",
+  ],
+  primaryUrl: "https://dynamic.capital",
+  supportEmail: "support@dynamic.capital",
+};
+
+const tokens: BrandingTokens = {
+  light: {
+    "--background": "0 0% 100%",
+    "--foreground": "224 71.4% 4.1%",
+    "--card": "0 0% 100%",
+    "--card-foreground": "224 71.4% 4.1%",
+    "--popover": "0 0% 100%",
+    "--popover-foreground": "224 71.4% 4.1%",
+    "--primary": "0 84% 58%",
+    "--primary-foreground": "0 0% 100%",
+    "--secondary": "0 68% 95%",
+    "--secondary-foreground": "0 45% 20%",
+    "--muted": "0 5% 96%",
+    "--muted-foreground": "0 5% 45%",
+    "--elevated": "0 72% 10%",
+    "--accent": "350 88% 60%",
+    "--accent-foreground": "0 0% 100%",
+    "--destructive": "0 72% 50%",
+    "--destructive-foreground": "0 0% 98%",
+    "--border": "0 10% 89%",
+    "--input": "0 10% 89%",
+    "--ring": "0 84% 58%",
+    "--radius": "0.5rem",
+    "--chart-1": "14 100% 57%",
+    "--chart-2": "200 100% 50%",
+    "--chart-3": "28 87% 67%",
+    "--chart-4": "340 82% 62%",
+    "--chart-5": "320 65% 55%",
+    "--motion-duration-fast": "0.15s",
+    "--motion-duration-normal": "0.3s",
+    "--motion-duration-slow": "0.6s",
+    "--motion-ease-spring": "cubic-bezier(0.16, 1, 0.3, 1)",
+    "--motion-ease-bounce": "cubic-bezier(0.68, -0.55, 0.265, 1.55)",
+    "--motion-ease-smooth": "cubic-bezier(0.4, 0, 0.2, 1)",
+    "--dc-brand": "0 84% 58%",
+    "--dc-brand-light": "0 92% 68%",
+    "--dc-brand-dark": "0 76% 48%",
+    "--dc-secondary": "200 96% 52%",
+    "--dc-accent": "350 88% 60%",
+    "--gradient-brand": gradients.brand,
+    "--gradient-primary": gradients.primary,
+    "--gradient-card": gradients.card,
+    "--gradient-hero": gradients.hero,
+    "--gradient-navigation": gradients.navigation,
+    "--gradient-motion-primary": gradients.motion.primary,
+    "--gradient-motion-card": gradients.motion.card,
+    "--gradient-motion-bg": gradients.motion.backgroundLight,
+    "--glass-motion-bg": gradients.glass.motionBackground,
+    "--glass-motion-border": gradients.glass.motionBorder,
+    "--glass-motion-shadow": gradients.glass.motionShadow,
+    "--glass-motion-blur": gradients.glass.motionBlur,
+    "--shadow-motion-sm": motion.shadows.sm,
+    "--shadow-motion-md": motion.shadows.md,
+    "--shadow-motion-lg": motion.shadows.lg,
+    "--shadow-motion-xl": motion.shadows.xl,
+    "--shadow-motion-glow": motion.shadows.glow,
+    "--scale-motion-sm": motion.scales.sm,
+    "--scale-motion-md": motion.scales.md,
+    "--scale-motion-lg": motion.scales.lg,
+    "--scale-motion-press": motion.scales.press,
+  },
+  dark: {
+    "--background": "0 5% 6%",
+    "--foreground": "0 5% 98%",
+    "--card": "0 8% 8%",
+    "--card-foreground": "0 5% 98%",
+    "--popover": "0 8% 8%",
+    "--popover-foreground": "0 5% 98%",
+    "--primary": "0 84% 58%",
+    "--primary-foreground": "0 0% 100%",
+    "--secondary": "0 10% 15%",
+    "--secondary-foreground": "0 5% 98%",
+    "--muted": "0 10% 15%",
+    "--muted-foreground": "0 5% 65%",
+    "--elevated": "0 5% 95%",
+    "--accent": "350 88% 60%",
+    "--accent-foreground": "0 0% 100%",
+    "--destructive": "0 68% 46%",
+    "--destructive-foreground": "0 5% 98%",
+    "--border": "0 15% 18%",
+    "--input": "0 15% 18%",
+    "--ring": "0 84% 58%",
+    "--radius": "0.5rem",
+    "--chart-1": "14 100% 57%",
+    "--chart-2": "200 100% 50%",
+    "--chart-3": "28 87% 67%",
+    "--chart-4": "340 82% 62%",
+    "--chart-5": "320 65% 55%",
+    "--motion-duration-fast": "0.15s",
+    "--motion-duration-normal": "0.3s",
+    "--motion-duration-slow": "0.6s",
+    "--motion-ease-spring": "cubic-bezier(0.16, 1, 0.3, 1)",
+    "--motion-ease-bounce": "cubic-bezier(0.68, -0.55, 0.265, 1.55)",
+    "--motion-ease-smooth": "cubic-bezier(0.4, 0, 0.2, 1)",
+    "--dc-brand": "0 84% 58%",
+    "--dc-brand-light": "0 92% 68%",
+    "--dc-brand-dark": "0 76% 48%",
+    "--dc-secondary": "200 96% 52%",
+    "--dc-accent": "350 88% 60%",
+    "--gradient-brand": gradients.brand,
+    "--gradient-primary": gradients.primary,
+    "--gradient-card": gradients.card,
+    "--gradient-hero": gradients.hero,
+    "--gradient-navigation": gradients.navigation,
+    "--gradient-motion-primary": gradients.motion.primary,
+    "--gradient-motion-card": gradients.motion.card,
+    "--gradient-motion-bg": gradients.motion.backgroundDark,
+    "--glass-motion-bg": gradients.glass.motionBackgroundDark,
+    "--glass-motion-border": gradients.glass.motionBorderDark,
+    "--glass-motion-shadow": gradients.glass.motionShadowDark,
+    "--glass-motion-blur": gradients.glass.motionBlur,
+    "--shadow-motion-sm": motion.shadows.sm,
+    "--shadow-motion-md": motion.shadows.md,
+    "--shadow-motion-lg": motion.shadows.lg,
+    "--shadow-motion-xl": motion.shadows.xl,
+    "--shadow-motion-glow": motion.shadows.glow,
+    "--scale-motion-sm": motion.scales.sm,
+    "--scale-motion-md": motion.scales.md,
+    "--scale-motion-lg": motion.scales.lg,
+    "--scale-motion-press": motion.scales.press,
+  },
+};
+
+const dynamicBranding: DynamicBrandingConfig = {
+  palette,
+  gradients,
+  motion,
+  tokens,
+  metadata,
+  assets: {
+    logo: "/logo.png",
+    favicon: "/favicon.ico",
+    appleTouchIcon: "/logo.png",
+    socialPreview: "/social/social-preview.svg",
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMerge<T>(base: T, overrides: DynamicBrandingOverrides): T {
+  if (!isRecord(overrides)) {
+    return JSON.parse(JSON.stringify(base)) as T;
+  }
+  const result: Record<string, unknown> = JSON.parse(JSON.stringify(base));
+
+  const stack: Array<
+    { target: Record<string, unknown>; source: Record<string, unknown> }
+  > = [
+    { target: result, source: overrides as Record<string, unknown> },
+  ];
+
+  while (stack.length > 0) {
+    const { target, source } = stack.pop()!;
+    for (const [key, value] of Object.entries(source)) {
+      if (value === undefined) continue;
+      if (isRecord(value) && isRecord(target[key])) {
+        stack.push({
+          target: target[key] as Record<string, unknown>,
+          source: value,
+        });
+      } else {
+        target[key] = value;
+      }
+    }
+  }
+
+  return result as T;
+}
+
+export function exportDynamicBranding(): DynamicBrandingConfig {
+  return JSON.parse(JSON.stringify(dynamicBranding)) as DynamicBrandingConfig;
+}
+
+export function importDynamicBranding(
+  overrides: DynamicBrandingOverrides = {},
+): DynamicBrandingConfig {
+  if (!isRecord(overrides)) {
+    return exportDynamicBranding();
+  }
+  return deepMerge(dynamicBranding, overrides);
+}
+
+export { dynamicBranding };

--- a/apps/web/resources/index.ts
+++ b/apps/web/resources/index.ts
@@ -27,6 +27,12 @@ export {
 } from "./dynamic-ui.config";
 
 export {
+  dynamicBranding,
+  exportDynamicBranding,
+  importDynamicBranding,
+} from "./dynamic-branding.config";
+
+export {
   magicPortfolioBucketBaseUrl,
   magicPortfolioBucketName,
   supabaseAsset,

--- a/apps/web/resources/types/branding.types.ts
+++ b/apps/web/resources/types/branding.types.ts
@@ -1,0 +1,142 @@
+/**
+ * The primary brand palette values shared across light and dark themes.
+ */
+export type BrandingCorePalette = {
+  base: string;
+  light: string;
+  dark: string;
+  secondary: string;
+  accent: string;
+};
+
+/**
+ * Palette tokens that change between light and dark surfaces.
+ */
+export type BrandingThemePalette = {
+  background: string;
+  foreground: string;
+  card: string;
+  cardForeground: string;
+  popover: string;
+  popoverForeground: string;
+  primary: string;
+  primaryForeground: string;
+  secondary: string;
+  secondaryForeground: string;
+  muted: string;
+  mutedForeground: string;
+  elevated: string;
+  accent: string;
+  accentForeground: string;
+  destructive: string;
+  destructiveForeground: string;
+  border: string;
+  input: string;
+  ring: string;
+  radius: string;
+  charts: [string, string, string, string, string];
+};
+
+/**
+ * Aggregate theme palette including core brand colors.
+ */
+export type BrandingPalette = {
+  brand: BrandingCorePalette;
+  light: BrandingThemePalette;
+  dark: BrandingThemePalette;
+};
+
+/**
+ * Gradient tokens used across backgrounds and effects.
+ */
+export type BrandingGradients = {
+  brand: string;
+  primary: string;
+  card: string;
+  hero: string;
+  navigation: string;
+  motion: {
+    primary: string;
+    card: string;
+    backgroundLight: string;
+    backgroundDark: string;
+  };
+  glass: {
+    base: string;
+    border: string;
+    shadow: string;
+    motionBackground: string;
+    motionBorder: string;
+    motionShadow: string;
+    motionBlur: string;
+    motionBackgroundDark: string;
+    motionBorderDark: string;
+    motionShadowDark: string;
+  };
+};
+
+/**
+ * Motion timing, easing, and elevation primitives.
+ */
+export type BrandingMotion = {
+  durations: Record<"fast" | "normal" | "slow", string>;
+  easings: Record<"spring" | "bounce" | "smooth", string>;
+  shadows: Record<"sm" | "md" | "lg" | "xl" | "glow", string>;
+  scales: Record<"sm" | "md" | "lg" | "press", string>;
+};
+
+/**
+ * Metadata associated with brand surfaces.
+ */
+export type BrandingMetadata = {
+  name: string;
+  tagline: string;
+  description: string;
+  keywords: string[];
+  primaryUrl: string;
+  supportEmail: string;
+};
+
+/**
+ * Theme token mapping keyed by CSS custom property name.
+ */
+export type BrandingThemeTokens = Record<string, string>;
+
+/**
+ * Token sets for light and dark modes.
+ */
+export type BrandingTokens = {
+  light: BrandingThemeTokens;
+  dark: BrandingThemeTokens;
+};
+
+/**
+ * Deep partial utility for nested configuration objects.
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U> ? Array<DeepPartial<U>>
+    : T[P] extends Record<string, unknown> ? DeepPartial<T[P]>
+    : T[P];
+};
+
+/**
+ * Exported representation of the Dynamic Branding system.
+ */
+export type DynamicBrandingConfig = {
+  palette: BrandingPalette;
+  gradients: BrandingGradients;
+  motion: BrandingMotion;
+  metadata: BrandingMetadata;
+  tokens: BrandingTokens;
+  assets: {
+    logo: string;
+    favicon: string;
+    appleTouchIcon: string;
+    socialPreview: string;
+  };
+};
+
+/**
+ * Helper type that allows partial overrides when importing branding config.
+ */
+export type DynamicBrandingOverrides = DeepPartial<DynamicBrandingConfig>;

--- a/apps/web/resources/types/config.types.ts
+++ b/apps/web/resources/types/config.types.ts
@@ -275,3 +275,17 @@ export type DynamicUIConfig = {
   effects: EffectsConfig;
   dataStyle: DataStyleConfig;
 };
+
+export type {
+  BrandingCorePalette,
+  BrandingGradients,
+  BrandingMetadata,
+  BrandingMotion,
+  BrandingPalette,
+  BrandingThemePalette,
+  BrandingThemeTokens,
+  BrandingTokens,
+  DeepPartial,
+  DynamicBrandingConfig,
+  DynamicBrandingOverrides,
+} from "./branding.types";

--- a/apps/web/resources/types/index.ts
+++ b/apps/web/resources/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./config.types";
 export * from "./content.types";
+export * from "./branding.types";

--- a/tests/dynamic-branding-config.test.ts
+++ b/tests/dynamic-branding-config.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import {
+  deepEqual as assertDeepEqual,
+  equal as assertEqual,
+  notEqual as assertNotEqual,
+} from "node:assert/strict";
+
+import {
+  dynamicBranding,
+  exportDynamicBranding,
+  importDynamicBranding,
+} from "../apps/web/resources/dynamic-branding.config.ts";
+
+const ORIGINAL_PRIMARY = dynamicBranding.palette.light.primary;
+const ORIGINAL_TAGLINE = dynamicBranding.metadata.tagline;
+
+test("exportDynamicBranding returns an immutable snapshot", () => {
+  const snapshot = exportDynamicBranding();
+  assertNotEqual(snapshot, dynamicBranding);
+  assertNotEqual(snapshot.palette, dynamicBranding.palette);
+  assertNotEqual(snapshot.tokens.light, dynamicBranding.tokens.light);
+
+  snapshot.palette.light.primary = "1 1% 1%";
+  snapshot.tokens.light["--primary"] = "1 1% 1%";
+
+  assertEqual(dynamicBranding.palette.light.primary, ORIGINAL_PRIMARY);
+  assertEqual(dynamicBranding.tokens.light["--primary"], ORIGINAL_PRIMARY);
+});
+
+test("importDynamicBranding merges overrides without mutating base config", () => {
+  const merged = importDynamicBranding({
+    palette: {
+      light: {
+        primary: "10 82% 52%",
+      },
+    },
+    metadata: {
+      tagline: "Test tagline",
+    },
+    tokens: {
+      light: {
+        "--primary": "10 82% 52%",
+      },
+    },
+  });
+
+  assertEqual(merged.palette.light.primary, "10 82% 52%");
+  assertEqual(merged.metadata.tagline, "Test tagline");
+  assertEqual(merged.tokens.light["--primary"], "10 82% 52%");
+
+  assertEqual(dynamicBranding.palette.light.primary, ORIGINAL_PRIMARY);
+  assertEqual(dynamicBranding.metadata.tagline, ORIGINAL_TAGLINE);
+  assertEqual(dynamicBranding.tokens.light["--primary"], ORIGINAL_PRIMARY);
+});
+
+test("importDynamicBranding gracefully handles non-object overrides", () => {
+  const merged = importDynamicBranding(
+    5 as unknown as Parameters<typeof importDynamicBranding>[0],
+  );
+  assertDeepEqual(merged, exportDynamicBranding());
+});


### PR DESCRIPTION
## Summary
- add a dedicated `dynamic-branding.config.ts` module that exposes the palette, gradients, motion tokens, and JSON import/export helpers for branding automation
- factor branding-specific types into their own module and re-export them so other resources can consume the schema without pulling in Next-specific dependencies
- cover the new helpers with node-based tests to confirm deep copies and override handling work as expected

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d48d49db548322a1f3039f3bed3dc6