### PR TITLE
Enable dynamic route access for blog and work pages

### DIFF
--- a/apps/web/resources/dynamic-ui.config.ts
+++ b/apps/web/resources/dynamic-ui.config.ts
@@ -5,7 +5,6 @@ import {
   FontsConfig,
   MailchimpConfig,
   ProtectedRoutesConfig,
-  RoutesConfig,
   SameAsConfig,
   SchemaConfig,
   SocialSharingConfig,
@@ -14,25 +13,12 @@ import {
 } from "@/resources/types";
 import { dynamicBranding } from "./dynamic-branding.config";
 import { home } from "./content";
+import { routes } from "./routes.config.ts";
 
 const brandingMetadata = dynamicBranding.metadata;
 const brandingAssets = dynamicBranding.assets;
 
 const baseURL: string = brandingMetadata.primaryUrl;
-
-const routes: RoutesConfig = {
-  "/": true,
-  "/about": true,
-  "/plans": true,
-  "/checkout": true,
-  "/login": true,
-  "/admin": true,
-  "/signal": true,
-  "/work": true,
-  "/blog": true,
-  "/gallery": false,
-  "/telegram": true,
-};
 
 const display: DisplayConfig = {
   location: true,

--- a/apps/web/resources/routes.config.ts
+++ b/apps/web/resources/routes.config.ts
@@ -1,0 +1,15 @@
+import type { RoutesConfig } from "./types/config.types.ts";
+
+export const routes: RoutesConfig = {
+  "/": true,
+  "/about": true,
+  "/plans": true,
+  "/checkout": true,
+  "/login": true,
+  "/admin": true,
+  "/signal": true,
+  "/work": { enabled: true, includeChildren: true },
+  "/blog": { enabled: true, includeChildren: true },
+  "/gallery": false,
+  "/telegram": true,
+};

--- a/apps/web/resources/routes.ts
+++ b/apps/web/resources/routes.ts
@@ -2,7 +2,7 @@ import type {
   NormalizedRouteDefinition,
   RouteConfigValue,
 } from "@/resources/types";
-import { routes } from "./dynamic-ui.config";
+import { routes } from "./routes.config.ts";
 
 const normalizeRoutePath = (path: string): `/${string}` => {
   if (!path) {

--- a/tests/routes-config.test.ts
+++ b/tests/routes-config.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import { equal as assertEqual } from "node:assert/strict";
+
+import { isRouteEnabled } from "../apps/web/resources/routes.ts";
+
+test("enables dynamic blog and work routes", () => {
+  assertEqual(isRouteEnabled("/blog/example-post"), true);
+  assertEqual(isRouteEnabled("/blog/example-post/insights"), true);
+  assertEqual(isRouteEnabled("/work/case-study"), true);
+  assertEqual(isRouteEnabled("/work/case-study/results"), true);
+});
+
+test("keeps disabled routes inaccessible", () => {
+  assertEqual(isRouteEnabled("/gallery"), false);
+  assertEqual(isRouteEnabled("/gallery/secret"), false);
+});


### PR DESCRIPTION
## Summary
- extract the route visibility map into a dedicated `routes.config.ts`
- enable child paths for the blog and work routes so dynamic slugs remain accessible
- cover the dynamic route behaviour with a regression test suite

## Testing
- npm run lint
- npm run typecheck
- npm run test -- --filter routes

------
https://chatgpt.com/codex/tasks/task_e_68d563148010832295d4f938b42bb876