### PR TITLE
fix: mark landing page component as client

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type ReactNode, useState } from "react";
 
 import {


### PR DESCRIPTION
## Summary
- add the missing "use client" directive to the DynamicCapitalLandingPage component so its stateful logic can compile

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d57dbcaffc8322a5f67469e1be4a62