### PR TITLE
Optimize CI and Deno workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -55,6 +59,17 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+
+      - name: Cache Deno dependencies
+        if: steps.script-flags.outputs.test != 'undefined'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            ~/.deno
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
 
       - name: Test
         if: steps.script-flags.outputs.test != 'undefined'

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -11,8 +11,24 @@ name: Deno
 on:
   push:
     branches: ["main"]
+    paths:
+      - 'supabase/**'
+      - 'tests/**'
+      - 'deno.json'
+      - 'deno.lock'
+      - '.github/workflows/deno.yml'
   pull_request:
     branches: ["main"]
+    paths:
+      - 'supabase/**'
+      - 'tests/**'
+      - 'deno.json'
+      - 'deno.lock'
+      - '.github/workflows/deno.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -29,6 +45,16 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/deno
+            ~/.deno
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
 
       # Uncomment this step to verify the use of 'deno fmt' on each commit.
       - name: Verify formatting


### PR DESCRIPTION
## Summary
- add concurrency control to the CI and Deno workflows so superseded runs are cancelled automatically
- cache Deno dependencies in both workflows to avoid refetching remote modules on every run
- limit the Deno workflow trigger to Deno-related paths so it only runs when relevant files change

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d50c80f9448322bfadd72a00b7d3bf