### PR TITLE
feat: expose public env vars in root harness

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,5 +54,6 @@ export default defineConfig(({ mode }) => ({
         'src/stubs/next-font-google.ts',
       ),
     }
-  }
+  },
+  envPrefix: ['VITE_', 'NEXT_PUBLIC_']
 }))


### PR DESCRIPTION
## Summary
- extend the shared env helper to read values from `import.meta.env` so the root harness can access browser-safe keys
- configure the Vite proxy to expose `NEXT_PUBLIC_` variables alongside the default `VITE_` prefix

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4ad446b0c8322a335d49b657db7cb