### PR TITLE
chore: expand trading algo improvement checklist

### DIFF
--- a/docs/trading-algo-improvement-checklist.md
+++ b/docs/trading-algo-improvement-checklist.md
@@ -3,7 +3,9 @@
 Use this checklist to tighten the Smart Money Concepts (SMC) workflow that
 supports the trading automation stack. Each section ladders into the repository
 touchpoints called out in `algorithms/`, Supabase Edge Functions, and the
-Telegram delivery surfaces so changes propagate end-to-end.
+Telegram delivery surfaces so changes propagate end-to-end. Treat the list as a
+living review ritual for each improvement sprint so that new ideas translate
+into measurable trading performance.
 
 ## 1. Foundation & Data Hygiene
 
@@ -16,8 +18,13 @@ Telegram delivery surfaces so changes propagate end-to-end.
 - [ ] Verify Supabase dashboards or logs capture BOS/liquidity sweep events for
       later review and store raw captures under `supabase/functions/*` logs or
       analytics tables.
+- [ ] Validate data timestamps and session boundaries against exchange calendars
+      after deployments or vendor switchovers so time-sensitive SMC logic does
+      not drift.
+- [ ] Archive notable feed anomalies (missing candles, widened spreads) inside
+      the analytics schema to build a reference library for future mitigations.
 
-## 2. Configuration Review
+## 2. Parameter & Configuration Governance
 
 - [ ] Revisit `TradeConfig` SMC settings weekly; tighten
       `smc_level_threshold_pips` if entries are late and raise `smc_bias_weight`
@@ -27,8 +34,12 @@ Telegram delivery surfaces so changes propagate end-to-end.
 - [ ] Ensure alerting thresholds mirror the glossary checkpoints and commit the
       configuration changes alongside updates to `.env.example` when new keys
       are introduced.
+- [ ] Add quick-hit postmortems for any config rollback so future operators
+      understand why a threshold failed in production.
+- [ ] Cross-check queue worker environment variables with Supabase edge function
+      settings after each release to prevent stale overrides.
 
-## 3. Analyzer Enhancements
+## 3. Analyzer & Signal Enhancements
 
 - [ ] Extend `SMCAnalyzer.observe` with new mitigation block or liquidity
       pattern checks before persisting context to Supabase.
@@ -37,8 +48,12 @@ Telegram delivery surfaces so changes propagate end-to-end.
 - [ ] Log additional analyzer outputs (e.g., swept level IDs, mitigation block
       hits) to the analytics tables surfaced in dashboards so reviewers can
       audit context.
+- [ ] Compare analyzer variants with shadow runs or notebook replays to confirm
+      new heuristics improve win rate or risk-adjusted returns before merging.
+- [ ] Document any external indicators or feature-engineering scripts in
+      `algorithms/docs/` so analysts can replicate the logic outside automation.
 
-## 4. Execution Discipline
+## 4. Execution & Risk Discipline
 
 - [ ] Require every published trade idea to reference the glossary checklist—
       call out BOS status, liquidity sweep confirmation, and mitigation
@@ -48,14 +63,32 @@ Telegram delivery surfaces so changes propagate end-to-end.
       (`queue/index.ts`, `supabase/functions/telegram-bot/*`).
 - [ ] Record reasons for overrides when human analysts diverge from automated
       recommendations and archive them in Supabase for feedback analysis.
+- [ ] Stress-test latency-sensitive paths (order routing, Telegram alerts,
+      Supabase webhooks) after every analyzer change to verify execution timing
+      stays inside the acceptable window.
+- [ ] Validate position sizing and risk caps against the portfolio policy doc
+      before enabling new strategies or leverage adjustments.
 
-## 5. Feedback Loop
+## 5. Deployment & Communication
+
+- [ ] Confirm deployment checklists for `algorithms/`, edge functions, and queue
+      workers remain synchronized so feature flags activate in the correct
+      sequence.
+- [ ] Update member-facing portals (e.g., Liquidity Signal Desk) to highlight
+      new checklist items and confirm the Telegram broadcast templates mirror
+      the latest vocabulary.
+- [ ] Notify data vendors or brokerage partners of significant behavioral
+      changes (new order types, higher message rates) before rollout to prevent
+      compliance issues.
+
+## 6. Feedback Loop & Continuous Improvement
 
 - [ ] Review post-trade analytics to correlate glossary-aligned setups with
       performance outcomes and adjust `TradeConfig` weights accordingly.
 - [ ] Schedule retrospective sessions to adjust SMC thresholds, analyzer
       filters, and documentation when patterns emerge; capture notes in
       `docs/meeting-notes/` or the shared project tracker.
-- [ ] Update member-facing portals (e.g., Liquidity Signal Desk) to highlight
-      new checklist items and confirm the Telegram broadcast templates mirror
-      the latest vocabulary.
+- [ ] Run quarterly scenario reviews comparing simulated and live fills to
+      surface slippage patterns or venue degradations.
+- [ ] Close the loop on overrides by tagging outcomes (positive, negative,
+      neutral) and summarizing insights during the next strategy sync.


### PR DESCRIPTION
## Summary
- enrich the trading algo improvement checklist with additional guardrails and cadence guidance
- extend foundation, configuration, analyzer, execution, and feedback sections with more actionable review items
- add new deployment and communication controls to ensure rollout alignment across Supabase, queue workers, and member-facing portals

## Testing
- ./node_modules/.bin/deno fmt docs/trading-algo-improvement-checklist.md

------
https://chatgpt.com/codex/tasks/task_e_68d57c7a18ec83228e51acbbba739889