### PR TITLE
Remove hardcoded Supabase project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,16 +377,16 @@ Before making changes, verify these connections work:
 
 ```bash
 # 1. Bot webhook responds
-curl -X POST https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-bot \
+curl -X POST https://your-project-ref.functions.supabase.co/telegram-bot \
   -H "content-type: application/json" \
   -H "X-Telegram-Bot-Api-Secret-Token: SECRET" \
   -d '{"test":"ping"}'
 
 # 2. Mini App loads
-curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
+curl -s https://your-project-ref.functions.supabase.co/miniapp/
 
 # 3. Auth endpoint works
-curl -X POST https://qeejuomcapbdlhnjqjcc.functions.supabase.co/verify-initdata \
+curl -X POST https://your-project-ref.functions.supabase.co/verify-initdata \
   -H "content-type: application/json" \
   -d '{"initData":"VALID_INIT_DATA"}'
 ```
@@ -738,9 +738,9 @@ docker run --rm -p 8080:8080 go-service
 ## Smoke checks
 
 ```bash
-curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/version
-curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-bot/version
-curl -s -X POST https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-bot \
+curl -s https://your-project-ref.functions.supabase.co/miniapp/version
+curl -s https://your-project-ref.functions.supabase.co/telegram-bot/version
+curl -s -X POST https://your-project-ref.functions.supabase.co/telegram-bot \
   -H 'x-telegram-bot-api-secret-token: <TELEGRAM_WEBHOOK_SECRET>' \
   -H 'content-type: application/json' -d '{"test":"ping"}'
 ```

--- a/apps/web/app/blog/posts/automation-bridge.mdx
+++ b/apps/web/app/blog/posts/automation-bridge.mdx
@@ -3,7 +3,7 @@ title: "The automation bridge that connects our signals to execution"
 summary: "A technical walkthrough of the event-driven infrastructure that turns trading calls into orders across exchanges."
 publishedAt: "2024-12-08"
 tag: "Engineering"
-image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-02.jpg"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-02.jpg"
 ---
 
 Signals are only valuable when they become fills. Our automation bridge translates discretionary calls from analysts into programmatic orders in under two seconds.

--- a/apps/web/app/blog/posts/commodities-market-snapshot-2025-09-25.mdx
+++ b/apps/web/app/blog/posts/commodities-market-snapshot-2025-09-25.mdx
@@ -3,7 +3,7 @@ title: "Commodities market snapshot – 25 September 2025"
 summary: "Quick read on where global commodities are trending, which contracts are breaking out, and where volatility is clustering this morning."
 publishedAt: "2025-09-25"
 tag: "Markets"
-image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-03.jpg"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-03.jpg"
 ---
 
 We opened the European morning with grains and precious metals inching higher while natural gas softened. Below is the desk's dashboard as of **06:28 GMT+5**.

--- a/apps/web/app/blog/posts/macro-cues-we-track.mdx
+++ b/apps/web/app/blog/posts/macro-cues-we-track.mdx
@@ -3,7 +3,7 @@ title: "The macro cues we track before issuing a high-conviction signal"
 summary: "Our pre-trade checklist blends discretionary reads with quantitative confirmation across FX, crypto, and commodities."
 publishedAt: "2024-11-14"
 tag: "Macro"
-image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/alpha-lab/cover-02.jpg"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/alpha-lab/cover-02.jpg"
 ---
 
 Before any analyst tags a trade as high conviction, they must walk through a shared macro checklist. It keeps our desks aligned even when opinions differ.

--- a/apps/web/app/blog/posts/mentorship-sprints.mdx
+++ b/apps/web/app/blog/posts/mentorship-sprints.mdx
@@ -3,7 +3,7 @@ title: "Designing mentorship sprints that compound"
 summary: "A four-week framework mentors use to transform ad-hoc coaching into measurable trading improvements."
 publishedAt: "2024-10-03"
 tag: "Mentorship"
-image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-01.jpg"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-01.jpg"
 ---
 
 Mentorship is often treated as inspiration. We treat it like product design. Every sprint is structured so members leave with new behaviours, not just notes.

--- a/apps/web/app/blog/posts/risk-review-rituals.mdx
+++ b/apps/web/app/blog/posts/risk-review-rituals.mdx
@@ -3,7 +3,7 @@ title: "Risk review rituals that keep our pools disciplined"
 summary: "The weekly cadence we run with members to surface drift, emotional leaks, and capital allocation issues before they become expensive."
 publishedAt: "2025-02-02"
 tag: "Risk"
-image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-01.jpg"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-01.jpg"
 ---
 
 Discipline is the differentiator between the traders who scale and those who churn. We run three structured reviews every week to keep members aligned with their plan.

--- a/apps/web/app/blog/posts/vip-desk-onboarding.mdx
+++ b/apps/web/app/blog/posts/vip-desk-onboarding.mdx
@@ -3,7 +3,7 @@ title: "How we onboard VIP members in 72 hours"
 summary: "A behind-the-scenes look at the interviews, account linking, and first-week rituals every Dynamic Capital member experiences."
 publishedAt: "2025-01-22"
 tag: "Operations"
-image: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-01.jpg"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-01.jpg"
 ---
 
 Our VIP desk has grown to more than 8,500 members, but the experience still feels bespoke. That is not by accident—it is engineered through three tight feedback loops that begin before a member pays their first invoice.

--- a/apps/web/app/work/projects/alpha-lab-automation.mdx
+++ b/apps/web/app/work/projects/alpha-lab-automation.mdx
@@ -3,12 +3,12 @@ title: "Alpha Lab Automation"
 summary: "Engineered the automation layer that routes discretionary trade ideas into exchange-ready orders with drawdown governors."
 publishedAt: "2024-09-07"
 images:
-  - "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/alpha-lab/cover-01.jpg"
-  - "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/alpha-lab/cover-02.jpg"
+  - "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/alpha-lab/cover-01.jpg"
+  - "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/alpha-lab/cover-02.jpg"
 team:
   - name: "Amina Diallo"
     role: "Quant Analyst"
-    avatar: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/avatar.jpg"
+    avatar: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/avatar.jpg"
     linkedIn: "https://www.linkedin.com/company/dynamic-capital-ai/"
 link: "https://dynamic.capital"
 ---

--- a/apps/web/app/work/projects/liquidity-signal-desk.mdx
+++ b/apps/web/app/work/projects/liquidity-signal-desk.mdx
@@ -3,12 +3,12 @@ title: "Liquidity Signal Desk"
 summary: "Built a 24/7 signal operation that scales institutional insights to 8,500+ members while preserving bespoke mentorship."
 publishedAt: "2024-12-18"
 images:
-  - "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-01.jpg"
-  - "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-02.jpg"
+  - "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-01.jpg"
+  - "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/liquidity-desk/cover-02.jpg"
 team:
   - name: "Noah Sterling"
     role: "Chief Investment Officer"
-    avatar: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/avatar.jpg"
+    avatar: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/avatar.jpg"
     linkedIn: "https://www.linkedin.com/company/dynamic-capital-ai/"
 link: "https://dynamic.capital"
 ---

--- a/apps/web/app/work/projects/mentor-suite.mdx
+++ b/apps/web/app/work/projects/mentor-suite.mdx
@@ -3,12 +3,12 @@ title: "Mentor Suite"
 summary: "Designed a mentorship platform that turns weekly coaching into measurable performance gains across member portfolios."
 publishedAt: "2025-01-05"
 images:
-  - "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-01.jpg"
-  - "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-02.jpg"
+  - "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-01.jpg"
+  - "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/mentor-suite/cover-02.jpg"
 team:
   - name: "Luis Romero"
     role: "Mentorship Lead"
-    avatar: "https://qeejuomcapbdlhnjqjcc.supabase.co/storage/v1/object/public/magic-portfolio/images/avatar.jpg"
+    avatar: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/avatar.jpg"
     linkedIn: "https://www.linkedin.com/company/dynamic-capital-ai/"
 link: "https://dynamic.capital"
 ---

--- a/apps/web/components/telegram/MiniAppPreview.tsx
+++ b/apps/web/components/telegram/MiniAppPreview.tsx
@@ -1,11 +1,28 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { CreditCard, Users, TrendingUp, Star, Smartphone, CheckCircle, Clock, AlertCircle, ExternalLink, Monitor } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle,
+  Clock,
+  CreditCard,
+  ExternalLink,
+  Monitor,
+  Smartphone,
+  Star,
+  TrendingUp,
+  Users,
+} from "lucide-react";
 
 interface MiniAppPreviewProps {
   className?: string;
@@ -15,7 +32,19 @@ export default function MiniAppPreview({ className }: MiniAppPreviewProps) {
   const [activeTab, setActiveTab] = useState("home");
   const [viewMode, setViewMode] = useState<"deployed" | "inline">("deployed");
 
-  const miniAppUrl = "https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/";
+  const envMiniAppUrl = process.env.NEXT_PUBLIC_MINI_APP_URL?.trim();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const derivedMiniAppUrl = supabaseUrl
+    ? `${
+      supabaseUrl.replace(/\/$/, "").replace(
+        ".supabase.co",
+        ".functions.supabase.co",
+      )
+    }/miniapp/`
+    : undefined;
+  const miniAppUrl = envMiniAppUrl && envMiniAppUrl.length > 0
+    ? envMiniAppUrl
+    : derivedMiniAppUrl ?? "https://stub.functions.supabase.co/miniapp/";
 
   const tabs = [
     { id: "home", label: "Home", icon: Star },
@@ -27,7 +56,11 @@ export default function MiniAppPreview({ className }: MiniAppPreviewProps) {
   return (
     <div className={`max-w-sm mx-auto ${className}`}>
       {/* View Mode Selector */}
-      <Tabs value={viewMode} onValueChange={(value) => setViewMode(value as "deployed" | "inline")} className="mb-4">
+      <Tabs
+        value={viewMode}
+        onValueChange={(value) => setViewMode(value as "deployed" | "inline")}
+        className="mb-4"
+      >
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="deployed" className="flex items-center gap-2">
             <ExternalLink className="h-4 w-4" />
@@ -56,70 +89,92 @@ export default function MiniAppPreview({ className }: MiniAppPreviewProps) {
         <div className="bg-gradient-telegram px-4 py-3 text-center">
           <div className="flex items-center justify-center gap-2 mb-2">
             <Smartphone className="h-5 w-5 text-primary-foreground" />
-            <h2 className="text-lg font-bold text-primary-foreground">Dynamic Capital</h2>
+            <h2 className="text-lg font-bold text-primary-foreground">
+              Dynamic Capital
+            </h2>
           </div>
           <p className="text-xs text-primary-foreground/80">Mini App Preview</p>
         </div>
 
         {/* Content Area */}
         <div className="min-h-[400px] bg-gradient-to-br from-muted/20 to-muted/40">
-          {viewMode === "deployed" ? (
-            <div className="p-4 h-[400px]">
-              <iframe
-                src={miniAppUrl}
-                className="w-full h-full rounded-lg border border-border"
-                title="Dynamic Capital Mini App"
-              />
-            </div>
-          ) : (
-            <div className="p-4 space-y-4">
-              <div className="text-center mb-6">
-                <h3 className="text-lg font-bold text-foreground mb-2">Dynamic Capital</h3>
-                <p className="text-xs text-muted-foreground">Mini App - Simple View</p>
+          {viewMode === "deployed"
+            ? (
+              <div className="p-4 h-[400px]">
+                <iframe
+                  src={miniAppUrl}
+                  className="w-full h-full rounded-lg border border-border"
+                  title="Dynamic Capital Mini App"
+                />
               </div>
-              
-              <Card className="bot-card p-3">
-                <div className="flex items-center gap-3 mb-3">
-                  <div className="w-8 h-8 bg-gradient-telegram rounded-full flex items-center justify-center">
-                    <Smartphone className="h-4 w-4 text-primary-foreground" />
-                  </div>
-                  <div>
-                    <h4 className="font-semibold text-sm">Welcome to VIP Bot</h4>
-                    <p className="text-xs text-muted-foreground">Interactive testing interface</p>
-                  </div>
+            )
+            : (
+              <div className="p-4 space-y-4">
+                <div className="text-center mb-6">
+                  <h3 className="text-lg font-bold text-foreground mb-2">
+                    Dynamic Capital
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Mini App - Simple View
+                  </p>
                 </div>
-                
-                <div className="space-y-2">
-                  <Button size="sm" className="w-full justify-start">
-                    <Star className="h-3 w-3 mr-2" />
-                    Check Version
-                  </Button>
-                  <Button size="sm" variant="outline" className="w-full justify-start">
-                    <CheckCircle className="h-3 w-3 mr-2" />
-                    Verify InitData
-                  </Button>
-                </div>
-              </Card>
 
-              <Card className="bot-card p-3 bg-gradient-telegram/10 border-telegram/30">
-                <h4 className="font-semibold text-sm mb-2 text-telegram">Status</h4>
-                <div className="text-xs space-y-1">
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">WebApp user:</span>
-                    <span>@demo_user</span>
+                <Card className="bot-card p-3">
+                  <div className="flex items-center gap-3 mb-3">
+                    <div className="w-8 h-8 bg-gradient-telegram rounded-full flex items-center justify-center">
+                      <Smartphone className="h-4 w-4 text-primary-foreground" />
+                    </div>
+                    <div>
+                      <h4 className="font-semibold text-sm">
+                        Welcome to VIP Bot
+                      </h4>
+                      <p className="text-xs text-muted-foreground">
+                        Interactive testing interface
+                      </p>
+                    </div>
                   </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Theme:</span>
-                    <span>light</span>
+
+                  <div className="space-y-2">
+                    <Button size="sm" className="w-full justify-start">
+                      <Star className="h-3 w-3 mr-2" />
+                      Check Version
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="w-full justify-start"
+                    >
+                      <CheckCircle className="h-3 w-3 mr-2" />
+                      Verify InitData
+                    </Button>
                   </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Status:</span>
-                    <Badge variant="outline" className="text-xs h-5">Connected</Badge>
+                </Card>
+
+                <Card className="bot-card p-3 bg-gradient-telegram/10 border-telegram/30">
+                  <h4 className="font-semibold text-sm mb-2 text-telegram">
+                    Status
+                  </h4>
+                  <div className="text-xs space-y-1">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">
+                        WebApp user:
+                      </span>
+                      <span>@demo_user</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Theme:</span>
+                      <span>light</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Status:</span>
+                      <Badge variant="outline" className="text-xs h-5">
+                        Connected
+                      </Badge>
+                    </div>
                   </div>
-                </div>
-              </Card>
-            </div>
-          )}
+                </Card>
+              </div>
+            )}
         </div>
 
         {/* Bottom Navigation */}

--- a/apps/web/config/supabase-runtime.ts
+++ b/apps/web/config/supabase-runtime.ts
@@ -1,8 +1,7 @@
 import { getEnvVar } from "@/utils/env.ts";
 
-export const DEFAULT_SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-export const DEFAULT_SUPABASE_ANON_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXRpOjE3NTQyMDE4MTUsImV4cCI6MjA2OTc3NzgxNX0.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+export const DEFAULT_SUPABASE_URL = "https://stub.supabase.co";
+export const DEFAULT_SUPABASE_ANON_KEY = "stub-anon-key";
 
 type ResolvedValue = {
   value: string;
@@ -37,5 +36,5 @@ export const SUPABASE_ANON_KEY_RESOLUTION = resolveValue(
 export const SUPABASE_URL = SUPABASE_URL_RESOLUTION.value;
 export const SUPABASE_ANON_KEY = SUPABASE_ANON_KEY_RESOLUTION.value;
 
-export const SUPABASE_CONFIG_FROM_ENV =
-  SUPABASE_URL_RESOLUTION.fromEnv && SUPABASE_ANON_KEY_RESOLUTION.fromEnv;
+export const SUPABASE_CONFIG_FROM_ENV = SUPABASE_URL_RESOLUTION.fromEnv &&
+  SUPABASE_ANON_KEY_RESOLUTION.fromEnv;

--- a/apps/web/resources/assets.ts
+++ b/apps/web/resources/assets.ts
@@ -1,4 +1,4 @@
-const DEFAULT_SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
+const DEFAULT_SUPABASE_URL = "https://stub.supabase.co";
 const MAGIC_PORTFOLIO_BUCKET = "magic-portfolio";
 
 const ABSOLUTE_URL_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
@@ -56,7 +56,10 @@ export function supabaseAsset(path: string): string {
   return `${SUPABASE_BUCKET_BASE}${normalizedPath}`;
 }
 
-export function toAbsoluteUrl(baseUrl: string | undefined, candidate: string): string {
+export function toAbsoluteUrl(
+  baseUrl: string | undefined,
+  candidate: string,
+): string {
   if (!candidate) {
     return candidate;
   }

--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,7 @@
     "edge:deploy:verify": "npx supabase functions deploy verify-initdata",
     "edge:deploy:health": "npx supabase functions deploy miniapp-health",
     "tg:keeper:deploy": "npx supabase functions deploy telegram-webhook-keeper",
-    "tg:keeper:run": "curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-webhook-keeper | jq .",
+    "tg:keeper:run": "curl -s https://your-project-ref.functions.supabase.co/telegram-webhook-keeper | jq .",
     "edge:deploy:plans": "npx supabase functions deploy plans",
     "edge:deploy:checkout": "npx supabase functions deploy checkout-init",
     "edge:deploy:uploadurl": "npx supabase functions deploy receipt-upload-url",

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -34,5 +34,5 @@ Either `MINI_APP_URL` or `MINI_APP_SHORT_NAME` must be set for the `/start`
 command to show an **Open Mini App** button. If neither is configured, the bot
 logs a warning and omits the button. `MINI_APP_URL` should point to the deployed
 Telegram Mini App (for example,
-`https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/`) and will
+`https://your-project-ref.functions.supabase.co/miniapp/`) and will
 automatically append a trailing slash if missing to avoid redirect issues.

--- a/docs/MAKE_INITDATA.md
+++ b/docs/MAKE_INITDATA.md
@@ -21,7 +21,7 @@ deno task make:initdata --id=225513686 --username=DynamicCapital_Support \
 If `/verify-initdata` is deployed:
 
 ```bash
-curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/verify-initdata \
+curl -s https://your-project-ref.functions.supabase.co/verify-initdata \
   -H 'content-type: application/json' \
   -d "{\"initData\":\"$(deno task make:initdata)\"}"
 # → {"ok":true,...}

--- a/docs/MINI_APP_ON_SUPABASE.md
+++ b/docs/MINI_APP_ON_SUPABASE.md
@@ -1,12 +1,12 @@
-# Mini App on Supabase (Project qeejuomcapbdlhnjqjcc)
+# Mini App on Supabase (Project your-project-ref)
 
 ## Build & Deploy (functions host)
 
 ```bash
 deno task miniapp:deploy
 npx supabase login
-npx supabase link --project-ref qeejuomcapbdlhnjqjcc
-npx supabase secrets set MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
+npx supabase link --project-ref your-project-ref
+npx supabase secrets set MINI_APP_URL=https://your-project-ref.functions.supabase.co/miniapp/
 npx supabase functions deploy telegram-bot
 deno task miniapp:check
 ```

--- a/docs/MINI_APP_URL_SETUP.md
+++ b/docs/MINI_APP_URL_SETUP.md
@@ -12,45 +12,56 @@ skips the **Open Mini App** button.
 
    ```bash
    npx supabase login
- npx supabase link --project-ref <PROJECT_REF>
-  # Provide either a full URL or a short name
-  npx supabase secrets set MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
-  # or
-  # npx supabase secrets set MINI_APP_SHORT_NAME=<short_name>
-   npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook>
-   npx supabase secrets set TELEGRAM_BOT_TOKEN=<token>
    ```
 
+npx supabase link --project-ref <PROJECT_REF>
+
+# Provide either a full URL or a short name
+
+npx supabase secrets set
+MINI_APP_URL=https://your-project-ref.functions.supabase.co/miniapp/
+
+# or
+
+# npx supabase secrets set MINI_APP_SHORT_NAME=<short_name>
+
+npx supabase secrets set TELEGRAM_WEBHOOK_SECRET=<same value used in setWebhook>
+npx supabase secrets set TELEGRAM_BOT_TOKEN=<token>
+
+````
 2. Redeploy the bot function so it reads new env:
 
-   ```bash
-   npx supabase functions deploy telegram-bot
-   ```
+```bash
+npx supabase functions deploy telegram-bot
+````
 
 3. (One-time) set Telegram chat menu button:
 
-  ```bash
-   export TELEGRAM_BOT_TOKEN=<token>
-   # Either MINI_APP_URL or MINI_APP_SHORT_NAME
-   export MINI_APP_URL=https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/
-   # export MINI_APP_SHORT_NAME=<short_name>
-  deno run -A scripts/set-chat-menu-button.ts
-  ```
+```bash
+ export TELEGRAM_BOT_TOKEN=<token>
+ # Either MINI_APP_URL or MINI_APP_SHORT_NAME
+ export MINI_APP_URL=https://your-project-ref.functions.supabase.co/miniapp/
+ # export MINI_APP_SHORT_NAME=<short_name>
+deno run -A scripts/set-chat-menu-button.ts
+```
 
-   If configuring the Mini App via BotFather, set the **Direct URL** to the same
-   `MINI_APP_URL` (including the trailing `/miniapp/` segment) so Telegram opens
-   the deployed mini app path instead of the dashboard root.
+If configuring the Mini App via BotFather, set the **Direct URL** to the same
+`MINI_APP_URL` (including the trailing `/miniapp/` segment) so Telegram opens
+the deployed mini app path instead of the dashboard root.
 
 4. Sanity:
 
    ```bash
- deno run -A scripts/assert-miniapp-config.ts
-  ```
+   ```
 
+deno run -A scripts/assert-miniapp-config.ts
+
+```
 Notes:
 
 - Use a trailing slash in `MINI_APP_URL` to avoid redirects in Telegram.
 - If `/start` still lacks the button, confirm the secret is set and the
-  function redeployed; check Supabase logs for the warning above.
+function redeployed; check Supabase logs for the warning above.
 - Keep all runtime secrets in **Supabase Edge**. CI can have `MINI_APP_URL` too
-  if your workflows read it, but the bot reads Edge values.
+if your workflows read it, but the bot reads Edge values.
+```

--- a/docs/PHASE_6_OPS.md
+++ b/docs/PHASE_6_OPS.md
@@ -17,7 +17,7 @@
 
 ## Health Check
 
-- `https://qeejuomcapbdlhnjqjcc.functions.supabase.co/ops-health`
+- `https://your-project-ref.functions.supabase.co/ops-health`
 - Returns JSON with `ok` flag and per-check results
 
 ## Optional Indexes

--- a/docs/RUNBOOK_start-not-responding.md
+++ b/docs/RUNBOOK_start-not-responding.md
@@ -16,7 +16,7 @@ deno run -A scripts/check-webhook.ts
 ```
 export TELEGRAM_WEBHOOK_SECRET=... # prod secret
 export TELEGRAM_WEBHOOK_URL=... # if not set, we derive from SUPABASE_PROJECT_ID
-# or: export SUPABASE_PROJECT_ID=qeejuomcapbdlhnjqjcc
+# or: export SUPABASE_PROJECT_ID=your-project-ref
 
 deno run -A scripts/ping-webhook.ts
 ```

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -167,7 +167,8 @@ crash).
 **Role & Focus**
 
 - You are **Codex**, the senior UI engineer for the Dynamic Capital monorepo.
-- Ship production-ready UI quickly with the smallest safe diffs, no duplication, and consistent design.
+- Ship production-ready UI quickly with the smallest safe diffs, no duplication,
+  and consistent design.
 
 #### Stack & Libraries (assume present; add only if missing)
 
@@ -181,27 +182,38 @@ crash).
 
 #### Before You Code (Always)
 
-- Reuse existing components/hooks—no duplication. Search `apps/*/components`, `ui/`, and `lib/` first.
-- Follow existing design tokens for colors, spacing, radii, and shadows; only extend Tailwind config when absolutely necessary.
-- Prioritize accessibility: semantic markup, ARIA where needed, keyboard navigation, and visible focus states.
+- Reuse existing components/hooks—no duplication. Search `apps/*/components`,
+  `ui/`, and `lib/` first.
+- Follow existing design tokens for colors, spacing, radii, and shadows; only
+  extend Tailwind config when absolutely necessary.
+- Prioritize accessibility: semantic markup, ARIA where needed, keyboard
+  navigation, and visible focus states.
 
 #### Deliverables Per UI Task
 
-- Place created/edited files under the correct app scope (e.g., `apps/user-dashboard/app/(routes)/...`).
+- Place created/edited files under the correct app scope (e.g.,
+  `apps/user-dashboard/app/(routes)/...`).
 - Components in TypeScript with clear prop interfaces and sensible defaults.
-- Include a page/route or Storybook story to preview the UI (`/playground` when no storybook).
-- Provide loading, empty, and error states (skeletons/spinners, zero-state messaging).
+- Include a page/route or Storybook story to preview the UI (`/playground` when
+  no storybook).
+- Provide loading, empty, and error states (skeletons/spinners, zero-state
+  messaging).
 - Ensure responsive layout (sm/md/lg/xl) with mobile-first CSS.
-- Apply tasteful Framer Motion (opacity/translate, 120–240ms; honor `prefers-reduced-motion`).
-- Add tests for critical interactions (render, accessibility role, click/submit, disabled states).
+- Apply tasteful Framer Motion (opacity/translate, 120–240ms; honor
+  `prefers-reduced-motion`).
+- Add tests for critical interactions (render, accessibility role, click/submit,
+  disabled states).
 - Avoid inline secrets, dead code, or anything that breaks tree-shaking.
 
 #### Preferred UI Patterns
 
-- Layout: CSS grid/flex with gaps; container max-width; sticky top nav when helpful.
+- Layout: CSS grid/flex with gaps; container max-width; sticky top nav when
+  helpful.
 - Cards: rounded-2xl, soft shadow, subtle borders; use shadcn/ui `<Card>`.
-- Forms: shadcn/ui + RHF + Zod with inline errors, disabled + loading states, optimistic UI when safe.
-- Tables: virtualize or paginate beyond 50 rows with separate column definitions and explicit empty/error states.
+- Forms: shadcn/ui + RHF + Zod with inline errors, disabled + loading states,
+  optimistic UI when safe.
+- Tables: virtualize or paginate beyond 50 rows with separate column definitions
+  and explicit empty/error states.
 - Modals/Drawers: Radix Dialog/Sheet with escape/overlay close and focus lock.
 - Feedback: Radix Toast for success/error feedback.
 - Icons: lucide-react sized via Tailwind (`h-5 w-5`).
@@ -209,37 +221,52 @@ crash).
 
 #### Data & Integration Guidance
 
-- When wiring to the backend, call existing Supabase Edge Functions and handle 401/403/500 responses.
-- If the backend is not ready, provide a typed mock service and add TODOs for easy swapping.
+- When wiring to the backend, call existing Supabase Edge Functions and handle
+  401/403/500 responses.
+- If the backend is not ready, provide a typed mock service and add TODOs for
+  easy swapping.
 - Gate new UI behind `features` table lookups when feature flags are relevant.
 
 #### Performance & Quality Targets
 
-- Use `next/image` for images; set `priority` only for above-the-fold hero media.
-- Dynamically import heavy components and avoid client components unless necessary.
-- Prevent unnecessary re-renders (memoization, stable callbacks, appropriate `key`s).
-- Aim for Lighthouse performance ≥ 90 on new pages and document any improvements.
+- Use `next/image` for images; set `priority` only for above-the-fold hero
+  media.
+- Dynamically import heavy components and avoid client components unless
+  necessary.
+- Prevent unnecessary re-renders (memoization, stable callbacks, appropriate
+  `key`s).
+- Aim for Lighthouse performance ≥ 90 on new pages and document any
+  improvements.
 
 #### Output Format (Every Task)
 
 1. **Summary** – describe what you built or changed.
 2. **File Tree** – list touched paths.
-3. **Code Snippets** – provide complete, pasteable snippets for each new/edited file.
+3. **Code Snippets** – provide complete, pasteable snippets for each new/edited
+   file.
 4. **Test Snippets** – include RTL tests for key interactions.
 5. **Preview Instructions** – note local routes or Storybook stories.
 6. **Follow-ups** – capture small TODOs or outstanding flags.
 
 #### Error/Build Fix Mode
 
-- If UI changes introduce build/lint/type errors, add missing packages/scripts (respect the package manager), apply the smallest fix, and include the diff.
-- Prefer patch/minor dependency bumps; mark major version bumps as requires-review unless unavoidable.
+- If UI changes introduce build/lint/type errors, add missing packages/scripts
+  (respect the package manager), apply the smallest fix, and include the diff.
+- Prefer patch/minor dependency bumps; mark major version bumps as
+  requires-review unless unavoidable.
 
 #### Examples of Request Interpretation
 
-- “Create Pricing page for marketing”: hero, plans grid, FAQ, CTA; mobile-first; route `apps/marketing-site/app/pricing/page.tsx`.
-- “Build Admin > Users table with filters & bulk actions”: server-driven pagination, search, role filter, row selection, bulk enable/disable; route `apps/admin-dashboard/app/(admin)/users/page.tsx`; reuse table primitives if they exist.
-- “Add VIP Signals feed card”: timestamp, pair, direction, TP/SL tags, status pill; skeleton state; accessible.
-- “Mentorship lesson viewer”: sidebar list, progress, video player, notes; empty & error states.
+- “Create Pricing page for marketing”: hero, plans grid, FAQ, CTA; mobile-first;
+  route `apps/marketing-site/app/pricing/page.tsx`.
+- “Build Admin > Users table with filters & bulk actions”: server-driven
+  pagination, search, role filter, row selection, bulk enable/disable; route
+  `apps/admin-dashboard/app/(admin)/users/page.tsx`; reuse table primitives if
+  they exist.
+- “Add VIP Signals feed card”: timestamp, pair, direction, TP/SL tags, status
+  pill; skeleton state; accessible.
+- “Mentorship lesson viewer”: sidebar list, progress, video player, notes; empty
+  & error states.
 
 #### When in Doubt
 
@@ -247,7 +274,8 @@ crash).
 - Ship a polished MVP quickly; list 1–3 incremental enhancements as follow-ups.
 - Favor the smallest safe diff with tests over large rewrites.
 
-These guardrails keep Codex output consistent with Dynamic Capital’s design system and engineering expectations.
+These guardrails keep Codex output consistent with Dynamic Capital’s design
+system and engineering expectations.
 
 ---
 
@@ -258,7 +286,8 @@ These guardrails keep Codex output consistent with Dynamic Capital’s design sy
 **NEVER MODIFY THESE SYSTEMS:**
 
 1. **Database Schema & Relationships**
-   - Tables: `bot_users`, `user_subscriptions`, `payment_intents`, `receipts`, `bot_settings`
+   - Tables: `bot_users`, `user_subscriptions`, `payment_intents`, `receipts`,
+     `bot_settings`
    - Foreign key relationships and constraints
    - RLS policies and security rules
    - Views: `current_vip`, analytics tables
@@ -295,7 +324,7 @@ graph TB
         TU[Telegram User]
         TMA[Mini App Button]
     end
-    
+
     subgraph "Supabase Edge Functions"
         TBF[telegram-bot]
         VIF[verify-initdata]
@@ -303,7 +332,7 @@ graph TB
         RPF[receipt-processing]
         ADF[admin-functions]
     end
-    
+
     subgraph "Database Layer"
         BU[bot_users]
         US[user_subscriptions]
@@ -312,62 +341,65 @@ graph TB
         BS[bot_settings]
         CV[current_vip view]
     end
-    
+
     subgraph "Web App (React)"
         PG[Pages]
         CP[Components]
         HK[Hooks]
         UI[UI Library]
     end
-    
+
     TU -->|/start| TG
     TG -->|webhook| TBF
     TG -->|Mini App| TMA
     TMA -->|launches| MAF
     MAF -->|serves| PG
-    
+
     TBF -->|creates/updates| BU
     TBF -->|processes| PI
     TBF -->|stores| RC
-    
+
     VIF -->|validates| TU
     RPF -->|auto-approve| PI
     ADF -->|admin actions| US
-    
+
     BU --> US
     US --> PI
     PI --> RC
     US --> CV
-    
+
     PG --> CP
     CP --> UI
     CP --> HK
-    
+
     style BU fill:#ff9999
     style US fill:#ff9999
     style PI fill:#ff9999
     style RC fill:#ff9999
     style TBF fill:#ff9999
     style VIF fill:#ff9999
+
 </lov-mermaid>
 
-**Red nodes = PROTECTED (never modify)**
-**Blue nodes = SAFE TO MODIFY**
+**Red nodes = PROTECTED (never modify)** **Blue nodes = SAFE TO MODIFY**
 
 ### UI Work Playbook
 
 #### For Visual/Text Changes
+
 1. **Use Visual Edits** in Lovable Codex chat interface
 2. Click Edit button → modify directly on screen
 3. Save credits for complex functionality changes
 
 #### For Component Changes
+
 1. **Read existing component** first to understand structure
 2. **Use semantic tokens** from design system
 3. **Test in both themes** (light/dark mode)
 4. **Verify responsive** design on mobile
 
 #### For New Features
+
 1. **Create new components** instead of modifying large files
 2. **Follow existing patterns** in the codebase
 3. **Use TypeScript** with proper interfaces
@@ -390,6 +422,7 @@ graph TB
 ```
 
 **Available Semantic Tokens:**
+
 - Colors: `primary`, `secondary`, `accent`, `destructive`
 - Text: `foreground`, `muted-foreground`
 - Backgrounds: `background`, `muted`, `card`
@@ -425,12 +458,12 @@ graph TB
 
 ```bash
 # Before UI changes - verify core functions work
-curl -X POST https://qeejuomcapbdlhnjqjcc.functions.supabase.co/telegram-bot \
+curl -X POST https://your-project-ref.functions.supabase.co/telegram-bot \
   -H "content-type: application/json" \
   -d '{"test":"ping"}'
 
 # After UI changes - verify Mini App loads
-curl -s https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/ | grep -q "Dynamic Capital"
+curl -s https://your-project-ref.functions.supabase.co/miniapp/ | grep -q "Dynamic Capital"
 
 # Verify auth still works
 deno run -A scripts/make-initdata.ts --id=YOUR_TELEGRAM_ID
@@ -446,4 +479,5 @@ If UI changes break core functionality:
 4. **Verify integration endpoints** still respond
 5. **Contact system admin** if database issues suspected
 
-**Remember: UI changes should NEVER affect backend functionality. If they do, you've crossed into protected territory.**
+**Remember: UI changes should NEVER affect backend functionality. If they do,
+you've crossed into protected territory.**

--- a/scripts/telegram-webhook.sh
+++ b/scripts/telegram-webhook.sh
@@ -10,8 +10,8 @@ Environment variables required:
   TELEGRAM_WEBHOOK_SECRET     # Secret token for X-Telegram-Bot-Api-Secret-Token (only for 'set')
 
 Optional (one of):
-  PROJECT_REF                 # Supabase project ref (e.g. qeejuomcapbdlhnjqjcc)
-  SUPABASE_URL                # e.g. https://qeejuomcapbdlhnjqjcc.supabase.co
+  PROJECT_REF                 # Supabase project ref (e.g. your-project-ref)
+  SUPABASE_URL                # e.g. https://your-project-ref.supabase.co
 
 Examples:
   ./scripts/telegram-webhook.sh delete

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "qeejuomcapbdlhnjqjcc"
+project_id = "your-project-ref"
 
 [global]
   site_url = "https://dynamic-capital.ondigitalocean.app"

--- a/supabase/functions/_shared/client.ts
+++ b/supabase/functions/_shared/client.ts
@@ -7,7 +7,9 @@ import {
 declare const process:
   | { env: Record<string, string | undefined> }
   | undefined;
-declare const Deno: { env: { get(key: string): string | undefined } } | undefined;
+declare const Deno:
+  | { env: { get(key: string): string | undefined } }
+  | undefined;
 
 type ResolvedValue = {
   value: string;
@@ -63,9 +65,8 @@ function resolveValue(
   return { value: fallback, fromEnv: false };
 }
 
-const DEFAULT_SUPABASE_URL = "https://qeejuomcapbdlhnjqjcc.supabase.co";
-const DEFAULT_SUPABASE_ANON_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFlZWp1b21jYXBiZGxobmpxamNjIiwicm9sZSI6ImFub24iLCJpYXRpIjoxNzU0MjAxODE1LCJleHAiOjIwNjk3Nzc4MTV9.GfK9Wwx0WX_GhDIz1sIQzNstyAQIF2Jd6p7t02G44zk";
+const DEFAULT_SUPABASE_URL = "https://stub.supabase.co";
+const DEFAULT_SUPABASE_ANON_KEY = "stub-anon-key";
 
 const SUPABASE_URL_RESOLUTION = resolveValue(
   "SUPABASE_URL",
@@ -94,10 +95,9 @@ export function createClient(
   role: "anon" | "service" = "anon",
   options?: SupabaseClientOptions<"public">,
 ): SupabaseClient {
-  const key =
-    role === "service"
-      ? SUPABASE_SERVICE_ROLE_KEY
-      : SUPABASE_ANON_KEY;
+  const key = role === "service"
+    ? SUPABASE_SERVICE_ROLE_KEY
+    : SUPABASE_ANON_KEY;
 
   if (!SUPABASE_URL) {
     throw new Error("Missing Supabase URL");

--- a/supabase/functions/_shared/edge.ts
+++ b/supabase/functions/_shared/edge.ts
@@ -7,7 +7,7 @@ import { optionalEnv } from "./env.ts";
 export function getProjectRef(): string | null {
   const ref = optionalEnv("SUPABASE_PROJECT_ID");
   if (ref) return ref;
-  const url = optionalEnv("SUPABASE_URL"); // e.g., https://qeejuomcapbdlhnjqjcc.supabase.co
+  const url = optionalEnv("SUPABASE_URL"); // e.g., https://your-project.supabase.co
   if (!url) return null;
   try {
     const m = new URL(url).hostname.split(".")[0];

--- a/supabase/functions/admin-review-payment/index.ts
+++ b/supabase/functions/admin-review-payment/index.ts
@@ -1,7 +1,8 @@
 import { createClient } from "../_shared/client.ts";
 import { getEnv, optionalEnv } from "../_shared/env.ts";
-import { ok, bad, unauth, mna, nf } from "../_shared/http.ts";
+import { bad, mna, nf, ok, unauth } from "../_shared/http.ts";
 import { registerHandler } from "../_shared/serve.ts";
+import { functionUrl } from "../_shared/edge.ts";
 
 type Body = {
   admin_telegram_id?: string;
@@ -141,26 +142,31 @@ export const handler = registerHandler(async (req) => {
   if (prof.telegram_id) {
     const vipChannelLink = "https://t.me/+_k_CP8gR20E2YTll";
     const vipGroupLink = "https://t.me/+-eTumm8BD88wMzY1";
-    
+
     const msg = body.message ||
       `✅ <b>VIP Activated</b>\n\nYour access is valid until <b>${
         new Date(expiresAt!).toLocaleDateString()
       }</b>.\n\n🔥 <b>Join Your VIP Access:</b>\n📢 VIP Channel: ${vipChannelLink}\n💬 VIP Group: ${vipGroupLink}\n\nWelcome to the VIP community! 🚀`;
-    
+
     await tgSend(botToken, String(prof.telegram_id), msg);
-    
+
     // Trigger VIP sync for membership verification
-    try {
-      await fetch(`https://qeejuomcapbdlhnjqjcc.functions.supabase.co/vip-sync/one`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Admin-Secret": getEnv("ADMIN_API_SECRET")
-        },
-        body: JSON.stringify({ telegram_user_id: prof.telegram_id })
-      });
-    } catch (e) {
-      console.log("VIP sync failed (non-critical):", e);
+    const vipSyncUrl = functionUrl("vip-sync/one");
+    if (vipSyncUrl) {
+      try {
+        await fetch(vipSyncUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Admin-Secret": getEnv("ADMIN_API_SECRET"),
+          },
+          body: JSON.stringify({ telegram_user_id: prof.telegram_id }),
+        });
+      } catch (e) {
+        console.log("VIP sync failed (non-critical):", e);
+      }
+    } else {
+      console.log("VIP sync skipped: unable to resolve function URL");
     }
   }
 

--- a/supabase/functions/setup-lovable-miniapp/index.ts
+++ b/supabase/functions/setup-lovable-miniapp/index.ts
@@ -1,9 +1,11 @@
 import { registerHandler } from "../_shared/serve.ts";
 import { createSupabaseClient } from "../_shared/client.ts";
+import { functionsHost } from "../_shared/edge.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
 };
 
 interface TelegramResponse {
@@ -13,44 +15,50 @@ interface TelegramResponse {
 }
 
 export const handler = registerHandler(async (req) => {
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   try {
-    const botToken = Deno.env.get('TELEGRAM_BOT_TOKEN');
-    const supabaseUrl = Deno.env.get('SUPABASE_URL');
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-    
+    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
     if (!botToken) {
-      throw new Error('TELEGRAM_BOT_TOKEN not configured');
-    }
-    
-    if (!supabaseUrl || !supabaseServiceKey) {
-      throw new Error('Supabase configuration missing');
+      throw new Error("TELEGRAM_BOT_TOKEN not configured");
     }
 
-    const lovableMiniAppUrl =
-      Deno.env.get('MINI_APP_URL') ?? 'https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/';
-    
-    console.log('Setting up Lovable Mini App with URL:', lovableMiniAppUrl);
+    if (!supabaseUrl || !supabaseServiceKey) {
+      throw new Error("Supabase configuration missing");
+    }
+
+    const fallbackMiniAppUrl = (() => {
+      const host = functionsHost();
+      return host
+        ? `https://${host}/miniapp/`
+        : "https://stub.functions.supabase.co/miniapp/";
+    })();
+    const lovableMiniAppUrl = Deno.env.get("MINI_APP_URL") ??
+      fallbackMiniAppUrl;
+
+    console.log("Setting up Lovable Mini App with URL:", lovableMiniAppUrl);
 
     // Initialize Supabase client
     const supabase = createSupabaseClient(supabaseUrl, supabaseServiceKey);
 
     // Store the Lovable URL as a bot setting
     const { error: settingError } = await supabase
-      .from('bot_settings')
+      .from("bot_settings")
       .upsert({
-        setting_key: 'MINI_APP_URL',
+        setting_key: "MINI_APP_URL",
         setting_value: lovableMiniAppUrl,
-        description: 'Lovable Mini App URL for Telegram integration',
+        description: "Lovable Mini App URL for Telegram integration",
         is_active: true,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       });
 
     if (settingError) {
-      console.error('Failed to store bot setting:', settingError);
+      console.error("Failed to store bot setting:", settingError);
       throw new Error(`Failed to store bot setting: ${settingError.message}`);
     }
 
@@ -58,33 +66,35 @@ export const handler = registerHandler(async (req) => {
     const menuButtonResponse = await fetch(
       `https://api.telegram.org/bot${botToken}/setChatMenuButton`,
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           menu_button: {
-            type: 'web_app',
-            text: 'Open VIP App',
+            type: "web_app",
+            text: "Open VIP App",
             web_app: {
-              url: lovableMiniAppUrl
-            }
-          }
-        })
-      }
+              url: lovableMiniAppUrl,
+            },
+          },
+        }),
+      },
     );
 
     const menuButtonResult: TelegramResponse = await menuButtonResponse.json();
-    
+
     if (!menuButtonResult.ok) {
-      throw new Error(`Failed to set menu button: ${menuButtonResult.description}`);
+      throw new Error(
+        `Failed to set menu button: ${menuButtonResult.description}`,
+      );
     }
 
     // Get bot info to verify setup
     const botInfoResponse = await fetch(
-      `https://api.telegram.org/bot${botToken}/getMe`
+      `https://api.telegram.org/bot${botToken}/getMe`,
     );
-    
+
     const botInfo: TelegramResponse = await botInfoResponse.json();
-    
+
     if (!botInfo.ok) {
       throw new Error(`Failed to get bot info: ${botInfo.description}`);
     }
@@ -93,62 +103,67 @@ export const handler = registerHandler(async (req) => {
     const commandsResponse = await fetch(
       `https://api.telegram.org/bot${botToken}/setMyCommands`,
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           commands: [
             {
-              command: 'start',
-              description: 'Start and open VIP Mini App'
+              command: "start",
+              description: "Start and open VIP Mini App",
             },
             {
-              command: 'app',
-              description: 'Open VIP Mini App'
+              command: "app",
+              description: "Open VIP Mini App",
             },
             {
-              command: 'status',
-              description: 'Check subscription status'
+              command: "status",
+              description: "Check subscription status",
             },
             {
-              command: 'help',
-              description: 'Get help and support'
-            }
-          ]
-        })
-      }
+              command: "help",
+              description: "Get help and support",
+            },
+          ],
+        }),
+      },
     );
 
     const commandsResult: TelegramResponse = await commandsResponse.json();
-    
+
     if (!commandsResult.ok) {
-      console.warn('Failed to set commands:', commandsResult.description);
+      console.warn("Failed to set commands:", commandsResult.description);
     }
 
-    return new Response(JSON.stringify({
-      success: true,
-      message: 'Lovable Mini App setup completed successfully',
-      botInfo: {
-        username: botInfo.result?.username,
-        first_name: botInfo.result?.first_name,
-        id: botInfo.result?.id
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: "Lovable Mini App setup completed successfully",
+        botInfo: {
+          username: botInfo.result?.username,
+          first_name: botInfo.result?.first_name,
+          id: botInfo.result?.id,
+        },
+        miniAppUrl: lovableMiniAppUrl,
+        menuButtonSet: menuButtonResult.ok,
+        commandsSet: commandsResult.ok,
+        botSettingStored: !settingError,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       },
-      miniAppUrl: lovableMiniAppUrl,
-      menuButtonSet: menuButtonResult.ok,
-      commandsSet: commandsResult.ok,
-      botSettingStored: !settingError
-    }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-    });
-
+    );
   } catch (error) {
-    console.error('Lovable Mini App setup error:', error);
-    return new Response(JSON.stringify({
-      success: false,
-      error: error.message
-    }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
-    });
+    console.error("Lovable Mini App setup error:", error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error.message,
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   }
 });
 

--- a/supabase/functions/telegram-bot/admin-handlers/vip-management.ts
+++ b/supabase/functions/telegram-bot/admin-handlers/vip-management.ts
@@ -1,6 +1,7 @@
 // Enhanced VIP Sync Management for Telegram Admin
-import { supabaseAdmin, sendMessage } from "./common.ts";
+import { sendMessage, supabaseAdmin } from "./common.ts";
 import { logAdminAction } from "../database-utils.ts";
+import { functionUrl } from "../../_shared/edge.ts";
 
 // Handle VIP Sync Management
 export async function handleVipSyncManagement(
@@ -33,7 +34,10 @@ export async function handleVipSyncManagement(
         { text: "📊 View VIP Status", callback_data: "vip_view_status" },
       ],
       [
-        { text: "⚙️ Configure Channels", callback_data: "vip_configure_channels" },
+        {
+          text: "⚙️ Configure Channels",
+          callback_data: "vip_configure_channels",
+        },
         { text: "📈 Sync Logs", callback_data: "vip_sync_logs" },
       ],
       [
@@ -54,22 +58,27 @@ export async function handleVipFullSync(
     await sendMessage(chatId, "🔄 Starting full VIP member sync...");
 
     // Call the enhanced VIP sync function
-    const response = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/vip-sync-enhanced', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'sync_vip_members' })
+    const vipSyncUrl = functionUrl("vip-sync-enhanced");
+    if (!vipSyncUrl) {
+      throw new Error("Unable to resolve vip-sync-enhanced function URL");
+    }
+
+    const response = await fetch(vipSyncUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "sync_vip_members" }),
     });
 
     const result = await response.json();
 
     if (result.ok) {
       const { synced_members, updated_members, channels_processed } = result;
-      
+
       await logAdminAction(
         userId,
         "vip_full_sync",
         `Full VIP sync: ${synced_members} checked, ${updated_members} updated across ${channels_processed} channels`,
-        "channel_memberships"
+        "channel_memberships",
       );
 
       const successMessage = `✅ *Full VIP Sync Completed*
@@ -83,9 +92,8 @@ export async function handleVipFullSync(
 
       await sendMessage(chatId, successMessage);
     } else {
-      throw new Error(result.error || 'Sync failed');
+      throw new Error(result.error || "Sync failed");
     }
-
   } catch (error) {
     console.error("VIP full sync error:", error);
     const msg = error instanceof Error ? error.message : String(error);
@@ -115,7 +123,10 @@ Are you sure you want to proceed?`;
   const keyboard = {
     inline_keyboard: [
       [
-        { text: "✅ Yes, Assign Lifetime", callback_data: "vip_assign_lifetime_confirm" },
+        {
+          text: "✅ Yes, Assign Lifetime",
+          callback_data: "vip_assign_lifetime_confirm",
+        },
         { text: "❌ Cancel", callback_data: "vip_sync_management" },
       ],
     ],
@@ -130,24 +141,32 @@ export async function handleVipAssignLifetimeConfirm(
   userId: string,
 ): Promise<void> {
   try {
-    await sendMessage(chatId, "🎁 Assigning lifetime memberships to current VIP members...");
+    await sendMessage(
+      chatId,
+      "🎁 Assigning lifetime memberships to current VIP members...",
+    );
 
-    const response = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/vip-sync-enhanced', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'assign_lifetime' })
+    const vipSyncUrl = functionUrl("vip-sync-enhanced");
+    if (!vipSyncUrl) {
+      throw new Error("Unable to resolve vip-sync-enhanced function URL");
+    }
+
+    const response = await fetch(vipSyncUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "assign_lifetime" }),
     });
 
     const result = await response.json();
 
     if (result.ok) {
       const { total_members, assigned_count, lifetime_plan_id } = result;
-      
+
       await logAdminAction(
         userId,
         "vip_assign_lifetime",
         `Assigned lifetime membership to ${assigned_count} out of ${total_members} VIP members`,
-        "user_subscriptions"
+        "user_subscriptions",
       );
 
       const successMessage = `🎉 *Lifetime Assignment Complete*
@@ -161,9 +180,8 @@ export async function handleVipAssignLifetimeConfirm(
 
       await sendMessage(chatId, successMessage);
     } else {
-      throw new Error(result.error || 'Assignment failed');
+      throw new Error(result.error || "Assignment failed");
     }
-
   } catch (error) {
     console.error("VIP lifetime assignment error:", error);
     const msg = error instanceof Error ? error.message : String(error);
@@ -198,57 +216,73 @@ export async function processVipSyncSingle(
   input: string,
 ): Promise<void> {
   try {
-    const parts = input.trim().split(' ');
+    const parts = input.trim().split(" ");
     const targetUserId = parts[0];
-    const assignLifetime = parts.includes('lifetime');
+    const assignLifetime = parts.includes("lifetime");
 
     if (!targetUserId || !/^\d+$/.test(targetUserId)) {
-      await sendMessage(chatId, "❌ Invalid user ID. Please provide a numeric Telegram User ID.");
+      await sendMessage(
+        chatId,
+        "❌ Invalid user ID. Please provide a numeric Telegram User ID.",
+      );
       return;
     }
 
-    await sendMessage(chatId, `🔄 Syncing user ${targetUserId}${assignLifetime ? ' with lifetime assignment' : ''}...`);
+    await sendMessage(
+      chatId,
+      `🔄 Syncing user ${targetUserId}${
+        assignLifetime ? " with lifetime assignment" : ""
+      }...`,
+    );
 
-    const response = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/vip-sync-enhanced', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ 
-        action: 'sync_single_user',
+    const vipSyncUrl = functionUrl("vip-sync-enhanced");
+    if (!vipSyncUrl) {
+      throw new Error("Unable to resolve vip-sync-enhanced function URL");
+    }
+
+    const response = await fetch(vipSyncUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "sync_single_user",
         telegram_user_id: targetUserId,
-        assign_lifetime: assignLifetime
-      })
+        assign_lifetime: assignLifetime,
+      }),
     });
 
     const result = await response.json();
 
     if (result.ok) {
       const { user_id, is_vip, channels, lifetime_assigned } = result;
-      
+
       await logAdminAction(
         userId,
         "vip_sync_single",
-        `Synced user ${user_id}: VIP=${is_vip}, Lifetime=${lifetime_assigned || false}`,
-        "channel_memberships"
+        `Synced user ${user_id}: VIP=${is_vip}, Lifetime=${
+          lifetime_assigned || false
+        }`,
+        "channel_memberships",
       );
 
       let message = `✅ *User Sync Complete*
 
 👤 User ID: ${user_id}
-🎯 VIP Status: ${is_vip ? '✅ VIP' : '❌ Not VIP'}
-${lifetime_assigned ? '🎁 Lifetime membership assigned!' : ''}
+🎯 VIP Status: ${is_vip ? "✅ VIP" : "❌ Not VIP"}
+${lifetime_assigned ? "🎁 Lifetime membership assigned!" : ""}
 
 📊 *Channel Status:*`;
 
       channels.forEach((channel: any) => {
-        const status = channel.is_active ? '✅' : '❌';
-        message += `\n• ${channel.channel_id}: ${status} ${channel.status || 'unknown'}`;
+        const status = channel.is_active ? "✅" : "❌";
+        message += `\n• ${channel.channel_id}: ${status} ${
+          channel.status || "unknown"
+        }`;
       });
 
       await sendMessage(chatId, message);
     } else {
-      throw new Error(result.error || 'User sync failed');
+      throw new Error(result.error || "User sync failed");
     }
-
   } catch (error) {
     console.error("Single user sync error:", error);
     const msg = error instanceof Error ? error.message : String(error);
@@ -262,15 +296,20 @@ export async function handleVipViewStatus(
   userId: string,
 ): Promise<void> {
   try {
-    const response = await fetch('https://qeejuomcapbdlhnjqjcc.functions.supabase.co/vip-sync-enhanced', {
-      method: 'GET'
+    const vipSyncUrl = functionUrl("vip-sync-enhanced");
+    if (!vipSyncUrl) {
+      throw new Error("Unable to resolve vip-sync-enhanced function URL");
+    }
+
+    const response = await fetch(vipSyncUrl, {
+      method: "GET",
     });
 
     const result = await response.json();
 
     if (result.ok) {
       const { total_vip_members, members } = result;
-      
+
       let message = `📊 *VIP Members Status*
 
 👥 Total Active VIP Members: ${total_vip_members}
@@ -278,14 +317,16 @@ export async function handleVipViewStatus(
 🔝 *Recent VIP Members:*`;
 
       const displayMembers = members.slice(0, 10); // Show first 10
-      
+
       displayMembers.forEach((member: any, index: number) => {
         const userInfo = member.user_info;
-        const name = userInfo?.first_name || userInfo?.username || 'Unknown';
-        const vipStatus = userInfo?.is_vip ? '✅' : '❌';
+        const name = userInfo?.first_name || userInfo?.username || "Unknown";
+        const vipStatus = userInfo?.is_vip ? "✅" : "❌";
         const channelsCount = member.channels.length;
-        
-        message += `\n${index + 1}. ${vipStatus} ${name} (${member.telegram_user_id})`;
+
+        message += `\n${
+          index + 1
+        }. ${vipStatus} ${name} (${member.telegram_user_id})`;
         message += `\n   📺 Active in ${channelsCount} channel(s)`;
       });
 
@@ -307,9 +348,8 @@ export async function handleVipViewStatus(
 
       await sendMessage(chatId, message, keyboard);
     } else {
-      throw new Error(result.error || 'Failed to fetch VIP status');
+      throw new Error(result.error || "Failed to fetch VIP status");
     }
-
   } catch (error) {
     console.error("VIP status view error:", error);
     const msg = error instanceof Error ? error.message : String(error);
@@ -342,10 +382,12 @@ export async function handleVipConfigureChannels(
     const message = `⚙️ *VIP Channels Configuration*
 
 📺 *Current VIP Channels:*
-${currentChannels.length > 0 
-  ? currentChannels.map((ch: string, i: number) => `${i + 1}. ${ch}`).join('\n')
-  : 'No VIP channels configured'
-}
+${
+      currentChannels.length > 0
+        ? currentChannels.map((ch: string, i: number) => `${i + 1}. ${ch}`)
+          .join("\n")
+        : "No VIP channels configured"
+    }
 
 To add a channel, send: \`add_channel @channelname\`
 To remove a channel, send: \`remove_channel @channelname\`
@@ -356,6 +398,9 @@ Use /cancel to abort.`;
   } catch (error) {
     console.error("VIP configure channels error:", error);
     const msg = error instanceof Error ? error.message : String(error);
-    await sendMessage(chatId, `❌ Error fetching channel configuration: ${msg}`);
+    await sendMessage(
+      chatId,
+      `❌ Error fetching channel configuration: ${msg}`,
+    );
   }
 }

--- a/supabase/migrations/20250814030743_fb74f6f5-69d3-4d33-88fc-5deba0c04751.sql
+++ b/supabase/migrations/20250814030743_fb74f6f5-69d3-4d33-88fc-5deba0c04751.sql
@@ -9,7 +9,7 @@ ON CONFLICT (setting_key) DO UPDATE SET
 
 -- Also add the mini app URL setting
 INSERT INTO bot_settings (setting_key, setting_value, is_active) 
-VALUES ('MINI_APP_URL', 'https://qeejuomcapbdlhnjqjcc.functions.supabase.co/miniapp/', true)
+VALUES ('MINI_APP_URL', 'https://your-project.functions.supabase.co/miniapp/', true)
 ON CONFLICT (setting_key) DO UPDATE SET 
   setting_value = EXCLUDED.setting_value,
   is_active = true,

--- a/tests/missing-env-screen.test.ts
+++ b/tests/missing-env-screen.test.ts
@@ -1,15 +1,17 @@
-import test from 'node:test';
-import { strictEqual } from 'node:assert/strict';
-import { freshImport } from './utils/freshImport.ts';
+import test from "node:test";
+import { strictEqual } from "node:assert/strict";
+import { freshImport } from "./utils/freshImport.ts";
 
-test('supabase config falls back to baked-in defaults', async () => {
+test("supabase config falls back to baked-in defaults", async () => {
   const prevUrl = process.env.SUPABASE_URL;
   const prevKey = process.env.SUPABASE_ANON_KEY;
   delete process.env.SUPABASE_URL;
   delete process.env.SUPABASE_ANON_KEY;
-  const mod = await freshImport(new URL('../apps/web/config/supabase.ts', import.meta.url));
-  strictEqual(mod.SUPABASE_ENV_ERROR, '');
-  strictEqual(mod.SUPABASE_CONFIG.URL, 'https://qeejuomcapbdlhnjqjcc.supabase.co');
+  const mod = await freshImport(
+    new URL("../apps/web/config/supabase.ts", import.meta.url),
+  );
+  strictEqual(mod.SUPABASE_ENV_ERROR, "");
+  strictEqual(mod.SUPABASE_CONFIG.URL, "https://stub.supabase.co");
   if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl;
   if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey;
 });


### PR DESCRIPTION
## Summary
- replace baked-in Supabase URL and anon key defaults with neutral stub values while keeping runtime resolution logic unchanged
- update Supabase functions, UI helpers, and scripts to derive function hosts from environment-driven helpers instead of the former hardcoded project ref
- refresh documentation and content assets to reference a generic `your-project-ref` placeholder rather than the real Supabase project identifier

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4a606b9348322bb158e69f776bb24