### PR TITLE
Add sticky navigation and mobile footer nav

### DIFF
--- a/apps/web/app/token/page.tsx
+++ b/apps/web/app/token/page.tsx
@@ -1,0 +1,196 @@
+import { Column, Heading, Icon, Row, Tag, Text } from "@/components/dynamic-ui-system";
+
+const TOKEN_NAME = "Dynamic Capital Token";
+const TOKEN_SYMBOL = "DCT";
+const TOKEN_DECIMALS = 9;
+const TOKEN_MAX_SUPPLY = 100_000_000;
+
+const SUPPLY_SPLITS = [
+  {
+    label: "Operations",
+    value: "60%",
+    description: "Fuel day-to-day desk execution, analytics, and mentor coverage.",
+    icon: "sparkles" as const,
+  },
+  {
+    label: "Auto-invest pool",
+    value: "30%",
+    description: "Deploy liquidity into strategies the desk validates each epoch.",
+    icon: "rocket" as const,
+  },
+  {
+    label: "Buyback & burn",
+    value: "10%",
+    description: "Stabilize the treasury with scheduled market operations and burns.",
+    icon: "repeat" as const,
+  },
+] as const;
+
+const LOCK_TIERS = [
+  {
+    tier: "Bronze",
+    duration: "3 months",
+    multiplier: "1.2×",
+    description: "Starter tier that unlocks curated market briefs and limited drops.",
+  },
+  {
+    tier: "Silver",
+    duration: "6 months",
+    multiplier: "1.5×",
+    description: "Enhance reward flow with priority access to automation templates.",
+  },
+  {
+    tier: "Gold",
+    duration: "12 months",
+    multiplier: "2.0×",
+    description: "Max utility with VIP desk passes, mentor escalations, and beta slots.",
+  },
+] as const;
+
+const TOKEN_UTILITIES = [
+  "Redeem on-chain for VIP membership credits and automation boosts.",
+  "Stake into the auto-invest pool to participate in weekly performance.",
+  "Vote on treasury moves through the 48-hour guarded governance window.",
+] as const;
+
+export const metadata = {
+  title: "Dynamic Capital Token (DCT)",
+  description:
+    "Explore the Dynamic Capital Token utility, distribution, and staking tiers powering the trading desk ecosystem.",
+};
+
+const formatNumber = (value: number) => value.toLocaleString("en-US");
+
+export default function TokenPage() {
+  return (
+    <Column
+      gap="40"
+      paddingY="48"
+      paddingX="16"
+      align="center"
+      horizontal="center"
+      fillWidth
+    >
+      <Column maxWidth={32} gap="12" align="center" horizontal="center">
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="shield">
+          Treasury utility
+        </Tag>
+        <Heading variant="display-strong-s" align="center">
+          {TOKEN_NAME} ({TOKEN_SYMBOL})
+        </Heading>
+        <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+          The membership currency that powers Dynamic Capital automations, treasury
+          governance, and community rewards.
+        </Text>
+        <Row gap="16" wrap horizontal="center">
+          <Row
+            gap="8"
+            background="page"
+            border="neutral-alpha-medium"
+            radius="l"
+            padding="12"
+            vertical="center"
+          >
+            <Icon name="infinity" onBackground="brand-medium" />
+            <Text variant="label-strong-s">Max supply {formatNumber(TOKEN_MAX_SUPPLY)}</Text>
+          </Row>
+          <Row
+            gap="8"
+            background="page"
+            border="neutral-alpha-medium"
+            radius="l"
+            padding="12"
+            vertical="center"
+          >
+            <Icon name="sparkles" onBackground="brand-medium" />
+            <Text variant="label-strong-s">Decimals {TOKEN_DECIMALS}</Text>
+          </Row>
+        </Row>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">Utility in motion</Heading>
+        <Column gap="16" as="ul">
+          {TOKEN_UTILITIES.map((utility) => (
+            <Row
+              key={utility}
+              gap="12"
+              as="li"
+              background="surface"
+              border="neutral-alpha-medium"
+              radius="l"
+              padding="16"
+              vertical="center"
+            >
+              <Icon name="check" onBackground="brand-medium" />
+              <Text variant="body-default-m" onBackground="neutral-weak">
+                {utility}
+              </Text>
+            </Row>
+          ))}
+        </Column>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">Supply allocation</Heading>
+        <Column gap="16">
+          {SUPPLY_SPLITS.map((split) => (
+            <Row
+              key={split.label}
+              gap="16"
+              background="page"
+              border="neutral-alpha-medium"
+              radius="l"
+              padding="20"
+              s={{ direction: "column" }}
+            >
+              <Row gap="12" vertical="center">
+                <Icon name={split.icon} onBackground="brand-medium" />
+                <Heading variant="heading-strong-m">{split.label}</Heading>
+                <Tag size="s" background="brand-alpha-weak">
+                  {split.value}
+                </Tag>
+              </Row>
+              <Text variant="body-default-m" onBackground="neutral-weak">
+                {split.description}
+              </Text>
+            </Row>
+          ))}
+        </Column>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">Lock tiers & multipliers</Heading>
+        <Column gap="16">
+          {LOCK_TIERS.map((tier) => (
+            <Row
+              key={tier.tier}
+              background="surface"
+              border="neutral-alpha-medium"
+              radius="l"
+              padding="20"
+              horizontal="between"
+              vertical="center"
+              s={{ direction: "column", align: "start" }}
+            >
+              <Column gap="8">
+                <Row gap="8" vertical="center">
+                  <Heading variant="heading-strong-m">{tier.tier}</Heading>
+                  <Tag size="s" background="neutral-alpha-weak">
+                    {tier.duration}
+                  </Tag>
+                  <Tag size="s" background="brand-alpha-weak">
+                    {tier.multiplier}
+                  </Tag>
+                </Row>
+                <Text variant="body-default-m" onBackground="neutral-weak">
+                  {tier.description}
+                </Text>
+              </Column>
+            </Row>
+          ))}
+        </Column>
+      </Column>
+    </Column>
+  );
+}

--- a/apps/web/components/magic-portfolio/Footer.module.scss
+++ b/apps/web/components/magic-portfolio/Footer.module.scss
@@ -1,7 +1,7 @@
 @use "./breakpoints.scss" as breakpoints;
 
 @media (max-width: breakpoints.$s) {
-    .mobile {
-        text-align: center;
-    }
+  .mobile {
+    text-align: center;
+  }
 }

--- a/apps/web/components/magic-portfolio/Footer.tsx
+++ b/apps/web/components/magic-portfolio/Footer.tsx
@@ -1,54 +1,58 @@
 import { IconButton, Row, Text } from "@/components/dynamic-ui-system";
 import { schema, social } from "@/resources";
 import styles from "./Footer.module.scss";
+import { MobileFooterNav } from "./MobileFooterNav";
 
 export const Footer = () => {
   const currentYear = new Date().getFullYear();
   const organizationName = schema.name;
 
   return (
-    <Row
-      as="footer"
-      fillWidth
-      padding="8"
-      horizontal="center"
-      s={{ direction: "column" }}
-    >
+    <>
       <Row
-        className={styles.mobile}
-        maxWidth="m"
-        paddingY="8"
-        paddingX="16"
-        gap="16"
-        horizontal="between"
-        vertical="center"
-        s={{
-          direction: "column",
-          horizontal: "center",
-          align: "center",
-        }}
+        as="footer"
+        fillWidth
+        padding="8"
+        horizontal="center"
+        s={{ direction: "column" }}
       >
-        <Text variant="body-default-s" onBackground="neutral-strong">
-          <Text onBackground="neutral-weak">© {currentYear} /</Text>
-          <Text paddingX="4">{organizationName}</Text>
-        </Text>
-        <Row gap="16">
-          {social.map(
-            (item) =>
-              item.link && (
-                <IconButton
-                  key={item.name}
-                  href={item.link}
-                  icon={item.icon}
-                  tooltip={item.name}
-                  size="s"
-                  variant="ghost"
-                />
-              ),
-          )}
+        <Row
+          className={styles.mobile}
+          maxWidth="m"
+          paddingY="8"
+          paddingX="16"
+          gap="16"
+          horizontal="between"
+          vertical="center"
+          s={{
+            direction: "column",
+            horizontal: "center",
+            align: "center",
+          }}
+        >
+          <Text variant="body-default-s" onBackground="neutral-strong">
+            <Text onBackground="neutral-weak">© {currentYear} /</Text>
+            <Text paddingX="4">{organizationName}</Text>
+          </Text>
+          <Row gap="16">
+            {social.map(
+              (item) =>
+                item.link && (
+                  <IconButton
+                    key={item.name}
+                    href={item.link}
+                    icon={item.icon}
+                    tooltip={item.name}
+                    size="s"
+                    variant="ghost"
+                  />
+                ),
+            )}
+          </Row>
         </Row>
+        <Row height={96} hide s={{ hide: false }} />
       </Row>
-      <Row height="80" hide s={{ hide: false }} />
-    </Row>
+      <MobileFooterNav />
+    </>
   );
 };

--- a/apps/web/components/magic-portfolio/Header.module.scss
+++ b/apps/web/components/magic-portfolio/Header.module.scss
@@ -1,21 +1,73 @@
 @use "./breakpoints.scss" as breakpoints;
 
 .mask {
-    pointer-events: none;
-    backdrop-filter: blur(0.5rem);
-    background: linear-gradient(to bottom, var(--page-background), var(--static-transparent));
-    mask-image: linear-gradient(rgba(0,0,0) 25%, rgba(0, 0, 0, 0) 100%);
-    mask-size: 100% 100%;
+  pointer-events: none;
+  backdrop-filter: blur(0.5rem);
+  background: linear-gradient(
+    to bottom,
+    var(--page-background),
+    var(--static-transparent)
+  );
+  mask-image: linear-gradient(rgba(0, 0, 0) 25%, rgba(0, 0, 0, 0) 100%);
+  mask-size: 100% 100%;
 }
 
 @media (max-width: breakpoints.$s) {
-    .position {
-        top: auto;
-        bottom: var(--static-space-24);
-    }
+  .position {
+    top: auto;
+    bottom: var(--static-space-24);
+  }
 
-    .mask {
-        transform: rotate(180deg);
-        bottom: 0;
-    }
+  .mask {
+    transform: rotate(180deg);
+    bottom: 0;
+  }
+}
+
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: hsl(var(--card));
+  border-radius: 9999px;
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+.divider {
+  color: hsl(var(--muted-foreground));
+  opacity: 0.6;
+  font-weight: 600;
+}
+
+.navLink {
+  color: hsl(var(--muted-foreground));
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.navLink:hover,
+.navLink:focus-visible {
+  color: hsl(var(--foreground));
+}
+
+.navLinkActive {
+  color: hsl(var(--primary));
+}
+
+.themeToggle {
+  margin-left: 1rem;
+}
+
+@media (max-width: breakpoints.$s) {
+  .navLinks {
+    display: none;
+  }
+
+  .themeToggle {
+    display: none;
+  }
 }

--- a/apps/web/components/magic-portfolio/MobileFooterNav.module.scss
+++ b/apps/web/components/magic-portfolio/MobileFooterNav.module.scss
@@ -1,0 +1,56 @@
+@use "./breakpoints.scss" as breakpoints;
+
+.container {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  display: none;
+}
+
+@media (max-width: breakpoints.$s) {
+  .container {
+    display: block;
+    background: hsl(var(--card));
+    border-top: 1px solid hsl(var(--border));
+    box-shadow: 0 -16px 40px rgba(0, 0, 0, 0.35);
+    padding: 0.75rem 1rem;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  .navList {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .navItem {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    text-decoration: none;
+    color: hsl(var(--muted-foreground));
+    font-size: var(--text-xs);
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.75rem;
+    transition: color 0.2s ease, background 0.2s ease;
+  }
+
+  .navItemActive {
+    color: hsl(var(--primary));
+    background: hsl(var(--primary) / 0.08);
+  }
+
+  .emoji {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  .label {
+    line-height: 1.2;
+  }
+}

--- a/apps/web/components/magic-portfolio/MobileFooterNav.tsx
+++ b/apps/web/components/magic-portfolio/MobileFooterNav.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import classNames from "classnames";
+import { usePathname } from "next/navigation";
+
+import styles from "./MobileFooterNav.module.scss";
+import { resolvePrimaryNavItems } from "./navigation";
+
+export function MobileFooterNav() {
+  const pathname = usePathname() ?? "";
+  const [hash, setHash] = useState<string>("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleHashChange = () => {
+      setHash(window.location.hash);
+    };
+
+    handleHashChange();
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setHash(window.location.hash);
+    }
+  }, [pathname]);
+
+  const navItems = resolvePrimaryNavItems(pathname, hash, (item) => item.includeInFooter);
+
+  if (!navItems.length) {
+    return null;
+  }
+
+  return (
+    <nav className={styles.container} aria-label="Mobile primary navigation">
+      <div className={styles.navList}>
+        {navItems.map((item) => (
+          <Link
+            key={item.key}
+            href={item.href}
+            className={classNames(styles.navItem, {
+              [styles.navItemActive]: item.selected,
+            })}
+          >
+            <span className={styles.emoji} aria-hidden>
+              {item.emoji}
+            </span>
+            <span className={styles.label}>{item.mobileLabel}</span>
+          </Link>
+        ))}
+      </div>
+    </nav>
+  );
+}
+
+export default MobileFooterNav;

--- a/apps/web/components/magic-portfolio/navigation.ts
+++ b/apps/web/components/magic-portfolio/navigation.ts
@@ -1,0 +1,104 @@
+import type { IconName } from "@/resources/icons";
+
+export type PrimaryNavItem = {
+  key: string;
+  label: string;
+  mobileLabel: string;
+  href: string;
+  icon: IconName;
+  emoji: string;
+  route: `/${string}`;
+  includeInFooter: boolean;
+  match: (pathname: string, hash: string) => boolean;
+};
+
+const normalizeHash = (hash: string): string => hash?.trim().toLowerCase() ?? "";
+
+export const PRIMARY_NAV_ITEMS: PrimaryNavItem[] = [
+  {
+    key: "home",
+    label: "Home",
+    mobileLabel: "Home",
+    href: "/",
+    icon: "home",
+    emoji: "🏠",
+    route: "/",
+    includeInFooter: true,
+    match: (pathname, hash) => {
+      if (pathname !== "/") {
+        return false;
+      }
+
+      const normalizedHash = normalizeHash(hash);
+      return normalizedHash === "" || normalizedHash === "#top";
+    },
+  },
+  {
+    key: "market",
+    label: "Market Watch",
+    mobileLabel: "Market",
+    href: "/#market-watchlist",
+    icon: "grid",
+    emoji: "📊",
+    route: "/",
+    includeInFooter: true,
+    match: (pathname, hash) =>
+      pathname === "/" && normalizeHash(hash) === "#market-watchlist",
+  },
+  {
+    key: "plans",
+    label: "Plans",
+    mobileLabel: "VIP Plans",
+    href: "/plans",
+    icon: "crown",
+    emoji: "💎",
+    route: "/plans",
+    includeInFooter: true,
+    match: (pathname) => pathname.startsWith("/plans"),
+  },
+  {
+    key: "token",
+    label: "Token",
+    mobileLabel: "Token",
+    href: "/token",
+    icon: "infinity",
+    emoji: "🪙",
+    route: "/token",
+    includeInFooter: false,
+    match: (pathname) => pathname.startsWith("/token"),
+  },
+  {
+    key: "learn",
+    label: "Learn",
+    mobileLabel: "Learn",
+    href: "/blog",
+    icon: "book",
+    emoji: "🎓",
+    route: "/blog",
+    includeInFooter: true,
+    match: (pathname) => pathname.startsWith("/blog"),
+  },
+  {
+    key: "support",
+    label: "Support",
+    mobileLabel: "Support",
+    href: "/telegram",
+    icon: "telegram",
+    emoji: "💬",
+    route: "/telegram",
+    includeInFooter: true,
+    match: (pathname) => pathname.startsWith("/telegram"),
+  },
+];
+
+export type PrimaryNavItemState = PrimaryNavItem & { selected: boolean };
+
+export const resolvePrimaryNavItems = (
+  pathname: string,
+  hash: string,
+  filter?: (item: PrimaryNavItem) => boolean,
+): PrimaryNavItemState[] =>
+  PRIMARY_NAV_ITEMS.filter((item) => (filter ? filter(item) : true)).map((item) => ({
+    ...item,
+    selected: Boolean(item.match(pathname, hash)),
+  }));

--- a/apps/web/resources/dynamic-ui.config.ts
+++ b/apps/web/resources/dynamic-ui.config.ts
@@ -32,6 +32,7 @@ const routes: RoutesConfig = {
   "/blog": true,
   "/gallery": false,
   "/telegram": true,
+  "/token": true,
 };
 
 const display: DisplayConfig = {


### PR DESCRIPTION
## Summary
- rebuild the site header to use a shared primary navigation config with the new Home, Market Watch, Plans, Token, Learn, and Support links
- add a mobile-friendly sticky footer nav that exposes the top targets on small screens
- publish a dedicated Token page and enable the route so the header and footer links resolve correctly

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56d3369048322924b7e7ad6906ff1