### PR TITLE
Add helper to sanitize legacy npm proxy env

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ platform's configuration for each component.
 > `node scripts/npm-safe.mjs run dev`) to strip the deprecated proxy keys and
 > silence the warning while preserving HTTP/HTTPS proxy support.
 
+If you regularly invoke bare `npm` commands (such as `npm audit --omit=dev`)
+and want to clean your current shell once per session, run:
+
+```bash
+eval "$(node scripts/env/clean-legacy-npm-proxy.mjs)"
+```
+
+The helper prints `export`/`unset` commands that remap the legacy proxy
+variables to the supported `proxy`/`https-proxy` keys so subsequent npm calls
+run without the deprecation warning.
+
 ## Project Structure
 
 - **Functions** – Edge functions live under `supabase/functions` and any

--- a/scripts/env/clean-legacy-npm-proxy.mjs
+++ b/scripts/env/clean-legacy-npm-proxy.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { createSanitizedNpmEnv } from '../utils/npm-env.mjs';
+
+function shellQuote(value) {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+const legacyHttpKeys = ['npm_config_http_proxy', 'NPM_CONFIG_HTTP_PROXY'];
+const canonicalKeys = [
+  ['npm_config_proxy', 'NPM_CONFIG_PROXY'],
+  ['npm_config_https_proxy', 'NPM_CONFIG_HTTPS_PROXY'],
+];
+
+const sanitized = createSanitizedNpmEnv();
+const commands = [];
+
+for (const [lowerKey, upperKey] of canonicalKeys) {
+  const value = sanitized[lowerKey];
+  if (typeof value === 'string') {
+    if (process.env[lowerKey] !== value) {
+      commands.push(`export ${lowerKey}=${shellQuote(value)}`);
+    }
+    if (process.env[upperKey] !== value) {
+      commands.push(`export ${upperKey}=${shellQuote(value)}`);
+    }
+  }
+}
+
+for (const key of legacyHttpKeys) {
+  if (key in process.env) {
+    commands.push(`unset ${key}`);
+  }
+}
+
+if (commands.length === 0) {
+  console.log('# No legacy npm proxy variables detected; nothing to update.');
+} else {
+  console.log('# Apply sanitized npm proxy environment settings');
+  for (const command of commands) {
+    console.log(command);
+  }
+}
+
+if (process.stdout.isTTY) {
+  console.error('Tip: eval "$(node scripts/env/clean-legacy-npm-proxy.mjs)" to update this shell.');
+}


### PR DESCRIPTION
## Summary
- add a helper script that emits shell exports/unsets to convert legacy npm proxy variables to the supported keys
- document how to use the helper so bare npm commands (e.g. npm audit) run without the deprecation warning

## Testing
- npm audit --omit=dev

------
https://chatgpt.com/codex/tasks/task_e_68d558954d8c832294e2f5d891720616