### PR TITLE
Add guide for reading the RORO meter

### DIFF
--- a/apps/web/app/blog/posts/risk-on-risk-off-meter.mdx
+++ b/apps/web/app/blog/posts/risk-on-risk-off-meter.mdx
@@ -1,0 +1,54 @@
+---
+title: "How to read our Risk-On / Risk-Off Meter"
+summary: "Use our RORO meter to align trading plans with the market's appetite for risk."
+publishedAt: "2025-02-21"
+tag: "Risk"
+image: "https://your-project-ref.supabase.co/storage/v1/object/public/magic-portfolio/images/projects/risk-meter/cover-01.jpg"
+---
+
+Understanding whether capital is seeking risk or hiding from it is one of the fastest ways to decide how aggressively you should trade. Our Risk-On / Risk-Off (RORO) Meter tracks a basket of macro signals so you can see the market's mood at a glance.
+
+## How to use the RORO meter
+
+1. **Check the daily read** – The meter updates in real time during market hours and prints a score from 0 (maximum risk-off) to 100 (maximum risk-on).
+2. **Map the score to bias** – Higher scores mean participants are rotating into growth-sensitive assets such as equities, commodities, AUD, and NZD. Lower scores mean flows are returning to bonds, gold, USD, and JPY.
+3. **Align your plan** – Decide whether upcoming trades rely on risk appetite or risk aversion. Size up directional ideas when the mood supports them and scale back when it does not.
+
+The meter is not a crystal ball; it is a temperature check. Use it alongside your playbook to avoid fighting the prevailing tone.
+
+## What defines a "risk on" day?
+
+A risk-on session shows up when the data, earnings tape, or policy backdrop invites traders to reach for yield. Price action confirms it as money leaves defensive assets and chases upside in equities, commodities, and high beta FX pairs. In these windows, be ready to:
+
+- Deploy strategies that need momentum or growth expectations.
+- Let winning trades run a bit longer, but keep stops honest in case sentiment cools.
+- Watch correlations—crypto, equities, and cyclicals often move together when the crowd is optimistic.
+
+## What defines a "risk off" day?
+
+Risk-off prints follow fear, uncertainty, or outright negative catalysts. Traders crowd into Treasuries, gold, USD, and JPY while cutting exposure to cyclical assets. When the mood shifts defensive:
+
+- Prioritize capital preservation and stick to setups with defined risk.
+- Shorten holding periods on high-beta trades or skip them altogether.
+- Expect volatility to spike around headlines; let the meter confirm when flows stabilize.
+
+## How the meter is built
+
+Behind the scenes we blend multiple instruments that historically signal risk appetite. Each component contributes to the composite score with a weight that reflects its sensitivity to sentiment shifts. Examples include:
+
+- Equity index futures versus prior closes
+- Credit spreads and high-yield ETF performance
+- Commodity benchmarks tied to growth demand
+- Safe-haven currency strength
+
+Every leg recalculates continuously while markets are open. As the inputs move, so does the score, giving you an up-to-the-minute read on crowd psychology.
+
+## Why it matters
+
+Risk sentiment can flip intraday, and ignoring it is a quick way to get chopped up. By glancing at the RORO meter before committing capital you:
+
+- Trade with, not against, the prevailing mood.
+- Catch inflection points when flows reverse between risk-on and risk-off regimes.
+- Anchor conversations with mentors and desk mates around objective data instead of gut feel.
+
+Use the meter as a guidepost. When it agrees with your setup, lean in. When it disagrees, reassess whether the trade still makes sense.


### PR DESCRIPTION
## Summary
- add a marketing blog post that explains how to read the Risk-On / Risk-Off meter and act on each regime

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5a4f8c0208322bc91f1cadfb6a240