### PR TITLE
Allow go-live checklist to run with fixtures

### DIFF
--- a/scripts/check-webhook.ts
+++ b/scripts/check-webhook.ts
@@ -12,25 +12,66 @@
  * Usage:
  *   deno run -A scripts/check-webhook.ts
  */
-const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
-if (!token) {
-  console.error("Missing TELEGRAM_BOT_TOKEN");
-  Deno.exit(1);
+
+type TelegramWebhookInfo = {
+  url?: string;
+  has_custom_certificate?: boolean;
+  pending_update_count?: number;
+  last_error_message?: string;
+  last_error_date?: number;
+};
+
+type TelegramWebhookResponse = {
+  ok?: boolean;
+  result?: TelegramWebhookInfo;
+};
+
+async function loadFixture(path: string): Promise<TelegramWebhookInfo> {
+  const text = await Deno.readTextFile(path);
+  const parsed = JSON.parse(text);
+  if (parsed && typeof parsed === "object" && "result" in parsed) {
+    return (parsed as TelegramWebhookResponse).result ?? {};
+  }
+  return (parsed ?? {}) as TelegramWebhookInfo;
 }
 
-const r = await fetch(`https://api.telegram.org/bot${token}/getWebhookInfo`);
-const j = await r.json();
-if (!j.ok) {
-  console.error("Telegram API error:", j);
-  Deno.exit(1);
+async function fetchWebhookInfo(): Promise<TelegramWebhookInfo> {
+  const fixturePath = Deno.env.get("TELEGRAM_WEBHOOK_INFO_PATH");
+  if (fixturePath) {
+    console.log(
+      `Using TELEGRAM_WEBHOOK_INFO_PATH fixture: ${fixturePath}`,
+    );
+    return await loadFixture(fixturePath);
+  }
+
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  if (!token) {
+    console.error("Missing TELEGRAM_BOT_TOKEN");
+    Deno.exit(1);
+  }
+
+  const apiBase =
+    (Deno.env.get("TELEGRAM_API_BASE") ?? "https://api.telegram.org")
+      .replace(/\/$/, "");
+  const response = await fetch(`${apiBase}/bot${token}/getWebhookInfo`);
+  const json = (await response.json()) as TelegramWebhookResponse;
+
+  if (!json.ok) {
+    console.error("Telegram API error:", json);
+    Deno.exit(1);
+  }
+
+  return json.result ?? {};
 }
 
-const info = j.result ?? {};
+const info = await fetchWebhookInfo();
 console.log("Webhook URL:", info.url || "(none)");
 console.log("Has custom cert:", !!info.has_custom_certificate);
 console.log("Pending updates:", info.pending_update_count ?? 0);
 if (info.last_error_message) {
-  const ts = info.last_error_date ? new Date(info.last_error_date * 1000).toISOString() : "";
+  const ts = info.last_error_date
+    ? new Date(info.last_error_date * 1000).toISOString()
+    : "";
   console.log("Last error:", info.last_error_message, ts ? `@ ${ts}` : "");
 } else {
   console.log("No recent webhook errors recorded.");

--- a/scripts/fixtures/mock-miniapp-smoke.json
+++ b/scripts/fixtures/mock-miniapp-smoke.json
@@ -1,0 +1,6 @@
+{
+  "HEAD /miniapp/": 200,
+  "GET /miniapp/version": 200,
+  "HEAD /functions/v1/miniapp/": 200,
+  "GET /functions/v1/miniapp/version": 200
+}

--- a/scripts/fixtures/mock-telegram-webhook.json
+++ b/scripts/fixtures/mock-telegram-webhook.json
@@ -1,0 +1,8 @@
+{
+  "ok": true,
+  "result": {
+    "url": "https://example.com/telegram/webhook",
+    "has_custom_certificate": false,
+    "pending_update_count": 0
+  }
+}

--- a/scripts/smoke-miniapp.ts
+++ b/scripts/smoke-miniapp.ts
@@ -3,7 +3,8 @@
  * Basic smoke checks for the deployed Mini App.
  *
  * Env:
- *   FUNCTIONS_BASE  Base URL for your Supabase functions (e.g. https://xyz.functions.supabase.co)
+ *   FUNCTIONS_BASE               Base URL for your Supabase functions (e.g. https://xyz.functions.supabase.co)
+ *   MINIAPP_SMOKE_FIXTURE_PATH   Optional path to a JSON fixture that mimics the remote responses.
  *
  * Usage:
  *   FUNCTIONS_BASE=https://xyz.functions.supabase.co deno run -A scripts/smoke-miniapp.ts
@@ -17,36 +18,76 @@
  *   GET /functions/v1/miniapp/version -> 200
  */
 
+type SmokeFixture = Record<string, number>;
+
+async function runFixture(path: string) {
+  const text = await Deno.readTextFile(path);
+  const fixture = JSON.parse(text) as SmokeFixture;
+  let fixtureFailed = false;
+
+  for (const [key, status] of Object.entries(fixture)) {
+    const [method, ...pathParts] = key.trim().split(/\s+/);
+    const requestMethod = (method || "GET").toUpperCase();
+    const requestPath = pathParts.join(" ") || "/";
+    const message = `${requestMethod} ${requestPath} -> ${status}`;
+
+    if (status !== 200) {
+      fixtureFailed = true;
+      console.error(`${message} (expected 200)`);
+    } else {
+      console.log(message);
+    }
+  }
+
+  if (fixtureFailed) {
+    console.error("One or more checks failed.");
+    Deno.exit(1);
+  }
+}
+
+async function runAgainstBase(base: string) {
+  let failed = false;
+
+  async function check(path: string, init?: RequestInit, failOnError = false) {
+    try {
+      const res = await fetch(`${base}${path}`, init);
+      const msg = `${init?.method ?? "GET"} ${path} -> ${res.status}`;
+      if (res.status !== 200 && failOnError) {
+        failed = true;
+        console.error(msg, "(expected 200)");
+      } else {
+        console.log(msg);
+      }
+    } catch (err) {
+      if (failOnError) failed = true;
+      console.error(`${init?.method ?? "GET"} ${path} -> error`, err);
+    }
+  }
+
+  await check("/miniapp/", { method: "HEAD" });
+  await check("/miniapp/version");
+  await check("/functions/v1/miniapp/", { method: "HEAD" }, true);
+  await check("/functions/v1/miniapp/version", undefined, true);
+
+  if (failed) {
+    console.error("One or more checks failed.");
+    Deno.exit(1);
+  }
+}
+
+const fixturePath = Deno.env.get("MINIAPP_SMOKE_FIXTURE_PATH");
+if (fixturePath) {
+  console.log(
+    `Using MINIAPP_SMOKE_FIXTURE_PATH fixture: ${fixturePath}`,
+  );
+  await runFixture(fixturePath);
+  Deno.exit(0);
+}
+
 const base = Deno.env.get("FUNCTIONS_BASE");
 if (!base) {
   console.error("Set FUNCTIONS_BASE to your functions base URL.");
   Deno.exit(1);
 }
 
-let failed = false;
-
-async function check(path: string, init?: RequestInit, failOnError = false) {
-  try {
-    const res = await fetch(`${base}${path}`, init);
-    const msg = `${init?.method ?? "GET"} ${path} -> ${res.status}`;
-    if (res.status !== 200 && failOnError) {
-      failed = true;
-      console.error(msg, "(expected 200)");
-    } else {
-      console.log(msg);
-    }
-  } catch (err) {
-    if (failOnError) failed = true;
-    console.error(`${init?.method ?? "GET"} ${path} -> error`, err);
-  }
-}
-
-await check("/miniapp/", { method: "HEAD" });
-await check("/miniapp/version");
-await check("/functions/v1/miniapp/", { method: "HEAD" }, true);
-await check("/functions/v1/miniapp/version", undefined, true);
-
-if (failed) {
-  console.error("One or more checks failed.");
-  Deno.exit(1);
-}
+await runAgainstBase(base);


### PR DESCRIPTION
## Summary
- allow the go-live webhook check script to consume fixture files or alternate API bases so it can run without real secrets
- add an optional fixture-driven execution path to the miniapp smoke test script for offline verification
- include sample fixture JSON responses used by the local go-live automation

## Testing
- TELEGRAM_WEBHOOK_INFO_PATH=scripts/fixtures/mock-telegram-webhook.json MINIAPP_SMOKE_FIXTURE_PATH=scripts/fixtures/mock-miniapp-smoke.json npm run checklists -- --checklist go-live --include-optional

------
https://chatgpt.com/codex/tasks/task_e_68d5502394ec8322a9bdba4bbc2f9b7f