### PR TITLE
Update support email to Gmail contact

### DIFF
--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -94,7 +94,7 @@ Our mission is to help traders succeed through:
 
 Our support team is here for you!
 
-📧 Email: support@dynamiccapital.com
+📧 Email: dynamiccapitalapp@gmail.com
 💬 Telegram: @DynamicCapital_Support
 🕐 Support Hours: 24/7
 

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1032,7 +1032,7 @@ async function fetchActiveContactLinks(): Promise<string> {
       .order("display_order");
 
     if (!links || links.length === 0) {
-      return "📧 Email: support@dynamiccapital.com\n💬 Telegram: @DynamicCapital_Support";
+      return "📧 Email: dynamiccapitalapp@gmail.com\n💬 Telegram: @DynamicCapital_Support";
     }
 
     return links
@@ -1045,7 +1045,7 @@ async function fetchActiveContactLinks(): Promise<string> {
       .join("\n");
   } catch (error) {
     console.error("Error fetching contact links:", error);
-    return "📧 Email: support@dynamiccapital.com\n💬 Telegram: @DynamicCapital_Support";
+    return "📧 Email: dynamiccapitalapp@gmail.com\n💬 Telegram: @DynamicCapital_Support";
   }
 }
 

--- a/supabase/migrations/20250807023345_navy_boat.sql
+++ b/supabase/migrations/20250807023345_navy_boat.sql
@@ -106,7 +106,7 @@ Our mission is to help traders succeed through:
 
 Our support team is here for you!
 
-📧 Email: support@dynamiccapital.com
+📧 Email: dynamiccapitalapp@gmail.com
 💬 Telegram: @DynamicCapital_Support
 🕐 Support Hours: 24/7
 

--- a/supabase/migrations/20250905121747_86c618de-f307-4a35-8bb1-4f3ae9127033.sql
+++ b/supabase/migrations/20250905121747_86c618de-f307-4a35-8bb1-4f3ae9127033.sql
@@ -42,7 +42,7 @@ Ready to continue your trading success? 🚀',
   'contact_message',
   '💬 Contact Dynamic Capital Support
 
-📧 Email: support@dynamiccapital.com
+📧 Email: dynamiccapitalapp@gmail.com
 💬 Telegram: @DynamicCapital_Support
 
 🕐 Support Hours: 24/7
@@ -63,7 +63,7 @@ ON CONFLICT (content_key) DO UPDATE SET
 
 -- Insert default contact links
 INSERT INTO public.contact_links (platform, display_name, url, icon_emoji, is_active, display_order) VALUES
-('email', 'Email', 'support@dynamiccapital.com', '📧', true, 1),
+('email', 'Email', 'dynamiccapitalapp@gmail.com', '📧', true, 1),
 ('telegram', 'Telegram Support', '@DynamicCapital_Support', '💬', true, 2),
 ('website', 'Website', 'https://dynamiccapital.com', '🌐', true, 3)
 ON CONFLICT (platform, display_name) DO UPDATE SET

--- a/supabase/migrations/20250905121819_3a6b932d-6d8c-4f0f-b384-44f485feaabd.sql
+++ b/supabase/migrations/20250905121819_3a6b932d-6d8c-4f0f-b384-44f485feaabd.sql
@@ -42,7 +42,7 @@ Ready to continue your trading success? 🚀',
   'contact_message',
   '💬 Contact Dynamic Capital Support
 
-📧 Email: support@dynamiccapital.com
+📧 Email: dynamiccapitalapp@gmail.com
 💬 Telegram: @DynamicCapital_Support
 
 🕐 Support Hours: 24/7
@@ -58,7 +58,7 @@ How can we help you today?',
 
 -- Insert default contact links (without ON CONFLICT since we don't have unique constraints on these fields)
 INSERT INTO public.contact_links (platform, display_name, url, icon_emoji, is_active, display_order) VALUES
-('email', 'Email', 'support@dynamiccapital.com', '📧', true, 1),
+('email', 'Email', 'dynamiccapitalapp@gmail.com', '📧', true, 1),
 ('telegram', 'Telegram Support', '@DynamicCapital_Support', '💬', true, 2),
 ('website', 'Website', 'https://dynamiccapital.com', '🌐', true, 3);
 

--- a/supabase/migrations/20250905121916_543bec67-525b-4ed7-9988-1a0ffcc9ab2d.sql
+++ b/supabase/migrations/20250905121916_543bec67-525b-4ed7-9988-1a0ffcc9ab2d.sql
@@ -39,7 +39,7 @@ Ready to continue your trading success? 🚀', 'text', 'Auto-intro message for r
     INSERT INTO public.bot_content (content_key, content_value, content_type, description, is_active, created_by, last_modified_by) VALUES
     ('contact_message', '💬 Contact Dynamic Capital Support
 
-📧 Email: support@dynamiccapital.com
+📧 Email: dynamiccapitalapp@gmail.com
 💬 Telegram: @DynamicCapital_Support
 
 🕐 Support Hours: 24/7
@@ -51,7 +51,7 @@ How can we help you today?', 'text', 'Contact information message for /contact c
   -- Insert default contact links if they don't exist
   IF NOT EXISTS (SELECT 1 FROM public.contact_links WHERE platform = 'email' AND display_name = 'Email') THEN
     INSERT INTO public.contact_links (platform, display_name, url, icon_emoji, is_active, display_order) VALUES
-    ('email', 'Email', 'support@dynamiccapital.com', '📧', true, 1);
+    ('email', 'Email', 'dynamiccapitalapp@gmail.com', '📧', true, 1);
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM public.contact_links WHERE platform = 'telegram' AND display_name = 'Telegram Support') THEN

--- a/supabase/migrations/20250907114510_5a98c592-f3cc-4221-af5d-53cf3a3f8cfd.sql
+++ b/supabase/migrations/20250907114510_5a98c592-f3cc-4221-af5d-53cf3a3f8cfd.sql
@@ -3,6 +3,6 @@ INSERT INTO public.contact_links (platform, display_name, url, icon_emoji, displ
   ('Telegram', 'Customer Support', 'https://t.me/Dynamic_VIP_Support', '💬', 1, true),
   ('Telegram', 'VIP Channel', 'https://t.me/Dynamic_VIP_Channel', '⭐', 2, true),
   ('WhatsApp', 'WhatsApp Support', 'https://wa.me/1234567890', '📱', 3, true),
-  ('Email', 'Support Email', 'mailto:support@dynamiccapital.com', '📧', 4, true),
+  ('Email', 'Support Email', 'mailto:dynamiccapitalapp@gmail.com', '📧', 4, true),
   ('Website', 'Official Website', 'https://dynamiccapital.com', '🌐', 5, true)
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- replace the legacy support@dynamiccapital.com address with dynamiccapitalapp@gmail.com in Telegram bot content defaults and fallbacks
- update seeded contact link migrations to publish the new Gmail support mailbox

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d49fefe3e0832285d03e10d40c475f