### PR TITLE
Fix Telegram admin login race condition in mini app

### DIFF
--- a/apps/web/hooks/useTelegramAuth.tsx
+++ b/apps/web/hooks/useTelegramAuth.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useEffect, createContext, useContext, useCallback } from 'react';
-import { callEdgeFunction, buildFunctionUrl } from '@/config/supabase';
 import {
-  VerifyInitDataResponse,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { buildFunctionUrl, callEdgeFunction } from "@/config/supabase";
+import {
   AdminCheckResponse,
+  VerifyInitDataResponse,
   VipStatusResponse,
-} from '@/types/api';
+} from "@/types/api";
 
 interface TelegramUser {
   id: number;
@@ -25,7 +31,10 @@ interface TelegramAuthContextType {
   loading: boolean;
   initData: string | null;
   verifyTelegramAuth: () => Promise<boolean>;
-  checkAdminStatus: () => Promise<boolean>;
+  checkAdminStatus: (
+    userId?: string,
+    initDataOverride?: string,
+  ) => Promise<boolean>;
   getAdminAuth: () => { initData?: string; token?: string } | null;
 }
 
@@ -47,7 +56,7 @@ interface TelegramWebApp {
   initDataUnsafe: TelegramInitDataUnsafe;
   ready: () => void;
   expand: () => void;
-  colorScheme: 'light' | 'dark';
+  colorScheme: "light" | "dark";
   onEvent?: (event: string, handler: () => void) => void;
   offEvent?: (event: string, handler: () => void) => void;
   MainButton: TelegramButtonControl;
@@ -55,107 +64,142 @@ interface TelegramWebApp {
   [key: string]: unknown;
 }
 
-const TelegramAuthContext = createContext<TelegramAuthContextType | undefined>(undefined);
+const TelegramAuthContext = createContext<TelegramAuthContextType | undefined>(
+  undefined,
+);
 
-export function TelegramAuthProvider({ children }: { children: React.ReactNode }) {
+export function TelegramAuthProvider(
+  { children }: { children: React.ReactNode },
+) {
   const [telegramUser, setTelegramUser] = useState<TelegramUser | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isVip, setIsVip] = useState(false);
   const [loading, setLoading] = useState(true);
   const [initData, setInitData] = useState<string | null>(null);
 
-  const verifyTelegramAuth = useCallback(async (initDataString?: string): Promise<boolean> => {
-    const dataToVerify = initDataString || initData;
-    if (!dataToVerify) return false;
+  const verifyTelegramAuth = useCallback(
+    async (initDataString?: string): Promise<boolean> => {
+      const dataToVerify = initDataString || initData;
+      if (!dataToVerify) return false;
 
-    const { data, error } = await callEdgeFunction<VerifyInitDataResponse>('VERIFY_INITDATA', {
-      method: 'POST',
-      body: { initData: dataToVerify },
-    });
+      const { data, error } = await callEdgeFunction<VerifyInitDataResponse>(
+        "VERIFY_INITDATA",
+        {
+          method: "POST",
+          body: { initData: dataToVerify },
+        },
+      );
 
-    if (error) {
-      console.error('Failed to verify telegram auth:', error.message);
-      return false;
-    }
+      if (error) {
+        console.error("Failed to verify telegram auth:", error.message);
+        return false;
+      }
 
-    return data?.ok === true;
-  }, [initData]);
+      return data?.ok === true;
+    },
+    [initData],
+  );
 
-  const checkAdminStatus = useCallback(async (userId?: string): Promise<boolean> => {
+  const checkAdminStatus = useCallback(async (
+    userId?: string,
+    initDataOverride?: string,
+  ): Promise<boolean> => {
     const userIdToCheck = userId || telegramUser?.id?.toString();
     if (!userIdToCheck) return false;
 
+    const initDataPayload = initDataOverride ?? initData;
+
     let data: AdminCheckResponse | undefined;
     let error;
-    if (initData) {
-      ({ data, error } = await callEdgeFunction<AdminCheckResponse>('ADMIN_CHECK', {
-        method: 'POST',
-        body: { initData },
-      }));
+    if (initDataPayload) {
+      ({ data, error } = await callEdgeFunction<AdminCheckResponse>(
+        "ADMIN_CHECK",
+        {
+          method: "POST",
+          body: { initData: initDataPayload },
+        },
+      ));
     } else {
-      ({ data, error } = await callEdgeFunction<AdminCheckResponse>('ADMIN_CHECK', {
-        method: 'POST',
-        body: { telegram_user_id: userIdToCheck },
-      }));
+      ({ data, error } = await callEdgeFunction<AdminCheckResponse>(
+        "ADMIN_CHECK",
+        {
+          method: "POST",
+          body: { telegram_user_id: userIdToCheck },
+        },
+      ));
     }
 
     if (error) {
-      console.error('Failed to check admin status:', error.message);
+      console.error("Failed to check admin status:", error.message);
       return false;
     }
 
-    const adminStatus = initData ? data?.ok === true : data?.is_admin === true;
+    const adminStatus = initDataPayload
+      ? data?.ok === true
+      : data?.is_admin === true;
     setIsAdmin(adminStatus);
     return adminStatus;
   }, [initData, telegramUser]);
 
-  const checkVipStatus = useCallback(async (userId: string): Promise<boolean> => {
-    const { data, error } = await callEdgeFunction<VipStatusResponse>('MINIAPP_HEALTH', {
-      method: 'POST',
-      body: { telegram_id: userId },
-    });
-
-    if (error) {
-      console.error('Failed to check VIP status:', error.message);
-      return false;
-    }
-
-    return data?.vip?.is_vip === true;
-  }, []);
-
-  const syncUser = useCallback(async (initDataString: string): Promise<void> => {
-    try {
-      await fetch(`${buildFunctionUrl('MINIAPP')}/api/sync-user`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+  const checkVipStatus = useCallback(
+    async (userId: string): Promise<boolean> => {
+      const { data, error } = await callEdgeFunction<VipStatusResponse>(
+        "MINIAPP_HEALTH",
+        {
+          method: "POST",
+          body: { telegram_id: userId },
         },
-        body: JSON.stringify({
-          initData: initDataString,
-        }),
-      });
-    } catch (error) {
-      console.error('Failed to sync user:', error);
-    }
-  }, []);
+      );
 
-  const verifyAndCheckStatus = useCallback(async (userId: string, initDataString: string) => {
-    try {
-      const verified = await verifyTelegramAuth(initDataString);
-
-      if (verified) {
-        await syncUser(initDataString);
-        const adminStatus = await checkAdminStatus(userId);
-        setIsAdmin(adminStatus);
-        const vipStatus = await checkVipStatus(userId);
-        setIsVip(vipStatus);
+      if (error) {
+        console.error("Failed to check VIP status:", error.message);
+        return false;
       }
-    } catch (error) {
-      console.error('Failed to verify telegram auth:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [verifyTelegramAuth, syncUser, checkAdminStatus, checkVipStatus]);
+
+      return data?.vip?.is_vip === true;
+    },
+    [],
+  );
+
+  const syncUser = useCallback(
+    async (initDataString: string): Promise<void> => {
+      try {
+        await fetch(`${buildFunctionUrl("MINIAPP")}/api/sync-user`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            initData: initDataString,
+          }),
+        });
+      } catch (error) {
+        console.error("Failed to sync user:", error);
+      }
+    },
+    [],
+  );
+
+  const verifyAndCheckStatus = useCallback(
+    async (userId: string, initDataString: string) => {
+      try {
+        const verified = await verifyTelegramAuth(initDataString);
+
+        if (verified) {
+          await syncUser(initDataString);
+          const adminStatus = await checkAdminStatus(userId, initDataString);
+          setIsAdmin(adminStatus);
+          const vipStatus = await checkVipStatus(userId);
+          setIsVip(vipStatus);
+        }
+      } catch (error) {
+        console.error("Failed to verify telegram auth:", error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [verifyTelegramAuth, syncUser, checkAdminStatus, checkVipStatus],
+  );
 
   useEffect(() => {
     if (globalThis.Telegram?.WebApp) {
@@ -177,25 +221,25 @@ export function TelegramAuthProvider({ children }: { children: React.ReactNode }
 
   const getAdminAuth = () => {
     // Check for stored admin token
-    const token = localStorage.getItem('dc_admin_token');
+    const token = localStorage.getItem("dc_admin_token");
     if (token) {
       try {
-        const payload = JSON.parse(atob(token.split('.')[1]));
+        const payload = JSON.parse(atob(token.split(".")[1]));
         if (payload.exp > Date.now() / 1000 && payload.admin) {
           return { token };
         }
         // Token expired, remove it
-        localStorage.removeItem('dc_admin_token');
+        localStorage.removeItem("dc_admin_token");
       } catch {
-        localStorage.removeItem('dc_admin_token');
+        localStorage.removeItem("dc_admin_token");
       }
     }
-    
+
     // Use initData if available
     if (initData) {
       return { initData };
     }
-    
+
     return null;
   };
 
@@ -207,7 +251,7 @@ export function TelegramAuthProvider({ children }: { children: React.ReactNode }
     initData,
     verifyTelegramAuth,
     checkAdminStatus,
-    getAdminAuth
+    getAdminAuth,
   };
 
   return (
@@ -220,7 +264,9 @@ export function TelegramAuthProvider({ children }: { children: React.ReactNode }
 export function useTelegramAuth() {
   const context = useContext(TelegramAuthContext);
   if (context === undefined) {
-    throw new Error('useTelegramAuth must be used within a TelegramAuthProvider');
+    throw new Error(
+      "useTelegramAuth must be used within a TelegramAuthProvider",
+    );
   }
   return context;
 }


### PR DESCRIPTION
## Summary
- pass the freshly received initData into the mini app admin check to avoid relying on asynchronous state updates
- store the optional initData override in checkAdminStatus so admin gating works immediately after login

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5559578c88322be3d7a319b63e38a