### PR TITLE
Fix build warnings for lovable build tasks

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import "@once-ui-system/core/css/tokens.css";
 import "@once-ui-system/core/css/styles.css";
@@ -215,6 +215,9 @@ export const metadata: Metadata = {
     shortcut: brandingAssets.favicon,
     apple: brandingAssets.appleTouchIcon,
   },
+};
+
+export const viewport: Viewport = {
   themeColor: themeColorMeta,
 };
 

--- a/apps/web/utils/env.ts
+++ b/apps/web/utils/env.ts
@@ -2,14 +2,31 @@
 declare const process:
   | { env: Record<string, string | undefined> }
   | undefined;
-declare const Deno: { env: { get(key: string): string | undefined } } | undefined;
+declare const Deno:
+  | { env: { get(key: string): string | undefined } }
+  | undefined;
 
 type ImportMetaWithEnv = { env?: Record<string, unknown> };
+
+function readImportMetaEnv(): Record<string, unknown> | undefined {
+  try {
+    const { env } = import.meta as unknown as ImportMetaWithEnv;
+    if (env && typeof env === "object") {
+      return env;
+    }
+  } catch {
+    // import.meta may not be available in all runtimes
+  }
+  return undefined;
+}
 
 function sanitize(v: string | undefined): string | undefined {
   if (!v) return undefined;
   const val = v.trim();
-  if (val === "" || val.toLowerCase() === "undefined" || val.toLowerCase() === "null") {
+  if (
+    val === "" || val.toLowerCase() === "undefined" ||
+    val.toLowerCase() === "null"
+  ) {
     return undefined;
   }
   return val;
@@ -28,20 +45,16 @@ function readEnv(key: string): string | undefined {
       // ignore permission errors
     }
   }
-  try {
-    if (typeof import.meta !== "undefined") {
-      const meta = import.meta as unknown as ImportMetaWithEnv;
-      const raw = meta.env?.[key];
-      if (typeof raw === "string") {
-        const v = sanitize(raw);
-        if (v !== undefined) return v;
-      } else if (typeof raw === "number" || typeof raw === "boolean") {
-        const v = sanitize(String(raw));
-        if (v !== undefined) return v;
-      }
+  const metaEnv = readImportMetaEnv();
+  if (metaEnv && key in metaEnv) {
+    const raw = metaEnv[key];
+    if (typeof raw === "string") {
+      const v = sanitize(raw);
+      if (v !== undefined) return v;
+    } else if (typeof raw === "number" || typeof raw === "boolean") {
+      const v = sanitize(String(raw));
+      if (v !== undefined) return v;
     }
-  } catch {
-    // import.meta may not be available in all runtimes
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- update the environment helper to read import.meta.env via destructuring to avoid Next.js critical dependency warnings
- move theme color metadata into a viewport export so Next.js build no longer warns about unsupported metadata fields

## Testing
- npm run lint
- npm run typecheck
- node lovable-build.js

------
https://chatgpt.com/codex/tasks/task_e_68d51085fc488322854f7ba4457158ad