### PR TITLE
Enable Telegram auth provider globally

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -22,6 +22,7 @@ import {
   TransitionStyle,
 } from "@/components/dynamic-ui-system";
 import { AuthProvider } from "@/hooks/useAuth";
+import { TelegramAuthProvider } from "@/hooks/useTelegramAuth";
 import { SupabaseProvider } from "@/context/SupabaseProvider";
 import { MotionConfigProvider } from "@/components/ui/motion-config";
 import { dynamicUI } from "@/resources";
@@ -74,7 +75,9 @@ export default function Providers({ children }: { children: ReactNode }) {
                   <QueryClientProvider client={queryClient}>
                     <AuthProvider>
                       <SupabaseProvider>
-                        {children}
+                        <TelegramAuthProvider>
+                          {children}
+                        </TelegramAuthProvider>
                       </SupabaseProvider>
                     </AuthProvider>
                   </QueryClientProvider>


### PR DESCRIPTION
## Summary
- wrap the shared provider tree with `TelegramAuthProvider` so components using `useTelegramAuth` receive context

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d552e485b88322b1bedc6053f292b7