### PR TITLE
feat: add education hub section to landing page

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.module.scss
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.module.scss
@@ -71,6 +71,31 @@
   grid-template-columns: repeat(auto-fit, minmax(21rem, 1fr));
 }
 
+.educationGrid {
+  @extend %gridBase;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(22rem, 1fr));
+}
+
+.educationVideo {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: clamp(0.75rem, 2vw, 1.25rem);
+  overflow: hidden;
+  background: rgba(7, 15, 28, 0.86);
+  box-shadow: 0 24px 48px rgba(3, 7, 18, 0.24);
+}
+
+.educationVideo iframe,
+.educationVideo video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 .card {
   height: 100%;
 }

--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -1,12 +1,16 @@
 import { type ReactNode } from "react";
 
 import {
+  AccordionGroup,
+  Button,
   Column,
   Heading,
   Icon,
+  Media,
   RevealFx,
   Row,
   Schema,
+  SmartLink,
   Tag,
   Text,
 } from "@/components/dynamic-ui-system";
@@ -19,6 +23,7 @@ import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchli
 import { cn } from "@/utils";
 import { about, baseURL, home, person, toAbsoluteUrl } from "@/resources";
 import styles from "./DynamicCapitalLandingPage.module.scss";
+import type { AccordionItem } from "@/components/dynamic-ui-system";
 
 const QUICK_METRICS = [
   {
@@ -167,6 +172,87 @@ const FUNDING_SUPPORT = [
   "Weekly portfolio reviews to unlock higher tiers without renegotiation",
 ];
 
+const EDUCATION_FAQ_ITEMS: AccordionItem[] = [
+  {
+    title: "What is Forex?",
+    content: (
+      <Column gap="12" align="start">
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Forex, or foreign exchange, is the 24-hour marketplace where banks,
+          institutions, and traders exchange global currencies. Prices are
+          quoted in pairs, so learning how majors like EUR/USD move and how pip
+          values translate into risk is the foundation of every trade idea.
+        </Text>
+        <Text
+          variant="body-default-s"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Focus on session overlaps, economic catalysts, and position sizing so
+          that every entry aligns with your playbook rather than noise.
+        </Text>
+      </Column>
+    ),
+  },
+  {
+    title: "How does staking work?",
+    content: (
+      <Column gap="12" align="start">
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Staking lets you commit tokens to a validator so the network can
+          process transactions securely. In return you earn rewards that accrue
+          block by block, and you can compound or withdraw them once the bonding
+          period ends.
+        </Text>
+        <Text
+          variant="body-default-s"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Dynamic Capital automates restaking windows and monitors validator
+          performance so your capital keeps working without manual intervention.
+        </Text>
+      </Column>
+    ),
+  },
+  {
+    title: "Why TON blockchain?",
+    content: (
+      <Column gap="12" align="start">
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          TON delivers sub-5 second finality, ultra-low fees, and native
+          integrations with Telegram. That combination lets us ship trading
+          automation, staking payouts, and account provisioning that feel
+          instant for members worldwide.
+        </Text>
+        <Text
+          variant="body-default-s"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Explore the latest releases on the{" "}
+          <SmartLink href="https://ton.org/" target="_blank" rel="noreferrer">
+            official TON hub
+          </SmartLink>{" "}
+          and see how the ecosystem keeps growing alongside our desk.
+        </Text>
+      </Column>
+    ),
+  },
+];
+
 export function DynamicCapitalLandingPage() {
   return (
     <Column
@@ -198,13 +284,16 @@ export function DynamicCapitalLandingPage() {
       <Section variant="wide" revealDelay={0.48}>
         <MarketIntelligenceSection />
       </Section>
-      <Section revealDelay={0.56}>
-        <MentorAndTrustSection />
+      <Section variant="wide" revealDelay={0.56}>
+        <EducationHubSection />
       </Section>
       <Section revealDelay={0.64}>
-        <FundingReadinessSection />
+        <MentorAndTrustSection />
       </Section>
       <Section revealDelay={0.72}>
+        <FundingReadinessSection />
+      </Section>
+      <Section revealDelay={0.8}>
         <CheckoutCallout />
       </Section>
       <Section reveal={false}>
@@ -431,6 +520,127 @@ function MarketIntelligenceSection() {
         <Column gap="16" className={styles.card}>
           <FxMarketSnapshotSection />
           <EconomicCalendarSection />
+        </Column>
+      </div>
+    </Column>
+  );
+}
+
+function EducationHubSection() {
+  return (
+    <Column fillWidth gap="24" align="start">
+      <Column gap="12" align="start">
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="info">
+          Education Hub · Beginners' Corner
+        </Tag>
+        <Heading variant="display-strong-xs" wrap="balance">
+          Build confidence with friendly explainers before you fund your desk
+        </Heading>
+        <Text
+          variant="body-default-l"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Walk through the fundamentals of forex, staking, and TON in plain
+          language. Each module pairs concise FAQs with rich media so your first
+          trade feels intentional.
+        </Text>
+      </Column>
+      <div className={styles.educationGrid}>
+        <Column
+          background="surface"
+          border="neutral-alpha-weak"
+          radius="l"
+          padding="xl"
+          gap="20"
+          className={styles.card}
+          align="start"
+        >
+          <Heading variant="heading-strong-m">Interactive FAQ</Heading>
+          <Text
+            variant="body-default-m"
+            onBackground="neutral-weak"
+            wrap="balance"
+          >
+            Expand each topic to unpack terminology, risk concepts, and the way
+            automation supports your learning curve.
+          </Text>
+          <AccordionGroup items={EDUCATION_FAQ_ITEMS} size="m" autoCollapse />
+          <Row>
+            <Button
+              size="m"
+              variant="primary"
+              data-border="rounded"
+              href="/checkout"
+            >
+              Start Your First Trade →
+            </Button>
+          </Row>
+        </Column>
+        <Column gap="20">
+          <Column
+            background="surface"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="xl"
+            gap="16"
+            className={styles.card}
+            align="start"
+          >
+            <Tag size="s" background="brand-alpha-weak" prefixIcon="play">
+              Watch
+            </Tag>
+            <Heading variant="heading-strong-m" wrap="balance">
+              Forex fundamentals in under five minutes
+            </Heading>
+            <Text
+              variant="body-default-s"
+              onBackground="neutral-weak"
+              wrap="balance"
+            >
+              A quick primer on how currency pairs, pips, and leverage interact
+              so you can practice risk-aware setups.
+            </Text>
+            <div className={styles.educationVideo}>
+              <iframe
+                src="https://www.youtube.com/embed/l1EssrLxt7E"
+                title="Forex trading basics video"
+                loading="lazy"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          </Column>
+          <Column
+            background="surface"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="xl"
+            gap="16"
+            className={styles.card}
+            align="start"
+          >
+            <Tag size="s" background="brand-alpha-weak" prefixIcon="world">
+              Infographic
+            </Tag>
+            <Heading variant="heading-strong-m" wrap="balance">
+              TON ecosystem at a glance
+            </Heading>
+            <Text
+              variant="body-default-s"
+              onBackground="neutral-weak"
+              wrap="balance"
+            >
+              Visualize why TON underpins our automation stack—speed, costs, and
+              interoperability engineered for modern desks.
+            </Text>
+            <Media
+              src="/education/ton-infographic.svg"
+              alt="Infographic summarizing the benefits of the TON blockchain"
+              aspectRatio="4 / 3"
+              fillWidth
+            />
+          </Column>
         </Column>
       </div>
     </Column>

--- a/apps/web/public/education/ton-infographic.svg
+++ b/apps/web/public/education/ton-infographic.svg
@@ -1,0 +1,193 @@
+<svg
+  width="720"
+  height="540"
+  viewBox="0 0 720 540"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <linearGradient id="tonGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2E8BFD" />
+      <stop offset="1" stop-color="#00E8C7" />
+    </linearGradient>
+    <linearGradient id="cardGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="rgba(46, 139, 253, 0.08)" />
+      <stop offset="1" stop-color="rgba(0, 232, 199, 0.12)" />
+    </linearGradient>
+    <filter
+      id="cardShadow"
+      x="-10%"
+      y="-10%"
+      width="120%"
+      height="120%"
+      color-interpolation-filters="sRGB"
+    >
+      <feDropShadow
+        dx="0"
+        dy="16"
+        stdDeviation="24"
+        flood-color="rgba(9, 20, 37, 0.12)"
+      />
+    </filter>
+  </defs>
+  <rect width="720" height="540" rx="32" fill="#030712" />
+  <rect
+    x="24"
+    y="24"
+    width="672"
+    height="492"
+    rx="28"
+    fill="url(#cardGradient)"
+    stroke="rgba(255, 255, 255, 0.08)"
+  />
+  <g filter="url(#cardShadow)">
+    <rect
+      x="72"
+      y="88"
+      width="576"
+      height="364"
+      rx="24"
+      fill="rgba(7, 15, 28, 0.86)"
+      stroke="rgba(255, 255, 255, 0.06)"
+    />
+    <rect
+      x="72"
+      y="88"
+      width="576"
+      height="364"
+      rx="24"
+      fill="url(#cardGradient)"
+    />
+    <rect
+      x="72"
+      y="88"
+      width="576"
+      height="364"
+      rx="24"
+      stroke="rgba(255, 255, 255, 0.08)"
+      stroke-width="2"
+    />
+  </g>
+  <circle cx="156" cy="168" r="48" fill="url(#tonGradient)" />
+  <path
+    d="M156 138L176 176L156 216L136 176L156 138Z"
+    fill="white"
+    fill-opacity="0.92"
+  />
+  <text
+    x="236"
+    y="165"
+    fill="#FFFFFF"
+    font-family="'Inter', 'Segoe UI', sans-serif"
+    font-size="28"
+    font-weight="700"
+    letter-spacing="0.02em"
+  >TON blockchain</text>
+  <text
+    x="236"
+    y="203"
+    fill="rgba(202, 214, 255, 0.9)"
+    font-family="'Inter', 'Segoe UI', sans-serif"
+    font-size="18"
+    letter-spacing="0.02em"
+  >Built for high-throughput financial automation</text>
+  <g>
+    <rect
+      x="120"
+      y="244"
+      width="192"
+      height="116"
+      rx="20"
+      fill="rgba(12, 21, 40, 0.85)"
+      stroke="rgba(255, 255, 255, 0.06)"
+    />
+    <text
+      x="144"
+      y="285"
+      fill="#77F2E0"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="16"
+      font-weight="700"
+    >Fast finality</text>
+    <text
+      x="144"
+      y="312"
+      fill="rgba(202, 214, 255, 0.85)"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="14"
+    >Sub-5s confirmations keep</text>
+    <text
+      x="144"
+      y="334"
+      fill="rgba(202, 214, 255, 0.85)"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="14"
+    >orders in sync with live markets.</text>
+  </g>
+  <g>
+    <rect
+      x="264"
+      y="356"
+      width="192"
+      height="116"
+      rx="20"
+      fill="rgba(12, 21, 40, 0.85)"
+      stroke="rgba(255, 255, 255, 0.06)"
+    />
+    <text
+      x="288"
+      y="397"
+      fill="#77F2E0"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="16"
+      font-weight="700"
+    >Ultra-low fees</text>
+    <text
+      x="288"
+      y="424"
+      fill="rgba(202, 214, 255, 0.85)"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="14"
+    >Microcent settlement keeps</text>
+    <text
+      x="288"
+      y="446"
+      fill="rgba(202, 214, 255, 0.85)"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="14"
+    >scalping and staking profitable.</text>
+  </g>
+  <g>
+    <rect
+      x="408"
+      y="244"
+      width="192"
+      height="116"
+      rx="20"
+      fill="rgba(12, 21, 40, 0.85)"
+      stroke="rgba(255, 255, 255, 0.06)"
+    />
+    <text
+      x="432"
+      y="285"
+      fill="#77F2E0"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="16"
+      font-weight="700"
+    >Interoperable</text>
+    <text
+      x="432"
+      y="312"
+      fill="rgba(202, 214, 255, 0.85)"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="14"
+    >Bridges and TON wallets plug</text>
+    <text
+      x="432"
+      y="334"
+      fill="rgba(202, 214, 255, 0.85)"
+      font-family="'Inter', 'Segoe UI', sans-serif"
+      font-size="14"
+    >directly into our automation stack.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- introduce a Beginners' Corner Education Hub to the landing page with accordion FAQs, video embed, and CTA
- add responsive styles for the new education layout and media treatment
- include a TON blockchain infographic asset for the education section

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56d27ad18832288ab45784c5551a0