### PR TITLE
Add School of Pipsology curriculum blog overview

### DIFF
--- a/apps/web/app/blog/posts/school-of-pipsology.mdx
+++ b/apps/web/app/blog/posts/school-of-pipsology.mdx
@@ -1,0 +1,153 @@
+---
+title: "School of Pipsology: A forex roadmap for absolute beginners"
+summary: "An overview of the 11-course curriculum that takes traders from zero forex knowledge to confident execution."
+publishedAt: "2025-02-15"
+tag: "Education"
+---
+
+Welcome! Are you new to trading forex? The School of Pipsology is our free online course that helps beginners learn how to trade forex. If you've always wanted to learn to trade but have no idea where to begin, then this course is for you.
+
+## Lessons completed
+
+- **168 of 372** lessons finished to date.
+- Sign in to track every lesson, unlock helpful markers, and see how much progress you have made.
+
+> 🔐 **Track your progress**
+>
+> Wish there was a way to keep track of lessons you've completed? Wish granted! Just sign in to unlock this feature and we'll display helpful markers and meters along the way showing just how much you've accomplished.
+
+## Course 1 of 11 — Preschool
+
+Currency trading? Forex trading? FX trading? Totally clueless about forex? Here's an introduction to the foreign exchange market.
+
+- **Start course:** Preschool
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - What is Forex?
+  - How Do You Trade Forex?
+  - When Can You Trade Forex?
+  - Who Trades Forex?
+  - Why Trade Forex?
+  - Margin Trading 101: Understand How Your Margin Account Works
+
+## Course 2 of 11 — Kindergarten
+
+Learn the basics on how to choose a forex broker and analyze the currency markets.
+
+- **Start course:** Kindergarten
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Forex Brokers 101
+  - Three Types of Analysis
+  - Types of Charts
+
+## Course 3 of 11 — Elementary
+
+The beginner's guide to technical analysis.
+
+- **Start course:** Elementary
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Grade 1 — Support and Resistance Levels
+  - Grade 2 — Japanese Candlesticks
+  - Grade 3 — Fibonacci
+  - Grade 4 — Moving Averages
+  - Grade 5 — Popular Chart Indicators
+
+## Course 4 of 11 — Middle School
+
+Learn how to properly use chart indicators, spot chart patterns, and use pivot points.
+
+- **Start course:** Middle School
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Grade 6 — Oscillators and Momentum Indicators
+  - Grade 7 — Important Chart Patterns
+  - Grade 8 — Pivot Points
+
+## Course 5 of 11 — Summer School
+
+Take your technical analysis and chart reading skills to another level by learning Heikin Ashi, Elliott Wave Theory, and harmonic price patterns.
+
+- **Start course:** Summer School
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Heikin Ashi
+  - Elliott Wave Theory
+  - Harmonic Price Patterns
+
+## Course 6 of 11 — High School
+
+Dig deeper into more technical analysis concepts like trading divergences, breakouts, and using multiple time frames on your charts.
+
+- **Start course:** High School
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Grade 9 — Trading Divergences
+  - Grade 10 — Market Environment
+  - Grade 11 — Trading Breakouts and Fakeouts
+  - Grade 12 — Fundamental Analysis
+  - Grade 13 — Currency Crosses
+  - Grade 14 — Multiple Time Frame Analysis
+
+## Course 7 of 11 — Undergraduate (Freshman)
+
+Learn how to gauge whether the market is bullish or bearish, how to trade during news releases, and how to potentially make money without price moving.
+
+- **Start course:** Undergraduate — Freshman
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Market Sentiment
+  - Trading the News
+  - Carry Trade
+
+## Course 8 of 11 — Undergraduate (Sophomore)
+
+Learn how other asset classes like stocks, bonds, and commodities can affect the foreign exchange market.
+
+- **Start course:** Undergraduate — Sophomore
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - The U.S. Dollar Index
+  - Intermarket Correlations
+  - Using Equities to Trade FX
+  - Country Profiles
+
+## Course 9 of 11 — Undergraduate (Junior)
+
+Learn how to develop a trading plan, create a trading system, and maintain a trading journal.
+
+- **Start course:** Undergraduate — Junior
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Developing Your Own Trading Plan
+  - Which Type of Trader Are You?
+  - Create Your Own Trading System
+  - Keeping a Trading Journal
+  - How to Use MetaTrader 4
+
+## Course 10 of 11 — Undergraduate (Senior)
+
+Develop the proper risk management skills and mindset so you don't become part of the 95% of new traders who end up losing all their money.
+
+- **Start course:** Undergraduate — Senior
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - Risk Management
+  - The Number 1 Cause of Death of Forex Traders
+  - Position Sizing
+  - Setting Stop Losses
+  - Scaling In and Out
+  - Currency Correlations
+
+## Course 11 of 11 — Graduation
+
+Some final words of wisdom before you venture out into the challenging world of trading forex.
+
+- **Start course:** Graduation
+- **Progress:** Sign in to unlock progress tracking
+- **Course outline:**
+  - The Most Common Trading Mistakes New Traders Make
+  - Forex Trading Scams
+  - Personality Quizzes
+  - Graduation Speech


### PR DESCRIPTION
## Summary
- add a new "School of Pipsology" blog post that outlines the full 11-course curriculum for forex beginners
- include lesson tracking context and individual course outlines with consistent call-to-action metadata

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d499c49edc8322aea613caa178ed86