### PR TITLE
Add DCT starter kit docs and auto-invest pipeline

### DIFF
--- a/docs/dct-jetton-starter-kit.md
+++ b/docs/dct-jetton-starter-kit.md
@@ -1,0 +1,151 @@
+# Dynamic Capital Token (DCT) Starter Kit
+
+## Overview
+
+This starter kit captures the core smart-contract, data, and backend flows for
+launching the Dynamic Capital Token (DCT) ecosystem on TON. It distills the
+design objectives into actionable checklists, a relational schema for Supabase,
+and a TypeScript Edge Function that automates the subscription → buyback → burn
+→ auto-invest pipeline.
+
+## Jetton Contract Checklist
+
+### Core Properties
+
+- [ ] `maxSupply()` returns `100,000,000 * 10^9` and is immutable after
+      deployment.
+- [ ] `decimals()` returns `9`.
+- [ ] `name()` and `symbol()` are hard-coded as "Dynamic Capital Token" and
+      "DCT".
+- [ ] `mint()` is callable **only** during genesis by the deployer wallet and
+      permanently disabled afterward.
+- [ ] `burn(amount)` is public and reduces the tracked `totalSupply`.
+
+### Allocation Enforcement
+
+- [ ] Genesis transactions mint the following fixed amounts to controlled
+      wallets:
+  | Allocation                | Amount (DCT) | Notes                                |
+  | ------------------------- | ------------ | ------------------------------------ |
+  | Community & Rewards       | 50,000,000   | Streamed via emissions controller    |
+  | Treasury / Operations     | 20,000,000   | Liquidity, partnerships, incentives  |
+  | Team & Advisors (Vested)  | 15,000,000   | 12-month cliff, 36-month linear vest |
+  | Liquidity & Market Making | 10,000,000   | Initial DEX & market making          |
+  | Ecosystem Grants          | 5,000,000    | Grants and ecosystem growth          |
+- [ ] After genesis, no account (including multisig) can mint additional tokens.
+
+### Governance & Safety Controls
+
+- [ ] `pauseTransfers(true|false)` is protected by the operations multisig and a
+      48-hour timelock.
+- [ ] `setTransferTax(bps)` is optional, capped between `0` and `100`, and
+      guarded by the same multisig + timelock.
+- [ ] `setController(address)` or equivalent hooks require multisig
+      authorization with timelock to avoid rogue upgrades.
+- [ ] Emergency functions (`pauseTransfers`, `pauseEmissions`) emit events for
+      off-chain monitoring.
+
+### Controller Interfaces
+
+- [ ] **Treasury Router:** `setSplits`, `collectPayment`, `setDEXRouter`,
+      `setTreasury` — enforce split bounds (Ops 40–75%, Invest 15–45%, Burn
+      5–20%) and apply timelock + rate limits.
+- [ ] **Emissions Controller:** `setEpochCap`, `setDecayParams`,
+      `distributeRewards`, `pauseEmissions`.
+- [ ] **Staking Vault (optional at launch):** `stake`, `unstake`,
+      `claimRewards`, lock-tier multipliers, and early-exit penalty that routes
+      to `burn()`.
+
+### Multisig Configuration
+
+- [ ] Operations multisig is 4/7 (upgradeable to 5/9) and is the sole owner of
+      sensitive functions.
+- [ ] Timelock delays are enforced on-chain; queued transactions must emit
+      `TimelockQueued` events with ETA.
+- [ ] A `maxDCVotingSharePct` guard (≤25%) is enforced when counting votes (via
+      token snapshots or controller logic).
+
+### Monitoring & Audits
+
+- [ ] Index all governance/timelock events for real-time dashboards.
+- [ ] Unit tests cover mint/burn caps, split bounds, and timelock execution
+      paths.
+- [ ] External audit report stored and referenced in repository docs before
+      mainnet launch.
+
+## Supabase Schema (SQL)
+
+The `supabase/migrations/202409081200_dct_foundation.sql` migration creates the
+persistence layer for subscriptions, staking balances, and emissions snapshots.
+
+Key tables:
+
+- `dct_users` — links Telegram identity, TON wallet, and creation metadata.
+- `dct_subscriptions` — immutable payment log capturing TON inflows, swap
+  output, and burn metrics per subscription cycle.
+- `dct_stakes` — tracks off-chain staking balances with lock windows, weights,
+  and status transitions.
+- `dct_emissions` — ledger for epoch rewards distributed from the Community &
+  Rewards allocation.
+
+Each table enforces referential integrity and retains operational metadata
+(created/updated timestamps, webhook trace IDs, etc.). Numeric columns use
+`numeric(30,9)` to match TON/Jetton precision.
+
+## Edge Function: `dct-auto-invest`
+
+Located at `supabase/functions/dct-auto-invest/index.ts`, this function
+orchestrates the subscription pipeline once a TON payment is confirmed via the
+Mini App.
+
+### Responsibilities
+
+1. Validate the request payload, enforce split bounds, and compute TON amounts
+   per bucket.
+2. Verify the TON transaction against an indexer (`TON_INDEXER_URL`) and ensure
+   funds landed in the intake wallet.
+3. Call the configured DEX router to buy DCT for auto-invest and burn buckets,
+   respecting slippage/price overrides.
+4. Trigger the Jetton burn (if amount > 0) and record external transaction
+   hashes for auditability.
+5. Upsert the user, insert subscription records, and create/update staking
+   ledgers with VIP lock multipliers.
+6. Emit a JSON response summarizing ton spent, DCT acquired, burn totals, and
+   next renewal date (if provided by the caller).
+
+### Environment Configuration
+
+Add the following keys to your Supabase Edge environment
+(`supabase secrets set ...`):
+
+- `OPERATIONS_TREASURY_WALLET` — TON wallet receiving the operations split.
+- `INTAKE_WALLET` — TON wallet monitored for subscription inflows.
+- `DCT_JETTON_MASTER` — Jetton master address used for burns.
+- `DEX_ROUTER_URL` — HTTP endpoint for swaps (wrap STON.fi or your router
+  abstraction).
+- `TON_INDEXER_URL` — Optional; skips verification if omitted (use during local
+  testing).
+- `DCT_PRICE_OVERRIDE` — Optional decimal (DCT per TON) for deterministic
+  testing.
+
+Optional automation hooks:
+
+- `BURN_WEBHOOK_URL` — If set, the function will `POST` burn instructions after
+  swaps.
+- `BOT_WEBHOOK_URL` — Receives subscription summaries to notify the Telegram
+  bot.
+
+### Testing Notes
+
+- Mock the router and indexer endpoints when running `deno test` or integration
+  suites.
+- Use the `DCT_PRICE_OVERRIDE` to run deterministic local tests without touching
+  mainnet/testnet liquidity.
+- Pair with the schema migration to ensure the necessary tables exist before
+  deploying the function.
+
+---
+
+With these pieces in place you can progress through Phase 1 of the rollout
+roadmap: launch the hard-capped Jetton, wire subscriptions to buyback/burn
+automation, and expose VIP staking multipliers via the Mini App.

--- a/supabase/migrations/202409081200_dct_foundation.sql
+++ b/supabase/migrations/202409081200_dct_foundation.sql
@@ -1,0 +1,110 @@
+-- Dynamic Capital Token (DCT) core schema
+-- Creates dedicated tables for subscriptions, staking, and emissions tracking.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.dct_users (
+  id uuid primary key default gen_random_uuid(),
+  telegram_id bigint unique,
+  wallet_address text not null unique,
+  ton_domain text,
+  metadata jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint dct_users_wallet_chk check (length(wallet_address) > 0)
+);
+
+create table if not exists public.dct_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.dct_users(id) on delete cascade,
+  plan text not null,
+  ton_paid numeric(30,9) not null,
+  operations_ton numeric(30,9) not null,
+  auto_invest_ton numeric(30,9) not null,
+  burn_ton numeric(30,9) not null,
+  dct_bought numeric(30,9) not null,
+  dct_auto_invest numeric(30,9) not null,
+  dct_burned numeric(30,9) not null,
+  tx_hash text not null,
+  router_swap_id text,
+  burn_tx_hash text,
+  split_operations_pct smallint not null,
+  split_auto_invest_pct smallint not null,
+  split_burn_pct smallint not null,
+  next_renewal_at timestamptz,
+  notes jsonb,
+  created_at timestamptz not null default now(),
+  constraint dct_subscriptions_tx_hash_unique unique (tx_hash),
+  constraint dct_subscriptions_split_bounds check (
+    split_operations_pct between 0 and 100
+    and split_auto_invest_pct between 0 and 100
+    and split_burn_pct between 0 and 100
+    and split_operations_pct + split_auto_invest_pct + split_burn_pct = 100
+  )
+);
+
+create index if not exists dct_subscriptions_user_id_idx
+  on public.dct_subscriptions (user_id, created_at desc);
+
+create type public.dct_stake_status as enum ('active', 'unlocking', 'released', 'cancelled');
+
+create table if not exists public.dct_stakes (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.dct_users(id) on delete cascade,
+  subscription_id uuid references public.dct_subscriptions(id) on delete set null,
+  dct_amount numeric(30,9) not null,
+  multiplier numeric(10,4) not null default 1.0,
+  weight numeric(30,9) not null,
+  lock_months smallint,
+  lock_until timestamptz,
+  early_exit_penalty_bps smallint not null default 0,
+  status public.dct_stake_status not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  released_at timestamptz,
+  notes jsonb,
+  constraint dct_stakes_positive_amount check (dct_amount > 0),
+  constraint dct_stakes_positive_weight check (weight > 0)
+);
+
+create index if not exists dct_stakes_user_status_idx
+  on public.dct_stakes (user_id, status, lock_until);
+
+create table if not exists public.dct_emissions (
+  epoch integer primary key,
+  total_reward numeric(30,9) not null,
+  decay_rate numeric(12,9),
+  distributed_at timestamptz,
+  notes jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.dct_emission_events (
+  id uuid primary key default gen_random_uuid(),
+  epoch integer not null references public.dct_emissions(epoch) on delete cascade,
+  stake_id uuid references public.dct_stakes(id) on delete set null,
+  user_id uuid references public.dct_users(id) on delete set null,
+  reward_amount numeric(30,9) not null,
+  snapshot_weight numeric(30,9) not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists dct_emission_events_user_idx
+  on public.dct_emission_events (user_id, epoch);
+
+-- Trigger helpers to keep updated_at current
+create or replace function public.dct_touch_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger dct_users_touch_updated_at
+before update on public.dct_users
+for each row execute procedure public.dct_touch_updated_at();
+
+create trigger dct_stakes_touch_updated_at
+before update on public.dct_stakes
+for each row execute procedure public.dct_touch_updated_at();


### PR DESCRIPTION
## Summary
- add a Dynamic Capital Token (DCT) starter kit document with contract, schema, and edge-function guidance
- introduce a dedicated Supabase migration for DCT subscription, staking, and emissions tracking tables
- scaffold a Supabase Edge Function that processes TON subscription payments into buyback, burn, and staking actions

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d5609cf6908322a8c06d17b52fc27b