### PR TITLE
Brand imported GitHub project titles

### DIFF
--- a/apps/web/app/work/[slug]/page.tsx
+++ b/apps/web/app/work/[slug]/page.tsx
@@ -1,23 +1,24 @@
 import { notFound } from "next/navigation";
-import { getPosts } from "@/utils/magic-portfolio/utils";
+import { brandProjectTitle, getPosts } from "@/utils/magic-portfolio/utils";
 import {
-  Meta,
-  Schema,
   AvatarGroup,
   Column,
   Heading,
-  Media,
-  Text,
-  SmartLink,
-  Row,
   Line,
+  Media,
+  Meta,
+  Row,
+  Schema,
+  SmartLink,
+  Text,
 } from "@/components/dynamic-ui-system";
-import { baseURL, about, person, toAbsoluteUrl, work } from "@/resources";
+import { about, baseURL, person, toAbsoluteUrl, work } from "@/resources";
 import { formatDate } from "@/utils/magic-portfolio/formatDate";
-import { ScrollToHash, CustomMDX } from "@/components/magic-portfolio";
+import { CustomMDX, ScrollToHash } from "@/components/magic-portfolio";
 import type { Metadata } from "next";
 import { cache } from "react";
 import { Projects } from "@/components/magic-portfolio/work/Projects";
+import { Badge } from "@/components/ui/badge";
 
 type MaybePromise<T> = T | Promise<T>;
 type WorkPageParams = { slug: string | string[] };
@@ -43,23 +44,32 @@ const resolveSlugFromParams = async (
   return slug || "";
 };
 
-const findWorkPost = (slug: string) => loadWorkPosts().find((post) => post.slug === slug);
+const findWorkPost = (slug: string) =>
+  loadWorkPosts().find((post) => post.slug === slug);
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
   return loadWorkPosts().map((post) => ({ slug: post.slug }));
 }
 
-export async function generateMetadata({ params }: WorkPageProps): Promise<Metadata> {
+export async function generateMetadata(
+  { params }: WorkPageProps,
+): Promise<Metadata> {
   const slugPath = await resolveSlugFromParams(params);
   const post = findWorkPost(slugPath);
 
   if (!post) return {};
 
+  const brandedTitle = brandProjectTitle(
+    post.metadata.title,
+    post.metadata.link,
+  );
+
   return Meta.generate({
-    title: post.metadata.title,
+    title: brandedTitle,
     description: post.metadata.summary,
     baseURL: baseURL,
-    image: post.metadata.image || `/api/og/generate?title=${post.metadata.title}`,
+    image: post.metadata.image ||
+      `/api/og/generate?title=${encodeURIComponent(brandedTitle)}`,
     path: `${work.path}/${post.slug}`,
   });
 }
@@ -72,10 +82,14 @@ export default async function Project({ params }: WorkPageProps) {
     notFound();
   }
 
-  const avatars =
-    post.metadata.team?.map((person) => ({
-      src: person.avatar,
-    })) || [];
+  const avatars = post.metadata.team?.map((person) => ({
+    src: person.avatar,
+  })) || [];
+
+  const brandedTitle = brandProjectTitle(
+    post.metadata.title,
+    post.metadata.link,
+  );
 
   return (
     <Column as="section" maxWidth="m" horizontal="center" gap="l">
@@ -83,13 +97,12 @@ export default async function Project({ params }: WorkPageProps) {
         as="blogPosting"
         baseURL={baseURL}
         path={`${work.path}/${post.slug}`}
-        title={post.metadata.title}
+        title={brandedTitle}
         description={post.metadata.summary}
         datePublished={post.metadata.publishedAt}
         dateModified={post.metadata.publishedAt}
-        image={
-          post.metadata.image || `/api/og/generate?title=${encodeURIComponent(post.metadata.title)}`
-        }
+        image={post.metadata.image ||
+          `/api/og/generate?title=${encodeURIComponent(brandedTitle)}`}
         author={{
           name: person.name,
           url: `${baseURL}${about.path}`,
@@ -97,17 +110,29 @@ export default async function Project({ params }: WorkPageProps) {
         }}
       />
       <Column maxWidth="s" gap="16" horizontal="center" align="center">
+        <Badge
+          variant="outline"
+          className="self-center border-dc-brand/30 bg-dc-brand/10 px-4 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-dc-brand-dark"
+        >
+          Dynamic Capital • ISO 27001
+        </Badge>
         <SmartLink href="/work">
           <Text variant="label-strong-m">Projects</Text>
         </SmartLink>
-        <Text variant="body-default-xs" onBackground="neutral-weak" marginBottom="12">
+        <Text
+          variant="body-default-xs"
+          onBackground="neutral-weak"
+          marginBottom="12"
+        >
           {post.metadata.publishedAt && formatDate(post.metadata.publishedAt)}
         </Text>
-        <Heading variant="display-strong-m">{post.metadata.title}</Heading>
+        <Heading variant="display-strong-m">{brandedTitle}</Heading>
       </Column>
       <Row marginBottom="32" horizontal="center">
         <Row gap="16" vertical="center">
-          {post.metadata.team && <AvatarGroup reverse avatars={avatars} size="s" />}
+          {post.metadata.team && (
+            <AvatarGroup reverse avatars={avatars} size="s" />
+          )}
           <Text variant="label-default-m" onBackground="brand-weak">
             {post.metadata.team?.map((member, idx) => (
               <span key={idx}>
@@ -123,7 +148,13 @@ export default async function Project({ params }: WorkPageProps) {
         </Row>
       </Row>
       {post.metadata.images.length > 0 && (
-        <Media priority aspectRatio="16 / 9" radius="m" alt="image" src={post.metadata.images[0]} />
+        <Media
+          priority
+          aspectRatio="16 / 9"
+          radius="m"
+          alt="image"
+          src={post.metadata.images[0]}
+        />
       )}
       <Column style={{ margin: "auto" }} as="article" maxWidth="xs">
         <CustomMDX source={post.content} />

--- a/apps/web/components/magic-portfolio/ProjectCard.tsx
+++ b/apps/web/components/magic-portfolio/ProjectCard.tsx
@@ -9,6 +9,7 @@ import {
   SmartLink,
   Text,
 } from "@/components/dynamic-ui-system";
+import { Badge } from "@/components/ui/badge";
 
 interface ProjectCardProps {
   href: string;
@@ -32,6 +33,12 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
 }) => {
   return (
     <Column fillWidth gap="m">
+      <Badge
+        variant="outline"
+        className="self-start border-dc-brand/30 bg-dc-brand/10 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-dc-brand-dark"
+      >
+        Dynamic Capital • ISO 27001
+      </Badge>
       <Carousel
         sizes="(max-width: 960px) 100vw, 960px"
         items={images.map((image) => ({

--- a/apps/web/components/magic-portfolio/work/Projects.tsx
+++ b/apps/web/components/magic-portfolio/work/Projects.tsx
@@ -1,4 +1,4 @@
-import { getPosts } from "@/utils/magic-portfolio/utils";
+import { brandProjectTitle, getPosts } from "@/utils/magic-portfolio/utils";
 import { Column } from "@/components/dynamic-ui-system";
 import { ProjectCard } from "@/components/magic-portfolio";
 
@@ -16,7 +16,8 @@ export function Projects({ range, exclude }: ProjectsProps) {
   }
 
   const sortedProjects = allProjects.sort((a, b) => {
-    return new Date(b.metadata.publishedAt).getTime() - new Date(a.metadata.publishedAt).getTime();
+    return new Date(b.metadata.publishedAt).getTime() -
+      new Date(a.metadata.publishedAt).getTime();
   });
 
   const displayedProjects = range
@@ -31,10 +32,12 @@ export function Projects({ range, exclude }: ProjectsProps) {
           key={post.slug}
           href={`/work/${post.slug}`}
           images={post.metadata.images}
-          title={post.metadata.title}
+          title={brandProjectTitle(post.metadata.title, post.metadata.link)}
           description={post.metadata.summary}
           content={post.content}
-          avatars={post.metadata.team?.map((member) => ({ src: member.avatar })) || []}
+          avatars={post.metadata.team?.map((member) => ({
+            src: member.avatar,
+          })) || []}
           link={post.metadata.link || ""}
         />
       ))}


### PR DESCRIPTION
## Summary
- add a helper to stamp GitHub-linked portfolio titles with Dynamic Capital branding
- apply the branded title across project listings, metadata, and detail headings so imported repos read consistently

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d555d96f8c8322a707c9e8e2e8050c