### PR TITLE
Add trading glossary index reference

### DIFF
--- a/docs/trading-glossary-index.md
+++ b/docs/trading-glossary-index.md
@@ -1,0 +1,601 @@
+# Trading Glossary Index
+
+This index groups trading, macroeconomic, and market-structure terminology into
+themed collections for quick reference while building Dynamic Capital
+automation, research, or ops playbooks.
+
+## A
+
+### Algo Trading
+
+- FIX API
+- High-Frequency Trading (HFT)
+- Time-Weighted Average Price (TWAP)
+- Volume-Weighted Average Price (VWAP) Algo
+
+## C
+
+### Candlestick Patterns
+
+- Abandoned Baby
+- Bearish Engulfing Pattern
+- Bullish Belt Hold
+- Bullish Engulfing Pattern
+- Dark Cloud Cover
+- Doji
+- Dragonfly Doji
+- Engulfing Pattern
+- Evening Doji Star
+- Evening Star
+- Falling Three Methods
+- Gravestone Doji
+- Hammer
+- Hanging Man
+
+### Central Banks
+
+- Bank of Canada (BoC)
+- Bank of England (BoE)
+- Bank of International Settlement (BIS)
+- Bank of Japan (BoJ)
+- Central Bank
+- Deutsche Bundesbank
+- European Central Bank (ECB)
+- Federal Open Market Committee (FOMC)
+- Federal Reserve
+- Monetary Policy Committee (MPC)
+- Norges Bank
+- Old Lady
+- People’s Bank of China (PBOC)
+- Reserve Bank of Australia (RBA)
+
+### Chart Patterns
+
+- Ascending Channel
+- Ascending Trend Line
+- Ascending Triangle
+- Bear Flag
+- Broadening Formation
+- Bull Flag
+- Continuation Diamond
+- Continuation Pattern
+- Cup and Handle
+- Descending Channel
+- Descending Trend Line
+- Descending Triangle
+- Diamond
+- Double Bottom
+
+### Commodities
+
+- Backwardation
+- Brent Crude Oil
+- Commodity
+- Copper
+- Corn
+- Crack Spread
+- Crush Spread
+- Gold
+- Lithium
+- Natural Gas
+- Oil
+- Silver
+- Soybean
+- Uranium
+
+### Common Trading Terms
+
+- Currency Trading
+- Daily Chart
+- Delivery
+- Delivery Date
+- Discretionary Account
+- Economic Calendar
+- Foreign Exchange
+- Mark To Market (MTM)
+- NDF
+- Over-The-Counter (OTC)
+- Pip
+- Profit/Loss
+- Risk Management
+- Transaction Cost
+
+### Cryptocurrencies
+
+- 0x (ZRX)
+- 51% Attack
+- Address
+- ADDY
+- Altcoin
+- Anti-Money Laundering
+- ASIC Mining
+- Asymmetric Encryption
+- Axie Infinity (AXS)
+- Bag
+- Bag Holder
+- BearWhale
+- Bitcoin (BTC)
+- Bitcoin Cash
+
+### Currencies
+
+- Afghanistan Afghani (AFN)
+- Albanian Lek (ALL)
+- Algerian Dinar (DZD)
+- Angola Kwanza (AOA)
+- Argentina Peso (ARS)
+- Armenian Dram (AMD)
+- Aruban Guilder (AWG)
+- Australian Dollar (AUD)
+- Azerbaijan Manat (AZN)
+- Bahamian Dollar (BSD)
+- Bahrain Dinars (BHD)
+- Bangladeshi Taka (BDT)
+- Barbados Dollar (BBD)
+- Belarusian ruble (BYN)
+
+## D
+
+### Derivatives
+
+- Binary Options
+- Contract For Difference (CFD)
+- Currency Forward
+- Currency Futures
+- Currency Option
+- Delta
+- Delta Hedging
+- Expiry Date
+- Forwards
+- Futures
+- FX Swap
+- Gamma Exposure (GEX)
+- Gamma Squeeze
+- International Monetary Market (IMM) Date
+
+## E
+
+### Economic Indicators
+
+- ADP National Employment Report
+- ANZ Commodity Price Index
+- API Weekly Statistical Bulletin (WSB)
+- Baker Hughes Rig Count
+- Balance of Trade
+- Baltic Dry Index (BDI)
+- Beige Book
+- Beveridge Curve
+- Big Mac Index
+- Bloomberg U.S. Economic Surprise Index
+- Building Permits Survey (BPS)
+- Business Inventories
+- Caixin Manufacturing PMI
+- Caixin Services PMI
+
+### European Union
+
+- Council of the European Union
+- Economic and Monetary Union (EMU)
+- Eurogroup
+- European Central Bank (ECB)
+- European Commission
+- European Currency Unit (ECU)
+- European Economic Area (EEA)
+- European Free Trade Association (EFTA)
+- European Parliament
+- European Union (EU)
+- eurozone
+- Governing Council
+- PIIGS
+- Schengen Area
+
+## F
+
+### Fibonacci Studies
+
+- Fibonacci Arcs
+- Fibonacci Channel
+- Fibonacci Ellipse
+- Fibonacci Extension
+- Fibonacci Fan
+- Fibonacci Retracement
+- Fibonacci Spiral
+- Fibonacci Studies
+- Fibonacci Time Projection
+- Fibonacci Time Zones
+
+### Financial Instruments
+
+- Asset
+- Bond
+- Bond Yield
+- Derivative
+- Forex (FX)
+- Forex Trading
+- Mortgage Backed Securities (MBS)
+- Stocks
+
+## I
+
+### Influential People
+
+- Alan Greenspan
+- Angela Merkel
+- Ben Bernanke
+- Boris Schlossberg
+- Christine Lagarde
+- Janet Yellen
+- Jerome Powell
+- Kathy Lien
+- Mario Draghi
+- Olaf Scholz
+- Yi Gang
+
+### International Economics
+
+- Balance of Payments
+- Capital Account
+- Central Bank Digital Currency (CBDC)
+- Currency
+- Currency Basket
+- Current Account
+- De-Dollarization
+- Financial Contagion
+- Financial Instability Hypothesis
+- Net International Investment Position (NIIP)
+- Non-Tariff Barriers (NTBs)
+- Petrodollar Recycling
+- Petrodollars
+- Protectionism
+
+### International Organizations
+
+- Bretton Woods Agreement
+- BRIC
+- BRICS
+- Financial Stability Board
+- G10
+- G15
+- G20
+- G5
+- G7
+- G77
+- G8
+- International Monetary and Financial Committee (IMFC)
+- International Monetary Fund (IMF)
+- ISO 4217
+
+## L
+
+### Line Studies
+
+- Andrews’ Pitchfork
+- Gann Fan
+- Gann Grid
+- Linear Regression Channel
+- Schiff Pitchfork
+
+## M
+
+### Macroeconomic Concepts
+
+- Balance Sheet Recession
+- Bond Vigilantes
+- Currency Manipulation
+- Debt Ceiling
+- Earnings Recession
+- Emerging Market (EM)
+- Exports
+- Fiscal Dominance
+- Fourth Turning
+- Global Macroeconomics
+- Globalization
+- Imports
+- Interest Rate Differential
+- Interest Rate Parity
+
+### Monetary Policy
+
+- Ample Reserves Regime
+- Asset Purchase Programme (APP)
+- Austerity
+- Bank Run
+- Base Rate
+- Basis Point
+- Central Bank Digital Currency (CBDC)
+- Central Bank Intervention
+- Currency Devaluation
+- Currency Exchange Controls
+- Currency Peg
+- Currency Risk
+- Currency Swap Line
+- Deflation
+
+## O
+
+### Order Execution
+
+- Agency Model
+- At Best
+- At Or Better
+- Bid-Offer Spread
+- Clearing
+- Clearing Price
+- Closed Position
+- Commission
+- Counterparty
+- End of Day Order
+- Entry Order
+- Fill
+- Fill Price
+- Fill Ratio
+
+### Order Types
+
+- All-or-None Order (AON)
+- Fill Or Kill Order (FOK)
+- Good Till Cancelled (GTC)
+- Immediate or Cancel Order (IOC)
+- Limit Order
+- Market Order
+- One Cancels Other (OCO)
+- One Triggers Other (OTO)
+- Stop Limit Order
+- Stop Loss (SL)
+- Stop Order
+- Take Profit (TP)
+- Trailing Stop
+
+### Other
+
+- Account Statement Report
+- Advance/Decline Index
+- Appreciation
+- Asset Purchases
+- Bail-In
+- Bailout
+- Bank Levy
+- Banking Institutions
+- Bar Chart
+- Bear
+- Biflation
+- Bond Auction
+- Cable
+- Cambist
+
+## P
+
+### Price Action
+
+- Accumulation Area
+- Aggressor
+- Basing
+- Breakdown
+- Breakout
+- Consolidation
+- Divergence
+- Downtrend
+- Fakeout
+- Gap
+- Inside Bar
+- Order Block
+- Parabolic
+- Price Action
+
+## R
+
+### Regulation
+
+- Autorité des marchés financiers
+- Commodity Futures Trading Commission (CFTC)
+- European Markets Infrastructure Regulation (EMIR)
+- European Securities and Markets Authority (ESMA)
+- Federal Deposit Insurance Corporation
+- Financial Conduct Authority (FCA)
+- Financial Institution (FI)
+- Futures Commission Merchant
+- Investment Industry Regulatory Organization of Canada (IIROC)
+- Markets in Financial Instruments Directive (MiFID)
+- MiFID II
+- National Futures Association (NFA)
+- Retail Foreign Exchange Dealer (RFED)
+- Securities and Exchange Commission (SEC)
+
+### Risk Management
+
+- Alpha
+- Beta
+- Correlation
+- Correlation Coefficient
+- Currency Correlation
+- Drawdown
+- Expectancy
+- Gearing
+- Hedge
+- Historical Volatility
+- Implied Volatility
+- Leverage
+- Margin Call
+- Market Risk
+
+## S
+
+### Sentiment Analysis
+
+- AAII Sentiment Survey
+- BlackRock Geopolitical Risk Indicator (BGRI)
+- Cboe EuroCurrency Volatility Index (EVZ)
+- CBOE Put-Call Ratio
+- Christmas Grinch
+- Commitments of Traders Report (COT)
+- Copper/Gold Ratio
+- FOMO
+- FUD
+- Investor Movement Index (IMX)
+- MOVE Index
+- NAAIM Exposure Index
+- Put/Call Ratio
+- Risk Appetite
+
+### Shadow Banking
+
+- Collateral
+- High-Quality Liquid Assets (HQLA)
+- LIBOR
+- Liquidity Coverage Ratio (LCR)
+- Secured Overnight Financing Rate (SOFR)
+- Securities Financing Transactions (SFTs)
+- Shadow Banking
+
+### Stocks
+
+- ASX 200
+- Blue Chip
+- CAC 40
+- DAX
+- Dow Jones Industrial Average (DJIA)
+- EURO STOXX 50
+- Exchange Traded Fund (ETF)
+- FTSE 100
+- FTSE China A50 Index
+- Hang Seng
+- IBEX 35
+- Mutual Fund
+- NASDAQ 100
+- NASDAQ Composite
+
+## T
+
+### Technical Analysis
+
+- Chart Pattern
+- Chartist
+- Crossover
+- Divergence
+- Dow Theory
+- Efficient Market Hypothesis (EMH)
+- Elliott Wave Theory (EWT)
+- Heikin Ashi
+- Multiple Time Frame Analysis
+- Range
+- Schiff Pitchfork
+- Technical Indicator
+- Triple Moving Average Crossover
+
+### Technical Indicators
+
+- Accumulative Swing Index (ASI)
+- Alligator
+- Aroon Oscillator
+- Aroon Up/Down
+- Average Directional Index (ADX)
+- Average True Range (ATR)
+- Awesome Oscillator
+- Bollinger Bands (BB)
+- Camarilla Pivot Points
+- Chaikin Oscillator
+- Commodity Channel Index (CCI)
+- Demarker Indicator
+- Detrended Price Oscillator
+- Directional Movement Index (DMI)
+
+### Trade Execution
+
+- Application Programming Interface (API)
+- Big Figure
+- Broker
+- Broker-Dealer
+- Buy-Side
+- Central Limit Order Book (CLOB)
+- Dark Pool
+- Dealer
+- Direct Price Stream
+- E-trading Desk
+- ECN
+- Electronic Brokering Services (EBS)
+- Electronic Direct Trading
+- Electronic Indirect Trading
+
+### Trading Concepts
+
+- Analyst
+- Breakeven
+- Confluence
+- Fundamental Analysis
+- Maturity
+- Money Management
+- Overnight Position
+- Psychology
+- Quantitative Analysis
+- Reward-To-Risk Ratio (RRR)
+- Short Squeeze
+- Technical Analysis
+- Triangular Arbitrage
+- TRIN
+
+### Trading Mechanics
+
+- Account Value
+- Ask
+- Asymmetric Slippage
+- Base Currency
+- Bid
+- Bid/Ask Spread
+- Continuous Linked Settlement (CLS)
+- Contract
+- Cost of Carry
+- Counter Currency
+- Currency Pair
+- Daily Cut-Off
+- Direct Market Access (DMA)
+- Exposure
+
+### Trading Platforms
+
+- cTrader
+- MetaTrader 4 (MT4)
+- MetaTrader 5 (MT5)
+
+### Trading Slang
+
+- ATH
+- Bear Market
+- Bear Trap
+- Bearish
+- Big Figure Quote
+- Book
+- BTFD
+- Bucket Shop
+- Bull
+- Bull Market
+- Bull Trap
+- Bullish
+- Catalyst
+- Comdoll
+
+### Trading Strategies
+
+- Arbitrage
+- Breakout Trading
+- Carry Trade
+- Commodity Trading Advisor (CTA)
+- Long/Short Equity (L/S)
+- Managed Futures
+- Mean Reversion
+- Momentum Trading
+- Range Trading
+- Risk Parity
+- Term Spread
+- Trend Following
+- Volatility Targeting
+
+### Trading Styles
+
+- Day Trading
+- Discretionary Trading
+- High-Frequency Trading (HFT)
+- Mechanical Trading
+- Position Trading
+- Scalping
+- Speculating
+- Swing Trading


### PR DESCRIPTION
## Summary
- add a trading glossary index document that organizes user-submitted definitions by topic and alphabet

## Testing
- $(bash scripts/deno_bin.sh) fmt docs/trading-glossary-index.md

------
https://chatgpt.com/codex/tasks/task_e_68d49967b3a083228acad70ab0e165ce