### PR TITLE
Align dynamic UI config with branding metadata

### DIFF
--- a/apps/web/resources/dynamic-ui.config.ts
+++ b/apps/web/resources/dynamic-ui.config.ts
@@ -12,9 +12,13 @@ import {
   StyleConfig,
   SystemUIConfig,
 } from "@/resources/types";
+import { dynamicBranding } from "./dynamic-branding.config";
 import { home } from "./content";
 
-const baseURL: string = "https://dynamic.capital";
+const brandingMetadata = dynamicBranding.metadata;
+const brandingAssets = dynamicBranding.assets;
+
+const baseURL: string = brandingMetadata.primaryUrl;
 
 const routes: RoutesConfig = {
   "/": true,
@@ -186,11 +190,11 @@ const mailchimp: MailchimpConfig = {
 };
 
 const schema: SchemaConfig = {
-  logo: "/logo.png",
+  logo: brandingAssets.logo,
   type: "Organization",
-  name: "Dynamic Capital",
+  name: brandingMetadata.name,
   description: home.description,
-  email: "support@dynamic.capital",
+  email: brandingMetadata.supportEmail,
 };
 
 const sameAs: SameAsConfig = {


### PR DESCRIPTION
## Summary
- source the system UI base URL and schema fields from the dynamic branding metadata
- reuse branding asset paths for the schema logo to avoid hardcoded paths

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4a2ad968c8322964d8a3d87b948bd