### PR TITLE
feat(web): auto sync desk timezone across app

### DIFF
--- a/apps/web/components/shared/RouteArchiveNotice.tsx
+++ b/apps/web/components/shared/RouteArchiveNotice.tsx
@@ -12,6 +12,7 @@ import {
   Text,
 } from "@/components/dynamic-ui-system";
 import { home, person, social } from "@/resources";
+import { DESK_TIME_ZONE, formatWithDeskTimezone } from "@/utils/deskTime";
 import { useEffect, useState } from "react";
 
 const TELEGRAM_LINK = social.find((item) => item.name === "Telegram")?.link ||
@@ -89,10 +90,7 @@ const ONBOARDING_STEPS = [
   },
 ];
 
-const DESK_TIME_ZONE = person.location ?? "UTC";
-
 const DESK_TIME_FORMAT: Intl.DateTimeFormatOptions = {
-  timeZone: DESK_TIME_ZONE,
   hour: "2-digit",
   minute: "2-digit",
   hour12: true,
@@ -100,7 +98,6 @@ const DESK_TIME_FORMAT: Intl.DateTimeFormatOptions = {
 };
 
 const DESK_DATE_FORMAT: Intl.DateTimeFormatOptions = {
-  timeZone: DESK_TIME_ZONE,
   weekday: "long",
   month: "long",
   day: "2-digit",
@@ -110,8 +107,8 @@ function getDeskSnapshot() {
   const now = new Date();
 
   return {
-    time: new Intl.DateTimeFormat("en-US", DESK_TIME_FORMAT).format(now),
-    date: new Intl.DateTimeFormat("en-US", DESK_DATE_FORMAT).format(now),
+    time: formatWithDeskTimezone(now, DESK_TIME_FORMAT, "en-US"),
+    date: formatWithDeskTimezone(now, DESK_DATE_FORMAT, "en-US"),
   };
 }
 

--- a/apps/web/utils/deskTime.ts
+++ b/apps/web/utils/deskTime.ts
@@ -1,0 +1,54 @@
+import { person } from "@/resources";
+
+const DEFAULT_TIME_ZONE = "UTC";
+const DEFAULT_SUFFIX = "UTC";
+const DEFAULT_LOCALE = "en-US";
+
+export const DESK_TIME_ZONE = person.location ?? DEFAULT_TIME_ZONE;
+
+function deriveTimeZoneName(
+  timeZone: string,
+  locale: string,
+  date: Date,
+): string {
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      timeZone,
+      timeZoneName: "short",
+    });
+    const parts = formatter.formatToParts(date);
+    const timeZoneName = parts.find((part) => part.type === "timeZoneName")?.
+      value;
+    if (!timeZoneName) {
+      return DEFAULT_SUFFIX;
+    }
+    if (timeZoneName.startsWith("GMT")) {
+      return timeZoneName.replace("GMT", "UTC");
+    }
+    return timeZoneName;
+  } catch {
+    return DEFAULT_SUFFIX;
+  }
+}
+
+export function getDeskTimeSuffix({
+  locale = DEFAULT_LOCALE,
+  date = new Date(),
+}: {
+  locale?: string;
+  date?: Date;
+} = {}): string {
+  return deriveTimeZoneName(DESK_TIME_ZONE, locale, date);
+}
+
+export function formatWithDeskTimezone(
+  date: Date,
+  options: Intl.DateTimeFormatOptions,
+  locale = DEFAULT_LOCALE,
+): string {
+  return new Intl.DateTimeFormat(locale, {
+    ...options,
+    timeZone: DESK_TIME_ZONE,
+  }).format(date);
+}
+

--- a/apps/web/utils/isoFormat.ts
+++ b/apps/web/utils/isoFormat.ts
@@ -1,7 +1,7 @@
+import { DESK_TIME_ZONE, getDeskTimeSuffix } from "@/utils/deskTime";
+
 export type IsoDateInput = string | number | Date;
 
-const MALDIVES_TIME_ZONE = "Indian/Maldives";
-const MALDIVES_TIME_SUFFIX = "MVT";
 const LOCALE = "en-GB";
 
 function toDate(value: IsoDateInput): Date | null {
@@ -15,7 +15,7 @@ function toDate(value: IsoDateInput): Date | null {
 
 function formatWithPrecision(date: Date, includeMilliseconds: boolean): string {
   const formatter = new Intl.DateTimeFormat(LOCALE, {
-    timeZone: MALDIVES_TIME_ZONE,
+    timeZone: DESK_TIME_ZONE,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -44,7 +44,7 @@ function formatWithPrecision(date: Date, includeMilliseconds: boolean): string {
     ? `.${String(date.getMilliseconds()).padStart(3, "0")}`
     : "";
 
-  return `${year}-${month}-${day}T${hour}:${minute}:${second}${milliseconds} (${MALDIVES_TIME_SUFFIX})`;
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}${milliseconds} (${getDeskTimeSuffix({ locale: LOCALE, date })})`;
 }
 
 export function formatIsoDateTime(


### PR DESCRIPTION
## Summary
- centralize desk timezone helpers so the web app reflects the configured desk location
- update ISO formatting and the archive route notice to use the shared desk timezone metadata

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d59db441388322bc15ac2872ffd73b