### PR TITLE
chore: update next eslint plugin

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -98,7 +98,7 @@
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@next/bundle-analyzer": "^15.5.3",
-    "@next/eslint-plugin-next": "^15.5.3",
+    "@next/eslint-plugin-next": "^15.5.4",
     "@playwright/test": "^1.55.0",
     "@tailwindcss/postcss": "^4.1.13",
     "@tailwindcss/typography": "^0.5.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,7 +128,7 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@next/bundle-analyzer": "^15.5.3",
-        "@next/eslint-plugin-next": "^15.5.3",
+        "@next/eslint-plugin-next": "^15.5.4",
         "@playwright/test": "^1.55.0",
         "@tailwindcss/postcss": "^4.1.13",
         "@tailwindcss/typography": "^0.5.15",
@@ -4796,9 +4796,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.3.tgz",
-      "integrity": "sha512-SdhaKdko6dpsSr0DldkESItVrnPYB1NS2NpShCSX5lc7SSQmLZt5Mug6t2xbiuVWEVDLZSuIAoQyYVBYp0dR5g==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.4.tgz",
+      "integrity": "sha512-SR1vhXNNg16T4zffhJ4TS7Xn7eq4NfKfcOsRwea7RIAHrjRpI9ALYbamqIJqkAhowLlERffiwk0FMvTLNdnVtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- bump @next/eslint-plugin-next to the latest 15.5.4 release for the web workspace
- refresh the lockfile to capture the patched ESLint plugin version

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56b32851083228bb07a3a4a3ff375