### PR TITLE
Expand trading algo checklist coverage

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -40,6 +40,7 @@ key.
 | 11       | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)          | Merging Dynamic Codex into this monorepo                                        | Completed — dashboard now lives at `/telegram` in the Next.js app                     | —                     |
 | 12       | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)              | Align Git branches with deployable services and domains                         | Rework branching strategy to support independent deployments                          | —                     |
 | 13       | [`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md) | Bringing Investing.com pattern data into Supabase, queue, and Mini App surfaces | Plan and track the signal ingestion + alert rollout                                   | —                     |
+| 14       | [`Trading Algo Improvement Checklist`](./trading-algo-improvement-checklist.md)            | Tune Smart Money Concepts configuration & QA loops                              | Iterate on BOS/liquidity heuristics across config, analyzers, and delivery            | —                     |
 
 ## Project delivery (priorities 1–3)
 

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -148,6 +148,9 @@ detailed checklists into project docs for visibility.
 3. **[Dynamic Codex Integration Checklist](./dynamic_codex_integration_checklist.md)**
    – Archived context after merging Dynamic Codex into the `/telegram` Next.js
    route; keep for historical reference.
+4. **[Trading Algo Improvement Checklist](./trading-algo-improvement-checklist.md)**
+   – Guides Smart Money Concepts tuning across configuration, analyzers, and
+   delivery workflows so BOS/liquidity updates land consistently.
 
 ## Completed Repo-Level Action Items
 

--- a/docs/trading-algo-improvement-checklist.md
+++ b/docs/trading-algo-improvement-checklist.md
@@ -1,0 +1,61 @@
+# Trading Algo Improvement Checklist
+
+Use this checklist to tighten the Smart Money Concepts (SMC) workflow that
+supports the trading automation stack. Each section ladders into the repository
+touchpoints called out in `algorithms/`, Supabase Edge Functions, and the
+Telegram delivery surfaces so changes propagate end-to-end.
+
+## 1. Foundation & Data Hygiene
+
+- [ ] Confirm live market data feeds include liquidity metrics (session
+      highs/lows, round numbers) required by SMC rules before signals flow into
+      Supabase.
+- [ ] Sync glossary terminology across bot configs, analyst runbooks, and UI
+      labels so BOS/SMS, liquidity sweeps, and mitigation blocks remain
+      consistent with `docs/glossary` references.
+- [ ] Verify Supabase dashboards or logs capture BOS/liquidity sweep events for
+      later review and store raw captures under `supabase/functions/*` logs or
+      analytics tables.
+
+## 2. Configuration Review
+
+- [ ] Revisit `TradeConfig` SMC settings weekly; tighten
+      `smc_level_threshold_pips` if entries are late and raise `smc_bias_weight`
+      when structural bias should dominate other signals.
+- [ ] Capture parameter changes plus performance metrics in the
+      `algorithms/README.md` handoff log (date, change, observed outcome).
+- [ ] Ensure alerting thresholds mirror the glossary checkpoints and commit the
+      configuration changes alongside updates to `.env.example` when new keys
+      are introduced.
+
+## 3. Analyzer Enhancements
+
+- [ ] Extend `SMCAnalyzer.observe` with new mitigation block or liquidity
+      pattern checks before persisting context to Supabase.
+- [ ] Add unit or integration tests for each new SMC filter under
+      `tests/trading-*` to prevent regressions in BOS/SMS detection.
+- [ ] Log additional analyzer outputs (e.g., swept level IDs, mitigation block
+      hits) to the analytics tables surfaced in dashboards so reviewers can
+      audit context.
+
+## 4. Execution Discipline
+
+- [ ] Require every published trade idea to reference the glossary checklist—
+      call out BOS status, liquidity sweep confirmation, and mitigation
+      alignment.
+- [ ] Gate automated entries on passing both the glossary checklist and analyzer
+      context review; wire the gating logic through queue and Supabase workers
+      (`queue/index.ts`, `supabase/functions/telegram-bot/*`).
+- [ ] Record reasons for overrides when human analysts diverge from automated
+      recommendations and archive them in Supabase for feedback analysis.
+
+## 5. Feedback Loop
+
+- [ ] Review post-trade analytics to correlate glossary-aligned setups with
+      performance outcomes and adjust `TradeConfig` weights accordingly.
+- [ ] Schedule retrospective sessions to adjust SMC thresholds, analyzer
+      filters, and documentation when patterns emerge; capture notes in
+      `docs/meeting-notes/` or the shared project tracker.
+- [ ] Update member-facing portals (e.g., Liquidity Signal Desk) to highlight
+      new checklist items and confirm the Telegram broadcast templates mirror
+      the latest vocabulary.


### PR DESCRIPTION
## Summary
- expand the trading algorithm improvement checklist with numbered sections and explicit repo touchpoints
- register the checklist in the checklist directory and dynamic capital tracker for discoverability

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d5380e8a108322812e39f908d09611