### PR TITLE
Refine navigation for beginner onboarding

### DIFF
--- a/apps/web/components/magic-portfolio/Header.tsx
+++ b/apps/web/components/magic-portfolio/Header.tsx
@@ -3,9 +3,18 @@
 import React, { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 
-import { Button, Fade, Flex, Line, Row, ToggleButton } from "@once-ui-system/core";
+import {
+  Button,
+  Column,
+  Fade,
+  Flex,
+  Line,
+  Row,
+  Text,
+  ToggleButton,
+} from "@once-ui-system/core";
 
-import { display, person, about, blog, work, gallery, isRouteEnabled } from "@/resources";
+import { display, isRouteEnabled, person } from "@/resources";
 import type { IconName } from "@/resources/icons";
 import { useAuth } from "@/hooks/useAuth";
 import { ThemeToggle } from "./ThemeToggle";
@@ -16,7 +25,9 @@ type TimeDisplayProps = {
   locale?: string; // Optionally allow locale, defaulting to 'en-GB'
 };
 
-const TimeDisplay: React.FC<TimeDisplayProps> = ({ timeZone, locale = "en-GB" }) => {
+const TimeDisplay: React.FC<TimeDisplayProps> = (
+  { timeZone, locale = "en-GB" },
+) => {
   const [currentTime, setCurrentTime] = useState("");
 
   useEffect(() => {
@@ -48,79 +59,81 @@ export const Header = () => {
   const pathname = usePathname() ?? "";
   const { user, signOut } = useAuth();
 
-  const homeEnabled = isRouteEnabled("/");
-  const plansEnabled = isRouteEnabled("/plans");
-  const aboutEnabled = isRouteEnabled("/about");
-  const workEnabled = isRouteEnabled("/work");
-  const blogEnabled = isRouteEnabled("/blog");
-  const galleryEnabled = isRouteEnabled("/gallery");
+  const navBlueprint = [
+    {
+      key: "start",
+      route: "/",
+      step: "Step 1",
+      label: "Start here",
+      description: "Follow the guided tour and set your first goal.",
+      icon: "sparkles" as IconName,
+      href: "/",
+      isActive: (currentPath: string) => currentPath === "/",
+    },
+    {
+      key: "learn",
+      route: "/blog",
+      step: "Step 2",
+      label: "Learn the basics",
+      description: "Browse beginner-friendly lessons from the desk.",
+      icon: "book" as IconName,
+      href: "/blog",
+      isActive: (currentPath: string) => currentPath.startsWith("/blog"),
+    },
+    {
+      key: "plans",
+      route: "/plans",
+      step: "Step 3",
+      label: "Choose a plan",
+      description: "Compare membership paths when you're ready to join.",
+      icon: "crown" as IconName,
+      href: "/plans",
+      isActive: (currentPath: string) => currentPath.startsWith("/plans"),
+    },
+    {
+      key: "results",
+      route: "/work",
+      step: "Step 4",
+      label: "See real results",
+      description: "Review live desk projects and member wins.",
+      icon: "grid" as IconName,
+      href: "/work",
+      isActive: (currentPath: string) => currentPath.startsWith("/work"),
+    },
+    {
+      key: "automation",
+      route: "/telegram",
+      step: "Step 5",
+      label: "Automation hub",
+      description: "Connect signals and manage the Telegram bot.",
+      icon: "telegram" as IconName,
+      href: "/telegram",
+      isActive: (currentPath: string) => currentPath.startsWith("/telegram"),
+    },
+  ] as const;
 
-  const navItems = [
-    homeEnabled
-      ? {
-          key: "home",
-          label: "Home",
-          icon: "home" as IconName,
-          href: "/",
-          selected: pathname === "/",
-        }
-      : null,
-    plansEnabled
-      ? {
-          key: "plans",
-          label: "VIP Plans",
-          icon: "crown" as IconName,
-          href: "/plans",
-          selected: pathname.startsWith("/plans"),
-        }
-      : null,
-    aboutEnabled
-      ? {
-          key: "about",
-          label: about.label,
-          icon: "person" as IconName,
-          href: "/about",
-          selected: pathname === "/about",
-        }
-      : null,
-    workEnabled
-      ? {
-          key: "work",
-          label: work.label,
-          icon: "grid" as IconName,
-          href: "/work",
-          selected: pathname.startsWith("/work"),
-        }
-      : null,
-    blogEnabled
-      ? {
-          key: "blog",
-          label: blog.label,
-          icon: "book" as IconName,
-          href: "/blog",
-          selected: pathname.startsWith("/blog"),
-        }
-      : null,
-    galleryEnabled
-      ? {
-          key: "gallery",
-          label: gallery.label,
-          icon: "gallery" as IconName,
-          href: "/gallery",
-          selected: pathname.startsWith("/gallery"),
-        }
-      : null,
-  ].filter((item): item is {
-    key: string;
-    label: string;
-    icon: IconName;
-    href: string;
-    selected: boolean;
-  } => Boolean(item));
+  const navItems = navBlueprint
+    .filter((item) => isRouteEnabled(item.route))
+    .map((item) => ({
+      key: item.key,
+      label: item.label,
+      icon: item.icon,
+      href: item.href,
+      step: item.step,
+      description: item.description,
+      ariaLabel: `${item.step}: ${item.label}. ${item.description}`,
+      selected: item.isActive(pathname),
+    }));
 
   return (
     <>
-      <Fade s={{ hide: true }} fillWidth position="fixed" height="80" zIndex={9} />
+      <Fade
+        s={{ hide: true }}
+        fillWidth
+        position="fixed"
+        height="80"
+        zIndex={9}
+      />
       <Fade
         hide
         s={{ hide: false }}
@@ -145,7 +158,12 @@ export const Header = () => {
           position: "fixed",
         }}
       >
-        <Row paddingLeft="12" fillWidth vertical="center" textVariant="body-default-s">
+        <Row
+          paddingLeft="12"
+          fillWidth
+          vertical="center"
+          textVariant="body-default-s"
+        >
           {display.location && <Row s={{ hide: true }}>{person.location}</Row>}
         </Row>
         <Row fillWidth horizontal="center">
@@ -158,23 +176,53 @@ export const Header = () => {
             horizontal="center"
             zIndex={1}
           >
-            <Row gap="4" vertical="center" textVariant="body-default-s" suppressHydrationWarning>
+            <Row
+              gap="4"
+              vertical="center"
+              textVariant="body-default-s"
+              suppressHydrationWarning
+            >
               {navItems.flatMap((item, index) => {
                 const toggle = (
                   <React.Fragment key={item.key}>
-                    <Row s={{ hide: true }}>
+                    <Column
+                      key={`${item.key}-desktop`}
+                      s={{ hide: true }}
+                      gap="4"
+                      horizontal="center"
+                      align="center"
+                    >
+                      <Text
+                        variant="label-strong-xs"
+                        align="center"
+                        onBackground={item.selected
+                          ? "brand-strong"
+                          : "neutral-weak"}
+                      >
+                        {item.step}
+                      </Text>
                       <ToggleButton
                         prefixIcon={item.icon}
                         href={item.href}
                         label={item.label}
                         selected={item.selected}
+                        aria-label={item.ariaLabel}
                       />
-                    </Row>
+                      <Text
+                        variant="body-default-xs"
+                        align="center"
+                        onBackground="neutral-weak"
+                        style={{ maxWidth: "14rem" }}
+                      >
+                        {item.description}
+                      </Text>
+                    </Column>
                     <Row hide s={{ hide: false }}>
                       <ToggleButton
                         prefixIcon={item.icon}
                         href={item.href}
                         selected={item.selected}
+                        aria-label={item.ariaLabel}
                       />
                     </Row>
                   </React.Fragment>
@@ -214,15 +262,17 @@ export const Header = () => {
             <Flex s={{ hide: true }}>
               {display.time && <TimeDisplay timeZone={person.location} />}
             </Flex>
-            {user ? (
-              <Button size="s" variant="secondary" onClick={() => signOut()}>
-                Logout
-              </Button>
-            ) : (
-              <Button size="s" variant="secondary" href="/login">
-                Login
-              </Button>
-            )}
+            {user
+              ? (
+                <Button size="s" variant="secondary" onClick={() => signOut()}>
+                  Logout
+                </Button>
+              )
+              : (
+                <Button size="s" variant="secondary" href="/login">
+                  Login
+                </Button>
+              )}
           </Flex>
         </Flex>
       </Row>

--- a/apps/web/components/navigation/DesktopNav.tsx
+++ b/apps/web/components/navigation/DesktopNav.tsx
@@ -5,8 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { CreditCard, User, LogIn, Zap } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
 import NAV_ITEMS from "./nav-items";
 
 const navItems = NAV_ITEMS;
@@ -15,7 +14,8 @@ export const DesktopNav: React.FC = () => {
   const pathname = usePathname();
   const shouldReduceMotion = useReducedMotion();
 
-  const isActive = (path: string) => pathname === path;
+  const isActive = (path: string) =>
+    path === "/" ? pathname === "/" : pathname.startsWith(path);
 
   return (
     <motion.nav
@@ -43,15 +43,38 @@ export const DesktopNav: React.FC = () => {
           >
             <Link
               href={item.path}
+              aria-label={item.ariaLabel}
               className={cn(
-                "flex items-center gap-2 px-4 py-2 rounded-md",
+                "flex min-w-[11rem] flex-col gap-1 rounded-md px-4 py-3 transition",
                 active
-                  ? "bg-primary text-primary-foreground"
-                  : "text-foreground hover:bg-accent hover:text-accent-foreground"
+                  ? "bg-primary text-primary-foreground shadow-sm shadow-primary/30"
+                  : "text-foreground hover:bg-accent hover:text-accent-foreground",
               )}
             >
-              <Icon className="h-4 w-4" />
-              {item.label}
+              <span
+                className={cn(
+                  "text-[11px] font-semibold uppercase tracking-wide",
+                  active
+                    ? "text-primary-foreground/80"
+                    : "text-muted-foreground",
+                )}
+              >
+                {item.step}
+              </span>
+              <div className="flex items-center gap-2 font-medium">
+                <Icon className="h-4 w-4" />
+                <span>{item.label}</span>
+              </div>
+              <span
+                className={cn(
+                  "text-xs leading-snug",
+                  active
+                    ? "text-primary-foreground/80"
+                    : "text-muted-foreground",
+                )}
+              >
+                {item.description}
+              </span>
             </Link>
           </motion.div>
         );

--- a/apps/web/components/navigation/FramerMainNav.tsx
+++ b/apps/web/components/navigation/FramerMainNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import MainComponent, { type MainNavItem } from "./framer/MainComponent";
 import NAV_ITEMS from "./nav-items";
@@ -29,7 +29,14 @@ const ICON_NODES: Record<string, Array<[string, Record<string, string>]>> = {
     ["path", { d: "M22 10v6" }],
     ["path", { d: "M6 12.5V16a6 3 0 0 0 12 0v-3.5" }],
   ],
-  contact: [["path", { d: "M7.9 20A9 9 0 1 0 4 16.1L2 22Z" }]],
+  success: [
+    [
+      "path",
+      {
+        d: "M12 3.5 14.09 8.26 19.2 8.96 15.55 12.44 16.58 17.5 12 15 7.42 17.5 8.45 12.44 4.8 8.96 9.91 8.26 12 3.5z",
+      },
+    ],
+  ],
   dashboard: [
     [
       "path",
@@ -70,7 +77,9 @@ const buildNavItems = (
     const color = NAV_COLORS[index] ?? NAV_COLORS[0];
     const iconNode = ICON_NODES[item.id] ?? ICON_NODES.home;
     const icon = iconNodeToSvg(iconNode);
-    const isActive = pathname === item.path;
+    const isActive = item.path === "/"
+      ? pathname === "/"
+      : pathname.startsWith(item.path);
 
     return {
       id: item.id,
@@ -96,7 +105,10 @@ const FramerMainNav = () => {
     [pathname, router],
   );
 
-  const items = useMemo(() => buildNavItems(pathname, navigate), [pathname, navigate]);
+  const items = useMemo(() => buildNavItems(pathname, navigate), [
+    pathname,
+    navigate,
+  ]);
 
   return <MainComponent items={items} />;
 };

--- a/apps/web/components/navigation/MobileBottomNav.tsx
+++ b/apps/web/components/navigation/MobileBottomNav.tsx
@@ -4,7 +4,12 @@ import React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/utils";
-import { motion, AnimatePresence, useReducedMotion, LayoutGroup } from "framer-motion";
+import {
+  AnimatePresence,
+  LayoutGroup,
+  motion,
+  useReducedMotion,
+} from "framer-motion";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import NAV_ITEMS from "./nav-items";
 
@@ -13,65 +18,93 @@ const navItems = NAV_ITEMS.filter((n) => n.showOnMobile);
 export const MobileBottomNav: React.FC = () => {
   const pathname = usePathname();
   const reduceMotion = useReducedMotion();
+  const columnCount = navItems.length || 1;
+
+  const isActive = (path: string) =>
+    path === "/" ? pathname === "/" : pathname.startsWith(path);
+
+  const activeIndex = navItems.findIndex((item) => isActive(item.path));
+  const indicatorWidth = 100 / columnCount;
 
   return (
     <motion.nav
       className={cn(
         "fixed bottom-0 left-0 right-0 z-50 md:hidden safe-area-bottom",
         "bg-gradient-navigation backdrop-blur-xl border-t border-border/50",
-        "shadow-2xl shadow-primary/10"
+        "shadow-2xl shadow-primary/10",
       )}
       role="navigation"
       aria-label="Mobile navigation"
       initial={reduceMotion ? false : { y: 100, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
-      transition={reduceMotion ? { duration: 0 } : { duration: 0.5, ease: "easeOut" }}
+      transition={reduceMotion
+        ? { duration: 0 }
+        : { duration: 0.5, ease: "easeOut" }}
     >
       <div className="container mx-auto px-2">
         <LayoutGroup>
-        <div className="grid grid-cols-5 gap-0">
-          {navItems.map((item, index) => {
-            const Icon = item.icon;
-            const isActive = pathname === item.path;
+          <div
+            className="relative grid gap-0"
+            style={{
+              gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+            }}
+          >
+            {navItems.map((item, index) => {
+              const Icon = item.icon;
+              const linkActive = isActive(item.path);
 
-            return (
-              <motion.div
-                key={item.id}
-                initial={reduceMotion ? false : { scale: 0, opacity: 0 }}
-                animate={{ scale: 1, opacity: 1 }}
-                transition={
-                  reduceMotion
+              return (
+                <motion.div
+                  key={item.id}
+                  initial={reduceMotion ? false : { scale: 0, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  transition={reduceMotion
                     ? { duration: 0 }
-                    : { delay: index * 0.05, duration: 0.3, ease: "easeOut" }
-                }
-              >
-                <Link
-                  href={item.path}
-                  className={cn(
-                    "flex flex-col items-center justify-center p-2 gap-1",
-                    "text-sm font-medium transition-colors",
-                    "hover:text-primary",
-                    isActive ? "text-primary" : "text-muted-foreground"
-                  )}
+                    : { delay: index * 0.05, duration: 0.3, ease: "easeOut" }}
                 >
-                  <Icon className="h-5 w-5" />
-                  <span>{item.label}</span>
-                </Link>
-              </motion.div>
-            );
-          })}
-          <AnimatePresence>
-            {pathname && (
-              <motion.div
-                className="absolute bottom-0 left-0 w-1/5 h-1 rounded-t-full bg-primary"
-                layoutId="activeIndicator"
-                initial={false}
-                animate={{ x: navItems.findIndex((n) => n.path === pathname) * 100 + "%" }}
-                transition={reduceMotion ? { duration: 0 } : { duration: 0.3, ease: "easeOut" }}
-              />
-            )}
-          </AnimatePresence>
-        </div>
+                  <Link
+                    href={item.path}
+                    aria-label={item.ariaLabel}
+                    title={item.description}
+                    className={cn(
+                      "flex flex-col items-center justify-center gap-1 p-2 text-center transition-colors",
+                      linkActive
+                        ? "text-primary"
+                        : "text-muted-foreground hover:text-primary",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "text-[10px] font-semibold uppercase tracking-wide",
+                        linkActive ? "text-primary" : "text-muted-foreground",
+                      )}
+                    >
+                      {item.step}
+                    </span>
+                    <Icon className="h-5 w-5" />
+                    <span className="text-xs font-medium leading-tight">
+                      {item.label}
+                    </span>
+                    <span className="sr-only">{item.description}</span>
+                  </Link>
+                </motion.div>
+              );
+            })}
+            <AnimatePresence>
+              {pathname && activeIndex >= 0 && (
+                <motion.div
+                  className="pointer-events-none absolute bottom-0 left-0 h-1 rounded-t-full bg-primary"
+                  layoutId="activeIndicator"
+                  initial={false}
+                  animate={{ x: `${activeIndex * indicatorWidth}%` }}
+                  style={{ width: `${indicatorWidth}%` }}
+                  transition={reduceMotion
+                    ? { duration: 0 }
+                    : { duration: 0.3, ease: "easeOut" }}
+                />
+              )}
+            </AnimatePresence>
+          </div>
         </LayoutGroup>
       </div>
     </motion.nav>

--- a/apps/web/components/navigation/MobileMenu.tsx
+++ b/apps/web/components/navigation/MobileMenu.tsx
@@ -4,62 +4,21 @@ import React, { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
-import { cn } from "@/utils";
 import {
-  Menu,
-  Home,
-  CreditCard,
-  Settings,
-  GraduationCap,
-  User,
-  LogIn,
-  X,
-  type LucideIcon,
-} from "lucide-react";
-
-interface NavItem {
-  id: string;
-  label: string;
-  icon: LucideIcon;
-  path: string;
-  ariaLabel: string;
-}
-
-const navItems: NavItem[] = [
-  {
-    id: "home",
-    label: "Home",
-    icon: Home,
-    path: "/",
-    ariaLabel: "Navigate to home page"
-  },
-  {
-    id: "plans",
-    label: "Plans",
-    icon: CreditCard,
-    path: "/plans",
-    ariaLabel: "View subscription plans"
-  },
-  {
-    id: "settings",
-    label: "Settings",
-    icon: Settings,
-    path: "/#settings",
-    ariaLabel: "Adjust user settings"
-  },
-  {
-    id: "education",
-    label: "Education",
-    icon: GraduationCap,
-    path: "/education",
-    ariaLabel: "Explore educational content"
-  }
-];
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { cn } from "@/utils";
+import { Menu, X } from "lucide-react";
+import NAV_ITEMS from "./nav-items";
 
 export const MobileMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
+  const navItems = NAV_ITEMS.filter((item) => item.showOnMobile);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -72,23 +31,41 @@ export const MobileMenu: React.FC = () => {
         <SheetHeader className="p-6">
           <SheetTitle>Menu</SheetTitle>
         </SheetHeader>
-        <nav className="px-6 py-4 space-y-1">
+        <nav className="px-6 py-4 space-y-2">
           {navItems.map((item) => {
             const Icon = item.icon;
-            const isActive = pathname === item.path;
+            const isActive = item.path === "/"
+              ? pathname === "/"
+              : pathname.startsWith(item.path);
             return (
               <Link
                 key={item.id}
                 href={item.path}
                 aria-label={item.ariaLabel}
+                title={item.description}
                 className={cn(
-                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium",
-                  "transition-colors hover:bg-accent hover:text-accent-foreground",
-                  isActive ? "bg-accent text-accent-foreground" : "text-muted-foreground"
+                  "block rounded-lg px-3 py-3 transition-colors",
+                  isActive
+                    ? "bg-accent text-accent-foreground shadow-sm"
+                    : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
                 )}
               >
-                <Icon className="h-4 w-4" />
-                {item.label}
+                <div className="flex items-start gap-3">
+                  <div className="mt-1 flex h-8 w-8 items-center justify-center rounded-md bg-accent/40">
+                    <Icon className="h-4 w-4" />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {item.step}
+                    </span>
+                    <span className="text-sm font-semibold text-foreground">
+                      {item.label}
+                    </span>
+                    <span className="text-sm leading-snug text-muted-foreground">
+                      {item.description}
+                    </span>
+                  </div>
+                </div>
               </Link>
             );
           })}

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -1,15 +1,17 @@
 import {
-  Home,
-  TrendingUp,
+  Award,
   GraduationCap,
-  MessageCircle,
-  Shield,
+  Home,
   type LucideIcon,
+  Shield,
+  TrendingUp,
 } from "lucide-react";
 
 export interface NavItem {
   id: string;
+  step: string;
   label: string;
+  description: string;
   icon: LucideIcon;
   path: string;
   ariaLabel: string;
@@ -19,42 +21,56 @@ export interface NavItem {
 export const NAV_ITEMS: NavItem[] = [
   {
     id: "home",
-    label: "Home",
+    step: "Step 1",
+    label: "Start here",
+    description: "Tour the platform and set your first goal.",
     icon: Home,
     path: "/",
-    ariaLabel: "Navigate to home page",
-    showOnMobile: true,
-  },
-  {
-    id: "plans",
-    label: "VIP Plans",
-    icon: TrendingUp,
-    path: "/plans",
-    ariaLabel: "View VIP subscription plans",
+    ariaLabel: "Step 1: Start here. Tour the platform and set your first goal.",
     showOnMobile: true,
   },
   {
     id: "education",
-    label: "Academy",
+    step: "Step 2",
+    label: "Learn the basics",
+    description: "Watch bite-sized lessons built for beginners.",
     icon: GraduationCap,
-    path: "/education",
-    ariaLabel: "Access trading academy",
+    path: "/blog",
+    ariaLabel:
+      "Step 2: Learn the basics. Watch bite-sized lessons built for beginners.",
     showOnMobile: true,
   },
   {
-    id: "contact",
-    label: "Support",
-    icon: MessageCircle,
-    path: "/contact",
-    ariaLabel: "Contact support team",
+    id: "plans",
+    step: "Step 3",
+    label: "Choose a plan",
+    description: "Compare membership paths when you're ready to join.",
+    icon: TrendingUp,
+    path: "/plans",
+    ariaLabel:
+      "Step 3: Choose a plan. Compare membership paths when you're ready to join.",
+    showOnMobile: true,
+  },
+  {
+    id: "success",
+    step: "Step 4",
+    label: "See real results",
+    description: "Browse live desk projects and member wins.",
+    icon: Award,
+    path: "/work",
+    ariaLabel:
+      "Step 4: See real results. Browse live desk projects and member wins.",
     showOnMobile: true,
   },
   {
     id: "dashboard",
-    label: "Bot Dashboard",
+    step: "Step 5",
+    label: "Automation hub",
+    description: "Connect signals and manage the Telegram bot.",
     icon: Shield,
     path: "/telegram",
-    ariaLabel: "View Telegram bot dashboard",
+    ariaLabel:
+      "Step 5: Automation hub. Connect signals and manage the Telegram bot.",
     showOnMobile: true,
   },
 ];

--- a/apps/web/resources/dynamic-ui.config.ts
+++ b/apps/web/resources/dynamic-ui.config.ts
@@ -24,8 +24,8 @@ const routes: RoutesConfig = {
   "/login": true,
   "/admin": true,
   "/signal": true,
-  "/work": false,
-  "/blog": false,
+  "/work": true,
+  "/blog": true,
   "/gallery": false,
   "/telegram": true,
 };


### PR DESCRIPTION
## Summary
- reorganized shared navigation data into a five-step beginner journey with descriptive copy
- refreshed desktop, mobile, and floating navigation components to surface the new steps, helper text, and improved accessibility
- rebuilt the site header to highlight the guided flow and enabled blog/work routes for the onboarding path

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d498eed14883228ebba9dc9a5500ef