### PR TITLE
Fix mini app safety scan hanging

### DIFF
--- a/scripts/verify/miniapp_safety.sh
+++ b/scripts/verify/miniapp_safety.sh
@@ -17,15 +17,15 @@ fi
 echo "miniapp_present=PASS" >> "$R"
 
 # 1) Ensure no bot token or service keys are present in client code
-leaks=$(git ls-files 'supabase/functions/miniapp/src/**' | xargs -I{} bash -lc 'grep -nE "TELEGRAM_BOT_TOKEN|SUPABASE_SERVICE_ROLE_KEY" "{}" || true' | wc -l)
-if [ "$leaks" -eq 0 ]; then
-  echo "client_token_leak=PASS" >> "$R"
-else
+if rg --no-messages -q -e 'TELEGRAM_BOT_TOKEN|SUPABASE_SERVICE_ROLE_KEY' \
+  supabase/functions/miniapp/src; then
   echo "client_token_leak=FAIL" >> "$R"
+else
+  echo "client_token_leak=PASS" >> "$R"
 fi
 
 # 2) Check use of initData verification endpoint (tg-verify-init)
-if git ls-files 'supabase/functions/miniapp/src/**' | xargs -I{} bash -lc 'grep -q "tg-verify-init" "{}" && echo hit || true' | grep -q hit; then
+if rg --no-messages -q 'tg-verify-init' supabase/functions/miniapp/src; then
   echo "initdata_verify_usage=PASS" >> "$R"
 else
   echo "initdata_verify_usage=FAIL" >> "$R"


### PR DESCRIPTION
## Summary
- replace recursive xargs-based grep with ripgrep to avoid verify script hang
- ensure mini app safety check completes quickly by short-circuiting on pattern match

## Testing
- npm run verify

------
https://chatgpt.com/codex/tasks/task_e_68d4b1f136848322bd5f16f586685968