### PR TITLE
Add live market widgets and sticky wallet CTA

### DIFF
--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { Background, Column, RevealFx } from "@/components/dynamic-ui-system";
 import { opacity, SpacingToken } from "@/components/dynamic-ui-system";
 import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
+import { StickyWalletCTA } from "@/components/shared/StickyWalletCTA";
 import { cn } from "@/utils";
 import { dynamicUI } from "@/resources";
 import { DynamicCapitalLandingPage } from "@/components/magic-portfolio/DynamicCapitalLandingPage";
@@ -122,6 +123,7 @@ export function LandingPageShell({
           </Column>
         )
         : null}
+      <StickyWalletCTA />
     </Column>
   );
 }

--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -14,8 +14,10 @@ import { CheckoutCallout } from "@/components/magic-portfolio/home/CheckoutCallo
 import { EconomicCalendarSection } from "@/components/magic-portfolio/home/EconomicCalendarSection";
 import { FxMarketSnapshotSection } from "@/components/magic-portfolio/home/FxMarketSnapshotSection";
 import { HeroExperience } from "@/components/magic-portfolio/home/HeroExperience";
+import { LiveMarketWidgets } from "@/components/magic-portfolio/home/LiveMarketWidgets";
 import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchlist";
+import { BeginnerJourneySection } from "@/components/magic-portfolio/home/BeginnerJourneySection";
 import { cn } from "@/utils";
 import { about, baseURL, home, person, toAbsoluteUrl } from "@/resources";
 import styles from "./DynamicCapitalLandingPage.module.scss";
@@ -195,16 +197,22 @@ export function DynamicCapitalLandingPage() {
       <Section revealDelay={0.4}>
         <ExperienceHighlightsSection />
       </Section>
-      <Section variant="wide" revealDelay={0.48}>
+      <Section revealDelay={0.48}>
+        <BeginnerJourneySection />
+      </Section>
+      <Section variant="wide" revealDelay={0.56}>
         <MarketIntelligenceSection />
       </Section>
-      <Section revealDelay={0.56}>
-        <MentorAndTrustSection />
-      </Section>
-      <Section revealDelay={0.64}>
-        <FundingReadinessSection />
+      <Section variant="wide" revealDelay={0.64}>
+        <LiveMarketWidgets />
       </Section>
       <Section revealDelay={0.72}>
+        <MentorAndTrustSection />
+      </Section>
+      <Section revealDelay={0.8}>
+        <FundingReadinessSection />
+      </Section>
+      <Section revealDelay={0.88}>
         <CheckoutCallout />
       </Section>
       <Section reveal={false}>

--- a/apps/web/components/magic-portfolio/home/BeginnerJourneySection.module.scss
+++ b/apps/web/components/magic-portfolio/home/BeginnerJourneySection.module.scss
@@ -1,0 +1,58 @@
+.flowGrid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.flowCard {
+  position: relative;
+  overflow: hidden;
+  height: 100%;
+}
+
+.flowAccent {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  background: radial-gradient(
+    75% 75% at 50% 20%,
+    hsl(var(--dc-brand) / 0.2),
+    transparent 70%
+  );
+  transition: opacity 200ms ease;
+}
+
+.flowCard:hover .flowAccent,
+.flowCard:focus-within .flowAccent {
+  opacity: 1;
+}
+
+.resources {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.timeline {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.timeline::before {
+  content: "";
+  display: block;
+  width: 2rem;
+  height: 2px;
+  background: hsl(var(--dc-brand) / 0.25);
+}
+
+@media (max-width: 48rem) {
+  .flowGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/web/components/magic-portfolio/home/BeginnerJourneySection.tsx
+++ b/apps/web/components/magic-portfolio/home/BeginnerJourneySection.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+import {
+  Button,
+  Column,
+  Heading,
+  Icon,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+
+import styles from "./BeginnerJourneySection.module.scss";
+
+type JourneyStep = {
+  title: string;
+  description: string;
+  milestone: string;
+  focus: string[];
+};
+
+type SupportResource = {
+  title: string;
+  description: string;
+  icon: "sparkles" | "book" | "repeat" | "globe";
+};
+
+const JOURNEY_STEPS: JourneyStep[] = [
+  {
+    title: "Guided desk tour",
+    milestone: "Day 0 · 5 minutes",
+    description:
+      "Interactive walkthrough shows where to find watchlists, mentor chat, and readiness scorecards without overwhelm.",
+    focus: ["Workspace primer", "Notification setup", "Desk orientation"],
+  },
+  {
+    title: "Practice with mentors",
+    milestone: "Day 2 · 20 minutes",
+    description:
+      "Mentor-led rehearsals pair timers, callouts, and feedback loops so you feel confident before the first live session.",
+    focus: ["Live drill replay", "Automation sandbox", "Feedback digest"],
+  },
+  {
+    title: "Flip the funding switch",
+    milestone: "Day 7 · 15 minutes",
+    description:
+      "Once your readiness score is verified, connect capital providers and sync guardrails without leaving the flow.",
+    focus: ["Broker linking", "Risk thresholds", "Capital unlock"],
+  },
+];
+
+const SUPPORT_RESOURCES: SupportResource[] = [
+  {
+    title: "Beginner playbook library",
+    description:
+      "Bite-sized lessons and checklists cover core concepts and vocabulary before you dive into live markets.",
+    icon: "book",
+  },
+  {
+    title: "Live desk orientation",
+    description:
+      "Join a real-time cohort welcome call where mentors answer questions and help you personalize the automation.",
+    icon: "sparkles",
+  },
+  {
+    title: "Automation concierge",
+    description:
+      "Dedicated specialists configure integrations, alerts, and risk settings so nothing breaks when you connect accounts.",
+    icon: "repeat",
+  },
+  {
+    title: "Global trading calendar",
+    description:
+      "See the macro roadmap by timezone so you always know which session to prep for next.",
+    icon: "globe",
+  },
+];
+
+export function BeginnerJourneySection() {
+  const reduceMotion = useReducedMotion();
+
+  const cardMotion = useMemo(
+    () => ({
+      initial: { opacity: 0, y: 20 },
+      whileInView: reduceMotion ? undefined : { opacity: 1, y: 0 },
+      viewport: { once: true, amount: 0.4 },
+      transition: reduceMotion
+        ? undefined
+        : ({ type: "spring", stiffness: 200, damping: 24 } as const),
+      whileHover: reduceMotion ? undefined : { y: -6, scale: 1.01 },
+    }),
+    [reduceMotion],
+  );
+
+  return (
+    <Column fillWidth gap="24" align="start">
+      <Column gap="12" align="start">
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="sparkles">
+          Step-by-step beginner flow
+        </Tag>
+        <Heading variant="display-strong-xs" wrap="balance">
+          Follow a calm path from first login to funded trading
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          Every stage is broken into approachable missions so new traders always
+          know the next best action, when to ask for help, and how close they
+          are to unlocking capital.
+        </Text>
+      </Column>
+      <div className={styles.flowGrid}>
+        {JOURNEY_STEPS.map((step, index) => (
+          <motion.article
+            key={step.title}
+            className={styles.flowCard}
+            {...cardMotion}
+          >
+            <span className={styles.flowAccent} aria-hidden />
+            <Column
+              background="surface"
+              border="neutral-alpha-weak"
+              radius="l"
+              padding="xl"
+              gap="16"
+              align="start"
+            >
+              <Row gap="12" vertical="center">
+                <Tag
+                  size="s"
+                  background="brand-alpha-weak"
+                  onBackground="brand-strong"
+                >
+                  Step {String(index + 1).padStart(2, "0")}
+                </Tag>
+                <Text variant="label-default-s" onBackground="brand-weak">
+                  {step.milestone}
+                </Text>
+              </Row>
+              <Heading variant="heading-strong-m">{step.title}</Heading>
+              <Text
+                variant="body-default-m"
+                onBackground="neutral-weak"
+                wrap="balance"
+              >
+                {step.description}
+              </Text>
+              <ul className={styles.resources}>
+                {step.focus.map((item) => (
+                  <li key={item}>
+                    <Row gap="8" vertical="center">
+                      <Icon name="check" onBackground="brand-medium" />
+                      <Text variant="body-default-s">{item}</Text>
+                    </Row>
+                  </li>
+                ))}
+              </ul>
+            </Column>
+          </motion.article>
+        ))}
+      </div>
+      <Column gap="16" align="start">
+        <Heading variant="heading-strong-m">
+          Personal support is available on every milestone
+        </Heading>
+        <Row gap="16" wrap>
+          {SUPPORT_RESOURCES.map((resource) => (
+            <motion.div
+              key={resource.title}
+              {...cardMotion}
+            >
+              <Column
+                background="surface"
+                border="neutral-alpha-weak"
+                radius="l"
+                padding="l"
+                gap="12"
+                align="start"
+              >
+                <Row gap="12" vertical="center">
+                  <Icon name={resource.icon} onBackground="brand-medium" />
+                  <Heading variant="heading-strong-s">{resource.title}</Heading>
+                </Row>
+                <Text
+                  variant="body-default-s"
+                  onBackground="neutral-weak"
+                  wrap="balance"
+                >
+                  {resource.description}
+                </Text>
+              </Column>
+            </motion.div>
+          ))}
+        </Row>
+        <Row className={styles.timeline}>
+          <Icon name="sparkles" onBackground="brand-medium" />
+          <Text variant="label-default-s" onBackground="neutral-weak">
+            Ready to start? The guided setup takes less than ten minutes.
+          </Text>
+        </Row>
+        <Button
+          href="#begin"
+          variant="primary"
+          size="l"
+          weight="strong"
+          prefixIcon="sparkles"
+        >
+          Launch the guided setup
+        </Button>
+      </Column>
+    </Column>
+  );
+}

--- a/apps/web/components/magic-portfolio/home/LiveMarketWidgets.module.scss
+++ b/apps/web/components/magic-portfolio/home/LiveMarketWidgets.module.scss
@@ -1,0 +1,71 @@
+.widgetGrid {
+  display: grid;
+  width: 100%;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+}
+
+.widgetCard {
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.statusRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.assetList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.assetRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.assetMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.assetBadges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.assetChangePositive {
+  color: hsl(var(--dc-success-strong));
+}
+
+.assetChangeNegative {
+  color: hsl(var(--dc-danger-strong));
+}
+
+.tradingViewContainer {
+  min-height: 260px;
+  width: 100%;
+}
+
+.tradingViewInner {
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 48rem) {
+  .widgetGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/web/components/magic-portfolio/home/LiveMarketWidgets.tsx
+++ b/apps/web/components/magic-portfolio/home/LiveMarketWidgets.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+import {
+  Column,
+  Heading,
+  Icon,
+  Row,
+  Tag,
+  Text,
+  useTheme,
+} from "@/components/dynamic-ui-system";
+import { formatIsoTime } from "@/utils/isoFormat";
+
+import styles from "./LiveMarketWidgets.module.scss";
+
+type CoinGeckoAsset = {
+  id: string;
+  symbol: string;
+  name: string;
+  current_price: number;
+  price_change_percentage_24h: number;
+  image: string;
+  market_cap_rank: number;
+};
+
+type YahooQuote = {
+  symbol: string;
+  shortName?: string;
+  regularMarketPrice?: number;
+  regularMarketChangePercent?: number;
+  marketState?: string;
+};
+
+type YahooQuoteResponse = {
+  quoteResponse: {
+    result: YahooQuote[];
+  };
+};
+
+type DataState = {
+  crypto: CoinGeckoAsset[];
+  equities: YahooQuote[];
+};
+
+const COINGECKO_ENDPOINT =
+  "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=bitcoin,ethereum,solana&price_change_percentage=1h,24h";
+const YAHOO_ENDPOINT =
+  "https://query1.finance.yahoo.com/v7/finance/quote?symbols=AAPL,MSFT,SPY";
+const TRADINGVIEW_SCRIPT =
+  "https://s3.tradingview.com/external-embedding/embed-widget-mini-symbol-overview.js";
+const TRADINGVIEW_SYMBOL = "NASDAQ:AAPL";
+const REFRESH_INTERVAL_MS = 60_000;
+
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2,
+});
+
+const resolveChangeClassName = (value?: number | null) => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (value > 0) {
+    return styles.assetChangePositive;
+  }
+  if (value < 0) {
+    return styles.assetChangeNegative;
+  }
+  return undefined;
+};
+
+const resolveChangeLabel = (value?: number | null) => {
+  if (value === undefined || value === null) {
+    return "—";
+  }
+  const formatted = percentFormatter.format(value / 100);
+  return value > 0 ? `+${formatted}` : formatted;
+};
+
+const resolveMarketBadge = (marketState?: string) => {
+  if (!marketState) {
+    return null;
+  }
+
+  const normalized = marketState.toLowerCase();
+
+  if (normalized.includes("pre")) {
+    return { label: "Pre-market", icon: "repeat" as const };
+  }
+
+  if (normalized.includes("post")) {
+    return { label: "After hours", icon: "document" as const };
+  }
+
+  return { label: "Live session", icon: "sparkles" as const };
+};
+
+const tradingViewConfig = (theme: string) => ({
+  symbol: TRADINGVIEW_SYMBOL,
+  width: "100%",
+  height: 220,
+  locale: "en",
+  dateRange: "1D",
+  colorTheme: theme === "dark" ? "dark" : "light",
+  trendLineColor: "rgba(34, 197, 94, 1)",
+  underLineColor: "rgba(34, 197, 94, 0.25)",
+  isTransparent: false,
+  autosize: true,
+  largeChartUrl: "https://www.tradingview.com/symbols/AAPL/",
+});
+
+export function LiveMarketWidgets() {
+  const { theme } = useTheme();
+  const [data, setData] = useState<DataState>({ crypto: [], equities: [] });
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const tradingViewRef = useRef<HTMLDivElement | null>(null);
+  const reduceMotion = useReducedMotion();
+
+  const statusLabel = useMemo(() => {
+    if (error) {
+      return error;
+    }
+    if (isLoading) {
+      return "Connecting to TradingView, CoinGecko, and Yahoo Finance…";
+    }
+    if (isRefreshing) {
+      return "Syncing live feeds…";
+    }
+    if (lastUpdated) {
+      return `Updated ${formatIsoTime(lastUpdated)}`;
+    }
+    return "Waiting for the first update…";
+  }, [error, isLoading, isRefreshing, lastUpdated]);
+
+  const refreshData = useCallback(async () => {
+    setIsRefreshing(true);
+
+    try {
+      const [cryptoResponse, yahooResponse] = await Promise.all([
+        fetch(COINGECKO_ENDPOINT, { cache: "no-store" }),
+        fetch(YAHOO_ENDPOINT, { cache: "no-store" }),
+      ]);
+
+      if (!cryptoResponse.ok) {
+        throw new Error(`CoinGecko responded with ${cryptoResponse.status}`);
+      }
+
+      if (!yahooResponse.ok) {
+        throw new Error(`Yahoo Finance responded with ${yahooResponse.status}`);
+      }
+
+      const cryptoPayload = (await cryptoResponse.json()) as CoinGeckoAsset[];
+      const yahooPayload = (await yahooResponse.json()) as YahooQuoteResponse;
+
+      setData({
+        crypto: cryptoPayload.slice(0, 3),
+        equities: yahooPayload.quoteResponse.result.slice(0, 3),
+      });
+      setLastUpdated(new Date());
+      setError(null);
+    } catch (refreshError) {
+      console.error(refreshError);
+      setError(
+        "We could not refresh every feed. The dashboard will try again automatically.",
+      );
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const load = async () => {
+      if (!mounted) {
+        return;
+      }
+      await refreshData();
+    };
+
+    load();
+    const intervalId = window.setInterval(load, REFRESH_INTERVAL_MS);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(intervalId);
+    };
+  }, [refreshData]);
+
+  useEffect(() => {
+    const container = tradingViewRef.current;
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = "";
+
+    const script = document.createElement("script");
+    script.src = TRADINGVIEW_SCRIPT;
+    script.async = true;
+    script.innerHTML = JSON.stringify(tradingViewConfig(theme));
+    container.appendChild(script);
+
+    return () => {
+      container.innerHTML = "";
+    };
+  }, [theme]);
+
+  const cardMotion = useMemo(
+    () => ({
+      whileHover: reduceMotion ? undefined : { y: -8, scale: 1.01 },
+      transition: reduceMotion
+        ? undefined
+        : ({ type: "spring", stiffness: 220, damping: 20 } as const),
+    }),
+    [reduceMotion],
+  );
+
+  return (
+    <Column fillWidth gap="24" align="start">
+      <Column gap="12" align="start">
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="sparkles">
+          Live data widgets
+        </Tag>
+        <Heading variant="display-strong-xs" wrap="balance">
+          One dashboard that keeps crypto, equities, and flows in sync
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          wrap="balance"
+        >
+          TradingView, CoinGecko, and Yahoo Finance streams power the cards
+          below so you can watch price action and session context without
+          leaving the desk.
+        </Text>
+      </Column>
+      <Row className={styles.statusRow} gap="12" vertical="center">
+        <Icon name="repeat" onBackground="brand-medium" />
+        <Text variant="body-default-s" onBackground="neutral-weak">
+          {statusLabel}
+        </Text>
+      </Row>
+      <div className={styles.widgetGrid}>
+        <motion.div
+          className={styles.widgetCard}
+          {...cardMotion}
+        >
+          <Column
+            background="surface"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="xl"
+            gap="16"
+            align="start"
+          >
+            <Row gap="12" vertical="center">
+              <Icon name="rocket" onBackground="brand-medium" />
+              <Heading variant="heading-strong-m">Top crypto movers</Heading>
+            </Row>
+            <Text variant="body-default-s" onBackground="neutral-weak">
+              CoinGecko 24h change
+            </Text>
+            <ul className={styles.assetList}>
+              {data.crypto.length === 0
+                ? (
+                  <li>
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      Waiting for CoinGecko to deliver the latest quotes…
+                    </Text>
+                  </li>
+                )
+                : data.crypto.map((asset) => {
+                  const changeValue = asset.price_change_percentage_24h;
+                  const changeClassName = resolveChangeClassName(changeValue);
+                  const formattedPrice = numberFormatter.format(
+                    asset.current_price,
+                  );
+                  const formattedChange = resolveChangeLabel(changeValue);
+
+                  return (
+                    <li key={asset.id} className={styles.assetRow}>
+                      <div className={styles.assetMeta}>
+                        <Row gap="8" vertical="center" wrap>
+                          <Tag size="s" prefixIcon="rocket">
+                            {asset.symbol.toUpperCase()}
+                          </Tag>
+                          <Tag
+                            size="s"
+                            background="brand-alpha-weak"
+                            onBackground="brand-strong"
+                          >
+                            Rank {asset.market_cap_rank ?? "—"}
+                          </Tag>
+                        </Row>
+                        <Text variant="body-default-m">{asset.name}</Text>
+                      </div>
+                      <Column gap="4" horizontal="end" align="end">
+                        <Text variant="heading-strong-s" align="right">
+                          {formattedPrice}
+                        </Text>
+                        <Text
+                          variant="label-default-s"
+                          align="right"
+                          className={changeClassName}
+                        >
+                          {formattedChange}
+                        </Text>
+                      </Column>
+                    </li>
+                  );
+                })}
+            </ul>
+          </Column>
+        </motion.div>
+        <motion.div
+          className={styles.widgetCard}
+          {...cardMotion}
+        >
+          <Column
+            background="surface"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="xl"
+            gap="16"
+            align="start"
+          >
+            <Row gap="12" vertical="center">
+              <Icon name="repeat" onBackground="brand-medium" />
+              <Heading variant="heading-strong-m">US market pulse</Heading>
+            </Row>
+            <Text variant="body-default-s" onBackground="neutral-weak">
+              Yahoo Finance spot quotes
+            </Text>
+            <ul className={styles.assetList}>
+              {data.equities.length === 0
+                ? (
+                  <li>
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      Waiting for Yahoo Finance to sync live market data…
+                    </Text>
+                  </li>
+                )
+                : data.equities.map((quote) => {
+                  const changeClassName = resolveChangeClassName(
+                    quote.regularMarketChangePercent,
+                  );
+                  const formattedChange = resolveChangeLabel(
+                    quote.regularMarketChangePercent,
+                  );
+                  const marketBadge = resolveMarketBadge(quote.marketState);
+                  const formattedPrice = quote.regularMarketPrice === undefined
+                    ? "—"
+                    : numberFormatter.format(quote.regularMarketPrice);
+
+                  return (
+                    <li key={quote.symbol} className={styles.assetRow}>
+                      <div className={styles.assetMeta}>
+                        <Row gap="8" vertical="center" wrap>
+                          <Tag size="s" prefixIcon="grid">
+                            {quote.symbol}
+                          </Tag>
+                          {marketBadge
+                            ? (
+                              <Tag
+                                size="s"
+                                background="brand-alpha-weak"
+                                prefixIcon={marketBadge.icon}
+                                onBackground="brand-strong"
+                              >
+                                {marketBadge.label}
+                              </Tag>
+                            )
+                            : null}
+                        </Row>
+                        <Text variant="body-default-m">
+                          {quote.shortName ?? quote.symbol}
+                        </Text>
+                      </div>
+                      <Column gap="4" horizontal="end" align="end">
+                        <Text variant="heading-strong-s" align="right">
+                          {formattedPrice}
+                        </Text>
+                        <Text
+                          variant="label-default-s"
+                          align="right"
+                          className={changeClassName}
+                        >
+                          {formattedChange}
+                        </Text>
+                      </Column>
+                    </li>
+                  );
+                })}
+            </ul>
+            <Row gap="8" vertical="center">
+              <Icon name="document" onBackground="brand-medium" />
+              <Text variant="label-default-s" onBackground="neutral-weak">
+                Market cap sizes use compact USD formatting
+              </Text>
+            </Row>
+          </Column>
+        </motion.div>
+        <motion.div
+          className={styles.widgetCard}
+          {...cardMotion}
+        >
+          <Column
+            background="surface"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="xl"
+            gap="16"
+            align="start"
+          >
+            <Row gap="12" vertical="center">
+              <Icon name="openLink" onBackground="brand-medium" />
+              <Heading variant="heading-strong-m">
+                TradingView mini chart
+              </Heading>
+            </Row>
+            <Text variant="body-default-s" onBackground="neutral-weak">
+              Live AAPL structure, 1 day range
+            </Text>
+            <div className={styles.tradingViewContainer}>
+              <div
+                className="tradingview-widget-container__widget"
+                ref={tradingViewRef}
+              />
+            </div>
+            <Row gap="8" vertical="center">
+              <Icon name="sparkles" onBackground="brand-medium" />
+              <Text variant="label-default-s" onBackground="neutral-weak">
+                Widget respects your light or dark mode preference
+              </Text>
+            </Row>
+          </Column>
+        </motion.div>
+      </div>
+    </Column>
+  );
+}

--- a/apps/web/components/shared/StickyWalletCTA.module.scss
+++ b/apps/web/components/shared/StickyWalletCTA.module.scss
@@ -1,0 +1,45 @@
+.container {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2.5rem);
+  bottom: clamp(1rem, 4vw, 2.5rem);
+  z-index: 40;
+  pointer-events: none;
+}
+
+.inner {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: color-mix(in srgb, hsl(var(--dc-brand) / 0.12) 50%, transparent);
+  border: 1px solid hsl(var(--dc-brand) / 0.35);
+  border-radius: 999px;
+  padding: 0.5rem 0.75rem 0.5rem 0.5rem;
+  box-shadow: 0 20px 45px -20px hsl(var(--dc-brand-dark) / 0.6);
+}
+
+.statusText {
+  display: none;
+}
+
+@media (min-width: 48rem) {
+  .statusText {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: hsl(var(--dc-brand-dark));
+    font-size: 0.75rem;
+  }
+}
+
+@media (max-width: 32rem) {
+  .container {
+    right: 0.75rem;
+    left: 0.75rem;
+  }
+
+  .inner {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/apps/web/components/shared/StickyWalletCTA.tsx
+++ b/apps/web/components/shared/StickyWalletCTA.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+import { Button, Icon, Text } from "@/components/dynamic-ui-system";
+
+import styles from "./StickyWalletCTA.module.scss";
+
+const STICKY_THRESHOLD = 320;
+
+export function StickyWalletCTA() {
+  const [hasScrolled, setHasScrolled] = useState(false);
+  const reduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHasScrolled(window.scrollY > STICKY_THRESHOLD);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const animation = useMemo(
+    () => ({
+      initial: { opacity: 0, y: 24, scale: 0.95 },
+      animate: hasScrolled
+        ? { opacity: 1, y: 0, scale: 1 }
+        : { opacity: 0, y: 24, scale: reduceMotion ? 1 : 0.95 },
+      transition: reduceMotion
+        ? undefined
+        : ({ type: "spring", stiffness: 200, damping: 30 } as const),
+    }),
+    [hasScrolled, reduceMotion],
+  );
+
+  return (
+    <motion.div className={styles.container} {...animation}>
+      <div className={styles.inner}>
+        <span className={styles.statusText}>
+          <Icon name="sparkles" onBackground="brand-medium" />
+          <Text variant="label-default-s" onBackground="brand-weak">
+            Wallets secured with institutional-grade custody
+          </Text>
+        </span>
+        <Button
+          href="/login?connect-wallet=true"
+          variant="primary"
+          size="m"
+          weight="strong"
+          prefixIcon="rocket"
+        >
+          Connect Wallet
+        </Button>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable sticky Connect Wallet call-to-action and surface it in the landing shell
- create live market widgets that stream data from CoinGecko, Yahoo Finance, and TradingView with hover motion effects
- introduce a beginner journey section with guided steps and support resources to make onboarding less intimidating

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56d3d0a148322bb7cf622ec18b02d