### PR TITLE
Update requests dependency version

### DIFF
--- a/algorithms/mql5/tradingview_to_mt5_bridge/requirements.txt
+++ b/algorithms/mql5/tradingview_to_mt5_bridge/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv==1.0.1
 redis==5.0.3
-requests==2.32.3
+requests~=2.32.4


### PR DESCRIPTION
## Summary
- bump the requests dependency used by the TradingView to MT5 bridge to the 2.32.4 compatible release range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d556f7e9dc8322afe0fc46d9988daa