### PR TITLE
Add commodities market snapshot post for 2025-09-25

### DIFF
--- a/apps/web/app/blog/posts/commodities-market-snapshot-2025-09-25.mdx
+++ b/apps/web/app/blog/posts/commodities-market-snapshot-2025-09-25.mdx
@@ -1,0 +1,60 @@
+---
+title: "Commodities market snapshot – 25 September 2025"
+summary: "Quick read on where global commodities are trending, which contracts are breaking out, and where volatility is clustering this morning."
+publishedAt: "2025-09-25"
+tag: "Markets"
+image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-03.jpg"
+---
+
+We opened the European morning with grains and precious metals inching higher while natural gas softened. Below is the desk's dashboard as of **06:28 GMT+5**.
+
+## Commodity strength meter
+
+| Contract | Bias |
+| --- | --- |
+| SOYF | Bullish tone holds as oilseeds extend the overnight bid. |
+| CORNF | Following soy higher on light positioning shifts. |
+| XAU/USD | Gold continues to benefit from rotation out of equities. |
+| Copper | Still constructive on Chinese demand headlines. |
+| UKOil | Brent stabilising after last week's drawdown. |
+| XAG/USD | Silver stays rangebound with gold leadership. |
+| USOil | WTI consolidates near $69. |
+| NGAS | Soft patch after yesterday's storage print. |
+| WHEATF | Under pressure as supply fears fade. |
+
+## Top gainers
+
+| Symbol | % Change | Abs Change | Last |
+| --- | --- | --- | --- |
+| SOYF | +0.20% | +1.99 | 1010.370 |
+| CORNF | +0.18% | +0.75 | 424.640 |
+| XAU/USD | +0.17% | +6.54 | 3746.25 |
+| Copper | +0.16% | +0.0079 | 4.8316 |
+| UKOil | +0.11% | +0.076 | 69.130 |
+
+## Top losers
+
+| Symbol | % Change | Abs Change | Last |
+| --- | --- | --- | --- |
+| WHEATF | -0.19% | -0.98 | 519.640 |
+| NGAS | -0.03% | -0.0011 | 3.1484 |
+
+## Volatility focus
+
+| Most volatile | Daily range |
+| --- | --- |
+| NGAS | 0.77% |
+| Copper | 0.71% |
+| WHEATF | 0.68% |
+| UKOil | 0.44% |
+| SOYF | 0.41% |
+
+| Least volatile | Daily range |
+| --- | --- |
+| CORNF | 0.24% |
+| XAG/USD | 0.28% |
+| XAU/USD | 0.34% |
+| USOil | 0.40% |
+| SOYF | 0.41% |
+
+Our plan: keep leaning into the grains strength while watching nat gas for a reversal once U.S. inventory chatter clears. Precious metals stay on the buy list above today's VWAP.


### PR DESCRIPTION
## Summary
- add a blog post that captures the 25 September 2025 commodities market strength, gainers/losers, and volatility tables

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d49acead3483228a74acd62c2499f0