### PR TITLE
feat: wire bank slip parsing into receipt flow

### DIFF
--- a/supabase/functions/_tests/bank-parsers.test.ts
+++ b/supabase/functions/_tests/bank-parsers.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "std/assert/mod.ts";
+import { parseBankSlip } from "../telegram-bot/bank-parsers.ts";
+
+Deno.test("parseBankSlip detects MIB statuses", () => {
+  const baseSlip =
+    `Maldives Islamic Bank\nTransaction Date : 2024-01-02 12:34:56\nTo Account 1234567890 Dynamic Capital\nReference # REF123\nAmount MVR 250.00`;
+
+  const cases: Array<
+    { text: string; expected: "SUCCESS" | "FAILED" | "PENDING" }
+  > = [
+    { text: `${baseSlip}\nStatus : Successful`, expected: "SUCCESS" },
+    {
+      text: `${baseSlip}\nTransaction Status Failed due to error`,
+      expected: "FAILED",
+    },
+    { text: `${baseSlip}\nStatus : Processing`, expected: "PENDING" },
+  ];
+
+  for (const { text, expected } of cases) {
+    const parsed = parseBankSlip(text);
+    assertEquals(parsed.bank, "MIB");
+    assertEquals(parsed.status, expected);
+  }
+});

--- a/supabase/functions/_tests/receipt-pipeline.test.ts
+++ b/supabase/functions/_tests/receipt-pipeline.test.ts
@@ -1,0 +1,301 @@
+import { assert, assertEquals } from "std/assert/mod.ts";
+import { stub } from "std/testing/mock.ts";
+import { clearTestEnv, setTestEnv } from "./env-mock.ts";
+
+Deno.test("startReceiptPipeline stores parsed bank slip on payment", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    SUPABASE_SERVICE_ROLE_KEY: "service-key",
+    TELEGRAM_BOT_TOKEN: "bot-token",
+    TELEGRAM_BOT_USERNAME: "dynamic_bot",
+  });
+
+  const storedBlobs = new Map<string, Blob>();
+  const payments = new Map<string, any>();
+  const receipts: any[] = [];
+
+  const fakeSupabase: any = {
+    storage: {
+      from(bucket: string) {
+        return {
+          async upload(path: string, blob: Blob) {
+            storedBlobs.set(`${bucket}:${path}`, blob);
+            return { data: { path }, error: null };
+          },
+          async download(path: string) {
+            const blob = storedBlobs.get(`${bucket}:${path}`);
+            if (!blob) return { data: null, error: new Error("missing") };
+            return { data: blob, error: null };
+          },
+          async remove(paths: string[]) {
+            for (const p of paths) storedBlobs.delete(`${bucket}:${p}`);
+            return { data: null, error: null };
+          },
+        };
+      },
+    },
+    from(table: string) {
+      switch (table) {
+        case "user_sessions":
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    maybeSingle: async () => ({
+                      data: {
+                        id: "session-1",
+                        awaiting_input: "receipt:plan-1",
+                      },
+                      error: null,
+                    }),
+                  };
+                },
+              };
+            },
+            update(values: Record<string, unknown>) {
+              return {
+                eq: async () => ({
+                  data: { id: "session-1", ...values },
+                  error: null,
+                }),
+              };
+            },
+            delete() {
+              return {
+                eq: async () => ({ error: null }),
+              };
+            },
+          };
+        case "bot_users":
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    maybeSingle: async () => ({
+                      data: { id: "user-1" },
+                      error: null,
+                    }),
+                  };
+                },
+              };
+            },
+          };
+        case "subscription_plans":
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    maybeSingle: async () => ({
+                      data: { price: 500, currency: "MVR" },
+                      error: null,
+                    }),
+                  };
+                },
+              };
+            },
+          };
+        case "payments":
+          return {
+            insert(values: Record<string, unknown>) {
+              const id = `pay-${payments.size + 1}`;
+              payments.set(id, { ...values, id, webhook_data: null });
+              return {
+                select() {
+                  return {
+                    single: async () => ({ data: { id }, error: null }),
+                  };
+                },
+              };
+            },
+            select() {
+              return {
+                eq(_col: string, value: string) {
+                  return {
+                    maybeSingle: async () => {
+                      const row = payments.get(value);
+                      if (!row) return { data: null, error: null };
+                      const { id, user_id, webhook_data } = row;
+                      return {
+                        data: { id, user_id, webhook_data },
+                        error: null,
+                      };
+                    },
+                  };
+                },
+              };
+            },
+            update(values: Record<string, unknown>) {
+              return {
+                eq(_col: string, value: string) {
+                  const row = payments.get(value);
+                  if (row) {
+                    const next = { ...row, ...values };
+                    payments.set(value, next);
+                    return Promise.resolve({ data: next, error: null });
+                  }
+                  return Promise.resolve({ data: null, error: null });
+                },
+              };
+            },
+            delete() {
+              return {
+                eq: async (_col: string, value: string) => {
+                  payments.delete(value);
+                  return { error: null };
+                },
+              };
+            },
+          };
+        case "receipts":
+          return {
+            select() {
+              return {
+                eq(_col: string, value: string) {
+                  return {
+                    limit() {
+                      return {
+                        maybeSingle: async () => ({
+                          data:
+                            receipts.find((r) => r.image_sha256 === value) ??
+                              null,
+                          error: null,
+                        }),
+                      };
+                    },
+                    maybeSingle: async () => ({
+                      data: receipts.find((r) => r.image_sha256 === value) ??
+                        null,
+                      error: null,
+                    }),
+                  };
+                },
+              };
+            },
+            insert(values: Record<string, unknown>) {
+              receipts.push({
+                ...values,
+                id: `receipt-${receipts.length + 1}`,
+              });
+              return Promise.resolve({ data: null, error: null });
+            },
+          };
+        case "user_subscriptions":
+          return {
+            update() {
+              return {
+                eq: async () => ({ data: null, error: null }),
+              };
+            },
+          };
+        default:
+          return {
+            select() {
+              return {
+                eq() {
+                  return {
+                    maybeSingle: async () => ({ data: null, error: null }),
+                  };
+                },
+              };
+            },
+          };
+      }
+    },
+  };
+
+  const clientModule = await import("../_shared/client.ts");
+  const createClientStub = stub(
+    clientModule,
+    "createClient",
+    () => fakeSupabase,
+  );
+
+  const configModule = await import("../_shared/config.ts");
+  const getFlagStub = stub(configModule, "getFlag", async () => true);
+  const originalGetContent = configModule.getContent;
+  configModule.__setGetContent(async () => null);
+
+  const { default: receiptSubmitHandler } = await import(
+    "../receipt-submit/index.ts"
+  );
+  const telegramModule = await import("../telegram-bot/index.ts");
+  const getSupabaseStub = stub(
+    telegramModule,
+    "getSupabase",
+    () => fakeSupabase,
+  );
+
+  const sampleSlipText =
+    `Maldives Islamic Bank\nTransaction Date : 2024-02-01 10:00:00\nStatus : Successful\nTo Account 9876543210 Dynamic Capital\nReference # REF999\nAmount MVR 750.00`;
+  telegramModule.__setReceiptParsingOverrides({
+    ocrTextFromBlob: async () => sampleSlipText,
+  });
+
+  const supabaseUrl = "https://stub.supabase.co/functions/v1/receipt-submit";
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: Request | string, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.includes("/getFile")) {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          result: { file_path: "receipts/image.png" },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    if (url.includes("/file/bot")) {
+      return new Response(new Blob(["fake image"], { type: "image/png" }), {
+        status: 200,
+      });
+    }
+    if (url.includes("/sendMessage")) {
+      return new Response(
+        JSON.stringify({ ok: true, result: { message_id: 42 } }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+    if (url === supabaseUrl) {
+      const req = new Request(url, init);
+      return receiptSubmitHandler(req);
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  try {
+    const update = {
+      message: {
+        chat: { id: 4242 },
+        photo: [{ file_id: "test-file" }],
+      },
+    };
+
+    await telegramModule.startReceiptPipeline(update as any);
+
+    const payment = payments.get("pay-1");
+    assert(payment, "payment row should be created");
+    assert(payment.webhook_data, "webhook data should be stored");
+    const parsed = payment.webhook_data.parsed_slip;
+    assert(parsed, "parsed slip should be attached");
+    assertEquals(parsed.status, "SUCCESS");
+    assertEquals(parsed.bank, "MIB");
+    assertEquals(parsed.rawText, sampleSlipText);
+  } finally {
+    globalThis.fetch = originalFetch;
+    telegramModule.__resetReceiptParsingOverrides();
+    getSupabaseStub.restore();
+    createClientStub.restore();
+    getFlagStub.restore();
+    configModule.__setGetContent(originalGetContent);
+    clearTestEnv();
+  }
+});

--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -1,22 +1,26 @@
 import { createClient, createSupabaseClient } from "../_shared/client.ts";
-import { json, bad, unauth, oops } from "../_shared/http.ts";
+import { bad, json, oops, unauth } from "../_shared/http.ts";
 import { getEnv } from "../_shared/env.ts";
 import { verifyInitData } from "../_shared/telegram_init.ts";
 import { registerHandler } from "../_shared/serve.ts";
 import { hashBlob } from "../_shared/hash.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
 };
 
 export const handler = registerHandler(async (req) => {
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }
 
   if (req.method !== "POST") {
-    return new Response("Method not allowed", { status: 405, headers: corsHeaders });
+    return new Response("Method not allowed", {
+      status: 405,
+      headers: corsHeaders,
+    });
   }
 
   // Attempt to identify user via Supabase session
@@ -27,7 +31,10 @@ export const handler = registerHandler(async (req) => {
       const supaAuth = createSupabaseClient(
         getEnv("SUPABASE_URL"),
         getEnv("SUPABASE_ANON_KEY"),
-        { global: { headers: { Authorization: authHeader } }, auth: { persistSession: false } },
+        {
+          global: { headers: { Authorization: authHeader } },
+          auth: { persistSession: false },
+        },
       );
       const { data: { user } } = await supaAuth.auth.getUser();
       if (user) {
@@ -45,7 +52,8 @@ export const handler = registerHandler(async (req) => {
     return bad("Invalid JSON");
   }
 
-  const { payment_id, file_path, bucket, initData, telegram_id } = body;
+  const { payment_id, file_path, bucket, initData, telegram_id, parsed_slip } =
+    body;
 
   // If no auth, try Telegram initData
   if (!telegramId && initData) {
@@ -73,7 +81,12 @@ export const handler = registerHandler(async (req) => {
     return bad("Missing required fields");
   }
 
-  console.log("Receipt submission:", { telegramId, payment_id, file_path, bucket });
+  console.log("Receipt submission:", {
+    telegramId,
+    payment_id,
+    file_path,
+    bucket,
+  });
 
   const supa = createClient("service");
 
@@ -117,15 +130,21 @@ export const handler = registerHandler(async (req) => {
     }
 
     if (existing) {
-      await supa.storage.from(storageBucket).remove([file_path]).catch((err) => {
-        console.warn("Failed to remove duplicate receipt upload", err);
-      });
-      return json({
-        ok: false,
-        error: "duplicate_receipt",
-        message:
-          "This receipt was already submitted. Please upload a new image.",
-      }, 409, corsHeaders);
+      await supa.storage.from(storageBucket).remove([file_path]).catch(
+        (err) => {
+          console.warn("Failed to remove duplicate receipt upload", err);
+        },
+      );
+      return json(
+        {
+          ok: false,
+          error: "duplicate_receipt",
+          message:
+            "This receipt was already submitted. Please upload a new image.",
+        },
+        409,
+        corsHeaders,
+      );
     }
 
     const baseWebhookData =
@@ -133,7 +152,11 @@ export const handler = registerHandler(async (req) => {
         ? payment.webhook_data
         : {};
     const submittedAt = new Date().toISOString();
-    const webhookData = {
+    const parsedSlipData = parsed_slip && typeof parsed_slip === "object"
+      ? parsed_slip
+      : null;
+
+    const webhookData: Record<string, unknown> = {
       ...baseWebhookData,
       file_path,
       bucket: storageBucket,
@@ -142,6 +165,10 @@ export const handler = registerHandler(async (req) => {
       image_sha256: imageHash,
       submitted_at: submittedAt,
     };
+
+    if (parsedSlipData) {
+      webhookData.parsed_slip = parsedSlipData;
+    }
 
     const { error: paymentError } = await supa
       .from("payments")
@@ -166,7 +193,10 @@ export const handler = registerHandler(async (req) => {
         .eq("telegram_user_id", telegramId);
 
       if (subscriptionError) {
-        console.log("Subscription update error (non-critical):", subscriptionError);
+        console.log(
+          "Subscription update error (non-critical):",
+          subscriptionError,
+        );
       }
     }
 
@@ -184,12 +214,16 @@ export const handler = registerHandler(async (req) => {
 
     console.log("Receipt submitted successfully for payment:", payment_id);
 
-    return json({
-      ok: true,
-      success: true,
-      message: "Receipt submitted successfully",
-      payment_id,
-    }, 200, corsHeaders);
+    return json(
+      {
+        ok: true,
+        success: true,
+        message: "Receipt submitted successfully",
+        payment_id,
+      },
+      200,
+      corsHeaders,
+    );
   } catch (error) {
     console.error("Receipt submission error:", error);
     return oops("Internal server error");

--- a/supabase/functions/telegram-bot/bank-parsers.ts
+++ b/supabase/functions/telegram-bot/bank-parsers.ts
@@ -100,7 +100,33 @@ export function parseBankSlip(ocrText: string): ParsedSlip {
       }
     }
   } else if (bank === "MIB") {
-    if (/Successful|Sucessful/i.test(joined)) status = "SUCCESS";
+    const statusMatchers: Array<{ regex: RegExp; value: typeof status }> = [
+      {
+        regex: /Status\s*:?\s*(Successful|Sucessful|Completed)/i,
+        value: "SUCCESS",
+      },
+      { regex: /Successful|Sucessful|Completed/i, value: "SUCCESS" },
+      {
+        regex: /Status\s*:?\s*(Failed|Unsuccessful|Declined)/i,
+        value: "FAILED",
+      },
+      { regex: /Failed|Unsuccessful|Declined/i, value: "FAILED" },
+      {
+        regex: /Status\s*:?\s*(Pending|Processing|In\s+Progress)/i,
+        value: "PENDING",
+      },
+      {
+        regex: /Pending|Processing|In\s+Progress|Awaiting/i,
+        value: "PENDING",
+      },
+    ];
+
+    for (const matcher of statusMatchers) {
+      if (matcher.regex.test(joined)) {
+        status = matcher.value;
+        break;
+      }
+    }
 
     const refMatch = joined.match(/Reference\s*#?\s*([A-Z0-9-]{6,24})/i);
     if (refMatch) reference = refMatch[1];


### PR DESCRIPTION
## Summary
- OCR receipts inside the Telegram bot pipeline, parse bank slips, and include the results with receipt submissions
- Extend Maldives Islamic Bank parsing to recognize success, failure, and pending keywords
- Persist parsed slip metadata during receipt submission and cover the flow with new integration tests

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5ad6ec288832299e960fdf339c218