### PR TITLE
refactor: route once ui imports through dynamic system

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -11,7 +11,7 @@ import {
   Meta,
   Schema,
   Row,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { baseURL, about, person, social, toAbsoluteUrl } from "@/resources";
 import TableOfContents from "@/components/magic-portfolio/about/TableOfContents";
 import styles from "@/components/magic-portfolio/about/about.module.scss";

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,4 +1,4 @@
-import { Column, Heading, Text } from "@once-ui-system/core";
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
 
 import { AdminGate } from "@/components/admin/AdminGate";
 import { AdminDashboard } from "@/components/admin/AdminDashboard";

--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -13,7 +13,7 @@ import {
   Avatar,
   Media,
   Line,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { baseURL, about, blog, person, toAbsoluteUrl } from "@/resources";
 import { formatDate } from "@/utils/magic-portfolio/formatDate";
 import { getPosts } from "@/utils/magic-portfolio/utils";

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -1,4 +1,4 @@
-import { Column, Heading, Meta, Schema } from "@once-ui-system/core";
+import { Column, Heading, Meta, Schema } from "@/components/dynamic-ui-system";
 import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { Posts } from "@/components/magic-portfolio/blog/Posts";
 import { baseURL, blog, person, toAbsoluteUrl } from "@/resources";

--- a/apps/web/app/checkout/page.tsx
+++ b/apps/web/app/checkout/page.tsx
@@ -1,4 +1,4 @@
-import { Column, Heading, Text } from "@once-ui-system/core";
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
 
 import { WebCheckout } from "@/components/checkout/WebCheckout";
 

--- a/apps/web/app/gallery/page.tsx
+++ b/apps/web/app/gallery/page.tsx
@@ -1,4 +1,4 @@
-import { Flex, Meta, Schema } from "@once-ui-system/core";
+import { Flex, Meta, Schema } from "@/components/dynamic-ui-system";
 import GalleryView from "@/components/magic-portfolio/gallery/GalleryView";
 import { baseURL, gallery, person, toAbsoluteUrl } from "@/resources";
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import "@once-ui-system/core/css/tokens.css";
-import "@once-ui-system/core/css/styles.css";
+import "@/components/dynamic-ui-system/css/tokens.css";
+import "@/components/dynamic-ui-system/css/styles.css";
 import "./dynamic-ui.css";
 import "./globals.css";
 import "@/lib/env";
@@ -14,7 +14,7 @@ import {
   opacity,
   RevealFx,
   SpacingToken,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 import Providers from "./providers";
 import { getStaticLandingDocument } from "@/lib/staticLanding";

--- a/apps/web/app/plans/page.tsx
+++ b/apps/web/app/plans/page.tsx
@@ -1,4 +1,4 @@
-import { Heading, Column, Text } from "@once-ui-system/core";
+import { Heading, Column, Text } from "@/components/dynamic-ui-system";
 
 import { VipPackagesSection } from "@/components/magic-portfolio/home/VipPackagesSection";
 import { CheckoutCallout } from "@/components/magic-portfolio/home/CheckoutCallout";

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -20,7 +20,7 @@ import {
   ThemeProvider,
   ToastProvider as DynamicToastProvider,
   TransitionStyle,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { AuthProvider } from "@/hooks/useAuth";
 import { SupabaseProvider } from "@/context/SupabaseProvider";
 import { MotionConfigProvider } from "@/components/ui/motion-config";

--- a/apps/web/app/work/[slug]/page.tsx
+++ b/apps/web/app/work/[slug]/page.tsx
@@ -11,7 +11,7 @@ import {
   SmartLink,
   Row,
   Line,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { baseURL, about, person, toAbsoluteUrl, work } from "@/resources";
 import { formatDate } from "@/utils/magic-portfolio/formatDate";
 import { ScrollToHash, CustomMDX } from "@/components/magic-portfolio";

--- a/apps/web/app/work/page.tsx
+++ b/apps/web/app/work/page.tsx
@@ -1,4 +1,4 @@
-import { Column, Heading, Meta, Schema } from "@once-ui-system/core";
+import { Column, Heading, Meta, Schema } from "@/components/dynamic-ui-system";
 import { baseURL, about, person, toAbsoluteUrl, work } from "@/resources";
 import { Projects } from "@/components/magic-portfolio/work/Projects";
 

--- a/apps/web/components/admin/AdminGate.tsx
+++ b/apps/web/components/admin/AdminGate.tsx
@@ -11,7 +11,7 @@ import {
   Spinner,
   Tag,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 import { callEdgeFunction } from "@/config/supabase";
 import { useToast } from "@/hooks/useToast";

--- a/apps/web/components/auth/AuthForm.tsx
+++ b/apps/web/components/auth/AuthForm.tsx
@@ -10,7 +10,7 @@ import {
   PasswordInput,
   Row,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/useToast";

--- a/apps/web/components/dynamic-ui-system/css/styles.css
+++ b/apps/web/components/dynamic-ui-system/css/styles.css
@@ -1,0 +1,1 @@
+@import "@once-ui-system/core/css/styles.css";

--- a/apps/web/components/dynamic-ui-system/css/tokens.css
+++ b/apps/web/components/dynamic-ui-system/css/tokens.css
@@ -1,0 +1,1 @@
+@import "@once-ui-system/core/css/tokens.css";

--- a/apps/web/components/dynamic-ui-system/index.d.ts
+++ b/apps/web/components/dynamic-ui-system/index.d.ts
@@ -1,0 +1,1 @@
+export * from "@once-ui-system/core";

--- a/apps/web/components/dynamic-ui-system/index.ts
+++ b/apps/web/components/dynamic-ui-system/index.ts
@@ -1,0 +1,1 @@
+export * from "@once-ui-system/core";

--- a/apps/web/components/dynamic-ui/dynamic-motion.tsx
+++ b/apps/web/components/dynamic-ui/dynamic-motion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { motion } from "framer-motion";
-import { Column, Flex, Row } from "@once-ui-system/core";
+import { Column, Flex, Row } from "@/components/dynamic-ui-system";
 
 import {
   type DynamicMotionVariantKey,

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { Background, Column, RevealFx } from "@once-ui-system/core";
-import { opacity, SpacingToken } from "@once-ui-system/core";
+import { Background, Column, RevealFx } from "@/components/dynamic-ui-system";
+import { opacity, SpacingToken } from "@/components/dynamic-ui-system";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
 import { dynamicUI } from "@/resources";

--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -1,4 +1,4 @@
-import { Column, RevealFx, Row, Schema } from "@once-ui-system/core";
+import { Column, RevealFx, Row, Schema } from "@/components/dynamic-ui-system";
 import { AboutShowcase } from "@/components/magic-portfolio/home/AboutShowcase";
 import { CheckoutCallout } from "@/components/magic-portfolio/home/CheckoutCallout";
 import { ComplianceCertificates } from "@/components/magic-portfolio/home/ComplianceCertificates";

--- a/apps/web/components/magic-portfolio/Footer.tsx
+++ b/apps/web/components/magic-portfolio/Footer.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Row, Text } from "@once-ui-system/core";
+import { IconButton, Row, Text } from "@/components/dynamic-ui-system";
 import { schema, social } from "@/resources";
 import styles from "./Footer.module.scss";
 

--- a/apps/web/components/magic-portfolio/Header.tsx
+++ b/apps/web/components/magic-portfolio/Header.tsx
@@ -12,7 +12,7 @@ import {
   Row,
   Text,
   ToggleButton,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 import { display, isRouteEnabled, person } from "@/resources";
 import type { IconName } from "@/resources/icons";

--- a/apps/web/components/magic-portfolio/HeadingLink.tsx
+++ b/apps/web/components/magic-portfolio/HeadingLink.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { JSX } from "react";
-import { Heading, Flex, IconButton, useToast } from "@once-ui-system/core";
+import { Heading, Flex, IconButton, useToast } from "@/components/dynamic-ui-system";
 
 import styles from "./HeadingLink.module.scss";
 

--- a/apps/web/components/magic-portfolio/Mailchimp.tsx
+++ b/apps/web/components/magic-portfolio/Mailchimp.tsx
@@ -9,8 +9,8 @@ import {
   Input,
   Row,
   Text,
-} from "@once-ui-system/core";
-import { opacity, SpacingToken } from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
+import { opacity, SpacingToken } from "@/components/dynamic-ui-system";
 import { useState } from "react";
 
 const {

--- a/apps/web/components/magic-portfolio/ProjectCard.tsx
+++ b/apps/web/components/magic-portfolio/ProjectCard.tsx
@@ -8,7 +8,7 @@ import {
   Heading,
   SmartLink,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 interface ProjectCardProps {
   href: string;

--- a/apps/web/components/magic-portfolio/RouteGuard.tsx
+++ b/apps/web/components/magic-portfolio/RouteGuard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { isRouteEnabled, protectedRoutes } from "@/resources";
-import { Flex, Spinner, Button, Heading, Column, PasswordInput } from "@once-ui-system/core";
+import { Flex, Spinner, Button, Heading, Column, PasswordInput } from "@/components/dynamic-ui-system";
 import NotFound from "@/app/not-found";
 
 interface RouteGuardProps {

--- a/apps/web/components/magic-portfolio/ThemeToggle.tsx
+++ b/apps/web/components/magic-portfolio/ThemeToggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Row, ToggleButton, useTheme } from "@once-ui-system/core";
+import { Row, ToggleButton, useTheme } from "@/components/dynamic-ui-system";
 
 export const ThemeToggle: React.FC = () => {
   const { theme, setTheme } = useTheme();

--- a/apps/web/components/magic-portfolio/about/TableOfContents.tsx
+++ b/apps/web/components/magic-portfolio/about/TableOfContents.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Column, Flex, Text } from "@once-ui-system/core";
+import { Column, Flex, Text } from "@/components/dynamic-ui-system";
 import styles from "./about.module.scss";
 
 interface TableOfContentsProps {

--- a/apps/web/components/magic-portfolio/blog/Post.tsx
+++ b/apps/web/components/magic-portfolio/blog/Post.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, Column, Media, Row, Avatar, Text } from "@once-ui-system/core";
+import { Card, Column, Media, Row, Avatar, Text } from "@/components/dynamic-ui-system";
 import { formatDate } from "@/utils/magic-portfolio/formatDate";
 import { person } from "@/resources";
 

--- a/apps/web/components/magic-portfolio/blog/Posts.tsx
+++ b/apps/web/components/magic-portfolio/blog/Posts.tsx
@@ -1,5 +1,5 @@
 import { getPosts } from "@/utils/magic-portfolio/utils";
-import { Grid } from "@once-ui-system/core";
+import { Grid } from "@/components/dynamic-ui-system";
 import Post from "./Post";
 
 interface PostsProps {

--- a/apps/web/components/magic-portfolio/blog/ShareSection.tsx
+++ b/apps/web/components/magic-portfolio/blog/ShareSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Row, Text, Button, useToast } from "@once-ui-system/core";
+import { Row, Text, Button, useToast } from "@/components/dynamic-ui-system";
 import { socialSharing } from "@/resources";
 
 interface ShareSectionProps {

--- a/apps/web/components/magic-portfolio/gallery/GalleryView.tsx
+++ b/apps/web/components/magic-portfolio/gallery/GalleryView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Media, MasonryGrid } from "@once-ui-system/core";
+import { Media, MasonryGrid } from "@/components/dynamic-ui-system";
 import { gallery } from "@/resources";
 
 export default function GalleryView() {

--- a/apps/web/components/magic-portfolio/home/AboutShowcase.tsx
+++ b/apps/web/components/magic-portfolio/home/AboutShowcase.tsx
@@ -8,7 +8,7 @@ import {
   Row,
   Tag,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 const experiences = about.work.experiences ?? [];
 const highlightExperience = experiences[0];

--- a/apps/web/components/magic-portfolio/home/CheckoutCallout.tsx
+++ b/apps/web/components/magic-portfolio/home/CheckoutCallout.tsx
@@ -1,4 +1,4 @@
-import { Button, Column, Heading, Row, Text } from "@once-ui-system/core";
+import { Button, Column, Heading, Row, Text } from "@/components/dynamic-ui-system";
 
 export function CheckoutCallout() {
   return (

--- a/apps/web/components/magic-portfolio/home/CommodityStrengthSection.tsx
+++ b/apps/web/components/magic-portfolio/home/CommodityStrengthSection.tsx
@@ -1,6 +1,6 @@
-import { Column, Heading, Line, Row, Tag, Text } from "@once-ui-system/core";
+import { Column, Heading, Line, Row, Tag, Text } from "@/components/dynamic-ui-system";
 
-import type { Colors } from "@once-ui-system/core";
+import type { Colors } from "@/components/dynamic-ui-system";
 
 type Sentiment = "Bullish" | "Bearish" | "Neutral";
 

--- a/apps/web/components/magic-portfolio/home/ComplianceCertificates.tsx
+++ b/apps/web/components/magic-portfolio/home/ComplianceCertificates.tsx
@@ -1,4 +1,4 @@
-import { Column, Heading, Icon, Row, Tag, Text } from "@once-ui-system/core";
+import { Column, Heading, Icon, Row, Tag, Text } from "@/components/dynamic-ui-system";
 import { schema } from "@/resources";
 
 interface Certificate {

--- a/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
+++ b/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 
-import { Column, Heading, Icon, Line, Row, Tag, Text } from "@once-ui-system/core";
-import type { Colors } from "@once-ui-system/core";
+import { Column, Heading, Icon, Line, Row, Tag, Text } from "@/components/dynamic-ui-system";
+import type { Colors } from "@/components/dynamic-ui-system";
 
 type ImpactLevel = "High" | "Medium" | "Low";
 

--- a/apps/web/components/magic-portfolio/home/FundamentalAnalysisSection.tsx
+++ b/apps/web/components/magic-portfolio/home/FundamentalAnalysisSection.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 
-import { Column, Heading, Icon, Line, Row, Tag, Text, type Colors } from "@once-ui-system/core";
+import { Column, Heading, Icon, Line, Row, Tag, Text, type Colors } from "@/components/dynamic-ui-system";
 
 type Positioning = "Overweight" | "Market weight" | "Underweight";
 

--- a/apps/web/components/magic-portfolio/home/FxMarketSnapshotSection.tsx
+++ b/apps/web/components/magic-portfolio/home/FxMarketSnapshotSection.tsx
@@ -1,5 +1,5 @@
-import { Column, Heading, Line, Row, Tag, Text } from "@once-ui-system/core";
-import type { Colors } from "@once-ui-system/core";
+import { Column, Heading, Line, Row, Tag, Text } from "@/components/dynamic-ui-system";
+import type { Colors } from "@/components/dynamic-ui-system";
 
 type CurrencyStrength = {
   code: string;

--- a/apps/web/components/magic-portfolio/home/HeroExperience.tsx
+++ b/apps/web/components/magic-portfolio/home/HeroExperience.tsx
@@ -17,7 +17,7 @@ import {
   Icon,
   Row,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { home } from "@/resources";
 import { cn } from "@/utils";
 import styles from "./HeroExperience.module.scss";

--- a/apps/web/components/magic-portfolio/home/MarketWatchlist.tsx
+++ b/apps/web/components/magic-portfolio/home/MarketWatchlist.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Column, Heading, Line, Row, Tag, Text } from "@once-ui-system/core";
+import { Column, Heading, Line, Row, Tag, Text } from "@/components/dynamic-ui-system";
 import type { IconName } from "@/resources/icons";
 import { formatIsoTime } from "@/utils/isoFormat";
 

--- a/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
+++ b/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
@@ -10,7 +10,7 @@ import {
   Row,
   Tag,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 type MentorshipProgram = {
   id: string;

--- a/apps/web/components/magic-portfolio/home/PerformanceInsightsSection.tsx
+++ b/apps/web/components/magic-portfolio/home/PerformanceInsightsSection.tsx
@@ -11,7 +11,7 @@ import {
   Row,
   Tag,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 import { CountUp } from "@/components/ui/enhanced-typography";
 

--- a/apps/web/components/magic-portfolio/home/PoolTradingSection.tsx
+++ b/apps/web/components/magic-portfolio/home/PoolTradingSection.tsx
@@ -1,5 +1,5 @@
 import { about } from "@/resources";
-import { Button, Column, Heading, Icon, Line, Row, Text } from "@once-ui-system/core";
+import { Button, Column, Heading, Icon, Line, Row, Text } from "@/components/dynamic-ui-system";
 
 const METRICS = [
   { label: "Capital under management", value: "$42M" },

--- a/apps/web/components/magic-portfolio/home/ValuePropositionSection.tsx
+++ b/apps/web/components/magic-portfolio/home/ValuePropositionSection.tsx
@@ -9,7 +9,7 @@ import {
   Row,
   Tag,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { schema } from "@/resources";
 
 type ValuePillar = {

--- a/apps/web/components/magic-portfolio/home/VipPackagesSection.tsx
+++ b/apps/web/components/magic-portfolio/home/VipPackagesSection.tsx
@@ -11,8 +11,8 @@ import {
   Spinner,
   Tag,
   Text,
-} from "@once-ui-system/core";
-import type { SpacingToken } from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
+import type { SpacingToken } from "@/components/dynamic-ui-system";
 
 import { formatPrice } from "@/utils";
 import type { Plan } from "@/types/plan";

--- a/apps/web/components/magic-portfolio/mdx.tsx
+++ b/apps/web/components/magic-portfolio/mdx.tsx
@@ -25,7 +25,7 @@ import {
   List,
   ListItem,
   Line,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 
 type CustomLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string;

--- a/apps/web/components/magic-portfolio/work/Projects.tsx
+++ b/apps/web/components/magic-portfolio/work/Projects.tsx
@@ -1,5 +1,5 @@
 import { getPosts } from "@/utils/magic-portfolio/utils";
-import { Column } from "@once-ui-system/core";
+import { Column } from "@/components/dynamic-ui-system";
 import { ProjectCard } from "@/components/magic-portfolio";
 
 interface ProjectsProps {

--- a/apps/web/components/shared/ChatAssistantWidget.tsx
+++ b/apps/web/components/shared/ChatAssistantWidget.tsx
@@ -36,7 +36,7 @@ import {
   Row,
   Spinner,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { useToast } from "@/hooks/useToast";
 import { supabase } from "@/integrations/supabase/client";
 import { logChatMessage } from "@/integrations/supabase/queries";

--- a/apps/web/components/shared/RouteArchiveNotice.tsx
+++ b/apps/web/components/shared/RouteArchiveNotice.tsx
@@ -8,7 +8,7 @@ import {
   SmartLink,
   Tag,
   Text,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { person, social } from "@/resources";
 
 const TELEGRAM_LINK = social.find((item) => item.name === "Telegram")?.link ||

--- a/apps/web/hooks/useTheme.tsx
+++ b/apps/web/hooks/useTheme.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useTheme as useDynamicUiTheme } from "@once-ui-system/core";
+import { useTheme as useDynamicUiTheme } from "@/components/dynamic-ui-system";
 
 import { callEdgeFunction } from "@/config/supabase";
 import { supabase } from "@/integrations/supabase/client";

--- a/apps/web/resources/content.tsx
+++ b/apps/web/resources/content.tsx
@@ -8,7 +8,7 @@ import {
   Social,
   Work,
 } from "@/resources/types";
-import { Line, Row, Text } from "@once-ui-system/core";
+import { Line, Row, Text } from "@/components/dynamic-ui-system";
 
 import { supabaseAsset } from "./assets";
 import { ogDefaults } from "./og-defaults";

--- a/apps/web/resources/types/config.types.ts
+++ b/apps/web/resources/types/config.types.ts
@@ -10,7 +10,7 @@ import {
   SurfaceStyle,
   Theme,
   TransitionStyle,
-} from "@once-ui-system/core";
+} from "@/components/dynamic-ui-system";
 import { NextFontWithVariable } from "next/dist/compiled/@next/font";
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@once-ui-system/core/css/tokens.css";
-import "@once-ui-system/core/css/styles.css";
+import "@/components/dynamic-ui-system/css/tokens.css";
+import "@/components/dynamic-ui-system/css/styles.css";
 import App from "./App.tsx";
 import "./index.css";
 import { applyDynamicBranding } from "./lib/dynamic-branding";

--- a/src/pages/CheckoutPage.tsx
+++ b/src/pages/CheckoutPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useLocation } from "react-router-dom";
-import { Column, Heading, Text } from "@once-ui-system/core";
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
 import { WebCheckout } from "@/components/checkout/WebCheckout";
 
 function useCheckoutParams() {


### PR DESCRIPTION
## Summary
- add a dynamic UI system bridge module that re-exports Once UI components and styles under the local alias
- update the Next.js app, shared components, and supporting modules to consume the new dynamic UI alias instead of the old Once UI path
- align standalone React entry points with the new dynamic UI imports to keep styling consistent across bundles

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5149036d48322a40acf3e9f11c552