### PR TITLE
chore: align node metadata with dynamic capital brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "dynamic-chatty-bot",
+  "name": "dynamic-capital",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dynamic-chatty-bot",
+      "name": "dynamic-capital",
       "workspaces": [
         "apps/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dynamic-chatty-bot",
+  "name": "dynamic-capital",
   "private": true,
   "workspaces": [
     "apps/*"

--- a/project.toml
+++ b/project.toml
@@ -1,6 +1,6 @@
 [project]
-id = "dynamic-chatty-bot"
-name = "Dynamic Chatty Bot"
+id = "dynamic-capital"
+name = "Dynamic Capital"
 version = "0.0.0"
 
 [build]


### PR DESCRIPTION
## Summary
- rename the workspace package metadata to use the Dynamic Capital brand
- update the DigitalOcean project manifest to carry the Dynamic Capital identifiers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d493831cd48322a45f1f6313f52e62