### PR TITLE
chore: update canonical domain to dynamic-capital.ondigitalocean.app

### DIFF
--- a/dns/dynamic-capital-qazf2.ondigitalocean.app.zone
+++ b/dns/dynamic-capital-qazf2.ondigitalocean.app.zone
@@ -1,9 +1,0 @@
-; DigitalOcean App Platform primary domain for Dynamic Capital
-$ORIGIN dynamic-capital-qazf2.ondigitalocean.app.
-$TTL 1800
-dynamic-capital-qazf2.ondigitalocean.app. IN SOA ns1.digitalocean.com. hostmaster.dynamic-capital-qazf2.ondigitalocean.app. 1757878623 10800 3600 604800 1800
-dynamic-capital-qazf2.ondigitalocean.app. 1800 IN NS ns1.digitalocean.com.
-dynamic-capital-qazf2.ondigitalocean.app. 1800 IN NS ns2.digitalocean.com.
-dynamic-capital-qazf2.ondigitalocean.app. 1800 IN NS ns3.digitalocean.com.
-dynamic-capital-qazf2.ondigitalocean.app. 3600 IN A 162.159.140.98
-dynamic-capital-qazf2.ondigitalocean.app. 3600 IN A 172.66.0.96

--- a/dns/dynamic-capital.ondigitalocean.app.zone
+++ b/dns/dynamic-capital.ondigitalocean.app.zone
@@ -1,0 +1,9 @@
+; DigitalOcean App Platform primary domain for Dynamic Capital
+$ORIGIN dynamic-capital.ondigitalocean.app.
+$TTL 1800
+dynamic-capital.ondigitalocean.app. IN SOA ns1.digitalocean.com. hostmaster.dynamic-capital.ondigitalocean.app. 1757878623 10800 3600 604800 1800
+dynamic-capital.ondigitalocean.app. 1800 IN NS ns1.digitalocean.com.
+dynamic-capital.ondigitalocean.app. 1800 IN NS ns2.digitalocean.com.
+dynamic-capital.ondigitalocean.app. 1800 IN NS ns3.digitalocean.com.
+dynamic-capital.ondigitalocean.app. 3600 IN A 162.159.140.98
+dynamic-capital.ondigitalocean.app. 3600 IN A 172.66.0.96

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,13 +11,13 @@ at [`.do/app.yml`](../.do/app.yml). Keep the spec in sync with any component or
 environment changes described in this document so the repository remains a
 single source of truth for deployments. The checked-in spec provisions a single
 Node.js service named `dynamic-capital`, configures
-`dynamic-capital-qazf2.ondigitalocean.app` as the primary domain while registering the
+`dynamic-capital.ondigitalocean.app` as the primary domain while registering the
 Vercel and Lovable hosts as aliases, and leaves ingress open so every hostname
 continues to route traffic. The service runs `node scripts/digitalocean-build.mjs`
 from the repository root before starting the Next.js server via `npm run start:web`.
 Requests are served on port `8080`, and the runtime sets `SITE_URL`,
 `NEXT_PUBLIC_SITE_URL`, `ALLOWED_ORIGINS`, and `MINIAPP_ORIGIN` to
-`https://dynamic-capital-qazf2.ondigitalocean.app` (while allowlisting the companion
+`https://dynamic-capital.ondigitalocean.app` (while allowlisting the companion
 hosts) so the web app, Supabase Edge Functions, and Telegram mini-app
 verification report the DigitalOcean-hosted canonical origin. Update those
 values if you move to a different hostname. The custom build helper first runs
@@ -47,8 +47,8 @@ Include your database connection string or anon key as needed:
 ## DNS for App Platform
 
 DigitalOcean provisions the
-`dynamic-capital-qazf2.ondigitalocean.app` domain. Its exported zone file lives in
-[`dns/dynamic-capital-qazf2.ondigitalocean.app.zone`](../dns/dynamic-capital-qazf2.ondigitalocean.app.zone)
+`dynamic-capital.ondigitalocean.app` domain. Its exported zone file lives in
+[`dns/dynamic-capital.ondigitalocean.app.zone`](../dns/dynamic-capital.ondigitalocean.app.zone)
 and captures the required NS and A records (162.159.140.98 and 172.66.0.96).
 Use that file if you need to rehydrate the canonical host while keeping
 Cloudflare in front of the service. Production traffic now targets the
@@ -71,7 +71,7 @@ deno run -A scripts/configure-digitalocean-dns.ts
 The repository ships with `scripts/doctl/sync-site-config.mjs` to patch the App
 Platform spec when `SITE_URL` (and related variables) drift or the primary
 domain is missing. The helper script also replays the exported zone file so the
-DigitalOcean-managed primary domain (`dynamic-capital-qazf2.ondigitalocean.app`)
+DigitalOcean-managed primary domain (`dynamic-capital.ondigitalocean.app`)
 stays aligned with Cloudflare while normalizing environment variables on the app
 itself along with any services, static sites, workers, jobs, and functions
 declared in the spec.
@@ -85,8 +85,8 @@ you only use the default context):
 # Update the app spec, aligning env vars, ingress, and primary domain.
 node scripts/doctl/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
-  --site-url https://dynamic-capital-qazf2.ondigitalocean.app \
-  --zone dynamic-capital-qazf2.ondigitalocean.app \
+  --site-url https://dynamic-capital.ondigitalocean.app \
+  --zone dynamic-capital.ondigitalocean.app \
   --spec .do/app.yml \
   --output .do/app.yml \
   --context $DOCTL_CONTEXT \
@@ -95,8 +95,8 @@ node scripts/doctl/sync-site-config.mjs \
 # Apply the spec changes and import the DNS zone in one go.
 node scripts/doctl/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
-  --site-url https://dynamic-capital-qazf2.ondigitalocean.app \
-  --zone dynamic-capital-qazf2.ondigitalocean.app \
+  --site-url https://dynamic-capital.ondigitalocean.app \
+  --zone dynamic-capital.ondigitalocean.app \
   --context $DOCTL_CONTEXT \
   --apply \
   --apply-zone
@@ -129,7 +129,7 @@ talks directly to the DigitalOcean REST API. Provide an API token via
 # Fetch, normalize, and optionally write the spec without applying.
 node scripts/digitalocean/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
-  --site-url https://dynamic-capital-qazf2.ondigitalocean.app \
+  --site-url https://dynamic-capital.ondigitalocean.app \
   --token $DIGITALOCEAN_TOKEN \
   --output .do/app.yml \
   --show-spec
@@ -137,7 +137,7 @@ node scripts/digitalocean/sync-site-config.mjs \
 # Push the rendered spec back to DigitalOcean via the REST API.
 node scripts/digitalocean/sync-site-config.mjs \
   --app-id $DIGITALOCEAN_APP_ID \
-  --site-url https://dynamic-capital-qazf2.ondigitalocean.app \
+  --site-url https://dynamic-capital.ondigitalocean.app \
   --token $DIGITALOCEAN_TOKEN \
   --apply
 ```
@@ -227,7 +227,7 @@ sync with local expectations. Update both the spec and this section if the
 build or runtime command changes.
 
 The `SITE_URL` variable must match your public domain, e.g.
-`https://dynamic-capital-qazf2.ondigitalocean.app`, and `ALLOWED_ORIGINS` should
+`https://dynamic-capital.ondigitalocean.app`, and `ALLOWED_ORIGINS` should
 include the Lovable and Vercel hosts if you continue to share load across them.
 
 ## Deployment logs

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -8,10 +8,10 @@ This project relies on a Next.js service and Supabase Edge Functions. Use the fo
 - Set `DOMAIN` in your `.env` to the root zone (e.g. `example.com`) for helper scripts and Nginx templates.
 - Update `SITE_URL` and `NEXT_PUBLIC_SITE_URL` to the canonical site URL, and adjust `NEXT_PUBLIC_API_URL` if using an API subdomain.
 - `ALLOWED_ORIGINS` should list the site and API origins so browsers can call the endpoints.
-- `dynamic-capital-qazf2.ondigitalocean.app` is the canonical production
+- `dynamic-capital.ondigitalocean.app` is the canonical production
   domain. Both `dynamic-capital.vercel.app` and `dynamic-capital.lovable.app`
   stay exported in
-  [`dns/dynamic-capital-qazf2.ondigitalocean.app.zone`](../dns/dynamic-capital-qazf2.ondigitalocean.app.zone)
+  [`dns/dynamic-capital.ondigitalocean.app.zone`](../dns/dynamic-capital.ondigitalocean.app.zone)
   and [`dns/dynamic-capital.lovable.app.json`](../dns/dynamic-capital.lovable.app.json)
   so every host can participate in load sharing while pointing at the same
   Cloudflare anycast IPs (162.159.140.98 and 172.66.0.96).
@@ -50,7 +50,7 @@ Traffic routed through Cloudflare may arrive from public IPs such as `162.159.14
 
 ## Origin alignment across platforms
 - The DigitalOcean App Platform spec keeps ingress open so
-  `dynamic-capital-qazf2.ondigitalocean.app`, `dynamic-capital.vercel.app`, and
+  `dynamic-capital.ondigitalocean.app`, `dynamic-capital.vercel.app`, and
   `dynamic-capital.lovable.app` all route to the same service while the app
   publishes DigitalOcean-hosted links.
 - `supabase/config.toml` now sets `site_url`, `additional_redirect_urls`, and

--- a/docs/REPO_INVENTORY.md
+++ b/docs/REPO_INVENTORY.md
@@ -30,7 +30,7 @@ _Last updated: 2025-09-15 (UTC)._
 ## 4. Supporting infrastructure & configuration
 
 - **`docker/`** – Container assets including app and Go service Dockerfiles, compose file, Nginx config, and health check script for running the stack in controlled environments.【b095f5†L1-L2】
-- **`dns/`** – DNS zone export (`dynamic-capital-qazf2.ondigitalocean.app.zone`) and
+- **`dns/`** – DNS zone export (`dynamic-capital.ondigitalocean.app.zone`) and
   DigitalOcean automation config (`dynamic-capital.lovable.app.json`) used to
   reproduce external records.【a93f31†L1-L2】
 - **`apps/web/app/telegram/`** – Next.js route for the Telegram operations dashboard, replacing the standalone Dynamic Codex Vite workspace so bot tooling ships from the unified build.【F:apps/web/app/telegram/page.tsx†L1-L11】【F:README.md†L96-L117】

--- a/docs/env.md
+++ b/docs/env.md
@@ -105,8 +105,8 @@ You can confirm access with `doctl spaces list`.
 | `A_SUPABASE_URL`      | Supabase URL used by audit scripts.      | No       | `https://xyz.supabase.co` | `scripts/audit/read_meta.mjs`     |
 | `A_SUPABASE_KEY`      | Supabase key used by audit scripts.      | No       | `service-role-key`        | `scripts/audit/read_meta.mjs`     |
 | `HEALTH_URL`          | Base URL for mini app health checks.     | No       | `https://example.com`     | `scripts/miniapp-health-check.ts` |
-| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `SITE_URL` or `http://localhost:3000`). | No       | `https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
-| `MINIAPP_ORIGIN`      | Origins allowed to call Telegram verification and mini-app APIs.              | No (required for production bots) | `https://dynamic-capital-qazf2.ondigitalocean.app` | `supabase/functions/verify-telegram/index.ts` |
+| `ALLOWED_ORIGINS`     | Comma-separated origins allowed for CORS (defaults to `SITE_URL` or `http://localhost:3000`). | No       | `https://dynamic-capital.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app`     | `middleware.ts`, `supabase/functions/_shared/http.ts` |
+| `MINIAPP_ORIGIN`      | Origins allowed to call Telegram verification and mini-app APIs.              | No (required for production bots) | `https://dynamic-capital.ondigitalocean.app` | `supabase/functions/verify-telegram/index.ts` |
 | `LOG_LEVEL`           | Minimum log level for server logs (`debug`, `info`, `warn`, `error`). | No       | `warn`                    | `utils/logger.ts` |
 | `FUNCTIONS_BASE_URL`   | Override Supabase functions host when provisioning database webhooks. | No       | `https://custom.functions.supabase.co` | `scripts/setup-db-webhooks.ts` |
 | `LOGTAIL_SOURCE_TOKEN` | Logtail source token used for Supabase log drain setup.              | No       | `gls_xxx`                    | `scripts/setup-log-drain.ts` |

--- a/lovable-build.js
+++ b/lovable-build.js
@@ -14,9 +14,9 @@ import {
 } from './scripts/utils/friendly-logger.js';
 import { createSanitizedNpmEnv } from './scripts/utils/npm-env.mjs';
 
-const PRODUCTION_ORIGIN = 'https://dynamic-capital-qazf2.ondigitalocean.app';
+const PRODUCTION_ORIGIN = 'https://dynamic-capital.ondigitalocean.app';
 const PRODUCTION_ALLOWED_ORIGINS = [
-  'https://dynamic-capital-qazf2.ondigitalocean.app',
+  'https://dynamic-capital.ondigitalocean.app',
   'https://dynamic-capital.vercel.app',
   'https://dynamic-capital.lovable.app',
 ].join(',');

--- a/lovable-dev.js
+++ b/lovable-dev.js
@@ -13,9 +13,9 @@ import {
 } from './scripts/utils/friendly-logger.js';
 import { createSanitizedNpmEnv } from './scripts/utils/npm-env.mjs';
 
-const PRODUCTION_ORIGIN = 'https://dynamic-capital-qazf2.ondigitalocean.app';
+const PRODUCTION_ORIGIN = 'https://dynamic-capital.ondigitalocean.app';
 const PRODUCTION_ALLOWED_ORIGINS = [
-  'https://dynamic-capital-qazf2.ondigitalocean.app',
+  'https://dynamic-capital.ondigitalocean.app',
   'https://dynamic-capital.vercel.app',
   'https://dynamic-capital.lovable.app',
 ].join(',');

--- a/project.toml
+++ b/project.toml
@@ -30,15 +30,15 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
+    value = "https://dynamic-capital.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
 
   [[build.env]]
     name = "SITE_URL"
-    value = "https://dynamic-capital-qazf2.ondigitalocean.app/"
+    value = "https://dynamic-capital.ondigitalocean.app/"
 
   [[build.env]]
     name = "MINIAPP_ORIGIN"
-    value = "https://dynamic-capital-qazf2.ondigitalocean.app"
+    value = "https://dynamic-capital.ondigitalocean.app"
 
   [[build.env]]
     name = "NEXT_TELEMETRY_DISABLED"

--- a/scripts/digitalocean/site-config-utils.mjs
+++ b/scripts/digitalocean/site-config-utils.mjs
@@ -1,7 +1,7 @@
 import { URL } from 'node:url';
 
 export const PRODUCTION_ALLOWED_ORIGINS = [
-  'https://dynamic-capital-qazf2.ondigitalocean.app',
+  'https://dynamic-capital.ondigitalocean.app',
   'https://dynamic-capital.vercel.app',
   'https://dynamic-capital.lovable.app',
 ];

--- a/scripts/digitalocean/sync-site-config.mjs
+++ b/scripts/digitalocean/sync-site-config.mjs
@@ -137,7 +137,7 @@ async function main() {
 
   if (!siteUrl) {
     usage();
-    throw new Error('--site-url is required (e.g. https://dynamic-capital-qazf2.ondigitalocean.app).');
+    throw new Error('--site-url is required (e.g. https://dynamic-capital.ondigitalocean.app).');
   }
 
   if (!specPath) {

--- a/scripts/doctl/sync-site-config.mjs
+++ b/scripts/doctl/sync-site-config.mjs
@@ -126,7 +126,7 @@ async function main() {
 
   if (!siteUrl) {
     usage();
-    throw new Error('--site-url is required (e.g. https://dynamic-capital-qazf2.ondigitalocean.app).');
+    throw new Error('--site-url is required (e.g. https://dynamic-capital.ondigitalocean.app).');
   }
 
   const domainOverride = values.domain;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,16 +1,16 @@
 project_id = "qeejuomcapbdlhnjqjcc"
 
 [global]
-  site_url = "https://dynamic-capital-qazf2.ondigitalocean.app"
+  site_url = "https://dynamic-capital.ondigitalocean.app"
   additional_redirect_urls = [
-    "https://dynamic-capital-qazf2.ondigitalocean.app",
+    "https://dynamic-capital.ondigitalocean.app",
     "https://dynamic-capital.vercel.app",
     "https://dynamic-capital.lovable.app",
   ]
 
 [functions]
   [functions.env]
-    SITE_URL = "https://dynamic-capital-qazf2.ondigitalocean.app"
-    NEXT_PUBLIC_SITE_URL = "https://dynamic-capital-qazf2.ondigitalocean.app"
-    ALLOWED_ORIGINS = "https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
-    MINIAPP_ORIGIN = "https://dynamic-capital-qazf2.ondigitalocean.app"
+    SITE_URL = "https://dynamic-capital.ondigitalocean.app"
+    NEXT_PUBLIC_SITE_URL = "https://dynamic-capital.ondigitalocean.app"
+    ALLOWED_ORIGINS = "https://dynamic-capital.ondigitalocean.app,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
+    MINIAPP_ORIGIN = "https://dynamic-capital.ondigitalocean.app"


### PR DESCRIPTION
## Summary
- set the production origin to `https://dynamic-capital.ondigitalocean.app` across Supabase config, App Platform env settings, the Lovable CLI helpers, and DigitalOcean sync tooling so every workflow resolves to the new host
- refresh deployment and networking docs to reference the new canonical domain and zone export while keeping the allowed-origin guidance in sync
- replace the DNS zone file with `dynamic-capital.ondigitalocean.app.zone` to match the updated production domain

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4922c48b88322bfcbf821448162c3