### PR TITLE
Use ISO timestamps in repo organizer

### DIFF
--- a/docs/REPO_FILE_ORGANIZER.md
+++ b/docs/REPO_FILE_ORGANIZER.md
@@ -1,6 +1,6 @@
 # Repository File Organizer — Dynamic-Capital
 
-**Generated:** Thu, 25 Sep 2025 00:38:52 GMT **Repo root:** Dynamic-Capital
+**Generated:** 2025-09-25T15:17:45.765Z **Repo root:** Dynamic-Capital
 
 This organizer groups top-level files and directories into logical domains so
 contributors can quickly locate the right surface when shipping changes.

--- a/scripts/repo-file-organizer.ts
+++ b/scripts/repo-file-organizer.ts
@@ -42,7 +42,7 @@ const projectName = relative(dirname(repoRoot), repoRoot) ||
   "repository";
 
 function formatDate(date: Date): string {
-  return date.toUTCString();
+  return date.toISOString();
 }
 
 const categories: CategoryBucket[] = [


### PR DESCRIPTION
## Summary
- update the repo file organizer generator to emit ISO 8601 timestamps
- regenerate the documentation so the generated timestamp follows the ISO format

## Testing
- npm run docs:organize
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55c8b02e08322a3ab3d337dc6c092