### PR TITLE
Guard miniapp Supabase proxy env requirements

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/README.md
+++ b/dynamic-capital-ton/apps/miniapp/README.md
@@ -18,3 +18,10 @@ SUPABASE_FN_URL=https://<project>.functions.supabase.co
 - `pnpm build`
 
 API routes proxy the Supabase Edge functions defined under `supabase/functions/*`.
+
+## Manual verification
+
+You can confirm the proxy guards behave correctly with curl:
+
+1. **Without `SUPABASE_FN_URL`**: run `pnpm dev` without the variable configured and call `curl -X POST http://localhost:3000/api/link-wallet -d '{}' -H 'Content-Type: application/json'`. The API should respond with `500` and a JSON error payload about the missing environment variable.
+2. **With `SUPABASE_FN_URL`**: export `SUPABASE_FN_URL="https://<project>.functions.supabase.co"` (or set it in `.env.local`), restart the dev server, and repeat the curl command. This time the request should proxy through to the Supabase Edge function and return its response.

--- a/dynamic-capital-ton/apps/miniapp/app/api/link-wallet/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/link-wallet/route.ts
@@ -1,6 +1,19 @@
 export async function POST(req: Request) {
+  const supabaseFnUrl = process.env.SUPABASE_FN_URL;
+
+  if (!supabaseFnUrl) {
+    console.error("[miniapp] Missing SUPABASE_FN_URL env variable when linking wallet");
+    return new Response(
+      JSON.stringify({ error: "SUPABASE_FN_URL environment variable is not configured" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
   const body = await req.json();
-  const response = await fetch(`${process.env.SUPABASE_FN_URL}/link-wallet`, {
+  const response = await fetch(`${supabaseFnUrl}/link-wallet`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/dynamic-capital-ton/apps/miniapp/app/api/process-subscription/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/process-subscription/route.ts
@@ -1,6 +1,19 @@
 export async function POST(req: Request) {
+  const supabaseFnUrl = process.env.SUPABASE_FN_URL;
+
+  if (!supabaseFnUrl) {
+    console.error("[miniapp] Missing SUPABASE_FN_URL env variable when processing subscription");
+    return new Response(
+      JSON.stringify({ error: "SUPABASE_FN_URL environment variable is not configured" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
   const body = await req.json();
-  const response = await fetch(`${process.env.SUPABASE_FN_URL}/process-subscription`, {
+  const response = await fetch(`${supabaseFnUrl}/process-subscription`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- add explicit SUPABASE_FN_URL guard clauses to the miniapp link-wallet and process-subscription API routes
- return descriptive 500 errors when the env variable is missing instead of throwing from fetch
- document manual curl steps to verify the new behavior in the miniapp README

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5aa0552c4832294d66e494d03f3ef