### PR TITLE
Sync desk plan output with trading algo

### DIFF
--- a/algorithms/python/desk_plan_formatter.py
+++ b/algorithms/python/desk_plan_formatter.py
@@ -1,0 +1,245 @@
+"""Helpers for translating trade decisions into desk plan bullet points."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Iterable, List, Optional
+
+from .trade_logic import TradeDecision
+
+
+def _determine_decimals(pip_size: Optional[float]) -> int:
+    if pip_size is None or pip_size <= 0:
+        return 2
+    try:
+        quant = Decimal(str(pip_size)).normalize()
+    except InvalidOperation:
+        return 2
+    exponent = -quant.as_tuple().exponent
+    if exponent < 0:
+        exponent = 0
+    return max(0, min(6, exponent))
+
+
+def _format_price(value: Optional[float], *, decimals: int) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.{decimals}f}"
+
+
+def _format_percent(value: Optional[float]) -> Optional[str]:
+    if value is None:
+        return None
+    return f"{value * 100:.0f}%"
+
+
+def _direction_label(direction: Optional[int]) -> str:
+    if direction is None or direction == 0:
+        return "flat"
+    return "long" if direction > 0 else "short"
+
+
+def _describe_correlation(meta: Dict[str, Any]) -> Optional[str]:
+    modifier = meta.get("modifier")
+    if modifier is None or abs(modifier - 1.0) <= 1e-6:
+        return None
+
+    penalty = meta.get("penalty")
+    boost = meta.get("boost")
+
+    detail: Optional[str] = None
+    source: Optional[Dict[str, Any]] = None
+    label: Optional[str] = None
+
+    penalised = meta.get("penalised")
+    boosted = meta.get("boosted")
+
+    if isinstance(penalised, Iterable):
+        penalised = list(penalised)
+        if penalised:
+            source = penalised[0]
+            label = "penalty"
+            if penalty is not None:
+                detail = f"{penalty * 100:.0f}% trim"
+    if detail is None and isinstance(boosted, Iterable):
+        boosted = list(boosted)
+        if boosted:
+            source = boosted[0]
+            label = "boost"
+            if boost is not None:
+                detail = f"+{boost * 100:.0f}% add"
+
+    description = f"correlation {modifier:.2f}x"
+    if source:
+        symbol = source.get("symbol", "correlated book")
+        direction = _direction_label(source.get("position_direction"))
+        description += f" from {symbol} {direction}"
+        if detail:
+            description += f" ({detail})"
+    elif detail:
+        description += f" ({detail})"
+
+    if label and label == "penalty" and penalty is not None:
+        pass
+    return description
+
+
+def _describe_seasonal(meta: Dict[str, Any]) -> Optional[str]:
+    modifier = meta.get("modifier")
+    if modifier is None or abs(modifier - 1.0) <= 1e-6:
+        return None
+    bias = meta.get("bias")
+    confidence = meta.get("confidence")
+    description = f"seasonal {modifier:.2f}x"
+    if bias is not None and confidence is not None:
+        description += f" (bias {bias:+.2f} @ {confidence * 100:.0f}% conviction)"
+    elif bias is not None:
+        description += f" (bias {bias:+.2f})"
+    return description
+
+
+def _describe_smc(meta: Dict[str, Any], *, decimals: int) -> Optional[str]:
+    if not meta.get("enabled"):
+        return None
+
+    parts: List[str] = []
+    levels = meta.get("levels", {})
+    near_levels = levels.get("near") or []
+    if near_levels:
+        highlights: List[str] = []
+        for level in near_levels[:2]:
+            name = level.get("name", "level")
+            relation = level.get("relation", "near")
+            highlights.append(f"{name} {relation}")
+        threshold = levels.get("threshold_pips")
+        if threshold is not None:
+            parts.append(
+                f"Liquidity zones {' & '.join(highlights)} within {threshold:.0f} pips"
+            )
+        else:
+            parts.append(f"Liquidity zones {' & '.join(highlights)}")
+
+    round_number = levels.get("round_number")
+    if isinstance(round_number, dict):
+        value = round_number.get("value")
+        relation = round_number.get("relation", "near")
+        distance = round_number.get("distance_pips")
+        rn_text = f"Round number { _format_price(value, decimals=decimals) } {relation}"
+        if distance is not None:
+            rn_text += f" ({distance:.1f} pips)"
+        parts.append(rn_text)
+
+    liquidity = meta.get("liquidity", {})
+    penalised_levels = liquidity.get("penalised_levels") or []
+    if penalised_levels:
+        formatted = ", ".join(str(level) for level in penalised_levels[:3])
+        parts.append(f"Liquidity pressure on {formatted}")
+
+    adjustment = meta.get("adjustment")
+    modifier = meta.get("modifier")
+    if modifier is not None and abs(modifier - 1.0) > 1e-6:
+        parts.append(f"SMC modifier {modifier:.2f}x (adj {adjustment:+.2f})")
+
+    if not parts:
+        return None
+
+    return "SMC context: " + "; ".join(parts)
+
+
+def render_desk_plan(
+    decision: TradeDecision,
+    *,
+    pip_size: Optional[float] = None,
+) -> List[str]:
+    """Generate bullet points describing a trade decision for desk operators."""
+
+    decimals = _determine_decimals(pip_size)
+    plan: List[str] = []
+
+    direction = _direction_label(decision.direction)
+    entry = decision.entry
+    stop = decision.stop_loss
+    target = decision.take_profit
+    size = decision.size or 0.0
+
+    entry_text = (
+        f"Lorentzian stack {direction} {decision.symbol}"
+        if direction != "flat"
+        else f"Lorentzian stack {decision.symbol}"
+    )
+    if entry is not None:
+        entry_text += f" at {_format_price(entry, decimals=decimals)}"
+    if size > 0:
+        entry_text += f" (size {size:.2f})"
+    entry_text += "."
+    plan.append(entry_text)
+
+    risk_bits: List[str] = []
+    if stop is not None:
+        risk_bits.append(f"stop {_format_price(stop, decimals=decimals)}")
+    if target is not None:
+        risk_bits.append(f"target {_format_price(target, decimals=decimals)}")
+
+    risk_text_parts: List[str] = []
+    risk_pips: Optional[float] = None
+    reward_pips: Optional[float] = None
+    rr: Optional[float] = None
+
+    if pip_size and pip_size > 0 and entry is not None:
+        if stop is not None:
+            risk_pips = abs(entry - stop) / pip_size
+        if target is not None:
+            reward_pips = abs(target - entry) / pip_size
+        if risk_pips and reward_pips:
+            if risk_pips > 0:
+                rr = reward_pips / risk_pips
+
+    if risk_pips is not None:
+        risk_text_parts.append(f"{risk_pips:.0f} pips risk")
+    if rr is not None:
+        risk_text_parts.append(f"≈{rr:.2f}R")
+
+    if risk_bits:
+        risk_text = "Risk plan: " + ", ".join(risk_bits)
+        if risk_text_parts:
+            risk_text += f" ({', '.join(risk_text_parts)})"
+        risk_text += "."
+        plan.append(risk_text)
+
+    context = decision.context or {}
+    original_conf = context.get("original_confidence")
+    final_conf = context.get("final_confidence")
+    correlation_meta = context.get("correlation", {})
+    seasonal_meta = context.get("seasonal", {})
+    smc_meta = context.get("smc", {})
+
+    adjustment_bits: List[str] = []
+    correlation_desc = _describe_correlation(correlation_meta)
+    if correlation_desc:
+        adjustment_bits.append(correlation_desc)
+    seasonal_desc = _describe_seasonal(seasonal_meta)
+    if seasonal_desc:
+        adjustment_bits.append(seasonal_desc)
+    smc_modifier = smc_meta.get("modifier")
+    if smc_modifier is not None and abs(smc_modifier - 1.0) > 1e-6:
+        adjustment_bits.append(f"SMC {smc_modifier:.2f}x")
+
+    if original_conf is not None and final_conf is not None:
+        confidence_line = (
+            f"Confidence adjusted {_format_percent(original_conf)} → {_format_percent(final_conf)}"
+        )
+        if adjustment_bits:
+            confidence_line += " via " + " and ".join(adjustment_bits)
+        confidence_line += "."
+        plan.append(confidence_line)
+    elif adjustment_bits:
+        plan.append("Context modifiers: " + " and ".join(adjustment_bits) + ".")
+
+    smc_desc = _describe_smc(smc_meta, decimals=decimals)
+    if smc_desc:
+        plan.append(smc_desc + ".")
+
+    return [line for line in plan if line]
+
+
+__all__ = ["render_desk_plan"]

--- a/algorithms/python/generate_desk_plan_snapshot.py
+++ b/algorithms/python/generate_desk_plan_snapshot.py
@@ -1,0 +1,379 @@
+"""Generate trading desk plan snapshots from the Lorentzian trade logic."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from .desk_plan_formatter import render_desk_plan
+from .trade_logic import (
+    ActivePosition,
+    MarketSnapshot,
+    TradeConfig,
+    TradeDecision,
+    TradeLogic,
+    TradeSignal,
+)
+
+
+class StaticStrategy:
+    def __init__(self, signal: TradeSignal) -> None:
+        self._signal = signal
+
+    def update(self, snapshot: MarketSnapshot) -> TradeSignal:  # pragma: no cover - simple pass-through
+        return self._signal
+
+
+@dataclass(slots=True)
+class Scenario:
+    id: str
+    config: TradeConfig
+    signal: TradeSignal
+    snapshot: MarketSnapshot
+    open_positions: List[ActivePosition]
+
+
+def _run_scenario(scenario: Scenario) -> tuple[TradeDecision, MarketSnapshot]:
+    logic = TradeLogic(config=scenario.config)
+    logic.strategy = StaticStrategy(scenario.signal)
+    decisions = logic.on_bar(
+        scenario.snapshot,
+        open_positions=scenario.open_positions,
+    )
+    decision = next(dec for dec in decisions if dec.action == "open")
+    return decision, scenario.snapshot
+
+
+def _direction(decision: TradeDecision) -> str:
+    if decision.direction and decision.direction > 0:
+        return "long"
+    if decision.direction and decision.direction < 0:
+        return "short"
+    return "flat"
+
+
+def _price_decimals(pip_size: float | None) -> int:
+    if pip_size is None or pip_size <= 0:
+        return 2
+    try:
+        quant = Decimal(str(pip_size)).normalize()
+    except InvalidOperation:
+        return 2
+    exponent = -quant.as_tuple().exponent
+    if exponent < 0:
+        exponent = 0
+    return max(0, min(6, exponent))
+
+
+def _round_price(value: float | None, *, pip_size: float | None) -> float | None:
+    if value is None:
+        return None
+    decimals = _price_decimals(pip_size)
+    return round(value, decimals)
+
+
+def _round_confidence(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(value, 4)
+
+
+def _scenario_data(decision: TradeDecision, snapshot: MarketSnapshot) -> dict:
+    plan = render_desk_plan(decision, pip_size=snapshot.pip_size)
+    context = decision.context or {}
+    return {
+        "symbol": decision.symbol,
+        "direction": _direction(decision),
+        "entry": _round_price(decision.entry, pip_size=snapshot.pip_size),
+        "stopLoss": _round_price(decision.stop_loss, pip_size=snapshot.pip_size),
+        "takeProfit": _round_price(decision.take_profit, pip_size=snapshot.pip_size),
+        "originalConfidence": _round_confidence(context.get("original_confidence")),
+        "finalConfidence": _round_confidence(context.get("final_confidence")),
+        "reason": decision.reason,
+        "plan": plan,
+    }
+
+
+def build_scenarios() -> List[Scenario]:
+    tz = timezone.utc
+
+    scenarios: List[Scenario] = []
+
+    scenarios.append(
+        Scenario(
+            id="fomc",
+            config=TradeConfig(
+                neighbors=3,
+                label_lookahead=2,
+                min_confidence=0.0,
+                use_adr=False,
+                manual_stop_loss_pips=30.0,
+                manual_take_profit_pips=60.0,
+                correlation_threshold=0.55,
+                correlation_weight=0.5,
+                max_correlation_adjustment=0.4,
+                seasonal_bias_weight=0.45,
+                max_seasonal_adjustment=0.25,
+                smc_level_threshold_pips=18.0,
+                smc_round_number_interval_pips=25.0,
+            ),
+            signal=TradeSignal(direction=-1, confidence=0.78, votes=9, neighbors_considered=12),
+            snapshot=MarketSnapshot(
+                symbol="US500",
+                timestamp=datetime(2025, 3, 19, 18, 0, tzinfo=tz),
+                open=5132.0,
+                high=5158.5,
+                low=5104.5,
+                close=5120.5,
+                rsi_fast=68.0,
+                adx_fast=24.0,
+                rsi_slow=60.5,
+                adx_slow=20.0,
+                pip_size=0.25,
+                pip_value=5.0,
+                daily_high=5158.5,
+                daily_low=5096.0,
+                previous_daily_high=5144.0,
+                previous_daily_low=5078.5,
+                weekly_high=5188.0,
+                weekly_low=5020.0,
+                previous_week_high=5206.0,
+                previous_week_low=5008.0,
+                correlation_scores={"US100": 0.82, "DXY": -0.67},
+                seasonal_bias=-0.38,
+                seasonal_confidence=0.6,
+            ),
+            open_positions=[
+                ActivePosition(
+                    symbol="US100",
+                    direction=-1,
+                    size=0.6,
+                    entry_price=17980.0,
+                    opened_at=datetime(2025, 3, 18, 14, 0, tzinfo=tz),
+                ),
+                ActivePosition(
+                    symbol="DXY",
+                    direction=1,
+                    size=0.3,
+                    entry_price=104.2,
+                    opened_at=datetime(2025, 3, 18, 10, 0, tzinfo=tz),
+                ),
+            ],
+        )
+    )
+
+    scenarios.append(
+        Scenario(
+            id="uk-cpi",
+            config=TradeConfig(
+                neighbors=3,
+                label_lookahead=2,
+                min_confidence=0.0,
+                use_adr=False,
+                manual_stop_loss_pips=28.0,
+                manual_take_profit_pips=56.0,
+                correlation_threshold=0.55,
+                correlation_weight=0.5,
+                max_correlation_adjustment=0.35,
+                seasonal_bias_weight=0.4,
+                max_seasonal_adjustment=0.25,
+                smc_level_threshold_pips=14.0,
+                smc_round_number_interval_pips=50.0,
+            ),
+            signal=TradeSignal(direction=-1, confidence=0.69, votes=7, neighbors_considered=10),
+            snapshot=MarketSnapshot(
+                symbol="GBPUSD",
+                timestamp=datetime(2025, 3, 19, 7, 0, tzinfo=tz),
+                open=1.2780,
+                high=1.2795,
+                low=1.2710,
+                close=1.2732,
+                rsi_fast=43.0,
+                adx_fast=23.0,
+                rsi_slow=46.0,
+                adx_slow=18.5,
+                pip_size=0.0001,
+                pip_value=10.0,
+                daily_high=1.2795,
+                daily_low=1.2705,
+                previous_daily_high=1.2830,
+                previous_daily_low=1.2718,
+                weekly_high=1.2890,
+                weekly_low=1.2620,
+                previous_week_high=1.2935,
+                previous_week_low=1.2585,
+                correlation_scores={"EURUSD": 0.66, "DXY": -0.63},
+                seasonal_bias=-0.32,
+                seasonal_confidence=0.62,
+            ),
+            open_positions=[
+                ActivePosition(
+                    symbol="EURUSD",
+                    direction=1,
+                    size=0.4,
+                    entry_price=1.0960,
+                    opened_at=datetime(2025, 3, 18, 11, 0, tzinfo=tz),
+                ),
+                ActivePosition(
+                    symbol="DXY",
+                    direction=1,
+                    size=0.25,
+                    entry_price=104.15,
+                    opened_at=datetime(2025, 3, 18, 8, 0, tzinfo=tz),
+                ),
+            ],
+        )
+    )
+
+    scenarios.append(
+        Scenario(
+            id="ecb-speeches",
+            config=TradeConfig(
+                neighbors=3,
+                label_lookahead=2,
+                min_confidence=0.0,
+                use_adr=False,
+                manual_stop_loss_pips=26.0,
+                manual_take_profit_pips=52.0,
+                correlation_threshold=0.5,
+                correlation_weight=0.45,
+                max_correlation_adjustment=0.3,
+                seasonal_bias_weight=0.35,
+                max_seasonal_adjustment=0.2,
+                smc_level_threshold_pips=12.0,
+                smc_round_number_interval_pips=40.0,
+            ),
+            signal=TradeSignal(direction=1, confidence=0.65, votes=6, neighbors_considered=9),
+            snapshot=MarketSnapshot(
+                symbol="EURUSD",
+                timestamp=datetime(2025, 3, 20, 9, 30, tzinfo=tz),
+                open=1.0915,
+                high=1.0948,
+                low=1.0892,
+                close=1.0936,
+                rsi_fast=57.0,
+                adx_fast=19.5,
+                rsi_slow=54.0,
+                adx_slow=17.0,
+                pip_size=0.0001,
+                pip_value=10.0,
+                daily_high=1.0948,
+                daily_low=1.0888,
+                previous_daily_high=1.0925,
+                previous_daily_low=1.0855,
+                weekly_high=1.0975,
+                weekly_low=1.0790,
+                previous_week_high=1.1020,
+                previous_week_low=1.0765,
+                correlation_scores={"EURJPY": 0.61, "DXY": -0.58},
+                seasonal_bias=0.28,
+                seasonal_confidence=0.58,
+            ),
+            open_positions=[
+                ActivePosition(
+                    symbol="EURJPY",
+                    direction=1,
+                    size=0.35,
+                    entry_price=163.8,
+                    opened_at=datetime(2025, 3, 19, 6, 0, tzinfo=tz),
+                ),
+                ActivePosition(
+                    symbol="DXY",
+                    direction=-1,
+                    size=0.2,
+                    entry_price=104.05,
+                    opened_at=datetime(2025, 3, 19, 4, 0, tzinfo=tz),
+                ),
+            ],
+        )
+    )
+
+    scenarios.append(
+        Scenario(
+            id="us-pmi",
+            config=TradeConfig(
+                neighbors=3,
+                label_lookahead=2,
+                min_confidence=0.0,
+                use_adr=False,
+                manual_stop_loss_pips=24.0,
+                manual_take_profit_pips=48.0,
+                correlation_threshold=0.5,
+                correlation_weight=0.45,
+                max_correlation_adjustment=0.35,
+                seasonal_bias_weight=0.4,
+                max_seasonal_adjustment=0.25,
+                smc_level_threshold_pips=15.0,
+                smc_round_number_interval_pips=20.0,
+            ),
+            signal=TradeSignal(direction=1, confidence=0.71, votes=8, neighbors_considered=11),
+            snapshot=MarketSnapshot(
+                symbol="XAUUSD",
+                timestamp=datetime(2025, 3, 21, 13, 45, tzinfo=tz),
+                open=2362.0,
+                high=2374.5,
+                low=2355.0,
+                close=2371.2,
+                rsi_fast=62.0,
+                adx_fast=25.0,
+                rsi_slow=58.0,
+                adx_slow=21.0,
+                pip_size=0.1,
+                pip_value=1.0,
+                daily_high=2374.5,
+                daily_low=2348.0,
+                previous_daily_high=2366.0,
+                previous_daily_low=2332.0,
+                weekly_high=2382.0,
+                weekly_low=2298.0,
+                previous_week_high=2394.0,
+                previous_week_low=2286.0,
+                correlation_scores={"WTICOUSD": 0.58, "DXY": -0.6},
+                seasonal_bias=0.34,
+                seasonal_confidence=0.64,
+            ),
+            open_positions=[
+                ActivePosition(
+                    symbol="WTICOUSD",
+                    direction=1,
+                    size=0.8,
+                    entry_price=78.4,
+                    opened_at=datetime(2025, 3, 20, 15, 0, tzinfo=tz),
+                ),
+                ActivePosition(
+                    symbol="USDJPY",
+                    direction=-1,
+                    size=0.5,
+                    entry_price=148.2,
+                    opened_at=datetime(2025, 3, 20, 9, 0, tzinfo=tz),
+                ),
+            ],
+        )
+    )
+
+    return scenarios
+
+
+def generate_snapshot() -> dict:
+    snapshot: dict[str, dict] = {}
+    for scenario in build_scenarios():
+        decision, market_snapshot = _run_scenario(scenario)
+        snapshot[scenario.id] = _scenario_data(decision, market_snapshot)
+    return snapshot
+
+
+def main() -> None:
+    data = generate_snapshot()
+    root = Path(__file__).resolve().parents[2]
+    target = root / "apps" / "web" / "data" / "trading-desk-plan.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(data, indent=2, sort_keys=True))
+    print(f"Wrote {target}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    main()

--- a/algorithms/python/tests/test_desk_plan_formatter.py
+++ b/algorithms/python/tests/test_desk_plan_formatter.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from algorithms.python.desk_plan_formatter import render_desk_plan
+from algorithms.python.trade_logic import (
+    ActivePosition,
+    MarketSnapshot,
+    TradeConfig,
+    TradeDecision,
+    TradeLogic,
+    TradeSignal,
+)
+
+
+class StaticStrategy:
+    def __init__(self, signal: TradeSignal) -> None:
+        self._signal = signal
+
+    def update(self, snapshot: MarketSnapshot) -> TradeSignal:  # pragma: no cover - simple pass-through
+        return self._signal
+
+
+def _build_decision() -> tuple[TradeDecision, MarketSnapshot]:
+    config = TradeConfig(
+        neighbors=1,
+        label_lookahead=0,
+        min_confidence=0.0,
+        use_adr=False,
+        manual_stop_loss_pips=30.0,
+        manual_take_profit_pips=60.0,
+    )
+    logic = TradeLogic(config=config)
+    signal = TradeSignal(direction=1, confidence=0.72, votes=5, neighbors_considered=8)
+    logic.strategy = StaticStrategy(signal)
+
+    snapshot = MarketSnapshot(
+        symbol="GBPUSD",
+        timestamp=datetime(2024, 3, 19, 7, 0, tzinfo=timezone.utc),
+        open=1.2740,
+        high=1.2775,
+        low=1.2730,
+        close=1.2755,
+        rsi_fast=55.0,
+        adx_fast=21.0,
+        rsi_slow=52.0,
+        adx_slow=18.0,
+        pip_size=0.0001,
+        pip_value=10.0,
+        daily_high=1.2775,
+        daily_low=1.2725,
+        previous_daily_high=1.2790,
+        previous_daily_low=1.2680,
+        weekly_high=1.2840,
+        weekly_low=1.2580,
+        previous_week_high=1.2880,
+        previous_week_low=1.2520,
+        correlation_scores={"EURUSD": 0.68},
+        seasonal_bias=0.45,
+        seasonal_confidence=0.65,
+    )
+    open_positions = [
+        ActivePosition(
+            symbol="EURUSD",
+            direction=1,
+            size=0.5,
+            entry_price=1.0900,
+            opened_at=datetime(2024, 3, 18, 13, 0, tzinfo=timezone.utc),
+        )
+    ]
+
+    decisions = logic.on_bar(snapshot, open_positions=open_positions)
+    decision = next(dec for dec in decisions if dec.action == "open")
+    return decision, snapshot
+
+
+def test_render_desk_plan_formats_trade_details() -> None:
+    decision, snapshot = _build_decision()
+
+    plan = render_desk_plan(decision, pip_size=snapshot.pip_size)
+
+    assert plan, "expected desk plan output"
+    assert any("Lorentzian stack" in line for line in plan)
+    assert any("Confidence adjusted" in line for line in plan)
+    assert any("SMC context" in line for line in plan)
+
+

--- a/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
+++ b/apps/web/components/magic-portfolio/home/EconomicCalendarSection.tsx
@@ -9,6 +9,7 @@ import {
   Tag,
   Text,
 } from "@/components/dynamic-ui-system";
+import tradingDeskPlan from "@/data/trading-desk-plan.json";
 import type { Colors } from "@/components/dynamic-ui-system";
 
 type ImpactLevel = "High" | "Medium" | "Low";
@@ -27,6 +28,31 @@ type EconomicEvent = {
   commentary: string;
   deskPlan: string[];
 };
+
+type TradingDeskPlanSnapshot = {
+  symbol: string;
+  direction: "long" | "short" | "flat";
+  entry: number | null;
+  stopLoss: number | null;
+  takeProfit: number | null;
+  originalConfidence: number | null;
+  finalConfidence: number | null;
+  reason: string;
+  plan: string[];
+};
+
+const TRADING_DESK_PLAN = tradingDeskPlan as Record<
+  string,
+  TradingDeskPlanSnapshot
+>;
+
+function getDeskPlan(eventId: string): string[] {
+  const snapshot = TRADING_DESK_PLAN[eventId];
+  if (snapshot && Array.isArray(snapshot.plan) && snapshot.plan.length > 0) {
+    return snapshot.plan;
+  }
+  return [];
+}
 
 const IMPACT_STYLES = {
   High: {
@@ -52,10 +78,7 @@ const ECONOMIC_EVENTS: EconomicEvent[] = [
     marketFocus: ["USD", "Rates", "US Indices"],
     commentary:
       "We expect the statement to keep optionality for mid-year cuts while Powell leans against premature easing. Volatility will spike across USD pairs and equity index futures.",
-    deskPlan: [
-      "Pause USD scalps 30 minutes before the statement and re-open only after the press conference tone is clear.",
-      "Automation primed to fade S&P strength if dot plot shifts hawkish and 5,200 fails to hold on retests.",
-    ],
+    deskPlan: getDeskPlan("fomc"),
   },
   {
     id: "uk-cpi",
@@ -66,10 +89,7 @@ const ECONOMIC_EVENTS: EconomicEvent[] = [
     marketFocus: ["GBP", "UK Rates"],
     commentary:
       "Sticky services inflation keeps the Bank of England boxed in. Consensus looks too light on core readings after energy base effects faded.",
-    deskPlan: [
-      "Short bias stays in place for GBP/USD below 1.28 with automation trimming risk if core prints under 5.0%.",
-      "Gilts desk watching 2Y yields for a break above 4.50% to add to short-duration hedges.",
-    ],
+    deskPlan: getDeskPlan("uk-cpi"),
   },
   {
     id: "ecb-speeches",
@@ -80,10 +100,7 @@ const ECONOMIC_EVENTS: EconomicEvent[] = [
     marketFocus: ["EUR", "European Banks"],
     commentary:
       "Lagarde, Villeroy, and Schnabel hit the wires across the session. Guidance around June easing path will steer EUR crosses.",
-    deskPlan: [
-      "Maintain light EUR/USD short starter with adds only if commentary dismisses back-to-back cuts.",
-      "Financials desk monitoring EuroStoxx banks for continuation above 130 to keep overweight exposure on.",
-    ],
+    deskPlan: getDeskPlan("ecb-speeches"),
   },
   {
     id: "us-pmi",
@@ -94,10 +111,7 @@ const ECONOMIC_EVENTS: EconomicEvent[] = [
     marketFocus: ["USD", "Commodities"],
     commentary:
       "Manufacturing prints are the swing factor for cyclical trades. A beat keeps the soft-landing narrative alive and supports metals demand.",
-    deskPlan: [
-      "Gold overlay hedges stay live while manufacturing PMI holds above 50; unwind if the composite slips under 49.5.",
-      "Energy team watching WTI for acceptance above $80 to re-enter trend longs on solid services demand signals.",
-    ],
+    deskPlan: getDeskPlan("us-pmi"),
   },
 ];
 

--- a/apps/web/data/trading-desk-plan.json
+++ b/apps/web/data/trading-desk-plan.json
@@ -1,0 +1,66 @@
+{
+  "ecb-speeches": {
+    "direction": "long",
+    "entry": 1.0936,
+    "finalConfidence": 0.4984,
+    "originalConfidence": 0.65,
+    "plan": [
+      "Lorentzian stack long EURUSD at 1.0936 (size 0.38).",
+      "Risk plan: stop 1.0910, target 1.0988 (26 pips risk, \u22482.00R).",
+      "Confidence adjusted 65% \u2192 50% via correlation 0.73x from EURJPY long (27% trim) and seasonal 1.06x (bias +0.28 @ 58% conviction).",
+      "SMC context: Liquidity zones PDH below within 12 pips; Round number 1.0920 below (16.0 pips)."
+    ],
+    "reason": "Lorentzian k-NN signal (correlation 0.73x, seasonal 1.06x)",
+    "stopLoss": 1.091,
+    "symbol": "EURUSD",
+    "takeProfit": 1.0988
+  },
+  "fomc": {
+    "direction": "short",
+    "entry": 5120.5,
+    "finalConfidence": 0.516,
+    "originalConfidence": 0.78,
+    "plan": [
+      "Lorentzian stack short US500 at 5120.50 (size 0.66).",
+      "Risk plan: stop 5128.00, target 5105.50 (30 pips risk, \u22482.00R).",
+      "Confidence adjusted 78% \u2192 52% via correlation 0.60x from US100 short (40% trim) and seasonal 1.10x (bias -0.38 @ 60% conviction).",
+      "SMC context: Liquidity zones RN below within 18 pips; Round number 5118.75 below (7.0 pips)."
+    ],
+    "reason": "Lorentzian k-NN signal (correlation 0.60x, seasonal 1.10x)",
+    "stopLoss": 5128.0,
+    "symbol": "US500",
+    "takeProfit": 5105.5
+  },
+  "uk-cpi": {
+    "direction": "short",
+    "entry": 1.2732,
+    "finalConfidence": 0.7559,
+    "originalConfidence": 0.69,
+    "plan": [
+      "Lorentzian stack short GBPUSD at 1.2732 (size 0.35).",
+      "Risk plan: stop 1.2760, target 1.2676 (28 pips risk, \u22482.00R).",
+      "Confidence adjusted 69% \u2192 76% via correlation 1.02x from DXY long (32% trim) and seasonal 1.08x (bias -0.32 @ 62% conviction).",
+      "SMC context: Round number 1.2750 above (18.0 pips)."
+    ],
+    "reason": "Lorentzian k-NN signal (correlation 1.02x, seasonal 1.08x)",
+    "stopLoss": 1.276,
+    "symbol": "GBPUSD",
+    "takeProfit": 1.2676
+  },
+  "us-pmi": {
+    "direction": "long",
+    "entry": 2371.2,
+    "finalConfidence": 0.5704,
+    "originalConfidence": 0.71,
+    "plan": [
+      "Lorentzian stack long XAUUSD at 2371.2 (size 4.16).",
+      "Risk plan: stop 2368.8, target 2376.0 (24 pips risk, \u22482.00R).",
+      "Confidence adjusted 71% \u2192 57% via correlation 0.74x from WTICOUSD long (26% trim) and seasonal 1.09x (bias +0.34 @ 64% conviction).",
+      "SMC context: Liquidity zones RN above within 15 pips; Round number 2372.0 above (8.0 pips)."
+    ],
+    "reason": "Lorentzian k-NN signal (correlation 0.74x, seasonal 1.09x)",
+    "stopLoss": 2368.8,
+    "symbol": "XAUUSD",
+    "takeProfit": 2376.0
+  }
+}


### PR DESCRIPTION
## Summary
- add a formatter and snapshot generator that convert Lorentzian trade decisions into desk plan bullets
- wire the economic calendar component to consume the generated trading desk plan snapshot
- cover the formatter with unit tests and check in the generated desk plan JSON for the UI

## Testing
- pytest algorithms/python/tests
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5a00612208322bc56167761381494