### PR TITLE
Add Grok-1 integration checklist

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -37,11 +37,12 @@ key.
 | 8        | [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)                          | Well-architected review for hosted frontends                                    | Audit Vercel deployments for operational readiness                                    | —                     |
 | 9        | [`Automated Trading System Build Checklist`](./automated-trading-checklist.md)             | TradingView → Vercel → Supabase → MetaTrader 5 pipeline                         | Stand up or extend the automated trading stack                                        | —                     |
 | 10       | [`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md)      | Cross-team onboarding for the TradingView webhook to MT5 flow                   | Coordinate roadmap execution across teams                                             | —                     |
-| 11       | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)          | Merging Dynamic Codex into this monorepo                                        | Completed — dashboard now lives at `/telegram` in the Next.js app                     | —                     |
-| 12       | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)              | Align Git branches with deployable services and domains                         | Rework branching strategy to support independent deployments                          | —                     |
-| 13       | [`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md) | Bringing Investing.com pattern data into Supabase, queue, and Mini App surfaces | Plan and track the signal ingestion + alert rollout                                   | —                     |
-| 14       | [`Trading Algo Improvement Checklist`](./trading-algo-improvement-checklist.md)            | Tune Smart Money Concepts configuration & QA loops                              | Iterate on BOS/liquidity heuristics across config, analyzers, and delivery            | —                     |
-| 15       | [`ISO 9241 Environment Alignment Checklist`](./iso9241_environment_checklist.md)          | ISO 9241-110-aligned review of environments, branches, builds, and configuration | Audit deployment hygiene against usability principles                              | —                     |
+| 11       | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)          | Merging Dynamic Codex into this monorepo                                        | Completed — dashboard now lives at `/telegram` in the Next.js app                  | —                     |
+| 12       | [`Grok-1 Integration Checklist`](./grok-1-integration-checklist.md)                        | Operationalizing Grok-1 across research, automation, and delivery pipelines     | Plan and track Grok-assisted workflows before exposing them to members                  | —                     |
+| 13       | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)              | Align Git branches with deployable services and domains                         | Rework branching strategy to support independent deployments                  | —                     |
+| 14       | [`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md) | Bringing Investing.com pattern data into Supabase, queue, and Mini App surfaces | Plan and track the signal ingestion + alert rollout                  | —                     |
+| 15       | [`Trading Algo Improvement Checklist`](./trading-algo-improvement-checklist.md)            | Tune Smart Money Concepts configuration & QA loops                              | Iterate on BOS/liquidity heuristics across config, analyzers, and delivery            | —                     |
+| 16       | [`ISO 9241 Environment Alignment Checklist`](./iso9241_environment_checklist.md)          | ISO 9241-110-aligned review of environments, branches, builds, and configuration | Audit deployment hygiene against usability principles               | —                     |
 
 ## Project delivery (priorities 1–3)
 
@@ -91,6 +92,9 @@ key.
 - **[`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)**
   – archived after Dynamic Codex was merged into the main `/telegram` route;
   keep for historical context.
+- **[`Grok-1 Integration Checklist`](./grok-1-integration-checklist.md)**
+  – coordinates research, automation, and delivery changes required to safely
+  roll Grok-assisted workflows across the stack.
 - **[`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)**
   – guides the restructuring of branches so each deployable service can map to
   its own domain and load-balanced release flow.

--- a/docs/grok-1-integration-checklist.md
+++ b/docs/grok-1-integration-checklist.md
@@ -1,0 +1,90 @@
+# Grok-1 Integration Checklist
+
+Use this checklist to operationalize Grok-1 inside the Dynamic Capital
+automation stack—from research workflows to Telegram delivery—without breaking
+existing guardrails.
+
+> **Status:** Planned. Complete each section before inviting broader team usage
+> or shipping Grok-powered outputs to members.
+
+## 1. Repository & Access Preparation
+
+- [ ] Fork or mirror [`xai-org/grok-1`](https://github.com/xai-org/grok-1) into
+a vetted organization account and review the license obligations.
+- [ ] Capture model weights, tokenizer assets, and required build tooling in a
+controlled artifact store (e.g., private bucket + checksum manifest).
+- [ ] Align environment variable naming with `docs/env.md`; document any new
+secrets in `.env.example` and Supabase/Vercel vaults without committing real
+values.
+- [ ] Update `docs/REPO_INVENTORY.md` (or equivalent) with the local cache
+location, synchronization cadence, and retention policy for Grok assets.
+
+## 2. Prompting & Context Design
+
+- [ ] Establish canonical prompt templates for SMC ideation, execution guardrail
+reviews, and UI copywriting; store them under `content/prompts/grok-1/`.
+- [ ] Map repository artifacts (TradeConfig logs, analyzer traces, glossary
+entries) to prompt attachments so responses stay grounded in current logic.
+- [ ] Define token budgets, truncation rules, and paraphrase safeguards before
+exposing prompts to automated jobs.
+- [ ] Record evaluation prompts and expected outputs in `tests/llm-scenarios/`
+for regression testing.
+
+## 3. Trading Strategy & Analyzer Enhancements
+
+- [ ] Integrate Grok-assisted idea reviews into the `algorithms/` workflow
+(e.g., PR template checkbox, reviewer step, or IDE helper notes).
+- [ ] Codify how Grok suggestions translate into Pine Script or TypeScript
+changes; update `algorithms/README.md` with the acceptance criteria.
+- [ ] Gate analyzer modifications on new or updated tests in
+`tests/trading-*`—include Grok-generated heuristics in test fixtures for
+repeatability.
+- [ ] Document a rollback plan when Grok-generated logic underperforms (feature
+flag, config revert, or analyzer toggle).
+
+## 4. Signal Ingestion & Supabase Coordination
+
+- [ ] Extend webhook payload schemas (`api/tradingview-alerts.ts`, Supabase
+migrations) to capture any new fields Grok recommends.
+- [ ] Run Supabase migrations in staging and update RLS policies if Grok outputs
+introduce new roles or columns.
+- [ ] Add logging that distinguishes Grok-suggested alerts versus human-crafted
+payloads to support downstream analytics.
+- [ ] Update `supabase/functions/*` docs so operators know which flows depend on
+Grok output and where to validate signals.
+
+## 5. Execution Layer & Risk Controls
+
+- [ ] Have Grok produce risk scenario scripts and validate them against existing
+Expert Advisor safeguards (`Experts/`, `Include/`).
+- [ ] Stress-test queue workers and Supabase polling with Grok-generated edge
+cases; capture failures in the runbook for remediation.
+- [ ] Ensure overrides or manual approvals log whether Grok participated in the
+decision so accountability is clear.
+- [ ] Confirm Task Scheduler / service restarts still recover cleanly with the
+new load profile.
+
+## 6. Telegram & Mini App Experiences
+
+- [ ] Prototype Grok-assisted copy in a staging branch of
+`apps/web/app/telegram/` while keeping Tailwind conventions intact.
+- [ ] Verify Mini App theming remains synced when Grok introduces new content
+modules or cards.
+- [ ] Add UX acceptance criteria for Grok responses (tone, length, disclaimers)
+to the UI QA checklist.
+- [ ] Update broadcast templates and admin tooling to highlight when content was
+assisted by Grok.
+
+## 7. Operations, Compliance & Monitoring
+
+- [ ] Expand monitoring dashboards (Supabase logs, Redis metrics, MT5 bridge
+health) with Grok-specific dimensions and alerts.
+- [ ] Capture evaluation metrics (win rate impact, reviewer acceptance) in a
+shared dashboard or Notion page.
+- [ ] Coordinate a security review covering prompt injection, data leakage, and
+secret handling before production rollout.
+- [ ] Train operators using refreshed runbooks and record dry-run transcripts in
+`docs/meeting-notes/`.
+
+Maintain this checklist as Grok-1 capabilities evolve so future upgrades follow
+the same guardrails.


### PR DESCRIPTION
## Summary
- add a dedicated Grok-1 integration checklist covering repository prep, prompting, trading, and ops tasks
- list the new checklist in the central checklist directory to surface it alongside other specialized workflows

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d57acf4ce4832290104ec9ef743ba2