### PR TITLE
Improve landing page responsiveness

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.module.scss
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.module.scss
@@ -1,0 +1,52 @@
+@use "./breakpoints.scss" as breakpoints;
+
+.page {
+  width: 100%;
+  padding-block: clamp(2.5rem, 6vw, 4.5rem);
+  padding-inline: clamp(1.25rem, 5vw, 3.5rem);
+  gap: clamp(3rem, 6vw, 4.25rem);
+}
+
+.section {
+  width: min(1100px, 100%);
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.sectionTight {
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.splitRow {
+  width: min(1100px, 100%);
+  margin-inline: auto;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+@media (max-width: breakpoints.$m) {
+  .page {
+    padding-inline: clamp(1rem, 4vw, 2.25rem);
+  }
+
+  .splitRow {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: breakpoints.$s) {
+  .page {
+    padding-inline: 1rem;
+    padding-block: clamp(2rem, 8vw, 3rem);
+  }
+
+  .section {
+    width: 100%;
+    gap: clamp(2rem, 6vw, 2.5rem);
+  }
+
+  .sectionTight {
+    gap: clamp(1.75rem, 6vw, 2.25rem);
+  }
+}

--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -15,10 +15,18 @@ import { MentorshipProgramsSection } from "@/components/magic-portfolio/home/Men
 import { PoolTradingSection } from "@/components/magic-portfolio/home/PoolTradingSection";
 import { VipPackagesSection } from "@/components/magic-portfolio/home/VipPackagesSection";
 import { about, baseURL, home, person, toAbsoluteUrl } from "@/resources";
+import { cn } from "@/utils";
+import styles from "./DynamicCapitalLandingPage.module.scss";
 
 export function DynamicCapitalLandingPage() {
   return (
-    <Column maxWidth="m" gap="xl" paddingY="12" horizontal="center">
+    <Column
+      as="main"
+      fillWidth
+      gap="xl"
+      horizontal="center"
+      className={styles.page}
+    >
       <Schema
         as="webPage"
         baseURL={baseURL}
@@ -32,85 +40,110 @@ export function DynamicCapitalLandingPage() {
           image: toAbsoluteUrl(baseURL, person.avatar),
         }}
       />
-      <HeroExperience />
+      <div className={styles.section}>
+        <HeroExperience />
+      </div>
       <RevealFx translateY="20" delay={0.6}>
-        <ValuePropositionSection />
+        <div className={styles.section}>
+          <ValuePropositionSection />
+        </div>
       </RevealFx>
       <RevealFx translateY="20" delay={0.64}>
-        <PerformanceInsightsSection />
+        <div className={styles.section}>
+          <PerformanceInsightsSection />
+        </div>
       </RevealFx>
-      <Row
-        fillWidth
-        gap="24"
-        wrap
-        s={{ direction: "column" }}
-        aria-label="Live market coverage"
-      >
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.68}>
-            <MarketWatchlist />
-          </RevealFx>
-        </Column>
-        <Column flex={1} minWidth={24} gap="16">
-          <Column gap="16">
-            <RevealFx translateY="20" delay={0.72}>
-              <FxMarketSnapshotSection />
-            </RevealFx>
-            <RevealFx translateY="20" delay={0.76}>
-              <EconomicCalendarSection />
+      <div className={cn(styles.section, styles.sectionTight)}>
+        <Row
+          className={styles.splitRow}
+          fillWidth
+          gap="24"
+          wrap
+          s={{ direction: "column" }}
+          aria-label="Live market coverage"
+        >
+          <Column flex={1} minWidth={24} gap="16">
+            <RevealFx translateY="20" delay={0.68}>
+              <MarketWatchlist />
             </RevealFx>
           </Column>
-        </Column>
-      </Row>
+          <Column flex={1} minWidth={24} gap="16">
+            <Column gap="16">
+              <RevealFx translateY="20" delay={0.72}>
+                <FxMarketSnapshotSection />
+              </RevealFx>
+              <RevealFx translateY="20" delay={0.76}>
+                <EconomicCalendarSection />
+              </RevealFx>
+            </Column>
+          </Column>
+        </Row>
+      </div>
       <RevealFx translateY="20" delay={0.76}>
-        <CommodityStrengthSection />
+        <div className={styles.section}>
+          <CommodityStrengthSection />
+        </div>
       </RevealFx>
-      <Row
-        fillWidth
-        gap="24"
-        wrap
-        s={{ direction: "column" }}
-        aria-label="Trading insights"
-      >
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.78}>
-            <FundamentalAnalysisSection />
-          </RevealFx>
-        </Column>
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.82}>
-            <PoolTradingSection />
-          </RevealFx>
-        </Column>
-      </Row>
+      <div className={cn(styles.section, styles.sectionTight)}>
+        <Row
+          className={styles.splitRow}
+          fillWidth
+          gap="24"
+          wrap
+          s={{ direction: "column" }}
+          aria-label="Trading insights"
+        >
+          <Column flex={1} minWidth={24} gap="16">
+            <RevealFx translateY="20" delay={0.78}>
+              <FundamentalAnalysisSection />
+            </RevealFx>
+          </Column>
+          <Column flex={1} minWidth={24} gap="16">
+            <RevealFx translateY="20" delay={0.82}>
+              <PoolTradingSection />
+            </RevealFx>
+          </Column>
+        </Row>
+      </div>
       <RevealFx translateY="20" delay={0.86}>
-        <MentorshipProgramsSection />
+        <div className={styles.section}>
+          <MentorshipProgramsSection />
+        </div>
       </RevealFx>
-      <Row
-        fillWidth
-        gap="24"
-        wrap
-        s={{ direction: "column" }}
-        aria-label="Brand trust"
-      >
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.9}>
-            <ComplianceCertificates />
-          </RevealFx>
-        </Column>
-        <Column flex={1} minWidth={24} gap="16">
-          <RevealFx translateY="20" delay={0.94}>
-            <AboutShowcase />
-          </RevealFx>
-        </Column>
-      </Row>
+      <div className={cn(styles.section, styles.sectionTight)}>
+        <Row
+          className={styles.splitRow}
+          fillWidth
+          gap="24"
+          wrap
+          s={{ direction: "column" }}
+          aria-label="Brand trust"
+        >
+          <Column flex={1} minWidth={24} gap="16">
+            <RevealFx translateY="20" delay={0.9}>
+              <ComplianceCertificates />
+            </RevealFx>
+          </Column>
+          <Column flex={1} minWidth={24} gap="16">
+            <RevealFx translateY="20" delay={0.94}>
+              <AboutShowcase />
+            </RevealFx>
+          </Column>
+        </Row>
+      </div>
       <RevealFx translateY="20" delay={0.98}>
-        <VipPackagesSection />
+        <div className={styles.section}>
+          <VipPackagesSection />
+        </div>
       </RevealFx>
       <RevealFx translateY="20" delay={1.02}>
-        <CheckoutCallout />
+        <div className={styles.section}>
+          <CheckoutCallout />
+        </div>
       </RevealFx>
-      <Mailchimp />
+      <div className={styles.section}>
+        <Mailchimp />
+      </div>
     </Column>
   );
 }

--- a/apps/web/components/magic-portfolio/home/HeroExperience.module.scss
+++ b/apps/web/components/magic-portfolio/home/HeroExperience.module.scss
@@ -1,0 +1,185 @@
+@use "../breakpoints.scss" as breakpoints;
+
+.hero {
+  width: 100%;
+  gap: clamp(2.5rem, 6vw, 3.5rem);
+}
+
+.heroIntro {
+  width: min(800px, 100%);
+  text-align: center;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.actionRow {
+  width: 100%;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: clamp(0.75rem, 2vw, 1rem);
+}
+
+.ctaButton {
+  min-width: clamp(12rem, 40vw, 16rem);
+}
+
+.socialProof {
+  width: 100%;
+  justify-content: center;
+  gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.heroLayout {
+  width: 100%;
+  gap: clamp(2rem, 5vw, 2.75rem);
+}
+
+.stepsGrid {
+  display: grid;
+  width: 100%;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.stepButton {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: clamp(1.25rem, 3vw, 1.5rem) clamp(1.5rem, 3.5vw, 1.75rem);
+  border-radius: 24px;
+  border: 1px solid transparent;
+  background: hsl(var(--dc-brand-dark) / 0.35);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  backdrop-filter: blur(14px);
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.stepButton:focus-visible {
+  outline: 2px solid hsl(var(--dc-secondary));
+  outline-offset: 2px;
+}
+
+.stepButtonActive {
+  box-shadow: 0 22px 60px hsl(var(--dc-brand-dark) / 0.45);
+}
+
+.stepDetail {
+  width: 100%;
+  border-radius: 24px;
+  padding: clamp(1.5rem, 3vw, 1.75rem);
+  border: 1px solid hsl(var(--dc-secondary) / 0.22);
+  background: hsl(var(--dc-brand-dark) / 0.4);
+  box-shadow: 0 18px 45px hsl(var(--dc-brand-dark) / 0.35);
+  backdrop-filter: blur(16px);
+}
+
+.previewSurface {
+  position: relative;
+  width: 100%;
+  border-radius: 32px;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  overflow: hidden;
+  perspective: 1400px;
+}
+
+.previewGlow {
+  position: absolute;
+  inset: 12%;
+  border-radius: 999px;
+  pointer-events: none;
+  filter: blur(60px);
+}
+
+.previewBorder {
+  position: absolute;
+  inset: 0;
+  border-radius: 32px;
+  pointer-events: none;
+}
+
+.previewCardStack {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.previewCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-radius: 28px;
+  padding: clamp(1.5rem, 3.5vw, 2rem);
+  color: white;
+  box-shadow: 0 30px 80px hsl(var(--dc-brand-dark) / 0.35);
+  transform-style: preserve-3d;
+}
+
+.previewCard + .previewCard {
+  margin-top: clamp(-3.5rem, -6vw, -2.75rem);
+}
+
+@media (max-width: breakpoints.$l) {
+  .heroIntro {
+    width: min(900px, 100%);
+  }
+}
+
+@media (max-width: breakpoints.$m) {
+  .heroLayout {
+    flex-direction: column;
+  }
+
+  .stepsGrid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .previewSurface,
+  .previewBorder {
+    border-radius: 28px;
+  }
+}
+
+@media (max-width: breakpoints.$s) {
+  .actionRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ctaButton {
+    width: 100%;
+  }
+
+  .socialProof {
+    justify-content: stretch;
+  }
+
+  .stepsGrid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .stepDetail {
+    border-radius: 20px;
+  }
+
+  .previewSurface {
+    padding: 1.5rem;
+    border-radius: 24px;
+  }
+
+  .previewBorder {
+    border-radius: 24px;
+  }
+
+  .previewCard {
+    padding: 1.35rem;
+    border-radius: 22px;
+  }
+
+  .previewCard + .previewCard {
+    margin-top: -2.5rem;
+  }
+}

--- a/apps/web/components/magic-portfolio/home/HeroExperience.tsx
+++ b/apps/web/components/magic-portfolio/home/HeroExperience.tsx
@@ -19,6 +19,8 @@ import {
   Text,
 } from "@once-ui-system/core";
 import { home } from "@/resources";
+import { cn } from "@/utils";
+import styles from "./HeroExperience.module.scss";
 
 const ONBOARDING_STEPS = [
   {
@@ -213,8 +215,14 @@ export function HeroExperience() {
       gap="32"
       horizontal="center"
       align="center"
+      className={styles.hero}
     >
-      <Column maxWidth="m" gap="24" align="center">
+      <Column
+        maxWidth="m"
+        gap="24"
+        align="center"
+        className={styles.heroIntro}
+      >
         {home.featured.display
           ? (
             <motion.div
@@ -289,7 +297,11 @@ export function HeroExperience() {
             damping: 24,
           }}
         >
-          <Row gap="12" s={{ direction: "column" }}>
+          <Row
+            gap="12"
+            s={{ direction: "column" }}
+            className={styles.actionRow}
+          >
             <Button
               id="begin"
               data-border="rounded"
@@ -298,6 +310,7 @@ export function HeroExperience() {
               size="l"
               weight="strong"
               prefixIcon="sparkles"
+              className={styles.ctaButton}
             >
               Create my trading plan
             </Button>
@@ -308,6 +321,7 @@ export function HeroExperience() {
               size="l"
               weight="default"
               arrowIcon
+              className={styles.ctaButton}
             >
               Explore VIP options
             </Button>
@@ -341,7 +355,12 @@ export function HeroExperience() {
             damping: 26,
           }}
         >
-          <Row gap="16" wrap horizontal="center">
+          <Row
+            gap="16"
+            wrap
+            horizontal="center"
+            className={styles.socialProof}
+          >
             {SOCIAL_PROOF.map((stat) => (
               <Column
                 key={stat.label}
@@ -374,6 +393,7 @@ export function HeroExperience() {
         align="start"
         fillWidth
         maxWidth="xl"
+        className={styles.heroLayout}
       >
         <Column flex={3} gap="20">
           <motion.div
@@ -412,12 +432,7 @@ export function HeroExperience() {
               stiffness: 180,
               damping: 24,
             }}
-            style={{
-              display: "grid",
-              gap: "12px",
-              width: "100%",
-              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-            }}
+            className={styles.stepsGrid}
           >
             {ONBOARDING_STEPS.map((step, index) => {
               const isActive = activeStepIndex === index;
@@ -430,13 +445,11 @@ export function HeroExperience() {
                   aria-pressed={isActive}
                   whileHover={{ y: -4, scale: 1.01 }}
                   whileTap={{ scale: 0.98 }}
+                  className={cn(
+                    styles.stepButton,
+                    isActive && styles.stepButtonActive,
+                  )}
                   style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "flex-start",
-                    gap: "10px",
-                    padding: "20px 24px",
-                    borderRadius: "24px",
                     border: `1px solid ${
                       isActive
                         ? brandColor("--dc-secondary", 0.45)
@@ -450,12 +463,6 @@ export function HeroExperience() {
                     boxShadow: isActive
                       ? `0 22px 60px ${brandColor("--dc-brand-dark", 0.45)}`
                       : `0 14px 40px ${brandColor("--dc-brand-dark", 0.28)}`,
-                    color: "inherit",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    backdropFilter: "blur(14px)",
-                    transition:
-                      "border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease",
                   }}
                 >
                   <Row gap="12" vertical="center">
@@ -487,14 +494,11 @@ export function HeroExperience() {
             initial={{ opacity: 0, y: 18 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ type: "spring", stiffness: 190, damping: 26 }}
+            className={styles.stepDetail}
             style={{
-              width: "100%",
-              borderRadius: "24px",
-              padding: "24px",
               border: `1px solid ${brandColor("--dc-secondary", 0.22)}`,
               background: brandColor("--dc-brand-dark", 0.4),
               boxShadow: `0 18px 45px ${brandColor("--dc-brand-dark", 0.35)}`,
-              backdropFilter: "blur(16px)",
             }}
           >
             <Text variant="body-default-m" onBackground="neutral-weak">
@@ -538,16 +542,11 @@ export function HeroExperience() {
             <motion.div
               onPointerMove={handlePointerMove}
               onPointerLeave={resetPointer}
+              className={styles.previewSurface}
               style={{
-                position: "relative",
-                width: "100%",
-                padding: "32px",
-                borderRadius: "32px",
                 background: `radial-gradient(circle at top, ${
                   brandColor("--dc-secondary", 0.25)
                 }, transparent 65%)`,
-                overflow: "hidden",
-                perspective: 1400,
               }}
             >
               <motion.div
@@ -557,69 +556,59 @@ export function HeroExperience() {
                   duration: 6,
                   ease: "easeInOut",
                 }}
+                className={styles.previewGlow}
                 style={{
-                  position: "absolute",
-                  inset: "12%",
-                  borderRadius: "999px",
                   background: `radial-gradient(circle, ${
                     brandColor("--dc-brand", 0.5)
                   }, transparent 70%)`,
-                  filter: "blur(60px)",
-                  pointerEvents: "none",
                 }}
               />
               <motion.div
+                className={styles.previewBorder}
                 style={{
-                  position: "absolute",
-                  inset: 0,
-                  borderRadius: "32px",
                   border: `1px solid ${brandColor("--dc-secondary", 0.18)}`,
-                  pointerEvents: "none",
                   opacity: floatOpacity,
                 }}
               />
 
-              {orderedCards.map((card, index) => (
-                <motion.div
-                  key={card.title}
-                  style={{
-                    position: "relative",
-                    zIndex: cardTransforms[index]?.zIndex ?? 1,
-                    borderRadius: "28px",
-                    padding: "24px",
-                    background: card.gradient,
-                    color: "white",
-                    boxShadow: `0 30px 80px ${
-                      brandColor("--dc-brand-dark", 0.35)
-                    }`,
-                    transformStyle: "preserve-3d",
-                    ...cardTransforms[index]?.style,
-                    marginTop: index === 0 ? 0 : -80,
-                  }}
-                >
-                  <Column gap="12">
-                    <Text variant="label-default-m" onBackground="brand-weak">
-                      {card.subtitle}
-                    </Text>
-                    <Heading variant="display-strong-xs" as="h3">
-                      {card.title}
-                    </Heading>
-                    <Row gap="12" vertical="center">
-                      <Badge
-                        background="neutral-alpha-weak"
-                        onBackground="neutral-strong"
-                        paddingX="12"
-                        paddingY="2"
-                        textVariant="label-default-s"
-                      >
-                        {card.metricLabel}
-                      </Badge>
-                      <Text variant="heading-strong-m">{card.metricValue}</Text>
-                    </Row>
-                    <Text variant="body-default-m">{card.description}</Text>
-                  </Column>
-                </motion.div>
-              ))}
+              <div className={styles.previewCardStack}>
+                {orderedCards.map((card, index) => (
+                  <motion.div
+                    key={card.title}
+                    className={styles.previewCard}
+                    style={{
+                      zIndex: cardTransforms[index]?.zIndex ?? 1,
+                      background: card.gradient,
+                      ...cardTransforms[index]?.style,
+                      marginTop: index === 0 ? 0 : undefined,
+                    }}
+                  >
+                    <Column gap="12">
+                      <Text variant="label-default-m" onBackground="brand-weak">
+                        {card.subtitle}
+                      </Text>
+                      <Heading variant="display-strong-xs" as="h3">
+                        {card.title}
+                      </Heading>
+                      <Row gap="12" vertical="center">
+                        <Badge
+                          background="neutral-alpha-weak"
+                          onBackground="neutral-strong"
+                          paddingX="12"
+                          paddingY="2"
+                          textVariant="label-default-s"
+                        >
+                          {card.metricLabel}
+                        </Badge>
+                        <Text variant="heading-strong-m">
+                          {card.metricValue}
+                        </Text>
+                      </Row>
+                      <Text variant="body-default-m">{card.description}</Text>
+                    </Column>
+                  </motion.div>
+                ))}
+              </div>
             </motion.div>
           </motion.div>
         </Column>

--- a/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
+++ b/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
@@ -29,7 +29,8 @@ const PROGRAMS: MentorshipProgram[] = [
     id: "performance-sprint",
     name: "Performance Sprint",
     cadence: "4-week intensive",
-    description: "Weekly accountability designed for traders who need sharper execution and risk discipline.",
+    description:
+      "Weekly accountability designed for traders who need sharper execution and risk discipline.",
     focus:
       "Pair live desk signals with one-on-one reviews so you ship more trades that respect the playbook you wrote.",
     features: [
@@ -45,7 +46,8 @@ const PROGRAMS: MentorshipProgram[] = [
     id: "founders-circle",
     name: "Founders Circle",
     cadence: "12-week residency",
-    description: "For fund leads and trading teams scaling managed capital with institutional oversight.",
+    description:
+      "For fund leads and trading teams scaling managed capital with institutional oversight.",
     focus:
       "Blend mentorship, automation, and reporting so every operator on your desk executes against the same guardrails.",
     features: [
@@ -70,11 +72,15 @@ export function MentorshipProgramsSection() {
       padding="xl"
       gap="32"
       shadow="l"
+      style={{ scrollMarginTop: "96px" }}
     >
       <Column gap="12" maxWidth={32}>
-        <Heading variant="display-strong-xs">Mentorship built around execution</Heading>
+        <Heading variant="display-strong-xs">
+          Mentorship built around execution
+        </Heading>
         <Text variant="body-default-l" onBackground="neutral-weak">
-          Cohorts pair live trading signals with accountability cadences so you build the habits that drive performance.
+          Cohorts pair live trading signals with accountability cadences so you
+          build the habits that drive performance.
         </Text>
       </Column>
       <Column gap="24">
@@ -87,7 +93,12 @@ export function MentorshipProgramsSection() {
               padding="l"
               gap="20"
             >
-              <Row horizontal="between" vertical="center" gap="12" s={{ direction: "column", align: "start" }}>
+              <Row
+                horizontal="between"
+                vertical="center"
+                gap="12"
+                s={{ direction: "column", align: "start" }}
+              >
                 <Column gap="8">
                   <Heading variant="heading-strong-m">{program.name}</Heading>
                   <Text variant="body-default-m" onBackground="neutral-weak">
@@ -119,20 +130,24 @@ export function MentorshipProgramsSection() {
                 >
                   {program.primaryCtaLabel}
                 </Button>
-                {about.calendar.display && about.calendar.link ? (
-                  <Button
-                    size="m"
-                    variant="secondary"
-                    data-border="rounded"
-                    prefixIcon="calendar"
-                    href={about.calendar.link}
-                  >
-                    {program.secondaryCtaLabel}
-                  </Button>
-                ) : null}
+                {about.calendar.display && about.calendar.link
+                  ? (
+                    <Button
+                      size="m"
+                      variant="secondary"
+                      data-border="rounded"
+                      prefixIcon="calendar"
+                      href={about.calendar.link}
+                    >
+                      {program.secondaryCtaLabel}
+                    </Button>
+                  )
+                  : null}
               </Row>
             </Column>
-            {index < PROGRAMS.length - 1 ? <Line background="neutral-alpha-weak" /> : null}
+            {index < PROGRAMS.length - 1
+              ? <Line background="neutral-alpha-weak" />
+              : null}
           </Fragment>
         ))}
       </Column>

--- a/apps/web/components/magic-portfolio/home/VipPackagesSection.tsx
+++ b/apps/web/components/magic-portfolio/home/VipPackagesSection.tsx
@@ -61,158 +61,189 @@ export function VipPackagesSection() {
       padding="xl"
       gap={SECTION_GAP}
       shadow="l"
+      style={{ scrollMarginTop: "96px" }}
     >
       <Column gap="12" maxWidth={32}>
         <Heading variant="display-strong-xs">VIP membership packages</Heading>
         <Text variant="body-default-l" onBackground="neutral-weak">
-          Choose the desk access that matches your trading cadence. Every package includes live signals, trade accountability, and automation templates.
+          Choose the desk access that matches your trading cadence. Every
+          package includes live signals, trade accountability, and automation
+          templates.
         </Text>
-        {error ? (
-          <Column gap={ERROR_STATE_GAP}>
-            <Text variant="body-default-s" onBackground="brand-weak">
-              {error}
+        {error
+          ? (
+            <Column gap={ERROR_STATE_GAP}>
+              <Text variant="body-default-s" onBackground="brand-weak">
+                {error}
+              </Text>
+              <Row gap={ERROR_STATE_GAP}>
+                <Button
+                  size="s"
+                  variant="secondary"
+                  data-border="rounded"
+                  onClick={() => refresh(true)}
+                >
+                  Retry loading plans
+                </Button>
+              </Row>
+            </Column>
+          )
+          : null}
+      </Column>
+      {loading
+        ? (
+          <Row fillWidth horizontal="center" paddingY="32" gap="16">
+            <Spinner />
+            <Text variant="body-default-m">Loading plans…</Text>
+          </Row>
+        )
+        : !hasData
+        ? (
+          <Column gap="12" paddingY="24">
+            <Text variant="body-default-m" onBackground="neutral-weak">
+              VIP packages will appear once they are published in Supabase.
+              Check back soon for live pricing.
             </Text>
-            <Row gap={ERROR_STATE_GAP}>
+            <Row gap="12" s={{ direction: "column" }}>
               <Button
-                size="s"
+                size="m"
                 variant="secondary"
                 data-border="rounded"
-                onClick={() => refresh(true)}
+                prefixIcon="rocket"
+                href="/checkout"
               >
-                Retry loading plans
+                Open secure checkout
+              </Button>
+              <Button
+                size="m"
+                variant="secondary"
+                data-border="rounded"
+                arrowIcon
+                href="#mentorship-programs"
+              >
+                Compare mentorship support
               </Button>
             </Row>
           </Column>
-        ) : null}
-      </Column>
-      {loading ? (
-        <Row fillWidth horizontal="center" paddingY="32" gap="16">
-          <Spinner />
-          <Text variant="body-default-m">Loading plans…</Text>
-        </Row>
-      ) : !hasData ? (
-        <Column gap="12" paddingY="24">
-          <Text variant="body-default-m" onBackground="neutral-weak">
-            VIP packages will appear once they are published in Supabase. Check back soon for live pricing.
-          </Text>
-          <Row gap="12" s={{ direction: "column" }}>
-            <Button
-              size="m"
-              variant="secondary"
-              data-border="rounded"
-              prefixIcon="rocket"
-              href="/checkout"
-            >
-              Open secure checkout
-            </Button>
-            <Button
-              size="m"
-              variant="secondary"
-              data-border="rounded"
-              arrowIcon
-              href="#mentorship-programs"
-            >
-              Compare mentorship support
-            </Button>
-          </Row>
-        </Column>
-      ) : (
-        <Column gap={SECTION_CONTENT_GAP}>
-          <Row gap="16" wrap>
-            {plans.map((plan) => (
-              <Column
-                key={plan.id}
-                flex={1}
-                minWidth={18}
-                maxWidth={24}
-                background="page"
-                border={plan.is_lifetime ? "brand-alpha-medium" : "neutral-alpha-weak"}
-                radius="l"
-                padding="l"
-                gap={PLAN_CARD_GAP}
-                shadow={plan.is_lifetime ? "l" : undefined}
-              >
-                <Column gap="12">
-                  <Row horizontal="between" vertical="center">
-                    <Text variant="heading-strong-m">{plan.name}</Text>
-                    <Tag size="s" prefixIcon={plan.is_lifetime ? "infinity" : "calendar"}>
-                      {formatDuration(plan)}
-                    </Tag>
-                  </Row>
-                  <Heading variant="display-strong-s">
-                    {formatPrice(plan.price, plan.currency)}
-                    {!plan.is_lifetime ? <Text as="span" variant="body-default-m" onBackground="neutral-weak">/period</Text> : null}
-                  </Heading>
-                  <Text variant="body-default-m" onBackground="neutral-weak">
-                    {plan.is_lifetime
-                      ? "Lifetime access to every desk upgrade and live mentor cohort."
-                      : "Recurring access with automation updates and weekly accountability."
-                    }
-                  </Text>
-                </Column>
-                {plan.features?.length ? (
-                  <Column as="ul" gap="8">
-                    {plan.features.slice(0, 4).map((feature, index) => (
-                      <Row key={index} gap="8" vertical="center">
-                        <Icon name="check" onBackground="brand-medium" />
-                        <Text as="li" variant="body-default-m">
-                          {feature}
-                        </Text>
-                      </Row>
-                    ))}
-                    {plan.features.length > 4 ? (
-                      <Text variant="body-default-s" onBackground="neutral-weak">
-                        +{plan.features.length - 4} more desk utilities
-                      </Text>
-                    ) : null}
+        )
+        : (
+          <Column gap={SECTION_CONTENT_GAP}>
+            <Row gap="16" wrap>
+              {plans.map((plan) => (
+                <Column
+                  key={plan.id}
+                  flex={1}
+                  minWidth={18}
+                  maxWidth={24}
+                  background="page"
+                  border={plan.is_lifetime
+                    ? "brand-alpha-medium"
+                    : "neutral-alpha-weak"}
+                  radius="l"
+                  padding="l"
+                  gap={PLAN_CARD_GAP}
+                  shadow={plan.is_lifetime ? "l" : undefined}
+                >
+                  <Column gap="12">
+                    <Row horizontal="between" vertical="center">
+                      <Text variant="heading-strong-m">{plan.name}</Text>
+                      <Tag
+                        size="s"
+                        prefixIcon={plan.is_lifetime ? "infinity" : "calendar"}
+                      >
+                        {formatDuration(plan)}
+                      </Tag>
+                    </Row>
+                    <Heading variant="display-strong-s">
+                      {formatPrice(plan.price, plan.currency)}
+                      {!plan.is_lifetime
+                        ? (
+                          <Text
+                            as="span"
+                            variant="body-default-m"
+                            onBackground="neutral-weak"
+                          >
+                            /period
+                          </Text>
+                        )
+                        : null}
+                    </Heading>
+                    <Text variant="body-default-m" onBackground="neutral-weak">
+                      {plan.is_lifetime
+                        ? "Lifetime access to every desk upgrade and live mentor cohort."
+                        : "Recurring access with automation updates and weekly accountability."}
+                    </Text>
                   </Column>
-                ) : null}
-                <Row gap="12" s={{ direction: "column" }}>
-                  <Button
-                    size="m"
-                    variant="secondary"
-                    data-border="rounded"
-                    onClick={() => handleCheckout(plan.id)}
-                    prefixIcon="sparkles"
-                  >
-                    Continue to checkout
-                  </Button>
-                  <Button
-                    size="m"
-                    variant="secondary"
-                    data-border="rounded"
-                    href={`/checkout?plan=${encodeURIComponent(plan.id)}`}
-                    arrowIcon
-                  >
-                    Preview payment options
-                  </Button>
-                </Row>
-              </Column>
-            ))}
-          </Row>
-          <Line background="neutral-alpha-weak" />
-          <Row gap="16" s={{ direction: "column" }}>
-            <Button
-              size="m"
-              variant="secondary"
-              data-border="rounded"
-              prefixIcon="rocket"
-              href="/checkout"
-            >
-              Open secure checkout
-            </Button>
-            <Button
-              size="m"
-              variant="secondary"
-              data-border="rounded"
-              arrowIcon
-              href="#mentorship-programs"
-            >
-              Compare mentorship support
-            </Button>
-          </Row>
-        </Column>
-      )}
+                  {plan.features?.length
+                    ? (
+                      <Column as="ul" gap="8">
+                        {plan.features.slice(0, 4).map((feature, index) => (
+                          <Row key={index} gap="8" vertical="center">
+                            <Icon name="check" onBackground="brand-medium" />
+                            <Text as="li" variant="body-default-m">
+                              {feature}
+                            </Text>
+                          </Row>
+                        ))}
+                        {plan.features.length > 4
+                          ? (
+                            <Text
+                              variant="body-default-s"
+                              onBackground="neutral-weak"
+                            >
+                              +{plan.features.length - 4} more desk utilities
+                            </Text>
+                          )
+                          : null}
+                      </Column>
+                    )
+                    : null}
+                  <Row gap="12" s={{ direction: "column" }}>
+                    <Button
+                      size="m"
+                      variant="secondary"
+                      data-border="rounded"
+                      onClick={() => handleCheckout(plan.id)}
+                      prefixIcon="sparkles"
+                    >
+                      Continue to checkout
+                    </Button>
+                    <Button
+                      size="m"
+                      variant="secondary"
+                      data-border="rounded"
+                      href={`/checkout?plan=${encodeURIComponent(plan.id)}`}
+                      arrowIcon
+                    >
+                      Preview payment options
+                    </Button>
+                  </Row>
+                </Column>
+              ))}
+            </Row>
+            <Line background="neutral-alpha-weak" />
+            <Row gap="16" s={{ direction: "column" }}>
+              <Button
+                size="m"
+                variant="secondary"
+                data-border="rounded"
+                prefixIcon="rocket"
+                href="/checkout"
+              >
+                Open secure checkout
+              </Button>
+              <Button
+                size="m"
+                variant="secondary"
+                data-border="rounded"
+                arrowIcon
+                href="#mentorship-programs"
+              >
+                Compare mentorship support
+              </Button>
+            </Row>
+          </Column>
+        )}
     </Column>
   );
 }


### PR DESCRIPTION
## Summary
- restructure the landing page shell with a reusable responsive container and tightened split layouts for tablet and desktop widths
- restyle the hero experience with a dedicated CSS module so buttons, stats, and the interactive card stack adapt cleanly from mobile through desktop
- add scroll offsets for mentorship and VIP sections so anchored navigation lands correctly on smaller screens

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4a1b1f66c83229c8e78476398f271