### PR TITLE
feat: allow crypto deposit address to use dynamic config

### DIFF
--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -137,6 +137,29 @@ async function envOrSetting<T = string>(
   return await getSetting<T>(settingKey);
 }
 
+function sanitizeConfigString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const lower = trimmed.toLowerCase();
+  if (lower === "null" || lower === "undefined") return null;
+  return trimmed;
+}
+
+export async function getCryptoDepositAddress(): Promise<string | null> {
+  const fromSetting = sanitizeConfigString(
+    await envOrSetting<string>("CRYPTO_DEPOSIT_ADDRESS", "crypto_usdt_trc20"),
+  );
+  if (fromSetting) return fromSetting;
+
+  const fromContent = sanitizeConfigString(
+    await getContent<string>("crypto_usdt_trc20"),
+  );
+  if (fromContent) return fromContent;
+
+  return null;
+}
+
 export let getContent = async <T = string>(
   key: string,
 ): Promise<T | null> => {

--- a/supabase/functions/checkout-init/index.ts
+++ b/supabase/functions/checkout-init/index.ts
@@ -5,7 +5,7 @@ import { bad, mna, oops, json } from "../_shared/http.ts";
 import { createSupabaseClient } from "../_shared/client.ts";
 import { version } from "../_shared/version.ts";
 import { verifyInitData } from "../_shared/telegram_init.ts";
-import { getContent } from "../_shared/config.ts";
+import { getCryptoDepositAddress } from "../_shared/config.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -141,15 +141,10 @@ export async function handler(req: Request): Promise<Response> {
       .order("display_order");
     instructions = { type: "bank_transfer", banks: (banks as BankAccount[]) || [] };
   } else if (body.method === "crypto") {
-    // Get crypto address from bot_settings
-    const { data: cryptoSetting } = await supa
-      .from("bot_settings")
-      .select("setting_value")
-      .eq("setting_key", "crypto_usdt_trc20")
-      .eq("is_active", true)
-      .single();
-    
-    const cryptoAddress = cryptoSetting?.setting_value || "TEX7N2YKZX2KJR8HXRZ5WQGK5JFCGR7";
+    const cryptoAddress = await getCryptoDepositAddress();
+    if (!cryptoAddress) {
+      return oops("Crypto deposit address is not configured");
+    }
     instructions = {
       type: "crypto",
       address: cryptoAddress,

--- a/supabase/functions/intent/index.ts
+++ b/supabase/functions/intent/index.ts
@@ -1,7 +1,7 @@
 import { verifyInitDataAndGetUser } from "../_shared/telegram.ts";
 import { createClient } from "../_shared/client.ts";
 import { ok, bad, unauth, mna, oops, corsHeaders } from "../_shared/http.ts";
-import { getContent } from "../_shared/config.ts";
+import { getContent, getCryptoDepositAddress } from "../_shared/config.ts";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 import { registerHandler } from "../_shared/serve.ts";
 
@@ -81,8 +81,10 @@ export const handler = registerHandler(async (req) => {
   }
 
   if (body.type === "crypto") {
-    const deposit_address = await getContent<string>("crypto_usdt_trc20")
-      || "DEMO-ADDRESS";
+    const deposit_address = await getCryptoDepositAddress();
+    if (!deposit_address) {
+      return oops("Crypto deposit address is not configured");
+    }
 
     // Get default crypto amount from config or use a reasonable default
     const defaultAmount = parseFloat(

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -13,7 +13,13 @@ import {
 } from "./database-utils.ts";
 import { createClient } from "../_shared/client.ts";
 type SupabaseClient = ReturnType<typeof createClient>;
-import { envOrSetting, getContent, getContentBatch, getFlag } from "../_shared/config.ts";
+import {
+  envOrSetting,
+  getContent,
+  getContentBatch,
+  getCryptoDepositAddress,
+  getFlag,
+} from "../_shared/config.ts";
 import { buildMainMenu, type MenuSection } from "./menu.ts";
 import {
   buildAdminCommandHandlers,
@@ -1669,8 +1675,7 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
           payment_method: "crypto",
           status: "pending",
         });
-        const address = await getContent("crypto_usdt_trc20") ||
-          optionalEnv("CRYPTO_DEPOSIT_ADDRESS") ||
+        const address = (await getCryptoDepositAddress()) ||
           "Please contact support for the crypto address.";
         if (perr) {
           console.error("create crypto payment error", perr);

--- a/tests/crypto-deposit-config.test.ts
+++ b/tests/crypto-deposit-config.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import { equal as assertEqual } from "node:assert/strict";
+import { freshImport } from "./utils/freshImport.ts";
+
+const CONFIG_MODULE = new URL(
+  "../supabase/functions/_shared/config.ts",
+  import.meta.url,
+);
+
+type ConfigModule = typeof import("../supabase/functions/_shared/config.ts");
+
+async function withCryptoEnv(
+  value: string | undefined,
+  run: () => Promise<void>,
+) {
+  const original = Deno.env.get("CRYPTO_DEPOSIT_ADDRESS");
+  if (value === undefined) {
+    Deno.env.delete("CRYPTO_DEPOSIT_ADDRESS");
+  } else {
+    Deno.env.set("CRYPTO_DEPOSIT_ADDRESS", value);
+  }
+  try {
+    await run();
+  } finally {
+    if (original === undefined) {
+      Deno.env.delete("CRYPTO_DEPOSIT_ADDRESS");
+    } else {
+      Deno.env.set("CRYPTO_DEPOSIT_ADDRESS", original);
+    }
+  }
+}
+
+async function withConfigModule(run: (cfg: ConfigModule) => Promise<void>) {
+  const cfg = await freshImport(CONFIG_MODULE) as ConfigModule;
+  const originalGetSetting = cfg.getSetting;
+  const originalGetContent = cfg.getContent;
+  try {
+    await run(cfg);
+  } finally {
+    cfg.__setGetSetting(originalGetSetting);
+    cfg.__setGetContent(originalGetContent);
+  }
+}
+
+test("getCryptoDepositAddress prefers env values", async () => {
+  await withCryptoEnv("  env-address  ", async () => {
+    await withConfigModule(async (cfg) => {
+      const result = await cfg.getCryptoDepositAddress();
+      assertEqual(result, "env-address");
+    });
+  });
+});
+
+test("getCryptoDepositAddress falls back to bot setting", async () => {
+  await withCryptoEnv(undefined, async () => {
+    await withConfigModule(async (cfg) => {
+      cfg.__setGetSetting(async () => "db-value");
+      const result = await cfg.getCryptoDepositAddress();
+      assertEqual(result, "db-value");
+    });
+  });
+});
+
+test("getCryptoDepositAddress falls back to bot content", async () => {
+  await withCryptoEnv(undefined, async () => {
+    await withConfigModule(async (cfg) => {
+      cfg.__setGetSetting(async () => " null ");
+      cfg.__setGetContent(async () => "content-value");
+      const result = await cfg.getCryptoDepositAddress();
+      assertEqual(result, "content-value");
+    });
+  });
+});
+
+test("getCryptoDepositAddress returns null when no sources configured", async () => {
+  await withCryptoEnv(undefined, async () => {
+    await withConfigModule(async (cfg) => {
+      cfg.__setGetSetting(async () => null);
+      cfg.__setGetContent(async () => null);
+      const result = await cfg.getCryptoDepositAddress();
+      assertEqual(result, null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper that resolves the crypto deposit address from env, bot settings, or content values
- update checkout-init, intent, and telegram bot flows to use the helper and surface an error when no address is configured
- cover the helper with dedicated tests to confirm env, setting, content, and null fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52c197f808322b67335f7247f8196