### PR TITLE
Align build branding defaults with production domain

### DIFF
--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -5,7 +5,10 @@ import { copyFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
-import { applyBrandingEnvDefaults } from "./utils/branding-env.mjs";
+import {
+  applyBrandingEnvDefaults,
+  PRODUCTION_ORIGIN,
+} from "./utils/branding-env.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,7 +20,7 @@ const {
   resolvedOrigin,
 } = applyBrandingEnvDefaults({
   allowedOrigins: ({ env, resolvedOrigin: origin }) => env.SITE_URL ?? origin,
-  fallbackOrigin: "http://localhost:8080",
+  fallbackOrigin: PRODUCTION_ORIGIN,
   includeSupabasePlaceholders: false,
 });
 

--- a/scripts/utils/branding-env.mjs
+++ b/scripts/utils/branding-env.mjs
@@ -1,6 +1,7 @@
-export const PRODUCTION_ORIGIN = "https://dynamic-capital.ondigitalocean.app";
+export const PRODUCTION_ORIGIN = "https://dynamic.capital";
 
 export const PRODUCTION_ALLOWED_ORIGIN_LIST = [
+  "https://dynamic.capital",
   "https://dynamic-capital.ondigitalocean.app",
   "https://dynamic-capital.vercel.app",
   "https://dynamic-capital.lovable.app",


### PR DESCRIPTION
## Summary
- update the branding environment defaults to use https://dynamic.capital as the canonical production origin and include the branded domain in the allowed list
- reuse the shared production origin when local Next.js builds resolve their fallback origin so metadata matches the Dynamic branding domain by default

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d51a1821d88322bf921a8880331d3d