### PR TITLE
Support structured Telegram broadcast payloads

### DIFF
--- a/supabase/functions/broadcast-dispatch/index.ts
+++ b/supabase/functions/broadcast-dispatch/index.ts
@@ -1,18 +1,38 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { optionalEnv, requireEnv } from "../_shared/env.ts";
-import { bad, nf, ok, mna } from "../_shared/http.ts";
+import { bad, mna, nf, ok } from "../_shared/http.ts";
 import { version } from "../_shared/version.ts";
+export type TelegramPayload = Record<string, unknown>;
+
+export function buildTelegramPayload(content: string | null): TelegramPayload {
+  if (!content) return {};
+  const trimmed = content.trim();
+  if (!trimmed) return {};
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as TelegramPayload;
+      }
+    } catch (_) {
+      // fall through to plain text handling
+    }
+  }
+  return { text: content };
+}
+
 export async function dispatchAudience(
   ids: number[],
-  text: string,
+  payload: TelegramPayload,
   rps: number,
-  send: (id: number, text: string) => Promise<boolean>,
+  send: (id: number, payload: TelegramPayload) => Promise<boolean>,
 ) {
   const delay = rps > 0 ? 1000 / rps : 0;
   let success = 0, failed = 0;
   for (const id of ids) {
-    const ok = await send(id, text);
-    if (ok) success++; else failed++;
+    const ok = await send(id, payload);
+    if (ok) success++;
+    else failed++;
     if (delay) await new Promise((r) => setTimeout(r, delay));
   }
   return { success, failed };
@@ -26,9 +46,14 @@ export async function handler(req: Request): Promise<Response> {
   if (!id) {
     return bad("bad_request");
   }
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN } = requireEnv(
-    ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "TELEGRAM_BOT_TOKEN"] as const,
-  );
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN } =
+    requireEnv(
+      [
+        "SUPABASE_URL",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "TELEGRAM_BOT_TOKEN",
+      ] as const,
+    );
   const headers = {
     apikey: SUPABASE_SERVICE_ROLE_KEY,
     Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
@@ -43,23 +68,26 @@ export async function handler(req: Request): Promise<Response> {
     return nf("not_found");
   }
   const targets: number[] = row.target_audience?.telegram_ids || [];
-  const text = row.content || "";
+  const payload = buildTelegramPayload(row.content ?? "");
   const rps = Number(optionalEnv("BROADCAST_RPS") || "25");
 
-  async function sendOnce(tid: number, msg: string) {
-    let attempt = 0; let wait = 500;
+  async function sendOnce(tid: number, basePayload: TelegramPayload) {
+    let attempt = 0;
+    let wait = 500;
     while (attempt < 3) {
+      const requestPayload = { ...basePayload, chat_id: tid };
       const resp = await fetch(
         `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ chat_id: tid, text: msg }),
+          body: JSON.stringify(requestPayload),
         },
       );
       if (resp.status === 429 || resp.status >= 500) {
         await new Promise((r) => setTimeout(r, wait));
-        wait *= 2; attempt++;
+        wait *= 2;
+        attempt++;
         continue;
       }
       return resp.ok;
@@ -67,7 +95,12 @@ export async function handler(req: Request): Promise<Response> {
     return false;
   }
 
-  const { success, failed } = await dispatchAudience(targets, text, rps, sendOnce);
+  const { success, failed } = await dispatchAudience(
+    targets,
+    payload,
+    rps,
+    sendOnce,
+  );
 
   await fetch(`${SUPABASE_URL}/rest/v1/broadcast_messages?id=eq.${id}`, {
     method: "PATCH",

--- a/tests/broadcast-dispatch-payload.test.ts
+++ b/tests/broadcast-dispatch-payload.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import {
+  deepEqual as assertDeepEqual,
+  equal as assertEqual,
+} from "node:assert/strict";
+import { freshImport } from "./utils/freshImport.ts";
+
+test("buildTelegramPayload falls back to text for plain strings", async () => {
+  const { buildTelegramPayload } = await freshImport(
+    new URL(
+      "../supabase/functions/broadcast-dispatch/index.ts",
+      import.meta.url,
+    ),
+  );
+  const payload = buildTelegramPayload("Hello world");
+  assertDeepEqual(payload, { text: "Hello world" });
+});
+
+test("buildTelegramPayload parses structured JSON content", async () => {
+  const { buildTelegramPayload } = await freshImport(
+    new URL(
+      "../supabase/functions/broadcast-dispatch/index.ts",
+      import.meta.url,
+    ),
+  );
+  const json = JSON.stringify({
+    text: "Check out the Mini App!",
+    parse_mode: "Markdown",
+    reply_markup: {
+      inline_keyboard: [
+        [{ text: "Open Mini App", url: "https://example.com/miniapp" }],
+      ],
+    },
+  });
+  const payload = buildTelegramPayload(json);
+  assertEqual(payload.text, "Check out the Mini App!");
+  assertEqual(payload.parse_mode, "Markdown");
+  assertDeepEqual(payload.reply_markup, {
+    inline_keyboard: [
+      [{ text: "Open Mini App", url: "https://example.com/miniapp" }],
+    ],
+  });
+});
+
+test("buildTelegramPayload ignores invalid JSON and returns text", async () => {
+  const { buildTelegramPayload } = await freshImport(
+    new URL(
+      "../supabase/functions/broadcast-dispatch/index.ts",
+      import.meta.url,
+    ),
+  );
+  const payload = buildTelegramPayload('{"text": "missing quote}');
+  assertDeepEqual(payload, { text: '{"text": "missing quote}' });
+});
+
+test("dispatchAudience forwards payload and tallies outcomes", async () => {
+  const { dispatchAudience } = await freshImport(
+    new URL(
+      "../supabase/functions/broadcast-dispatch/index.ts",
+      import.meta.url,
+    ),
+  );
+  const basePayload = {
+    text: "Dynamic Capital update",
+    parse_mode: "Markdown",
+  };
+  const calls: Array<{ id: number; payload: unknown }> = [];
+  const { success, failed } = await dispatchAudience(
+    [1, 2, 3],
+    basePayload,
+    0,
+    async (id, payload) => {
+      calls.push({ id, payload });
+      return id !== 2;
+    },
+  );
+  assertEqual(success, 2);
+  assertEqual(failed, 1);
+  calls.forEach((call) => {
+    assertDeepEqual(call.payload, basePayload);
+  });
+});


### PR DESCRIPTION
## Summary
- allow broadcast dispatch to parse JSON payloads, supporting parse_mode and reply markup while keeping chat_id per recipient
- expose payload helper and adjust queue dispatch to send structured payloads
- add regression tests covering payload parsing and dispatch accounting

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d554a5fe748322b4eb95b326005ae1