### PR TITLE
Adjust impulse extremes on BOS breakouts

### DIFF
--- a/algorithms/pine-script/strategies/dynamic_capital_regime_playbook.pine
+++ b/algorithms/pine-script/strategies/dynamic_capital_regime_playbook.pine
@@ -170,7 +170,7 @@ if bosUp
     currentRegime := lastBosDirection == -1 ? Regime.Reversal : Regime.Breakout
     lastBosDirection := 1
     lastBosBar := bar_index
-    lastImpulseHigh := nzfloat(lastSwingHigh, high)
+    lastImpulseHigh := math.max(high, nzfloat(lastSwingHigh, high))
     lastImpulseLow := nzfloat(lastSwingLow, low)
 else if bosDown
     primaryTrend := -1
@@ -180,7 +180,7 @@ else if bosDown
     lastBosDirection := -1
     lastBosBar := bar_index
     lastImpulseHigh := nzfloat(lastSwingHigh, high)
-    lastImpulseLow := nzfloat(lastSwingLow, low)
+    lastImpulseLow := math.min(low, nzfloat(lastSwingLow, low))
 else
     if lastBosBar != na and bar_index - lastBosBar > 3 * (pivotLeft + pivotRight)
         currentRegime := primaryTrend == 0 ? Regime.Consolidation : Regime.Trending


### PR DESCRIPTION
## Summary
- update bullish BOS handling to capture the breakout bar's high when storing the last impulse high
- update bearish BOS handling to capture the breakout bar's low when storing the last impulse low

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b17e0d7883228a150709b96bcdb4