### PR TITLE
feat: add VIP pricing plans with wallet connect CTA

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -16,6 +16,7 @@ import { FxMarketSnapshotSection } from "@/components/magic-portfolio/home/FxMar
 import { HeroExperience } from "@/components/magic-portfolio/home/HeroExperience";
 import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchlist";
+import { VipPlansPricingSection } from "@/components/magic-portfolio/home/VipPlansPricingSection";
 import { cn } from "@/utils";
 import { about, baseURL, home, person, toAbsoluteUrl } from "@/resources";
 import styles from "./DynamicCapitalLandingPage.module.scss";
@@ -199,12 +200,15 @@ export function DynamicCapitalLandingPage() {
         <MarketIntelligenceSection />
       </Section>
       <Section revealDelay={0.56}>
-        <MentorAndTrustSection />
+        <VipPlansPricingSection />
       </Section>
       <Section revealDelay={0.64}>
-        <FundingReadinessSection />
+        <MentorAndTrustSection />
       </Section>
       <Section revealDelay={0.72}>
+        <FundingReadinessSection />
+      </Section>
+      <Section revealDelay={0.8}>
         <CheckoutCallout />
       </Section>
       <Section reveal={false}>

--- a/apps/web/components/magic-portfolio/home/VipPlansPricingSection.module.scss
+++ b/apps/web/components/magic-portfolio/home/VipPlansPricingSection.module.scss
@@ -1,0 +1,203 @@
+@use "../breakpoints.scss" as breakpoints;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.toggleGroup {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 0.5rem;
+  border-radius: 9999px;
+  background: hsl(var(--surface-strong));
+  border: 1px solid hsla(var(--brand-base), 0.25);
+  box-shadow: 0 12px 32px hsla(var(--brand-dark), 0.12);
+  gap: 0.5rem;
+  width: fit-content;
+}
+
+.toggleButton {
+  position: relative;
+  border: none;
+  background: transparent;
+  color: hsl(var(--neutral-weak));
+  border-radius: 9999px;
+  padding: 0.6rem 1.5rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  transition: color 0.2s ease;
+}
+
+.toggleButton[aria-pressed="true"] {
+  color: hsl(var(--brand-strong));
+}
+
+.toggleHighlight {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: linear-gradient(
+    135deg,
+    hsla(var(--brand-base), 0.18),
+    hsla(var(--accent-base), 0.2)
+  );
+  box-shadow: 0 10px 24px hsla(var(--brand-dark), 0.25);
+  z-index: 0;
+}
+
+.toggleLabel,
+.toggleDescription {
+  position: relative;
+  z-index: 1;
+  font-weight: 600;
+}
+
+.toggleDescription {
+  font-size: 0.75rem;
+  letter-spacing: 0.01em;
+  color: hsl(var(--neutral-weak));
+}
+
+.planGrid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(18.5rem, 1fr));
+  width: 100%;
+}
+
+.planCard {
+  position: relative;
+  height: 100%;
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  background: hsl(var(--surface-strong));
+  border: 1px solid hsla(var(--neutral-strong), 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.1rem, 2.5vw, 1.6rem);
+  overflow: hidden;
+  box-shadow: 0 20px 50px hsla(var(--neutral-strong), 0.08);
+}
+
+.popularCard {
+  border: 1px solid hsla(var(--brand-base), 0.35);
+  box-shadow: 0 30px 60px hsla(var(--brand-dark), 0.18);
+}
+
+.popularGlow {
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    hsla(var(--brand-base), 0.35),
+    hsla(var(--accent-base), 0.25)
+  );
+  opacity: 0.9;
+  z-index: 0;
+}
+
+.popularCardContent {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: inherit;
+}
+
+.popularBadge {
+  align-self: center;
+  padding-inline: 0.85rem;
+  padding-block: 0.35rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    120deg,
+    hsl(var(--brand-base)),
+    hsl(var(--accent-base))
+  );
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  box-shadow: 0 12px 32px hsla(var(--brand-dark), 0.35);
+}
+
+.popularBadgeIcon {
+  width: 1rem;
+  height: 1rem;
+  color: inherit;
+}
+
+.priceWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.priceLabel {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--neutral-weak));
+}
+
+.priceValue {
+  font-size: clamp(2.25rem, 4vw, 2.85rem);
+  font-weight: 800;
+  color: hsl(var(--brand-strong));
+  line-height: 1.1;
+}
+
+.priceSuffix {
+  font-size: 0.9rem;
+  color: hsl(var(--neutral-weak));
+  margin-left: 0.4rem;
+}
+
+.featureList {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.6rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.featureItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  color: hsl(var(--neutral-weak));
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.featureIcon {
+  color: hsl(var(--brand-strong));
+  width: 1rem;
+  height: 1rem;
+}
+
+.footer {
+  margin-top: auto;
+}
+
+@media (max-width: breakpoints.$s) {
+  .toggleGroup {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .toggleButton {
+    padding-inline: 1.25rem;
+  }
+}

--- a/apps/web/components/magic-portfolio/home/VipPlansPricingSection.tsx
+++ b/apps/web/components/magic-portfolio/home/VipPlansPricingSection.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import {
+  Button,
+  Column,
+  Heading,
+  Icon,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+import { formatPrice } from "@/utils";
+import { useWalletConnect } from "@/hooks/useWalletConnect";
+
+import styles from "./VipPlansPricingSection.module.scss";
+
+type BillingInterval = "monthly" | "yearly";
+
+type PlanDefinition = {
+  id: "bronze" | "silver" | "gold";
+  name: string;
+  description: string;
+  monthlyPrice: number;
+  yearlyPrice: number;
+  badge?: string;
+  features: string[];
+  icon: string;
+};
+
+type BillingOption = {
+  id: BillingInterval;
+  label: string;
+  description: string;
+};
+
+const BILLING_OPTIONS: BillingOption[] = [
+  {
+    id: "monthly",
+    label: "Monthly",
+    description: "Cancel anytime",
+  },
+  {
+    id: "yearly",
+    label: "Yearly",
+    description: "2 months free",
+  },
+];
+
+const PLAN_DEFINITIONS: PlanDefinition[] = [
+  {
+    id: "bronze",
+    name: "Bronze",
+    description:
+      "Kickstart your desk with automation primers and curated market prep.",
+    monthlyPrice: 149,
+    yearlyPrice: 1490,
+    features: [
+      "Daily market posture briefs",
+      "Foundational automation recipes",
+      "Weekly mentor Q&A circles",
+      "Performance journaling templates",
+    ],
+    icon: "sparkles",
+  },
+  {
+    id: "silver",
+    name: "Silver",
+    description:
+      "Most popular for active operators who want real-time oversight and desk accountability.",
+    monthlyPrice: 279,
+    yearlyPrice: 2790,
+    badge: "Most Popular",
+    features: [
+      "Live trade desk with escalation paths",
+      "Mentor-led readiness reviews every week",
+      "Automation guardrails tuned to your risk profile",
+      "Desk analytics with funding readiness score",
+    ],
+    icon: "crown",
+  },
+  {
+    id: "gold",
+    name: "Gold",
+    description:
+      "Institutional concierge with bespoke automations, capital routing, and portfolio support.",
+    monthlyPrice: 499,
+    yearlyPrice: 4990,
+    features: [
+      "Dedicated mentor pod + direct escalation",
+      "Custom automation builds & liquidity routing",
+      "Bi-weekly performance strategy sessions",
+      "Capital deployment with risk oversight",
+    ],
+    icon: "shield",
+  },
+];
+
+export function VipPlansPricingSection() {
+  const [billingInterval, setBillingInterval] = useState<BillingInterval>(
+    "monthly",
+  );
+  const connectWallet = useWalletConnect();
+  const reduceMotion = useReducedMotion();
+
+  const pricingCopy = useMemo(() => {
+    return billingInterval === "monthly" ? "per month" : "per year";
+  }, [billingInterval]);
+
+  return (
+    <Column gap="20" align="start" className={styles.section}>
+      <Column gap="12" align="start">
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="sparkles">
+          VIP plans
+        </Tag>
+        <Heading variant="display-strong-xs" wrap="balance">
+          Choose the desk access tier that fits your momentum
+        </Heading>
+        <Text
+          variant="body-default-l"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Toggle between monthly and yearly billing to see how much runway you
+          gain by locking in annual access.
+        </Text>
+      </Column>
+
+      <div
+        className={styles.toggleGroup}
+        role="group"
+        aria-label="Billing interval"
+      >
+        {BILLING_OPTIONS.map((option) => {
+          const isActive = option.id === billingInterval;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setBillingInterval(option.id)}
+              className={styles.toggleButton}
+              aria-pressed={isActive}
+            >
+              {isActive && (
+                <motion.span
+                  layoutId="billing-pill"
+                  className={styles.toggleHighlight}
+                  transition={{
+                    type: "spring",
+                    stiffness: 300,
+                    damping: 30,
+                  }}
+                />
+              )}
+              <span className={styles.toggleLabel}>{option.label}</span>
+              <span className={styles.toggleDescription}>
+                {option.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.planGrid}>
+        {PLAN_DEFINITIONS.map((plan, index) => {
+          const isPopular = plan.id === "silver";
+          const price = billingInterval === "monthly"
+            ? plan.monthlyPrice
+            : plan.yearlyPrice;
+          return (
+            <motion.div
+              key={plan.id}
+              initial={{ opacity: 0, y: reduceMotion ? 0 : 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{
+                delay: index * 0.08,
+                duration: reduceMotion ? 0 : 0.4,
+              }}
+              viewport={{ once: true, amount: 0.3 }}
+            >
+              <div
+                className={`${styles.planCard} ${
+                  isPopular ? styles.popularCard : ""
+                }`}
+              >
+                {isPopular && (
+                  <span className={styles.popularGlow} aria-hidden="true" />
+                )}
+                <div
+                  className={isPopular ? styles.popularCardContent : undefined}
+                >
+                  {isPopular && (
+                    <span className={styles.popularBadge}>
+                      <Icon name="crown" className={styles.popularBadgeIcon} />
+                      {plan.badge}
+                    </span>
+                  )}
+                  <Column gap="12" align="start">
+                    <Row gap="12" vertical="center">
+                      <Icon name={plan.icon} onBackground="brand-medium" />
+                      <Heading variant="heading-strong-m">{plan.name}</Heading>
+                    </Row>
+                    <Text
+                      variant="body-default-m"
+                      onBackground="neutral-weak"
+                      wrap="balance"
+                    >
+                      {plan.description}
+                    </Text>
+                  </Column>
+                  <div className={styles.priceWrap}>
+                    <span className={styles.priceLabel}>Investment</span>
+                    <AnimatePresence mode="wait" initial={false}>
+                      <motion.span
+                        key={`${plan.id}-${billingInterval}`}
+                        className={styles.priceValue}
+                        initial={{ opacity: 0, y: reduceMotion ? 0 : 12 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: reduceMotion ? 0 : -12 }}
+                        transition={{ duration: reduceMotion ? 0 : 0.25 }}
+                      >
+                        {formatPrice(price)}
+                        <span className={styles.priceSuffix}>
+                          /{pricingCopy}
+                        </span>
+                      </motion.span>
+                    </AnimatePresence>
+                  </div>
+                  <ul className={styles.featureList}>
+                    {plan.features.map((feature) => (
+                      <li key={feature} className={styles.featureItem}>
+                        <Icon name="check" className={styles.featureIcon} />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className={styles.footer}>
+                    <Button
+                      size="m"
+                      variant={isPopular ? "primary" : "secondary"}
+                      data-border="rounded"
+                      onClick={() => connectWallet({ planId: plan.id })}
+                      prefixIcon="sparkles"
+                    >
+                      Subscribe Now
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
+      </div>
+    </Column>
+  );
+}
+
+export default VipPlansPricingSection;

--- a/apps/web/hooks/useWalletConnect.ts
+++ b/apps/web/hooks/useWalletConnect.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback } from "react";
+
+type WalletTrigger = (options?: unknown) => void;
+
+type WalletConnectOptions = {
+  planId?: string;
+};
+
+function isFunction(value: unknown): value is WalletTrigger {
+  return typeof value === "function";
+}
+
+export function useWalletConnect() {
+  return useCallback((options?: WalletConnectOptions) => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const globalWindow = window as typeof window & {
+      tonConnectUI?: { openModal?: WalletTrigger };
+      TonConnectUI?: { openModal?: WalletTrigger };
+      openTonConnectModal?: WalletTrigger;
+      tonconnect?: { openModal?: WalletTrigger };
+    };
+
+    const possibleTriggers: (WalletTrigger | undefined)[] = [
+      globalWindow.tonConnectUI?.openModal,
+      globalWindow.TonConnectUI?.openModal,
+      globalWindow.openTonConnectModal,
+      globalWindow.tonconnect?.openModal,
+    ];
+
+    for (const trigger of possibleTriggers) {
+      if (isFunction(trigger)) {
+        trigger(options);
+        return;
+      }
+    }
+
+    const event = new CustomEvent("wallet-connect:open", {
+      detail: options ?? {},
+    });
+    window.dispatchEvent(event);
+  }, []);
+}


### PR DESCRIPTION
## Summary
- add a dedicated VipPlansPricingSection with animated monthly/yearly toggle and bronze, silver, and gold plan details
- highlight the silver plan as most popular and surface a Subscribe Now CTA that dispatches wallet connect actions
- expose a reusable useWalletConnect hook and mount the pricing section within the landing page flow

## Testing
- npm run lint
- npm run typecheck
- npm run test *(fails: local Next.js server used by tests never reported ready, so `path-traversal` and `root-query` suites timed out waiting for `/healthz`)*

------
https://chatgpt.com/codex/tasks/task_e_68d56d12e0488322b55dbaf565656959