### PR TITLE
Adjust Next.js build fallback origin for local runs

### DIFF
--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -17,7 +17,13 @@ process.env.NODE_ENV = "production";
 
 const LOCAL_DEV_ORIGIN = "http://localhost:8080";
 
-const fallbackOrigin = process.env.CI === "1"
+const isCI =
+  typeof process.env.CI === "string" &&
+  process.env.CI.length > 0 &&
+  process.env.CI !== "0" &&
+  process.env.CI.toLowerCase() !== "false";
+
+const fallbackOrigin = isCI
   ? PRODUCTION_ORIGIN
   : LOCAL_DEV_ORIGIN;
 


### PR DESCRIPTION
## Summary
- default the Next.js build helper to a localhost origin during local runs so missing env vars no longer fall back to the production domain
- keep the production origin fallback when running in CI to preserve deploy-time behaviour

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5418e61548322a04502e7b2b2c76f