### PR TITLE
Ensure builds synchronize Maldives timezone

### DIFF
--- a/scripts/build-landing.mjs
+++ b/scripts/build-landing.mjs
@@ -1,17 +1,25 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { cp, mkdir, rm, access, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { createSanitizedNpmEnv } from './utils/npm-env.mjs';
+import { spawn } from "node:child_process";
+import { access, cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createSanitizedNpmEnv } from "./utils/npm-env.mjs";
+import { syncMaldivesClock } from "./utils/time-sync.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(__dirname, '..');
-const webWorkspace = join(repoRoot, 'apps', 'web');
-const staticDir = join(repoRoot, '_static');
-const backupDir = join(repoRoot, '_static.backup');
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const repoRoot = join(__dirname, "..");
+const webWorkspace = join(repoRoot, "apps", "web");
+const staticDir = join(repoRoot, "_static");
+const backupDir = join(repoRoot, "_static.backup");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+
+const timeSyncOutcome = syncMaldivesClock({ logger: console });
+if (!timeSyncOutcome.ok) {
+  console.warn(
+    "⚠️  Proceeding with landing snapshot build despite timezone synchronization issues.",
+  );
+}
 
 async function pathExists(path) {
   try {
@@ -27,12 +35,12 @@ function runCommand(command, args, options = {}) {
   const env = createSanitizedNpmEnv(envOverrides ?? {});
   return new Promise((resolve) => {
     const child = spawn(command, args, {
-      stdio: 'inherit',
+      stdio: "inherit",
       ...rest,
       env,
     });
 
-    child.on('close', (code, signal) => {
+    child.on("close", (code, signal) => {
       if (signal) {
         resolve(1);
         return;
@@ -40,7 +48,7 @@ function runCommand(command, args, options = {}) {
       resolve(code ?? 0);
     });
 
-    child.on('error', () => {
+    child.on("error", () => {
       resolve(1);
     });
   });
@@ -70,9 +78,9 @@ async function restoreBackup() {
 }
 
 async function writeFallbackHtml() {
-  const title = 'Dynamic Capital – Snapshot unavailable';
+  const title = "Dynamic Capital – Snapshot unavailable";
   const message =
-    'We\'re temporarily unable to refresh the landing snapshot because the web build did not succeed. The previous export will remain in place until the build is fixed.';
+    "We're temporarily unable to refresh the landing snapshot because the web build did not succeed. The previous export will remain in place until the build is fixed.";
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -162,26 +170,26 @@ async function writeFallbackHtml() {
 
   await rm(staticDir, { recursive: true, force: true });
   await mkdir(staticDir, { recursive: true });
-  await writeFile(join(staticDir, 'index.html'), html, 'utf8');
-  await writeFile(join(staticDir, '404.html'), notFound, 'utf8');
+  await writeFile(join(staticDir, "index.html"), html, "utf8");
+  await writeFile(join(staticDir, "404.html"), notFound, "utf8");
 }
 
 async function runCopyStatic({ copyOnly, extraEnv = {} }) {
   if (copyOnly) {
-    return runCommand(npmCommand, ['run', 'copy-static'], {
+    return runCommand(npmCommand, ["run", "copy-static"], {
       cwd: webWorkspace,
       env: extraEnv,
     });
   }
 
-  return runCommand(npxCommand, ['tsx', '../../scripts/copy-static.ts'], {
+  return runCommand(npxCommand, ["tsx", "../../scripts/copy-static.ts"], {
     cwd: webWorkspace,
     env: extraEnv,
   });
 }
 
 async function landingSnapshotExists() {
-  return pathExists(join(staticDir, 'index.html'));
+  return pathExists(join(staticDir, "index.html"));
 }
 
 async function main() {
@@ -190,12 +198,14 @@ async function main() {
   let status = await runCopyStatic({
     copyOnly: true,
     extraEnv: {
-      SKIP_NEXT_BUILD: '1',
+      SKIP_NEXT_BUILD: "1",
     },
   });
 
   if (status !== 0) {
-    console.warn('⚠️  Copy-only snapshot refresh failed. Attempting full rebuild via Next.js…');
+    console.warn(
+      "⚠️  Copy-only snapshot refresh failed. Attempting full rebuild via Next.js…",
+    );
     status = await runCopyStatic({ copyOnly: false });
   }
 
@@ -203,17 +213,21 @@ async function main() {
 
   if (status === 0 && snapshotPresent) {
     await rm(backupDir, { recursive: true, force: true });
-    console.log('✅ Landing snapshot refreshed from Next.js build.');
+    console.log("✅ Landing snapshot refreshed from Next.js build.");
     return;
   }
 
-  console.warn('⚠️  Unable to refresh landing snapshot from the Next.js app. Preserving the last good export.');
+  console.warn(
+    "⚠️  Unable to refresh landing snapshot from the Next.js app. Preserving the last good export.",
+  );
 
   if (hadBackup && (await restoreBackup())) {
-    console.warn('ℹ️  Restored previous `_static/` snapshot from backup.');
+    console.warn("ℹ️  Restored previous `_static/` snapshot from backup.");
   } else {
     await writeFallbackHtml();
-    console.warn('ℹ️  Generated a minimal placeholder snapshot so the build can continue.');
+    console.warn(
+      "ℹ️  Generated a minimal placeholder snapshot so the build can continue.",
+    );
   }
 
   await rm(backupDir, { recursive: true, force: true });
@@ -221,6 +235,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error('❌ Unexpected error while building landing snapshot:', err);
+  console.error("❌ Unexpected error while building landing snapshot:", err);
   process.exit(1);
 });

--- a/scripts/build-miniapp.sh
+++ b/scripts/build-miniapp.sh
@@ -8,6 +8,10 @@ NPM_SAFE=(node "$ROOT_DIR/scripts/npm-safe.mjs")
 STAMP_FILE="node_modules/.npm-install.hash"
 LOCKFILE="package-lock.json"
 
+if ! node "$ROOT_DIR/scripts/sync-maldives-time.mjs" --strict; then
+  echo "⚠️  Proceeding with miniapp build despite timezone synchronization issues."
+fi
+
 compute_lock_hash() {
   node - "$1" <<'NODE'
 const fs = require('fs');

--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -9,23 +9,28 @@ import {
   applyBrandingEnvDefaults,
   PRODUCTION_ORIGIN,
 } from "./utils/branding-env.mjs";
+import { syncMaldivesClock } from "./utils/time-sync.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const timeSyncOutcome = syncMaldivesClock({ logger: console });
+if (!timeSyncOutcome.ok) {
+  console.warn(
+    "⚠️  Proceeding with Next.js build despite timezone synchronization issues.",
+  );
+}
 
 process.env.NODE_ENV = "production";
 
 const LOCAL_DEV_ORIGIN = "http://localhost:8080";
 
-const isCI =
-  typeof process.env.CI === "string" &&
+const isCI = typeof process.env.CI === "string" &&
   process.env.CI.length > 0 &&
   process.env.CI !== "0" &&
   process.env.CI.toLowerCase() !== "false";
 
-const fallbackOrigin = isCI
-  ? PRODUCTION_ORIGIN
-  : LOCAL_DEV_ORIGIN;
+const fallbackOrigin = isCI ? PRODUCTION_ORIGIN : LOCAL_DEV_ORIGIN;
 
 const {
   defaultedKeys: defaultNotices,

--- a/scripts/sync-maldives-time.mjs
+++ b/scripts/sync-maldives-time.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { syncMaldivesClock } from "./utils/time-sync.mjs";
+
+const strict = process.argv.includes("--strict");
+const result = syncMaldivesClock({ logger: console });
+
+if (!result.ok) {
+  console.warn(
+    "⚠️  Required Maldives time synchronization steps were not successful.",
+  );
+  if (result.requiredFailures.length > 0) {
+    for (const message of result.requiredFailures) {
+      console.warn(`   • ${message}`);
+    }
+  }
+
+  if (strict) {
+    process.exit(1);
+  }
+}
+
+process.exit(0);

--- a/scripts/utils/time-sync.mjs
+++ b/scripts/utils/time-sync.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const MALDIVES_TIME_ZONE = "Indian/Maldives";
+
+function normalizeLogger(logger = console) {
+  const fallback = {
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    debug: console.debug.bind(console),
+  };
+
+  if (!logger) {
+    return fallback;
+  }
+
+  return {
+    info: typeof logger.info === "function"
+      ? logger.info.bind(logger)
+      : fallback.info,
+    warn: typeof logger.warn === "function"
+      ? logger.warn.bind(logger)
+      : fallback.warn,
+    error: typeof logger.error === "function"
+      ? logger.error.bind(logger)
+      : fallback.error,
+    debug: typeof logger.debug === "function"
+      ? logger.debug.bind(logger)
+      : fallback.debug,
+  };
+}
+
+export function syncMaldivesClock({ logger = console } = {}) {
+  const { info, warn, debug } = normalizeLogger(logger);
+
+  const steps = [
+    {
+      label: `Set system timezone to ${MALDIVES_TIME_ZONE}`,
+      command: "timedatectl",
+      args: ["set-timezone", MALDIVES_TIME_ZONE],
+      required: true,
+    },
+    {
+      label: "Trigger chrony immediate time sync",
+      command: "chronyc",
+      args: ["-a", "makestep"],
+      required: false,
+    },
+  ];
+
+  info(
+    "🕒 Ensuring build environment clock is aligned with Maldives time (UTC+05:00)…",
+  );
+
+  const requiredFailures = [];
+  const optionalWarnings = [];
+  let successfulSteps = 0;
+
+  for (const step of steps) {
+    info(`↪ ${step.label}`);
+    const result = spawnSync(step.command, step.args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    if (result.error) {
+      const message = result.error.code === "ENOENT"
+        ? `Command '${step.command}' is not available on this system.`
+        : result.error.message ?? String(result.error);
+
+      if (step.required) {
+        requiredFailures.push(`${step.label}: ${message}`);
+      } else {
+        optionalWarnings.push(`${step.label}: ${message}`);
+      }
+      warn(`⚠️  ${step.label} skipped — ${message}`);
+      continue;
+    }
+
+    if (result.status !== 0) {
+      const stderr = result.stderr ? result.stderr.trim() : "";
+      const detail = stderr.length > 0
+        ? stderr
+        : `Exited with status ${result.status}`;
+      if (step.required) {
+        requiredFailures.push(`${step.label}: ${detail}`);
+      } else {
+        optionalWarnings.push(`${step.label}: ${detail}`);
+      }
+      warn(`⚠️  ${step.label} did not complete successfully (${detail}).`);
+      continue;
+    }
+
+    successfulSteps += 1;
+    const stdout = result.stdout ? result.stdout.trim() : "";
+    if (stdout.length > 0) {
+      debug(stdout);
+    }
+  }
+
+  const ok = requiredFailures.length === 0;
+
+  if (ok) {
+    info("✅ Maldives time synchronization steps completed.");
+  } else {
+    warn(
+      "⚠️  Maldives time synchronization encountered required-step failures.",
+    );
+  }
+
+  if (optionalWarnings.length > 0) {
+    warn("ℹ️  Optional time sync steps reported warnings:");
+    for (const message of optionalWarnings) {
+      warn(`   • ${message}`);
+    }
+  }
+
+  return {
+    ok,
+    successfulSteps,
+    requiredFailures,
+    optionalWarnings,
+  };
+}
+
+export default syncMaldivesClock;


### PR DESCRIPTION
## Summary
- add a reusable Maldives time synchronization helper to run before build steps
- invoke the helper from the web, landing, and miniapp build scripts so all builds align to MVT

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d56eafa8288322a5b594dea0af584b