### PR TITLE
docs: add automation roadmap for july cohort

### DIFF
--- a/docs/mentorship/july-2025-cohort-overview.md
+++ b/docs/mentorship/july-2025-cohort-overview.md
@@ -1,0 +1,89 @@
+# Dynamic Mentorship – July 2025 Cohort Overview
+
+## Program Vision
+
+- Four-week intensive led by Mumin (Founder, Dynamic Capital) focused on clarity, confidence, and consistency in discretionary trading.
+- Core curriculum builds from market structure foundations to execution, psychology, and journaling habits.
+- Participants are expected to engage daily, maintain clean charts, and document their learning process.
+
+## Weekly Themes
+
+1. **Week 1 – Market Basics & Structure**
+   - Trending versus ranging conditions, candlestick behavior, and clean chart setup.
+   - Building market structure literacy: HH/HL, LL/LH, BOS versus ChoCh, and timeframe context.
+2. **Week 2 – Zones & Entry Triggers**
+   - Liquidity concepts, supply and demand mapping, order blocks, breaker blocks, and entry confirmations.
+   - Homework emphasizing structured trade ideas with bias, zone logic, and risk parameters.
+3. **Week 3 – Strategy & Routine**
+   - Consolidation, breakout, trending, and reversal playbooks.
+   - Translating higher timeframe bias into lower timeframe execution.
+4. **Week 4 – Psychology & Journaling**
+   - Performance mindset, gradual risk scaling, and maintaining balance outside of charts.
+   - Reinforcing consistency through reflective practice and trade journaling.
+
+## Daily Operating Rhythm
+
+- Lessons release Monday through Friday, combining written modules, screenshots, and voice notes.
+- Homework distributed on Fridays with individualized feedback delivered via voice or text.
+- Group chat remains the hub for questions, chart markups, and collaborative breakdowns—professional etiquette is required.
+
+## Initial Onboarding Checklist
+
+- Share a personal introduction: name, location, trading experience, and key improvement goal.
+- Prepare tooling: TradingView account (free or paid) and a trade journal in notebook, Notion, or spreadsheet form.
+
+## Content Drop Timeline
+
+| Date (2025) | Theme & Assets | Key Actions |
+|-------------|----------------|-------------|
+| Jul 11      | Welcome announcement | Align expectations on four-week roadmap and participation standards. |
+| Jul 14      | Pre-work reminder | Submit introduction and confirm tooling readiness before Day 1. |
+| Jul 15      | Day 1 launch – Market basics & tools | Clean TradingView chart, identify trending vs. ranging behavior on XAUUSD or GBPUSD, and share observations. |
+| Jul 16      | Day 1 & 2 deep dive – Market movement & structure | Study provided PDFs/screenshots covering market types, candlesticks, HH/HL logic, BOS vs. ChoCh, and structured reactions. |
+| Jul 17      | Day 3 – Timeframe breakdown | Review monthly-to-M5 bias generation, plus shared XAUUSD analyses. |
+| Jul 18      | Day 4 – Liquidity & stop hunts | Learn liquidity mapping and manipulation tactics; PDFs on institutional concepts released. |
+| Jul 19      | Day 5 homework + Day 6 supply & demand | Submit two structured trade markups; study zone creation, mapping frameworks, and supplemental market basics resources. |
+| Jul 20      | Liquidity extensions | Digest materials on manipulation, liquidity pools, institutional applications, and zone mapping examples. |
+| Jul 21      | Day 7 preview – Order blocks & breaker blocks | Prepare for institutional entry frameworks and mitigation techniques. |
+| Jul 22      | Day 8 – Entry confirmations | Learn aggressive vs. safe entries and the Dynamic Capital sell model. |
+| Jul 24      | Day 9 reminder – Risk & reward | Emphasize smart stop placement, position sizing, and RR math. |
+| Jul 27      | Day 10 homework prompt | Document two trades detailing zones, confirmations, and risk logic for feedback. |
+| Jul 28      | Psychology insights | Apply five reminders covering perfectionism, process focus, risk scaling, breaks, and lifestyle balance. |
+| Jul 31      | Day 9 materials delivered | Finalize risk and reward management review resources. |
+
+## Automation & Sync Strategy
+
+- **Source of truth hub:** Maintain a single shared workspace (e.g., Notion or Supabase table) where lesson assets, voice notes, and TradingView links are logged with timestamps and access levels. Mirror this data into the community channel via scheduled posts or webhook automations so late-joining mentees receive the full archive instantly.
+- **Auto-publish cadence:** Use a scheduler (Zapier, n8n, or Supabase Edge Functions) to push daily reminders, homework prompts, and resource drops at 9:00 local cohort time. The scheduler should reference the source-of-truth hub to avoid manual duplication.
+- **Version tagging:** Tag each upload with cohort, week, and lesson IDs (e.g., `2025-07-W2-D6`) so historical content can be resurfaced programmatically and reused for future cohorts with minimal editing.
+- **TradingView sync:** Capture snapshot URLs plus `.tv` script exports and store them alongside contextual notes. Automate link validation weekly to ensure expired or updated charts trigger alerts for replacement.
+
+## Future-Proofing Playbook
+
+- **Reusable templates:** Standardize welcome packs, homework briefs, and feedback forms as modular templates. Update templates quarterly and propagate changes automatically through the scheduler to keep messaging current.
+- **Curriculum diff reviews:** At the close of each cohort, run a retrospective that diffs planned lessons against delivered materials. Log discoveries in the source-of-truth hub and queue high-impact improvements for the next cycle.
+- **Dynamic cohort settings:** Parameterize variables such as trading focus pairs, market sessions, and risk modules so the automation layer can adjust announcements when the mentorship scope evolves.
+- **Continuity backups:** Export weekly archives (PDF bundles + CSV metadata) to redundant storage (cloud drive + repository) to guard against platform outages and preserve institutional knowledge.
+
+## Self-Learning Feedback Loop
+
+- **Daily sentiment pulse:** Automate end-of-day micro-surveys capturing clarity, confidence, and outstanding questions. Aggregate responses into dashboards that highlight cohorts needing intervention.
+- **Performance telemetry:** Integrate journaling tools with Google Sheets or Supabase to ingest trade metrics (win rate, RR, adherence). Feed summaries back into the community on Mondays to reinforce data-driven growth.
+- **Adaptive content nudges:** Trigger supplemental lessons when telemetry shows specific gaps (e.g., risk breaches or mis-identified structure). The automation layer should recommend targeted replays or office hours.
+- **Mentor review sprints:** Schedule weekly mentor syncs with AI-assisted summarization of chat highlights, survey data, and trade outcomes so facilitators can iterate on delivery in near real-time.
+
+## Mindset Pillars
+
+- **Consistency over intensity:** Small, repeatable improvements beat sporadic effort.
+- **Process fidelity:** Validate setups by plan adherence, risk management, and adaptability rather than outcome alone.
+- **Community engagement:** Sharing charts and questions accelerates clarity; feedback loops are daily.
+- **Balanced growth:** Protect mental bandwidth by stepping away when needed and cultivating interests beyond trading.
+
+## Reference Materials Catalog
+
+- Market basics, structure frameworks, and trading psychology notes.
+- Liquidity, institutional trading guides, and manipulation breakdowns.
+- Supply and demand mapping frameworks, zone creation workflows, and entry models.
+- Risk and reward calculators, journaling templates, and ICT terminology cheat sheets.
+
+Use this overview to onboard new cohort members quickly, align weekly study plans, and centralize the July 2025 resource stack.


### PR DESCRIPTION
## Summary
- expand the July 2025 mentorship overview with automation and sync guidance
- document future-proofing tactics that keep curriculum assets reusable across cohorts
- outline a self-learning loop to feed telemetry and participant feedback back into program updates

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d55a96e0088322a9442b6f81b78ff8