### PR TITLE
feat: add self replication automation

### DIFF
--- a/.github/workflows/self-replication.yml
+++ b/.github/workflows/self-replication.yml
@@ -1,0 +1,93 @@
+name: Self Replication
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*", "release-*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Optional branch or tag to replicate"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-package:
+    name: Build replica artifact
+    runs-on: ubuntu-latest
+    env:
+      DENO_TLS_CA_STORE: system
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout requested ref
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != '' }}
+        run: |
+          git fetch origin "${{ github.event.inputs.ref }}" --tags --prune
+          git checkout "${{ github.event.inputs.ref }}"
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        run: npm run build
+
+      - name: Install Deno 2.x
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v2.x
+
+      - id: replicate
+        name: Generate self-replication artifact
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts out
+          ARCHIVE="artifacts/dynamic-capital-self-replica.tar.gz"
+          deno run -A scripts/self-replication.ts \
+            --repo . \
+            --dest ./out/self-replica \
+            --archive "$ARCHIVE" \
+            --template \
+            --initGit
+          echo "archive_path=$ARCHIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dynamic-capital-self-replica
+          path: ${{ steps.replicate.outputs.archive_path }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-release:
+    name: Publish release asset
+    needs: build-and-package
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dynamic-capital-self-replica
+          path: ./artifact
+
+      - name: Publish GitHub release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./artifact/dynamic-capital-self-replica.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/automation/self-replication.md
+++ b/docs/automation/self-replication.md
@@ -1,0 +1,97 @@
+# Self-replication and Automated Releases
+
+This guide explains how the project can now replicate itself into fresh
+checkouts, produce release-ready build artifacts, and publish those artifacts
+automatically whenever a new tag is pushed.
+
+## Overview
+
+The self-replication workflow has two cooperating pieces:
+
+1. **`scripts/self-replication.ts`** – a Deno-based command-line utility that
+   clones (or updates) the repository, installs dependencies, builds the
+   workspace, optionally runs quality gates, and can package the result as a
+   tarball. It also offers a "template" mode that strips Git metadata so that
+   the output can serve as the foundation for a brand-new instance of Dynamic
+   Capital.
+2. **`self-replication.yml` GitHub Action** – an automated pipeline that
+   executes on pushes to `main`, annotated tags (e.g. `v*`), or manual dispatch.
+   It generates a clean tarball using the script above, uploads it as a workflow
+   artifact, and automatically attaches the artifact to tagged releases.
+
+Together they cover the three goals that were requested:
+
+- **Automated CI/CD builds** – the workflow rebuilds the application and
+  produces an artifact every time changes merge into `main`.
+- **Bot-driven cloning** – the Deno script can be executed locally or in
+  automation to clone or refresh downstream copies without manual intervention.
+- **Templated scaffolding** – template mode removes Git history and optionally
+  reinitialises a repository so teams can spin up new installations rapidly.
+
+## Running the replication script locally
+
+```bash
+# Basic usage – clone origin, install deps, run the workspace build, and archive the output
+deno run -A scripts/self-replication.ts --archive ./artifacts/dynamic-capital.tar.gz
+```
+
+Key flags:
+
+- `--repo <url-or-path>` – source repository. Defaults to the local repo's
+  `origin` remote.
+- `--dest <path>` – destination directory for the replica. Defaults to
+  `./replicas/dynamic-capital-<timestamp>`.
+- `--branch <name>` – branch or tag to replicate.
+- `--[no-]install` / `--[no-]build` – skip the dependency install or build steps
+  if you simply want a working tree.
+- `--lint`, `--typecheck`, `--test` – opt-in quality gates mirroring the main CI
+  workflow.
+- `--template` – remove `.git` from the destination to create a reusable
+  scaffold. Combine with `--initGit` if you want a fresh repository initialised
+  in-place.
+- `--archive <path>` – output a compressed tarball of the replica (useful for
+  promotions, backups, or distribution).
+- `--update` – refresh an existing clone rather than recloning from scratch.
+  Combine with `--force` to blow away the directory first.
+
+The command prints a JSON summary at the end that captures the actions taken
+(install, build, lint, etc.), the resolved commit hash, and the archive
+location.
+
+## GitHub Actions automation
+
+The new workflow lives at `.github/workflows/self-replication.yml` and performs
+the following steps:
+
+1. Checks out the repository with full history so tags are available for release
+   builds.
+2. Installs Node.js 20 and runs the standard `npm ci` + `npm run build`
+   commands.
+3. Uses `denoland/setup-deno` to expose Deno 2.x and executes
+   `scripts/self-replication.ts` in template mode to create a tarball.
+4. Uploads the tarball as an artifact named `dynamic-capital-self-replica` for
+   every run.
+5. When the workflow is triggered by a tag (e.g. `v1.2.3`), a dependent job
+   downloads the artifact and publishes it as a GitHub release asset
+   automatically.
+
+You can manually kick off the pipeline from the Actions tab using the **Run
+workflow** button. The `workflow_dispatch` input lets you set a custom
+branch/tag to replicate without creating a new commit.
+
+## Integrating downstream
+
+- **Automated environments** – Infrastructure scripts (Terraform, Ansible, etc.)
+  can call the Deno utility to materialise the latest build artifacts on demand.
+- **Custom forks** – Set up scheduled workflows in downstream repositories that
+  invoke
+  `scripts/self-replication.ts --repo https://github.com/dynamic-capital/dynamic-capital.git --update`
+  to stay in sync with upstream.
+- **Bootstrap new instances** – Run the script locally with
+  `--template --initGit` to prepare a clean repository, then push it to a new
+  remote.
+
+These additions keep the project "self-replicating": every time new features or
+fixes land, a fresh build and distributable bundle is available automatically,
+while teams retain the option to script their own cloning and templating flows
+using the shared utility.

--- a/scripts/self-replication.ts
+++ b/scripts/self-replication.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env -S deno run -A
+import { parse } from "jsr:@std/cli/parse";
+import { ensureDir } from "jsr:@std/fs/ensure_dir";
+import { exists } from "jsr:@std/fs/exists";
+import { dirname, join, relative, resolve } from "jsr:@std/path";
+
+const decoder = new TextDecoder();
+
+interface RunOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  quiet?: boolean;
+  allowFailure?: boolean;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: RunOptions = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const { cwd, env, quiet = false, allowFailure = false } = options;
+  if (!quiet) {
+    const displayCwd = cwd ? relative(Deno.cwd(), cwd) || "." : ".";
+    console.log(`$ (${displayCwd}) ${command} ${args.join(" ")}`);
+  }
+
+  const cmd = new Deno.Command(command, {
+    args,
+    cwd,
+    env,
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout, stderr } = await cmd.output();
+  const stdoutText = decoder.decode(stdout).trimEnd();
+  const stderrText = decoder.decode(stderr).trimEnd();
+
+  if (!quiet) {
+    if (stdoutText.length > 0) {
+      console.log(stdoutText);
+    }
+    if (stderrText.length > 0) {
+      console.error(stderrText);
+    }
+  }
+
+  if (code !== 0 && !allowFailure) {
+    throw new Error(
+      `Command failed with exit code ${code}: ${command} ${args.join(" ")}`,
+    );
+  }
+
+  return { code, stdout: stdoutText, stderr: stderrText };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function banner(message: string) {
+  console.log(`\n=== ${message} ===`);
+}
+
+async function detectOrigin(): Promise<string | undefined> {
+  const result = await runCommand(
+    "git",
+    ["config", "--get", "remote.origin.url"],
+    { quiet: true, allowFailure: true },
+  );
+
+  if (result.code === 0) {
+    const value = result.stdout.trim();
+    return value.length > 0 ? value : undefined;
+  }
+  return undefined;
+}
+
+async function detectCurrentBranch(cwd: string): Promise<string | undefined> {
+  const result = await runCommand(
+    "git",
+    ["rev-parse", "--abbrev-ref", "HEAD"],
+    { cwd, quiet: true, allowFailure: true },
+  );
+
+  if (result.code === 0) {
+    const branch = result.stdout.trim();
+    if (branch.length > 0 && branch !== "HEAD") {
+      return branch;
+    }
+  }
+  return undefined;
+}
+
+async function cloneRepository(
+  source: string,
+  destination: string,
+  branch?: string,
+) {
+  banner(`Cloning ${source} → ${destination}`);
+  await ensureDir(dirname(destination));
+
+  const cloneArgs = ["clone", "--depth", "1"];
+  if (branch) {
+    cloneArgs.push("--branch", branch);
+  }
+  cloneArgs.push(source, destination);
+  await runCommand("git", cloneArgs);
+}
+
+async function updateRepository(dest: string, branch?: string) {
+  banner(`Updating existing repository at ${dest}`);
+  await runCommand("git", ["fetch", "--prune", "--tags", "--force"], {
+    cwd: dest,
+  });
+
+  const branchToUse = branch ?? await detectCurrentBranch(dest);
+  if (branchToUse) {
+    await runCommand("git", ["checkout", branchToUse], { cwd: dest });
+    const remoteRef = `origin/${branchToUse}`;
+    await runCommand("git", ["reset", "--hard", remoteRef], { cwd: dest });
+  } else {
+    await runCommand("git", ["pull", "--ff-only"], { cwd: dest });
+  }
+}
+
+async function removeGitHistory(dest: string) {
+  const gitDir = join(dest, ".git");
+  if (await exists(gitDir)) {
+    banner("Stripping Git metadata for template mode");
+    await Deno.remove(gitDir, { recursive: true });
+  }
+}
+
+async function createArchive(dest: string, archivePath: string) {
+  banner(`Creating archive at ${archivePath}`);
+  await ensureDir(dirname(archivePath));
+  const tarArgs = ["-czf", archivePath, "-C", dest, "."];
+  await runCommand("tar", tarArgs);
+}
+
+async function main() {
+  const flags = parse(Deno.args, {
+    string: ["repo", "branch", "dest", "archive"],
+    boolean: [
+      "install",
+      "build",
+      "lint",
+      "typecheck",
+      "test",
+      "force",
+      "update",
+      "template",
+      "initGit",
+    ],
+    alias: {
+      r: "repo",
+      b: "branch",
+      d: "dest",
+      a: "archive",
+    },
+    default: {
+      install: true,
+      build: true,
+      lint: false,
+      typecheck: false,
+      test: false,
+      force: false,
+      update: false,
+      template: false,
+      initGit: false,
+    },
+  });
+
+  const now = new Date().toISOString().replace(/[:.]/g, "-");
+  const dest = resolve(
+    typeof flags.dest === "string"
+      ? flags.dest
+      : join("replicas", `dynamic-capital-${now}`),
+  );
+
+  const sourceRepo = typeof flags.repo === "string"
+    ? flags.repo
+    : await detectOrigin() ?? ".";
+  const branch = typeof flags.branch === "string" && flags.branch.length > 0
+    ? flags.branch
+    : undefined;
+  const archivePath = typeof flags.archive === "string" &&
+      flags.archive.length > 0
+    ? resolve(flags.archive)
+    : undefined;
+
+  const destExists = await pathExists(dest);
+
+  if (destExists && !flags.update) {
+    if (!flags.force) {
+      throw new Error(
+        `Destination ${dest} already exists. Use --force to overwrite or --update to pull changes.`,
+      );
+    }
+
+    banner(`Removing existing directory ${dest}`);
+    await Deno.remove(dest, { recursive: true });
+  }
+
+  if (!destExists || flags.force) {
+    await cloneRepository(sourceRepo, dest, branch);
+  } else if (flags.update) {
+    await updateRepository(dest, branch);
+  }
+
+  if (flags.template) {
+    await removeGitHistory(dest);
+    if (flags.initGit) {
+      banner("Initializing fresh Git repository");
+      await runCommand("git", ["init"], { cwd: dest });
+    }
+  }
+
+  const summary: Record<string, unknown> = {
+    source: sourceRepo,
+    destination: dest,
+  };
+
+  async function runWorkspaceCommand(script: string, command: string[]) {
+    summary[script] = true;
+    await runCommand(command[0], command.slice(1), { cwd: dest });
+  }
+
+  if (flags.install) {
+    await runWorkspaceCommand("install", ["npm", "ci"]);
+  } else {
+    summary.install = false;
+  }
+
+  if (flags.build) {
+    await runWorkspaceCommand("build", ["npm", "run", "build"]);
+  } else {
+    summary.build = false;
+  }
+
+  if (flags.lint) {
+    await runWorkspaceCommand("lint", ["npm", "run", "lint"]);
+  } else {
+    summary.lint = false;
+  }
+
+  if (flags.typecheck) {
+    await runWorkspaceCommand("typecheck", ["npm", "run", "typecheck"]);
+  } else {
+    summary.typecheck = false;
+  }
+
+  if (flags.test) {
+    await runWorkspaceCommand("test", ["npm", "run", "test"]);
+  } else {
+    summary.test = false;
+  }
+
+  const commitResult = await runCommand(
+    "git",
+    ["rev-parse", "HEAD"],
+    { cwd: dest, quiet: true, allowFailure: true },
+  );
+  if (commitResult.code === 0) {
+    summary.commit = commitResult.stdout.trim();
+  }
+
+  if (archivePath) {
+    await createArchive(dest, archivePath);
+    summary.archive = archivePath;
+  }
+
+  console.log("\nReplication summary:");
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("\n❌ Self-replication failed:", error.message ?? error);
+    Deno.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add a Deno-based `scripts/self-replication.ts` utility that can clone, update, template, and archive replicas of the repository
- wire up a `self-replication.yml` workflow to build the workspace, generate a tarball, and attach it to tagged releases automatically
- document the replication workflow and script usage in `docs/automation/self-replication.md`

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d579d951788322b6eabff8630fad4e