### PR TITLE
Expand ts comment codemod coverage

### DIFF
--- a/docs/CLEANUP_AND_CODEMODS.md
+++ b/docs/CLEANUP_AND_CODEMODS.md
@@ -12,6 +12,6 @@ This repository includes maintenance scripts for asset hygiene and code quality.
 - **utils.sh** &mdash; shared helpers for logging and managing the `.out` directory.
 
 ## Codemods (`scripts/codemods/`)
-- **wrap_ts_comments.mjs** &mdash; ensures any `@ts-ignore` or `@ts-expect-error` comment is preceded by `// deno-lint-ignore ban-ts-comment`.
+- **wrap_ts_comments.mjs** &mdash; scans all tracked TypeScript/JavaScript files and ensures any `@ts-ignore` or `@ts-expect-error` comment is preceded by `// deno-lint-ignore ban-ts-comment`.
 - **require_await_pad.mjs** &mdash; inserts a no-op `await Promise.resolve()` into async functions that lack an `await`, satisfying the `require-await` lint rule.
 

--- a/scripts/codemods/wrap_ts_comments.mjs
+++ b/scripts/codemods/wrap_ts_comments.mjs
@@ -1,15 +1,30 @@
 import fs from "fs";
 import path from "path";
 
-const roots = ["src", "supabase/functions"];
+const roots = [process.cwd()];
 const exts = /\.(ts|tsx|js|jsx|mjs)$/;
+const ignoredDirectories = new Set([
+  ".git",
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+  "coverage",
+  ".turbo",
+  "tmp",
+  "out",
+  ".vercel",
+  "vendor",
+]);
 
 function* walk(dir) {
   if (!fs.existsSync(dir)) return;
-  for (const d of fs.readdirSync(dir, { withFileTypes: true })) {
-    const p = path.join(dir, d.name);
-    if (d.isDirectory()) yield* walk(p);
-    else if (exts.test(d.name)) yield p;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (ignoredDirectories.has(entry.name)) continue;
+      yield* walk(entryPath);
+    } else if (exts.test(entry.name)) yield entryPath;
   }
 }
 


### PR DESCRIPTION
## Summary
- update wrap_ts_comments codemod to walk the entire repository while skipping common build and dependency folders so @ts-ignore annotations are consistently guarded
- document that the codemod now scans all tracked JavaScript and TypeScript sources

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5481412dc8322bedf9aa3cde615d1