### PR TITLE
Organize economic catalysts layout

### DIFF
--- a/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
+++ b/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
@@ -1,6 +1,14 @@
 import { Fragment } from "react";
 
-import { Column, Heading, Icon, Line, Row, Tag, Text } from "@/components/dynamic-ui-system";
+import {
+  Column,
+  Heading,
+  Icon,
+  Line,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
 import type { Colors } from "@/components/dynamic-ui-system";
 
 type ImpactLevel = "High" | "Medium" | "Low";
@@ -21,8 +29,16 @@ type EconomicEvent = {
 };
 
 const IMPACT_STYLES = {
-  High: { label: "High impact", background: "danger-alpha-weak", icon: "alert-triangle" },
-  Medium: { label: "Medium impact", background: "brand-alpha-weak", icon: "activity" },
+  High: {
+    label: "High impact",
+    background: "danger-alpha-weak",
+    icon: "alert-triangle",
+  },
+  Medium: {
+    label: "Medium impact",
+    background: "brand-alpha-weak",
+    icon: "activity",
+  },
   Low: { label: "Low impact", background: "neutral-alpha-weak", icon: "info" },
 } as const satisfies Record<ImpactLevel, ImpactStyle>;
 
@@ -98,9 +114,13 @@ export function EconomicCalendarSection() {
       shadow="l"
     >
       <Column gap="12" maxWidth={32}>
-        <Heading variant="display-strong-xs">Upcoming economic catalysts</Heading>
+        <Heading variant="display-strong-xs">
+          Upcoming economic catalysts
+        </Heading>
         <Text variant="body-default-l" onBackground="neutral-weak">
-          The desk tracks macro releases that can reprice risk within minutes. Each listing includes the positioning gameplan so you know how we manage exposure into and out of the data.
+          The desk tracks macro releases that can reprice risk within minutes.
+          Each listing includes the positioning gameplan so you know how we
+          manage exposure into and out of the data.
         </Text>
       </Column>
       <Column gap="24">
@@ -114,46 +134,88 @@ export function EconomicCalendarSection() {
                 border="neutral-alpha-weak"
                 radius="l"
                 padding="l"
-                gap="16"
+                gap="20"
               >
-                <Row horizontal="between" vertical="center" gap="16" s={{ direction: "column", align: "start" }}>
-                  <Column gap="8">
-                    <Row gap="8" wrap>
-                      <Tag size="s" background="neutral-alpha-weak" prefixIcon="calendar">
-                        {event.day}
-                      </Tag>
-                      <Tag size="s" background="neutral-alpha-weak" prefixIcon="clock">
-                        {event.time}
-                      </Tag>
-                    </Row>
-                    <Heading variant="heading-strong-m">{event.title}</Heading>
-                  </Column>
-                  <Tag size="s" background={impactDetails.background} prefixIcon={impactDetails.icon}>
-                    {impactDetails.label}
-                  </Tag>
-                </Row>
-                <Text variant="body-default-m" onBackground="neutral-weak">
-                  {event.commentary}
-                </Text>
-                <Row gap="8" wrap>
-                  {event.marketFocus.map((focus) => (
-                    <Tag key={focus} size="s" background="brand-alpha-weak" prefixIcon="target">
-                      {focus}
-                    </Tag>
-                  ))}
-                </Row>
-                <Column as="ul" gap="8">
-                  {event.deskPlan.map((plan, planIndex) => (
-                    <Row key={planIndex} gap="8" vertical="start">
-                      <Icon name="sparkles" onBackground="brand-medium" />
-                      <Text as="li" variant="body-default-m">
-                        {plan}
+                <Row
+                  gap="24"
+                  vertical="start"
+                  s={{ direction: "column", align: "start", gap: "16" }}
+                >
+                  <Column gap="16" maxWidth={40}>
+                    <Column gap="8">
+                      <Row gap="8" wrap>
+                        <Tag
+                          size="s"
+                          background="neutral-alpha-weak"
+                          prefixIcon="calendar"
+                        >
+                          {event.day}
+                        </Tag>
+                        <Tag
+                          size="s"
+                          background="neutral-alpha-weak"
+                          prefixIcon="clock"
+                        >
+                          {event.time}
+                        </Tag>
+                      </Row>
+                      <Row gap="8" wrap vertical="center">
+                        <Heading variant="heading-strong-m">
+                          {event.title}
+                        </Heading>
+                        <Tag
+                          size="s"
+                          background={impactDetails.background}
+                          prefixIcon={impactDetails.icon}
+                        >
+                          {impactDetails.label}
+                        </Tag>
+                      </Row>
+                    </Column>
+                    <Text variant="body-default-m" onBackground="neutral-weak">
+                      {event.commentary}
+                    </Text>
+                    <Column gap="8">
+                      <Text
+                        variant="body-strong-s"
+                        onBackground="neutral-strong"
+                      >
+                        Market focus
                       </Text>
-                    </Row>
-                  ))}
-                </Column>
+                      <Row gap="8" wrap>
+                        {event.marketFocus.map((focus) => (
+                          <Tag
+                            key={focus}
+                            size="s"
+                            background="brand-alpha-weak"
+                            prefixIcon="target"
+                          >
+                            {focus}
+                          </Tag>
+                        ))}
+                      </Row>
+                    </Column>
+                  </Column>
+                  <Column gap="12" as="section">
+                    <Text variant="body-strong-s" onBackground="neutral-strong">
+                      Desk plan
+                    </Text>
+                    <Column as="ul" gap="12">
+                      {event.deskPlan.map((plan, planIndex) => (
+                        <Row key={planIndex} gap="8" vertical="start">
+                          <Icon name="sparkles" onBackground="brand-medium" />
+                          <Text as="li" variant="body-default-m">
+                            {plan}
+                          </Text>
+                        </Row>
+                      ))}
+                    </Column>
+                  </Column>
+                </Row>
               </Column>
-              {index < ECONOMIC_EVENTS.length - 1 ? <Line background="neutral-alpha-weak" /> : null}
+              {index < ECONOMIC_EVENTS.length - 1
+                ? <Line background="neutral-alpha-weak" />
+                : null}
             </Fragment>
           );
         })}


### PR DESCRIPTION
## Summary
- restructure the Upcoming economic catalysts cards into a two-column layout that separates macro context from desk plans
- highlight impact level alongside the event title and add headings for market focus and desk plan to improve readability

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d597dd54dc83228dc4bcc62328f4cf