### PR TITLE
Integrate Grok advisor hook and stabilize Grok runner

### DIFF
--- a/algorithms/README.md
+++ b/algorithms/README.md
@@ -17,3 +17,18 @@ engineers, and QA can collaborate without stepping on each other's toes.
 Refer to the README in each sub-folder for layout details, build commands, and
 handoff expectations between teams. Supabase database migrations and functions
 remain in the top-level `supabase/` directory.
+
+## Grok advisory workflow
+
+- `python/grok_advisor.py` – prompt builder and completion helpers that relay
+  live trade context to Grok-1.
+- `python/trade_logic.py` – accepts an optional Grok advisor during
+  `TradeLogic.on_bar` so Grok can suggest confidence adjustments before trades
+  are finalised.
+- `python/realtime.py` – wire Grok into `RealtimeExecutor` by supplying an
+  advisor instance; decisions surface the returned rationale under the
+  `context["advisor"]` key for downstream audit trails.
+
+To enable Grok feedback in a live service, instantiate a completion client
+(e.g. wrapping the local `grok-1` `InferenceRunner`) and pass a configured
+`GrokAdvisor` instance into `RealtimeExecutor`.

--- a/algorithms/python/grok_advisor.py
+++ b/algorithms/python/grok_advisor.py
@@ -1,0 +1,257 @@
+"""Utilities for requesting Grok-backed advice on trading decisions."""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Protocol, Sequence
+
+from .trade_logic import ActivePosition, MarketSnapshot, TradeSignal
+
+
+class CompletionClient(Protocol):  # pragma: no cover - interface definition
+    def complete(
+        self,
+        prompt: str,
+        *,
+        temperature: float,
+        max_tokens: int,
+        nucleus_p: float,
+    ) -> str:
+        """Return a completion for the supplied prompt."""
+
+
+@dataclass(slots=True)
+class AdvisorFeedback:
+    """Structured response from a trade advisor."""
+
+    adjusted_signal: Optional[TradeSignal] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    raw_response: Optional[str] = None
+
+
+class TradeAdvisor(Protocol):  # pragma: no cover - interface definition
+    def review(
+        self,
+        *,
+        snapshot: MarketSnapshot,
+        signal: TradeSignal,
+        context: Dict[str, Any],
+        open_positions: Sequence[ActivePosition],
+    ) -> Optional[AdvisorFeedback]:
+        """Return optional adjustments for the supplied signal."""
+
+
+@dataclass(slots=True)
+class GrokAdvisor:
+    """High-level adapter that prompts Grok for risk/context adjustments."""
+
+    client: CompletionClient
+    temperature: float = 0.25
+    nucleus_p: float = 0.9
+    max_tokens: int = 256
+
+    def review(
+        self,
+        *,
+        snapshot: MarketSnapshot,
+        signal: TradeSignal,
+        context: Dict[str, Any],
+        open_positions: Sequence[ActivePosition],
+    ) -> Optional[AdvisorFeedback]:
+        prompt = self._build_prompt(snapshot=snapshot, signal=signal, context=context, open_positions=open_positions)
+        response = self.client.complete(
+            prompt,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            nucleus_p=self.nucleus_p,
+        )
+        feedback = AdvisorFeedback(
+            metadata={"source": "grok", "prompt": prompt},
+            raw_response=response.strip() or None,
+        )
+        parsed = self._parse_response(response)
+        if parsed:
+            feedback.metadata.update(parsed)
+            new_conf = self._extract_confidence(parsed)
+            if new_conf is not None:
+                adjusted = TradeSignal(
+                    direction=signal.direction,
+                    confidence=new_conf,
+                    votes=signal.votes,
+                    neighbors_considered=signal.neighbors_considered,
+                )
+                feedback.adjusted_signal = adjusted
+        return feedback
+
+    def _build_prompt(
+        self,
+        *,
+        snapshot: MarketSnapshot,
+        signal: TradeSignal,
+        context: Dict[str, Any],
+        open_positions: Sequence[ActivePosition],
+    ) -> str:
+        open_lines = [
+            f"- {pos.symbol} {self._direction(pos.direction)} {pos.size} @ {pos.entry_price}"
+            for pos in open_positions
+        ]
+        if not open_lines:
+            open_lines = ["- none"]
+        summary = textwrap.dedent(
+            f"""
+            You are reviewing a foreign-exchange trading signal. Return a single JSON object
+            with the fields:
+              - "adjusted_confidence": number between 0 and 1 when you recommend overriding the
+                supplied confidence (omit the field to keep the value unchanged)
+              - "rationale": short human-readable explanation (string)
+              - "alerts": optional array of strings highlighting material risks or TODOs
+            Keep commentary concise and grounded in the provided telemetry.
+            """
+        ).strip()
+        context_json = json.dumps(context, indent=2, default=str, sort_keys=True)
+        prompt = textwrap.dedent(
+            f"""
+            {summary}
+
+            Signal:
+              direction: {self._direction(signal.direction)}
+              confidence: {signal.confidence:.4f}
+              votes: {signal.votes}
+              neighbours: {signal.neighbors_considered}
+
+            Market snapshot:
+              symbol: {snapshot.symbol}
+              timestamp: {snapshot.timestamp.isoformat()}
+              close: {snapshot.close}
+              rsi_fast: {snapshot.rsi_fast}
+              adx_fast: {snapshot.adx_fast}
+              rsi_slow: {snapshot.rsi_slow}
+              adx_slow: {snapshot.adx_slow}
+              seasonal_bias: {snapshot.seasonal_bias}
+              seasonal_confidence: {snapshot.seasonal_confidence}
+
+            Context modifiers:
+            {context_json}
+
+            Open positions:
+            {chr(10).join(open_lines)}
+            """
+        ).strip()
+        return prompt
+
+    @staticmethod
+    def _direction(direction: int) -> str:
+        if direction > 0:
+            return "long"
+        if direction < 0:
+            return "short"
+        return "flat"
+
+    @staticmethod
+    def _parse_response(response: str) -> Optional[Dict[str, Any]]:
+        text = response.strip()
+        if not text:
+            return None
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+            if not match:
+                return {"rationale": text}
+            try:
+                data = json.loads(match.group(0))
+            except json.JSONDecodeError:
+                return {"rationale": text}
+        if isinstance(data, dict):
+            return data
+        return {"rationale": text}
+
+    @staticmethod
+    def _extract_confidence(payload: Dict[str, Any]) -> Optional[float]:
+        for key in ("adjusted_confidence", "confidence", "final_confidence"):
+            if key in payload:
+                try:
+                    value = float(payload[key])
+                except (TypeError, ValueError):
+                    continue
+                return max(0.0, min(1.0, value))
+        return None
+
+
+@dataclass
+class LocalGrokClient:
+    """Completion client that proxies the reference Grok runner."""
+
+    runner: Any
+    nucleus_p: float = 0.9
+    auto_initialize: bool = False
+
+    def __post_init__(self) -> None:
+        self._generator = None
+        self._request_cls = None
+        self._nucleus_p = self.nucleus_p
+        self._rng = random.Random(42)
+        if self.auto_initialize:
+            self.initialize()
+
+    def initialize(self) -> None:
+        self._ensure_runtime()
+        if getattr(self.runner, "params", None) is not None:
+            return
+        if hasattr(self.runner, "initialize"):
+            self.runner.initialize()
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        temperature: float,
+        max_tokens: int,
+        nucleus_p: float,
+    ) -> str:
+        self._ensure_runtime()
+        if getattr(self.runner, "params", None) is None and hasattr(self.runner, "initialize"):
+            self.runner.initialize()
+        if self._generator is None and hasattr(self.runner, "run"):
+            self._generator = self.runner.run()
+        if self._generator is None:
+            raise RuntimeError("Runner does not provide a generator interface")
+        generator = self._generator
+        request_cls = self._request_cls
+        if request_cls is None:
+            raise RuntimeError("Grok runtime was not initialised correctly")
+        next(generator)
+        request = request_cls(
+            prompt=prompt,
+            temperature=temperature,
+            nucleus_p=nucleus_p or self._nucleus_p,
+            rng_seed=self._rng.getrandbits(64),
+            max_len=max_tokens,
+        )
+        return generator.send(request)
+
+    def _ensure_runtime(self) -> None:
+        if self._request_cls is not None:
+            return
+        grok_root = Path(__file__).resolve().parents[2] / "grok-1"
+        if str(grok_root) not in sys.path:
+            sys.path.insert(0, str(grok_root))
+        import runners  # type: ignore  # noqa: WPS433,E402
+
+        self._request_cls = getattr(runners, "Request")
+        self._generator = None
+
+
+__all__ = [
+    "AdvisorFeedback",
+    "CompletionClient",
+    "GrokAdvisor",
+    "LocalGrokClient",
+    "TradeAdvisor",
+]

--- a/algorithms/python/tests/test_grok_advisor.py
+++ b/algorithms/python/tests/test_grok_advisor.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from algorithms.python.grok_advisor import AdvisorFeedback, GrokAdvisor
+from algorithms.python.trade_logic import ActivePosition, MarketSnapshot, TradeSignal
+
+
+class StubClient:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def complete(self, prompt: str, *, temperature: float, max_tokens: int, nucleus_p: float) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "nucleus_p": nucleus_p,
+            }
+        )
+        return self.response
+
+
+def _snapshot() -> MarketSnapshot:
+    return MarketSnapshot(
+        symbol="GBPUSD",
+        timestamp=datetime(2024, 3, 19, 7, 0, tzinfo=timezone.utc),
+        close=1.2755,
+        rsi_fast=55.0,
+        adx_fast=21.0,
+        rsi_slow=52.0,
+        adx_slow=18.0,
+        pip_size=0.0001,
+        pip_value=10.0,
+        seasonal_bias=0.4,
+        seasonal_confidence=0.7,
+    )
+
+
+def test_grok_advisor_parses_confidence_adjustment() -> None:
+    client = StubClient('{"adjusted_confidence": 0.45, "rationale": "Macro headwinds"}')
+    advisor = GrokAdvisor(client=client, temperature=0.1, nucleus_p=0.95, max_tokens=128)
+
+    signal = TradeSignal(direction=1, confidence=0.6, votes=5, neighbors_considered=8)
+    feedback = advisor.review(
+        snapshot=_snapshot(),
+        signal=signal,
+        context={"final_confidence": 0.6},
+        open_positions=[ActivePosition(symbol="EURUSD", direction=1, size=0.2, entry_price=1.09)],
+    )
+
+    assert feedback is not None
+    assert isinstance(feedback, AdvisorFeedback)
+    assert feedback.adjusted_signal is not None
+    assert feedback.adjusted_signal.confidence == pytest.approx(0.45)
+    assert feedback.metadata["rationale"] == "Macro headwinds"
+    assert client.calls and "GBPUSD" in client.calls[0]["prompt"]
+
+
+def test_grok_advisor_handles_text_response() -> None:
+    client = StubClient("Maintain current plan; monitor ECB guidance.")
+    advisor = GrokAdvisor(client=client)
+
+    signal = TradeSignal(direction=-1, confidence=0.55, votes=4, neighbors_considered=6)
+    feedback = advisor.review(
+        snapshot=_snapshot(),
+        signal=signal,
+        context={"final_confidence": 0.55},
+        open_positions=[],
+    )
+
+    assert feedback is not None
+    assert feedback.adjusted_signal is None
+    assert "Maintain current plan" in feedback.metadata["rationale"]
+    assert feedback.raw_response.startswith("Maintain")

--- a/docs/grok-1-integration-checklist.md
+++ b/docs/grok-1-integration-checklist.md
@@ -4,8 +4,8 @@ Use this checklist to operationalize Grok-1 inside the Dynamic Capital
 automation stack—from research workflows to Telegram delivery—without breaking
 existing guardrails.
 
-> **Status:** Planned. Complete each section before inviting broader team usage
-> or shipping Grok-powered outputs to members.
+> **Status:** In progress. Complete each section before inviting broader team
+> usage or shipping Grok-powered outputs to members.
 
 ## 1. Repository & Access Preparation
 
@@ -32,8 +32,10 @@ for regression testing.
 
 ## 3. Trading Strategy & Analyzer Enhancements
 
-- [ ] Integrate Grok-assisted idea reviews into the `algorithms/` workflow
-(e.g., PR template checkbox, reviewer step, or IDE helper notes).
+- [x] Integrate Grok-assisted idea reviews into the `algorithms/` workflow
+  (e.g., PR template checkbox, reviewer step, or IDE helper notes). See
+  `algorithms/python/grok_advisor.py` and the `TradeLogic` advisor hook for the
+  live prompt pipeline.
 - [ ] Codify how Grok suggestions translate into Pine Script or TypeScript
 changes; update `algorithms/README.md` with the acceptance criteria.
 - [ ] Gate analyzer modifications on new or updated tests in

--- a/grok-1/README.md
+++ b/grok-1/README.md
@@ -11,7 +11,9 @@ pip install -r requirements.txt
 python run.py
 ```
 
-to test the code.
+to test the code. On developer workstations that only expose a single GPU, keep
+`bs_per_device` at `1` or higher in `run.py` (or rely on the built-in clamp in
+`ModelRunner`) so the sampler retains a non-zero batch size.
 
 The script loads the checkpoint and samples from the model on a test input.
 

--- a/grok-1/run.py
+++ b/grok-1/run.py
@@ -51,7 +51,10 @@ def main():
         pad_sizes=(1024,),
         runner=ModelRunner(
             model=grok_1_model,
-            bs_per_device=0.125,
+            # ``bs_per_device`` can be fractional in large distributed runs, but use an
+            # integer-friendly default here so single-device machines keep producing
+            # tokens even when the environment truncates batch sizes aggressively.
+            bs_per_device=1.0,
             checkpoint_path=CKPT_PATH,
         ),
         name="local",

--- a/grok-1/tests/test_model_runner.py
+++ b/grok-1/tests/test_model_runner.py
@@ -1,0 +1,69 @@
+"""Regression tests for the Grok model runner sizing helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Ensure the Grok reference implementation modules are importable.
+GROK_PATH = Path(__file__).resolve().parents[2] / "grok-1"
+if str(GROK_PATH) not in sys.path:
+    sys.path.insert(0, str(GROK_PATH))
+
+jax = pytest.importorskip("jax")  # noqa: F401  # pragma: no cover - dependency guard
+haiku = pytest.importorskip("haiku")  # noqa: F401  # pragma: no cover - dependency guard
+
+import runners  # type: ignore  # noqa: E402
+
+
+class _IdentityTransform:
+    def __init__(self, fn):
+        self._fn = fn
+
+    def apply(self, *args, **kwargs):  # pragma: no cover - behaviour is trivial
+        return self._fn(*args, **kwargs)
+
+
+class _DummyModel:
+    def __init__(self) -> None:
+        self.fprop_dtype = None
+        self.sequence_len = 16
+        self.vocab_size = 32
+        self.eos_token = 0
+
+    def initialize(self) -> None:
+        pass
+
+    def make(self, *, mesh):  # noqa: D401 - signature mirrors real model
+        def _forward(tokens):
+            return SimpleNamespace(logits=None, model_state=None)
+
+        return _forward
+
+
+def _patch_runtime(monkeypatch: pytest.MonkeyPatch, *, local_devices: int) -> None:
+    monkeypatch.setattr(runners, "make_mesh", lambda *args, **kwargs: object())
+    monkeypatch.setattr(runners.hk, "transform", lambda fn: _IdentityTransform(fn))
+    monkeypatch.setattr(runners.jax, "local_devices", lambda: [object()] * local_devices)
+    monkeypatch.setattr(runners.jax, "process_count", lambda: 1)
+
+
+def test_initialize_clamps_batch_size_on_single_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_runtime(monkeypatch, local_devices=1)
+    runner = runners.ModelRunner(model=_DummyModel(), bs_per_device=0.125)
+
+    runner.initialize({}, local_mesh_config=(1, 1), between_hosts_config=(1, 1))
+
+    assert runner.batch_size == 1
+    assert runner.local_batch_size == 1
+
+
+def test_initialize_requires_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_runtime(monkeypatch, local_devices=0)
+    runner = runners.ModelRunner(model=_DummyModel(), bs_per_device=0.125)
+
+    with pytest.raises(RuntimeError, match="requires at least one JAX device"):
+        runner.initialize({}, local_mesh_config=(1, 1), between_hosts_config=(1, 1))


### PR DESCRIPTION
## Summary
- add a Grok advisor module plus tests and wire the optional advisor through `TradeLogic` and the realtime executor
- document the advisory workflow and mark Grok checklist progress for the new integration hook
- clamp Grok runner batch sizing, adjust the sample runner defaults, and cover the change with unit tests

## Testing
- npm run lint
- npm run typecheck
- python -m pytest algorithms/python/tests
- python -m pytest grok-1/tests

------
https://chatgpt.com/codex/tasks/task_e_68d5b75d760c8322b9c749d2c092ff48