### PR TITLE
Allow loopback hosts to bypass canonical redirect

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,8 @@ import { getCacheControl, getContentType } from './scripts/utils/static-assets.j
 const port = process.env.PORT || 3000;
 const root = process.cwd();
 const staticRoot = join(root, '_static');
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+const LOOPBACK_PATTERNS = [/^127\./, /^::1$/, /^::ffff:127\./];
 
 function coerceSiteUrl(raw) {
   if (!raw) return undefined;
@@ -315,7 +317,13 @@ async function handler(req, res) {
     } catch {}
   }
 
-  if (requestHost && requestHost !== CANONICAL_HOST) {
+  const isLoopbackHost = Boolean(
+    requestHost &&
+      (LOOPBACK_HOSTS.has(requestHost) ||
+        LOOPBACK_PATTERNS.some((pattern) => pattern.test(requestHost))),
+  );
+
+  if (requestHost && requestHost !== CANONICAL_HOST && !isLoopbackHost) {
     let requestPath = req.url || '/';
     if (!requestPath.startsWith('/')) {
       try {


### PR DESCRIPTION
## Summary
- allow localhost and other loopback hosts to bypass canonical host redirects so the local server stays reachable
- add a small helper set and pattern list to recognize loopback hostnames and addresses

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56fa3293c8322a60b3aaa8effdec1