### PR TITLE
feat: add landing section navigation and anchors

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { Column, RevealFx, Row, Schema } from "@once-ui-system/core";
 import { AboutShowcase } from "@/components/magic-portfolio/home/AboutShowcase";
 import { CheckoutCallout } from "@/components/magic-portfolio/home/CheckoutCallout";
@@ -5,13 +6,206 @@ import { ComplianceCertificates } from "@/components/magic-portfolio/home/Compli
 import { EconomicCalendarSection } from "@/components/magic-portfolio/home/EconomicCalendarSection";
 import { FundamentalAnalysisSection } from "@/components/magic-portfolio/home/FundamentalAnalysisSection";
 import { HeroExperience } from "@/components/magic-portfolio/home/HeroExperience";
-import { ValuePropositionSection } from "@/components/magic-portfolio/home/ValuePropositionSection";
-import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchlist";
 import { MentorshipProgramsSection } from "@/components/magic-portfolio/home/MentorshipProgramsSection";
 import { PoolTradingSection } from "@/components/magic-portfolio/home/PoolTradingSection";
+import {
+  SectionNavigation,
+  type SectionNavItem,
+} from "@/components/magic-portfolio/home/SectionNavigation";
+import { ValuePropositionSection } from "@/components/magic-portfolio/home/ValuePropositionSection";
 import { VipPackagesSection } from "@/components/magic-portfolio/home/VipPackagesSection";
+import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { about, baseURL, home, person, toAbsoluteUrl } from "@/resources";
+
+type SectionColumnConfig = {
+  key: string;
+  element: ReactNode;
+  delay: number;
+  minWidth?: number;
+};
+
+type SectionRowConfig = {
+  key: string;
+  ariaLabel: string;
+  columns: SectionColumnConfig[];
+};
+
+type SingleSectionConfig = {
+  key: string;
+  element: ReactNode;
+  delay: number;
+};
+
+const SECTION_NAV_ITEMS: SectionNavItem[] = [
+  {
+    id: "value-proposition",
+    label: "Why the desk",
+    description: "Clarity, guardrails, and accountability",
+    icon: "shield",
+  },
+  {
+    id: "market-watchlist",
+    label: "Live watchlist",
+    description: "Spot quotes with desk bias",
+    icon: "activity",
+  },
+  {
+    id: "economic-calendar",
+    label: "Catalysts",
+    description: "Macro events & trading plans",
+    icon: "calendar",
+  },
+  {
+    id: "fundamental-analysis",
+    label: "Fundamentals",
+    description: "Conviction positioning notes",
+    icon: "trending-up",
+  },
+  {
+    id: "pool-trading",
+    label: "Pool trading",
+    description: "Managed capital controls",
+    icon: "coins",
+  },
+  {
+    id: "mentorship-programs",
+    label: "Mentorship",
+    description: "Cohorts & accountability",
+    icon: "users",
+  },
+  {
+    id: "compliance",
+    label: "Compliance",
+    description: "Security certifications",
+    icon: "check",
+  },
+  {
+    id: "about-desk",
+    label: "Desk lead",
+    description: "Meet the operators",
+    icon: "globe",
+  },
+  {
+    id: "vip-packages",
+    label: "VIP packages",
+    description: "Membership pricing",
+    icon: "sparkles",
+  },
+  {
+    id: "checkout",
+    label: "Checkout",
+    description: "Activate the desk",
+    icon: "rocket",
+  },
+];
+
+const SECTION_ROWS_BEFORE_MENTORSHIP: SectionRowConfig[] = [
+  {
+    key: "market-intel",
+    ariaLabel: "Live market coverage",
+    columns: [
+      {
+        key: "market-watchlist",
+        element: <MarketWatchlist />,
+        delay: 0.7,
+        minWidth: 24,
+      },
+      {
+        key: "economic-calendar",
+        element: <EconomicCalendarSection />,
+        delay: 0.74,
+        minWidth: 24,
+      },
+    ],
+  },
+  {
+    key: "trading-insights",
+    ariaLabel: "Trading insights",
+    columns: [
+      {
+        key: "fundamental-analysis",
+        element: <FundamentalAnalysisSection />,
+        delay: 0.78,
+        minWidth: 24,
+      },
+      {
+        key: "pool-trading",
+        element: <PoolTradingSection />,
+        delay: 0.82,
+        minWidth: 24,
+      },
+    ],
+  },
+];
+
+const SECTION_ROWS_AFTER_MENTORSHIP: SectionRowConfig[] = [
+  {
+    key: "brand-trust",
+    ariaLabel: "Brand trust",
+    columns: [
+      {
+        key: "compliance",
+        element: <ComplianceCertificates />,
+        delay: 0.9,
+        minWidth: 24,
+      },
+      {
+        key: "about-desk",
+        element: <AboutShowcase />,
+        delay: 0.94,
+        minWidth: 24,
+      },
+    ],
+  },
+];
+
+const FINAL_SECTIONS: SingleSectionConfig[] = [
+  {
+    key: "vip-packages",
+    element: <VipPackagesSection />,
+    delay: 0.98,
+  },
+  {
+    key: "checkout",
+    element: <CheckoutCallout />,
+    delay: 1.02,
+  },
+];
+
+function SectionRows({ rows }: { rows: SectionRowConfig[] }) {
+  if (!rows.length) {
+    return null;
+  }
+
+  return (
+    <>
+      {rows.map((row) => (
+        <Row
+          key={row.key}
+          fillWidth
+          gap="24"
+          wrap
+          s={{ direction: "column" }}
+          aria-label={row.ariaLabel}
+        >
+          {row.columns.map((column) => (
+            <Column
+              key={column.key}
+              flex={1}
+              minWidth={column.minWidth ?? 24}
+              gap="16"
+            >
+              <RevealFx translateY="20" delay={column.delay}>
+                {column.element}
+              </RevealFx>
+            </Column>
+          ))}
+        </Row>
+      ))}
+    </>
+  );
+}
 
 export function DynamicCapitalLandingPage() {
   return (
@@ -30,72 +224,22 @@ export function DynamicCapitalLandingPage() {
         }}
       />
       <HeroExperience />
-      <RevealFx translateY="20" delay={0.6}>
+      <RevealFx translateY="20" delay={0.62}>
+        <SectionNavigation items={SECTION_NAV_ITEMS} />
+      </RevealFx>
+      <RevealFx translateY="20" delay={0.66}>
         <ValuePropositionSection />
       </RevealFx>
-      <Row
-        fillWidth
-        gap="24"
-        wrap
-        s={{ direction: "column" }}
-        aria-label="Live market coverage"
-      >
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.68}>
-            <MarketWatchlist />
-          </RevealFx>
-        </Column>
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.72}>
-            <EconomicCalendarSection />
-          </RevealFx>
-        </Column>
-      </Row>
-      <Row
-        fillWidth
-        gap="24"
-        wrap
-        s={{ direction: "column" }}
-        aria-label="Trading insights"
-      >
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.78}>
-            <FundamentalAnalysisSection />
-          </RevealFx>
-        </Column>
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.82}>
-            <PoolTradingSection />
-          </RevealFx>
-        </Column>
-      </Row>
+      <SectionRows rows={SECTION_ROWS_BEFORE_MENTORSHIP} />
       <RevealFx translateY="20" delay={0.86}>
         <MentorshipProgramsSection />
       </RevealFx>
-      <Row
-        fillWidth
-        gap="24"
-        wrap
-        s={{ direction: "column" }}
-        aria-label="Brand trust"
-      >
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.9}>
-            <ComplianceCertificates />
-          </RevealFx>
-        </Column>
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.94}>
-            <AboutShowcase />
-          </RevealFx>
-        </Column>
-      </Row>
-      <RevealFx translateY="20" delay={0.98}>
-        <VipPackagesSection />
-      </RevealFx>
-      <RevealFx translateY="20" delay={1.02}>
-        <CheckoutCallout />
-      </RevealFx>
+      <SectionRows rows={SECTION_ROWS_AFTER_MENTORSHIP} />
+      {FINAL_SECTIONS.map((section) => (
+        <RevealFx key={section.key} translateY="20" delay={section.delay}>
+          {section.element}
+        </RevealFx>
+      ))}
       <Mailchimp />
     </Column>
   );

--- a/apps/web/components/magic-portfolio/home/AboutShowcase.tsx
+++ b/apps/web/components/magic-portfolio/home/AboutShowcase.tsx
@@ -21,6 +21,7 @@ export function AboutShowcase() {
 
   return (
     <Column
+      id="about-desk"
       fillWidth
       background="surface"
       border="neutral-alpha-medium"

--- a/apps/web/components/magic-portfolio/home/CheckoutCallout.tsx
+++ b/apps/web/components/magic-portfolio/home/CheckoutCallout.tsx
@@ -3,6 +3,7 @@ import { Button, Column, Heading, Row, Text } from "@once-ui-system/core";
 export function CheckoutCallout() {
   return (
     <Column
+      id="checkout"
       fillWidth
       background="brand-alpha-weak"
       border="brand-alpha-medium"
@@ -17,7 +18,9 @@ export function CheckoutCallout() {
         Ready to activate the desk?
       </Heading>
       <Text variant="body-default-l" onBackground="brand-weak" wrap="balance">
-        Move through checkout in under two minutes and gain access to the real-time signal desk, vault of trading systems, and live mentorship calendar.
+        Move through checkout in under two minutes and gain access to the
+        real-time signal desk, vault of trading systems, and live mentorship
+        calendar.
       </Text>
       <Row gap="12" s={{ direction: "column" }}>
         <Button

--- a/apps/web/components/magic-portfolio/home/SectionNavigation.tsx
+++ b/apps/web/components/magic-portfolio/home/SectionNavigation.tsx
@@ -1,0 +1,75 @@
+import { Button, Column, Heading, Row, Text } from "@once-ui-system/core";
+import type { IconName } from "@/resources/icons";
+
+export type SectionNavItem = {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: IconName;
+};
+
+interface SectionNavigationProps {
+  items: SectionNavItem[];
+}
+
+function getUniqueItems(items: SectionNavItem[]): SectionNavItem[] {
+  const seen = new Set<string>();
+
+  return items.filter((item) => {
+    if (!item.id || seen.has(item.id)) {
+      return false;
+    }
+
+    seen.add(item.id);
+    return true;
+  });
+}
+
+export function SectionNavigation({ items }: SectionNavigationProps) {
+  const uniqueItems = getUniqueItems(items);
+
+  if (uniqueItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <Column
+      id="section-navigation"
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="20"
+      shadow="l"
+    >
+      <Column gap="8" maxWidth={32}>
+        <Heading variant="display-strong-xs">Navigate the desk</Heading>
+        <Text variant="body-default-m" onBackground="neutral-weak">
+          Jump straight to the section you need—live market intel, pricing,
+          mentorship, and compliance resources are all one click away.
+        </Text>
+      </Column>
+      <Row as="nav" aria-label="Landing page sections" gap="12" wrap>
+        {uniqueItems.map((item) => (
+          <Button
+            key={item.id}
+            href={`#${item.id}`}
+            variant="secondary"
+            size="s"
+            data-border="rounded"
+            prefixIcon={item.icon}
+            aria-label={item.description
+              ? `${item.label} — ${item.description}`
+              : `Jump to ${item.label}`}
+            title={item.description}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </Row>
+    </Column>
+  );
+}
+
+export default SectionNavigation;


### PR DESCRIPTION
## Summary
- add a reusable SectionNavigation component that surfaces quick anchor links for key landing sections
- reorganize the DynamicCapitalLandingPage layout into configuration-driven rows and hook up the navigation items
- expose anchor ids on existing sections so the navigation targets work as expected

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4952b72148322a9f9e3bf3ffce030