### PR TITLE
Optimize build workflows

### DIFF
--- a/lovable-build.js
+++ b/lovable-build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import {
   banner,
   celebrate,
@@ -80,34 +80,96 @@ try {
   process.exit(1);
 }
 
+const args = new Set(process.argv.slice(2));
+const runSerial = args.has("--serial") ||
+  process.env.LOVABLE_BUILD_SERIAL === "1";
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
 const tasks = [
-  { cmd: "npm run build", label: "Next.js build" },
-  { cmd: "npm run build:miniapp", label: "Miniapp build" },
+  { label: "Next.js build", command: npmCommand, args: ["run", "build"] },
+  {
+    label: "Miniapp build",
+    command: npmCommand,
+    args: ["run", "build:miniapp"],
+  },
 ];
 
-divider();
-let exitCode = 0;
-for (const { cmd, label } of tasks) {
+function runTask({ label, command, args: commandArgs }) {
   step(`${label} in progress...`);
-  try {
-    execSync(cmd, {
+  const env = createSanitizedNpmEnv();
+
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const finalize = ({ code, signal, error }) => {
+      if (settled) return;
+      settled = true;
+
+      if (code === 0) {
+        success(`${label} completed successfully!`);
+      } else {
+        const details = [];
+        if (signal) {
+          details.push(`terminated by signal ${signal}`);
+        }
+        if (error) {
+          details.push(error.message ? error.message : String(error));
+        } else if (code !== undefined) {
+          details.push(`exited with code ${code}`);
+        }
+
+        logError(`${label} failed. Check the output above for details.`, {
+          details: details.length > 0 ? details : undefined,
+        });
+      }
+
+      divider();
+      resolve({ label, code: code ?? 1 });
+    };
+
+    const child = spawn(command, commandArgs, {
       stdio: "inherit",
-      env: createSanitizedNpmEnv(),
+      env,
     });
-    success(`${label} completed successfully!`);
-  } catch (error) {
-    logError(`${label} failed. Check the output above for details.`, {
-      details: error?.message ? [error.message] : undefined,
+
+    child.on("error", (error) => {
+      finalize({ code: 1, error });
     });
-    exitCode = 1;
-  }
-  divider();
+
+    child.on("close", (code, signal) => {
+      if (signal) {
+        finalize({ code: 1, signal });
+        return;
+      }
+      finalize({ code: code ?? 1 });
+    });
+  });
 }
 
-if (exitCode === 0) {
+divider();
+if (runSerial) {
+  note("Serial mode requested. Build tasks will run one after another.");
+} else {
+  info("Running build tasks in parallel to shorten overall build times.");
+}
+
+const results = [];
+if (runSerial) {
+  for (const task of tasks) {
+    const result = await runTask(task);
+    results.push(result);
+  }
+} else {
+  const parallelResults = await Promise.all(tasks.map((task) => runTask(task)));
+  results.push(...parallelResults);
+}
+
+const failed = results.filter((result) => result.code !== 0);
+
+if (failed.length === 0) {
   celebrate("All Codex CLI build tasks finished with a smile!");
+  process.exitCode = 0;
 } else {
   warn("Some build tasks did not finish successfully. Review the logs above.");
+  process.exitCode = 1;
 }
-
-process.exitCode = exitCode;

--- a/scripts/build-miniapp.sh
+++ b/scripts/build-miniapp.sh
@@ -5,10 +5,57 @@ set -e
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 NPM_SAFE=(node "$ROOT_DIR/scripts/npm-safe.mjs")
+STAMP_FILE="node_modules/.npm-install.hash"
+LOCKFILE="package-lock.json"
+
+compute_lock_hash() {
+  node - "$1" <<'NODE'
+const fs = require('fs');
+const crypto = require('crypto');
+const file = process.argv[2] ?? process.argv[1];
+try {
+  const data = fs.readFileSync(file);
+  process.stdout.write(crypto.createHash('sha256').update(data).digest('hex'));
+} catch {
+  process.stdout.write('');
+}
+NODE
+}
 
 echo "Building miniapp..."
 cd "$ROOT_DIR/supabase/functions/miniapp"
-"${NPM_SAFE[@]}" ci
+lock_hash="$(compute_lock_hash "$LOCKFILE")"
+previous_hash=""
+skip_install=0
+
+if [[ -n "$lock_hash" && -d node_modules && -f "$STAMP_FILE" ]]; then
+  previous_hash="$(cat "$STAMP_FILE" 2>/dev/null || true)"
+  if [[ "$previous_hash" == "$lock_hash" ]]; then
+    echo "Dependencies unchanged (hash $lock_hash); reusing existing install."
+    skip_install=1
+  else
+    echo "Lockfile hash updated (was ${previous_hash:-unknown}, now $lock_hash); refreshing install."
+  fi
+elif [[ ! -d node_modules ]]; then
+  echo "node_modules missing; installing dependencies from scratch."
+fi
+
+if [[ $skip_install -ne 1 ]]; then
+  if [[ -z "$lock_hash" ]]; then
+    echo "Computing package-lock hash failed; running npm ci for safety."
+  fi
+  "${NPM_SAFE[@]}" ci
+  if [[ -n "$lock_hash" ]]; then
+    printf "%s\n" "$lock_hash" > "$STAMP_FILE"
+  else
+    rm -f "$STAMP_FILE"
+  fi
+else
+  if [[ -n "$lock_hash" ]]; then
+    printf "%s\n" "$lock_hash" > "$STAMP_FILE"
+  fi
+fi
+
 "${NPM_SAFE[@]}" run build
 cd "$ROOT_DIR"
 


### PR DESCRIPTION
## Summary
- run the Next.js and miniapp tasks in parallel inside `lovable-build.js` while keeping a serial fallback and improved logging
- cache the miniapp dependencies in `scripts/build-miniapp.sh` by hashing `package-lock.json` and skipping `npm ci` when the install is up to date

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build:miniapp

------
https://chatgpt.com/codex/tasks/task_e_68d508e8b2008322ace59f0b31a7eeba