### PR TITLE
Integrate real TON settlement across mini app and backend

### DIFF
--- a/apps/web/components/magic-portfolio/Header.tsx
+++ b/apps/web/components/magic-portfolio/Header.tsx
@@ -50,7 +50,7 @@ export default TimeDisplay;
 
 export const Header = () => {
   const pathname = usePathname() ?? "";
-  const { user, signOut } = useAuth();
+  const { wallet, connect, disconnect, loading, connecting } = useAuth();
   const [hash, setHash] = useState<string>("");
 
   useEffect(() => {
@@ -163,15 +163,25 @@ export const Header = () => {
             <Flex s={{ hide: true }}>
               {display.time && <TimeDisplay timeZone={person.location} />}
             </Flex>
-            {user
+            {wallet
               ? (
-                <Button size="s" variant="secondary" onClick={() => signOut()}>
-                  Logout
+                <Button
+                  size="s"
+                  variant="secondary"
+                  disabled={connecting}
+                  onClick={() => void disconnect()}
+                >
+                  Disconnect
                 </Button>
               )
               : (
-                <Button size="s" variant="secondary" href="/login">
-                  Login
+                <Button
+                  size="s"
+                  variant="secondary"
+                  disabled={loading || connecting}
+                  onClick={() => void connect()}
+                >
+                  Connect wallet
                 </Button>
               )}
           </Flex>

--- a/dynamic-capital-ton/apps/miniapp/README.md
+++ b/dynamic-capital-ton/apps/miniapp/README.md
@@ -8,6 +8,7 @@ Create a `.env.local` file with the following values:
 
 ```bash
 NEXT_PUBLIC_APP_URL=https://dynamic-capital-qazf2.ondigitalocean.app
+NEXT_PUBLIC_TON_OPERATIONS_WALLET=EQOpsTreasuryXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 SUPABASE_FN_URL=https://<project>.functions.supabase.co
 ```
 

--- a/dynamic-capital-ton/apps/miniapp/package-lock.json
+++ b/dynamic-capital-ton/apps/miniapp/package-lock.json
@@ -1,0 +1,659 @@
+{
+  "name": "dynamic-capital-miniapp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dynamic-capital-miniapp",
+      "dependencies": {
+        "@ton/core": "^0.53.0",
+        "@tonconnect/ui-react": "^2.3.1",
+        "next": "^13.5.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.9.tgz",
+      "integrity": "sha512-pVyd8/1y1l5atQRvOaLOvfbmRwefxLhqQOzYo/M7FQ5eaRwA1+wuCn7t39VwEgDd7Aw1+AIWwd+MURXUeXhwDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.9.tgz",
+      "integrity": "sha512-DwdeJqP7v8wmoyTWPbPVodTwCybBZa02xjSJ6YQFIFZFZ7dFgrieKW4Eo0GoIcOJq5+JxkQyejmI+8zwDp3pwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.9.tgz",
+      "integrity": "sha512-wdQsKsIsGSNdFojvjW3Ozrh8Q00+GqL3wTaMjDkQxVtRbAqfFBtrLPO0IuWChVUP2UeuQcHpVeUvu0YgOP00+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.9.tgz",
+      "integrity": "sha512-6VpS+bodQqzOeCwGxoimlRoosiWlSc0C224I7SQWJZoyJuT1ChNCo+45QQH+/GtbR/s7nhaUqmiHdzZC9TXnXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.9.tgz",
+      "integrity": "sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.9.tgz",
+      "integrity": "sha512-/dnscWqfO3+U8asd+Fc6dwL2l9AZDl7eKtPNKW8mKLh4Y4wOpjJiamhe8Dx+D+Oq0GYVjuW0WwjIxYWVozt2bA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.9.tgz",
+      "integrity": "sha512-T/iPnyurOK5a4HRUcxAlss8uzoEf5h9tkd+W2dSWAfzxv8WLKlUgbfk+DH43JY3Gc2xK5URLuXrxDZ2mGfk/jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.9.tgz",
+      "integrity": "sha512-BLiPKJomaPrTAb7ykjA0LPcuuNMLDVK177Z1xe0nAem33+9FIayU4k/OWrtSn9SAJW/U60+1hoey5z+KCHdRLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.9.tgz",
+      "integrity": "sha512-/72/dZfjXXNY/u+n8gqZDjI6rxKMpYsgBBYNZKWOQw0BpBF7WCnPflRy3ZtvQ2+IYI3ZH2bPyj7K+6a6wNk90Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@ton/core": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.53.0.tgz",
+      "integrity": "sha512-tB5RxXFS6Z/ivmsqMn/eebEZmkWXIAz+hS1PDZXhbBkcvnBTknZ12g2AFrZtXyuvpm8O6SbL15UI/3NgkyIWzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "symbol.inspect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@ton/crypto": ">=3.2.0"
+      }
+    },
+    "node_modules/@ton/crypto": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto/-/crypto-3.3.0.tgz",
+      "integrity": "sha512-/A6CYGgA/H36OZ9BbTaGerKtzWp50rg67ZCH2oIjV1NcrBaCK9Z343M+CxedvM7Haf3f/Ee9EhxyeTp0GKMUpA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ton/crypto-primitives": "2.1.0",
+        "jssha": "3.2.0",
+        "tweetnacl": "1.0.3"
+      }
+    },
+    "node_modules/@ton/crypto-primitives": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
+      "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "jssha": "3.2.0"
+      }
+    },
+    "node_modules/@tonconnect/isomorphic-eventsource": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@tonconnect/isomorphic-eventsource/-/isomorphic-eventsource-0.0.2.tgz",
+      "integrity": "sha512-B4UoIjPi0QkvIzZH5fV3BQLWrqSYABdrzZQSI9sJA9aA+iC0ohOzFwVVGXanlxeDAy1bcvPbb29f6sVUk0UnnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "eventsource": "^2.0.2"
+      }
+    },
+    "node_modules/@tonconnect/isomorphic-fetch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@tonconnect/isomorphic-fetch/-/isomorphic-fetch-0.0.3.tgz",
+      "integrity": "sha512-jIg5nTrDwnite4fXao3dD83eCpTvInTjZon/rZZrIftIegh4XxyVb5G2mpMqXrVGk1e8SVXm3Kj5OtfMplQs0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-fetch": "^2.6.9"
+      }
+    },
+    "node_modules/@tonconnect/protocol": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@tonconnect/protocol/-/protocol-2.3.0.tgz",
+      "integrity": "sha512-OxrmcXF/EsSdGeASP9VpTRojuMtTV87DKYFLRq4ZJvF/Hirfm2cgcxzzj2uksEGm5IIR010UWo6b38RuokNwFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      }
+    },
+    "node_modules/@tonconnect/sdk": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@tonconnect/sdk/-/sdk-3.3.1.tgz",
+      "integrity": "sha512-lhXJu95VvbD36u5mMPg2sg+w4GQwkrYnHeJ8rVveu2N7UPwt0jvrEqKlvf7Ss1gh5RDtzs35SS3GbJlaIOAJNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tonconnect/isomorphic-eventsource": "0.0.2",
+        "@tonconnect/isomorphic-fetch": "0.0.3",
+        "@tonconnect/protocol": "2.3.0"
+      }
+    },
+    "node_modules/@tonconnect/ui": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tonconnect/ui/-/ui-2.3.1.tgz",
+      "integrity": "sha512-G1hKn5TrqFYztbR94EG8YuhGUpp7wY8PjC1Fu7/d8rFg7XnPGlUcGmuqH8+2lYrb9Ms0M7v6+5U6S4q4+yCQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tonconnect/sdk": "3.3.1",
+        "classnames": "^2.5.1",
+        "csstype": "^3.1.3",
+        "deepmerge": "^4.3.1",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/@tonconnect/ui-react": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tonconnect/ui-react/-/ui-react-2.3.1.tgz",
+      "integrity": "sha512-dAMqNG5X8Llh1m3eIOvIQlXgMazrZrmnQGefJmlmyghwwGydR0O9NGpW7I7s2CN24usAaRGX8mVJPemsa2oHSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tonconnect/ui": "2.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jssha": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
+      "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.11.tgz",
+      "integrity": "sha512-WUPJ6WbAX9tdC86kGTu92qkrRdgRqVrY++nwM+shmWQwmyxt4zhZfR59moXSI4N8GDYCBY3lIAqhzjDd4rTC8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "13.5.11",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "13.5.9",
+        "@next/swc-darwin-x64": "13.5.9",
+        "@next/swc-linux-arm64-gnu": "13.5.9",
+        "@next/swc-linux-arm64-musl": "13.5.9",
+        "@next/swc-linux-x64-gnu": "13.5.9",
+        "@next/swc-linux-x64-musl": "13.5.9",
+        "@next/swc-win32-arm64-msvc": "13.5.9",
+        "@next/swc-win32-ia32-msvc": "13.5.9",
+        "@next/swc-win32-x64-msvc": "13.5.9"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/symbol.inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol.inspect/-/symbol.inspect-1.0.1.tgz",
+      "integrity": "sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ==",
+      "license": "ISC"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "license": "Unlicense"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts
+++ b/dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts
@@ -1,5 +1,6 @@
 import {
   assertEquals,
+  assertExists,
   assertStringIncludes,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
@@ -9,6 +10,7 @@ Deno.env.set("TELEGRAM_BOT_TOKEN", "bot-token");
 Deno.env.set("ANNOUNCE_CHAT_ID", "chat-id");
 Deno.env.set("APP_URL", "https://app.example");
 Deno.env.set("TON_INDEXER_URL", "https://indexer.example");
+Deno.env.set("BURN_WEBHOOK_URL", "https://burn.example");
 
 const { handler } = await import("./index.ts");
 type HandlerDependencies = NonNullable<Parameters<typeof handler>[1]>;
@@ -29,7 +31,11 @@ type AppConfigRow = {
 };
 
 function createSupabaseStub(config: AppConfigRow) {
-  return {
+  const subscriptions: Array<Record<string, unknown>> = [];
+  const logs: Array<Record<string, unknown>> = [];
+  const stakes: Array<Record<string, unknown>> = [];
+
+  const supabase = {
     from(table: string) {
       if (table === "app_config") {
         return {
@@ -42,9 +48,60 @@ function createSupabaseStub(config: AppConfigRow) {
           },
         };
       }
+
+      if (table === "users") {
+        return {
+          select() {
+            return {
+              eq: () => ({
+                single: async () => ({ data: { id: "user-1" }, error: null }),
+              }),
+            };
+          },
+        };
+      }
+
+      if (table === "subscriptions") {
+        return {
+          insert(payload: Record<string, unknown>) {
+            return {
+              select() {
+                return {
+                  single: async () => {
+                    const record = { id: "sub-1", ...payload };
+                    subscriptions.push(record);
+                    return { data: record, error: null };
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+
+      if (table === "stakes") {
+        return {
+          insert(payload: Record<string, unknown>) {
+            stakes.push(payload);
+            return { error: null };
+          },
+        };
+      }
+
+      if (table === "tx_logs") {
+        return {
+          insert(rows: Array<Record<string, unknown>>) {
+            logs.push(...rows);
+            return { error: null };
+          },
+        };
+      }
+
       throw new Error(`Unexpected table access: ${table}`);
     },
   };
+
+  return { supabase: supabase as HandlerDependencies["supabase"], subscriptions, logs, stakes };
 }
 
 Deno.test("rejects subscription when TON transfer goes to different wallet", async () => {
@@ -61,7 +118,7 @@ Deno.test("rejects subscription when TON transfer goes to different wallet", asy
     },
   );
 
-  const supabaseStub = createSupabaseStub({
+  const { supabase } = createSupabaseStub({
     operations_pct: 60,
     autoinvest_pct: 30,
     buyback_burn_pct: 10,
@@ -102,7 +159,7 @@ Deno.test("rejects subscription when TON transfer goes to different wallet", asy
   };
 
   const response = await handler(request, {
-    supabase: supabaseStub as HandlerDependencies["supabase"],
+    supabase,
     fetch: fetchStub,
   });
 
@@ -110,4 +167,196 @@ Deno.test("rejects subscription when TON transfer goes to different wallet", asy
   const body = await response.text();
   assertStringIncludes(body, "Funds not received");
   assertEquals(fetchCalls.length, 1);
+});
+
+Deno.test("rejects subscription when TON amount is insufficient", async () => {
+  const request = new Request(
+    "https://example/functions/process-subscription",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        telegram_id: "1234",
+        plan: "vip_bronze",
+        tx_hash: "0xlowton",
+      }),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+
+  const { supabase } = createSupabaseStub({
+    operations_pct: 60,
+    autoinvest_pct: 30,
+    buyback_burn_pct: 10,
+    min_ops_pct: 40,
+    max_ops_pct: 75,
+    min_invest_pct: 15,
+    max_invest_pct: 45,
+    min_burn_pct: 5,
+    max_burn_pct: 20,
+    ops_treasury: "EQOPS",
+    dct_master: "EQMASTER",
+    dex_router: "https://dex.example",
+  });
+
+  const fetchStub: typeof fetch = async (input) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+
+    if (url.includes("/transactions/")) {
+      return new Response(
+        JSON.stringify({
+          destination: "EQOPS",
+          amountTon: 119,
+        }),
+        { status: 200 },
+      );
+    }
+
+    throw new Error(`Unexpected fetch call: ${url}`);
+  };
+
+  const response = await handler(request, {
+    supabase,
+    fetch: fetchStub,
+  });
+
+  assertEquals(response.status, 400);
+  const body = await response.text();
+  assertStringIncludes(body, "less than expected");
+});
+
+Deno.test("processes TON subscription and records swap + burn hashes", async () => {
+  const request = new Request(
+    "https://example/functions/process-subscription",
+    {
+      method: "POST",
+      body: JSON.stringify({
+        telegram_id: "1234",
+        plan: "vip_bronze",
+        tx_hash: "0xfullton",
+      }),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+
+  const stub = createSupabaseStub({
+    operations_pct: 60,
+    autoinvest_pct: 30,
+    buyback_burn_pct: 10,
+    min_ops_pct: 40,
+    max_ops_pct: 75,
+    min_invest_pct: 15,
+    max_invest_pct: 45,
+    min_burn_pct: 5,
+    max_burn_pct: 20,
+    ops_treasury: "EQOPS",
+    dct_master: "EQMASTER",
+    dex_router: "https://dex.example",
+  });
+
+  const fetchCalls: Array<{ url: string; body?: string }> = [];
+  const fetchStub: typeof fetch = async (input, init) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    const bodyText = typeof init?.body === "string"
+      ? init.body
+      : init?.body instanceof Uint8Array
+      ? new TextDecoder().decode(init.body)
+      : init?.body
+      ? String(init.body)
+      : undefined;
+    fetchCalls.push({ url, body: bodyText });
+
+    if (url.includes("/transactions/")) {
+      return new Response(
+        JSON.stringify({
+          destination: "EQOPS",
+          amountTon: 120,
+          source: "EQUSER",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+        { status: 200 },
+      );
+    }
+
+    if (url === "https://dex.example/swap") {
+      const payload = bodyText ? JSON.parse(bodyText) : {};
+      if (payload.tag === "auto-invest") {
+        return new Response(
+          JSON.stringify({
+            dctAmount: 3600,
+            swapTxHash: "swap-auto",
+            swapId: "swap-auto-id",
+            tonSpent: payload.amountTon,
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (payload.tag === "buyback-burn") {
+        return new Response(
+          JSON.stringify({
+            dctAmount: 1200,
+            swapTxHash: "swap-burn",
+            swapId: "swap-burn-id",
+            tonSpent: payload.amountTon,
+          }),
+          { status: 200 },
+        );
+      }
+
+      throw new Error("Unexpected swap payload");
+    }
+
+    if (url === "https://burn.example") {
+      return new Response(JSON.stringify({ burnTxHash: "burn-hash" }), {
+        status: 200,
+      });
+    }
+
+    if (url.startsWith("https://api.telegram.org")) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+
+    throw new Error(`Unexpected fetch call: ${url}`);
+  };
+
+  const response = await handler(request, {
+    supabase: stub.supabase,
+    fetch: fetchStub,
+  });
+
+  assertEquals(response.status, 200);
+  const payload = await response.json();
+  assertEquals(payload, { ok: true });
+
+  assertEquals(stub.subscriptions.length, 1);
+  const subscription = stub.subscriptions[0];
+  assertEquals(subscription.plan, "vip_bronze");
+  assertEquals(subscription.ton_paid, 120);
+  assertEquals(subscription.dct_bought, 3600);
+  assertEquals(subscription.dct_burned, 1200);
+
+  assertEquals(stub.logs.length, 4);
+  const buybackLog = stub.logs.find((log) => log.kind === "buyback");
+  assertExists(buybackLog);
+  const buybackMeta = (buybackLog?.meta ?? {}) as Record<string, unknown>;
+  assertEquals(buybackMeta.swapTxHash as string, "swap-auto");
+  assertEquals(buybackMeta.routerSwapId as string, "swap-auto-id");
+  const burnLog = stub.logs.find((log) => log.kind === "burn");
+  assertExists(burnLog);
+  const burnMeta = (burnLog?.meta ?? {}) as Record<string, unknown>;
+  assertEquals(burnMeta.burnTxHash as string, "burn-hash");
+  assertEquals(burnMeta.swapTxHash as string, "swap-burn");
+
+  const telegramCall = fetchCalls.find((call) =>
+    call.url.startsWith("https://api.telegram.org")
+  );
+  assertExists(telegramCall);
 });

--- a/dynamic-capital-ton/supabase/functions/process-subscription/index.ts
+++ b/dynamic-capital-ton/supabase/functions/process-subscription/index.ts
@@ -42,8 +42,20 @@ const supabase = createClient(supabaseUrl, supabaseServiceKey);
 type SupabaseClient = typeof supabase;
 
 type VerifyTonPaymentResult =
-  | { ok: true; amountTON: number; payerAddress?: string }
+  | {
+      ok: true;
+      amountTON: number;
+      payerAddress?: string;
+      blockTime?: string;
+    }
   | { ok: false; error: string };
+
+type DexSwapResult = {
+  dctAmount: number;
+  tonSpent: number;
+  swapTxHash: string;
+  routerSwapId: string;
+};
 
 const PLAN_PRICES_TON: Record<Plan, number> = {
   vip_bronze: 120,
@@ -56,6 +68,10 @@ function normalizeAddress(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function roundTon(value: number): number {
+  return Number(value.toFixed(9));
+}
+
 async function verifyTonPayment(
   txHash: string,
   expectedWallet: string,
@@ -64,7 +80,7 @@ async function verifyTonPayment(
 ): Promise<VerifyTonPaymentResult> {
   const indexerUrl = Deno.env.get("TON_INDEXER_URL");
   if (!indexerUrl) {
-    return { ok: true, amountTON: expectedAmount };
+    return { ok: false, error: "TON indexer URL is not configured" };
   }
 
   const response = await fetchFn(
@@ -113,21 +129,107 @@ async function verifyTonPayment(
   const payerAddress = typeof payerCandidate === "string"
     ? payerCandidate
     : undefined;
+  const blockTime: string | undefined = typeof payload.timestamp === "string"
+    ? payload.timestamp
+    : payload.utime
+    ? new Date(Number(payload.utime) * 1000).toISOString()
+    : undefined;
 
-  return { ok: true, amountTON: amountTon, payerAddress };
+  return { ok: true, amountTON: amountTon, payerAddress, blockTime };
+}
+
+function resolveRouterEndpoint(routerCandidate: string): string {
+  const trimmed = routerCandidate.trim();
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return trimmed.replace(/\/$/, "");
+  }
+
+  const fallback = Deno.env.get("DEX_ROUTER_URL");
+  if (fallback && (fallback.startsWith("http://") || fallback.startsWith("https://"))) {
+    return fallback.replace(/\/$/, "");
+  }
+
+  throw new Error("DEX router endpoint is not configured");
 }
 
 async function dexBuyDCT(
-  _routerAddr: string,
+  routerEndpoint: string,
   tonAmount: number,
-): Promise<{ dctAmount: number }> {
-  console.log("dexBuyDCT placeholder", tonAmount);
-  return { dctAmount: tonAmount * 100 };
+  tag: "auto-invest" | "buyback-burn",
+  fetchFn: typeof fetch,
+): Promise<DexSwapResult> {
+  if (tonAmount <= 0) {
+    return { dctAmount: 0, tonSpent: 0, swapTxHash: "", routerSwapId: "" };
+  }
+
+  const response = await fetchFn(`${routerEndpoint}/swap`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fromToken: "TON",
+      toToken: "DCT",
+      amountTon: tonAmount,
+      tag,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`DEX router error ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const dctAmount = Number(payload.dctAmount ?? payload.amount ?? 0);
+  if (!Number.isFinite(dctAmount) || dctAmount < 0) {
+    throw new Error("Router returned invalid DCT amount");
+  }
+
+  const tonSpent = Number(payload.tonSpent ?? payload.amountTon ?? tonAmount);
+  if (!Number.isFinite(tonSpent) || tonSpent < 0) {
+    throw new Error("Router returned invalid TON spend amount");
+  }
+
+  const swapTxHash = String(payload.swapTxHash ?? payload.txHash ?? "");
+  if (!swapTxHash) {
+    throw new Error("Router response missing swapTxHash");
+  }
+
+  const routerSwapId = String(
+    payload.swapId ?? payload.id ?? swapTxHash || crypto.randomUUID(),
+  );
+
+  return { dctAmount, tonSpent, swapTxHash, routerSwapId };
 }
 
-async function burnDCT(_dctMaster: string, amount: number) {
-  console.log("burnDCT placeholder", amount);
-  return true;
+async function burnDCT(
+  dctMaster: string,
+  amount: number,
+  tonTxHash: string,
+  fetchFn: typeof fetch,
+): Promise<string | null> {
+  if (amount <= 0) {
+    return null;
+  }
+
+  const burnWebhook = Deno.env.get("BURN_WEBHOOK_URL");
+  if (!burnWebhook) {
+    throw new Error("Burn webhook URL is not configured");
+  }
+
+  const response = await fetchFn(burnWebhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ amount, dctMaster, tonTxHash }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Burn webhook error ${response.status}`);
+  }
+
+  const payload = await response.json().catch(
+    () => ({} as Record<string, unknown>),
+  );
+  const burnHash = payload.burnTxHash ?? payload.txHash ?? null;
+  return burnHash ? String(burnHash) : null;
 }
 
 async function notifyUser(fetchFn: typeof fetch, text: string) {
@@ -240,18 +342,29 @@ export async function handler(
       return new Response(verify.error, { status: 400 });
     }
 
-    const tonPaid = verify.amountTON;
-    const opsTON = (tonPaid * config.operations_pct) / 100;
-    const buyTON = (tonPaid * config.autoinvest_pct) / 100;
-    const burnTON = (tonPaid * config.buyback_burn_pct) / 100;
+    const tonPaid = roundTon(verify.amountTON);
+    const opsTON = roundTon((tonPaid * config.operations_pct) / 100);
+    const autoInvestBase = (tonPaid * config.autoinvest_pct) / 100;
+    const burnBase = tonPaid - opsTON - autoInvestBase;
+    const buyTON = roundTon(autoInvestBase);
+    const burnTON = roundTon(Math.max(burnBase, 0));
 
-    const [{ dctAmount: dctForUser }, { dctAmount: dctForBurn }] = await Promise
-      .all([
-        dexBuyDCT(config.dex_router, buyTON),
-        dexBuyDCT(config.dex_router, burnTON),
-      ]);
+    const routerEndpoint = resolveRouterEndpoint(config.dex_router);
 
-    await burnDCT(config.dct_master, dctForBurn);
+    const [autoInvestSwap, burnSwap] = await Promise.all([
+      dexBuyDCT(routerEndpoint, buyTON, "auto-invest", deps.fetch),
+      dexBuyDCT(routerEndpoint, burnTON, "buyback-burn", deps.fetch),
+    ]);
+
+    const burnTxHash = await burnDCT(
+      config.dct_master,
+      burnSwap.dctAmount,
+      tx_hash,
+      deps.fetch,
+    );
+
+    const dctForUser = autoInvestSwap.dctAmount;
+    const dctForBurn = burnSwap.dctAmount;
 
     const { data: userRow, error: userError } = await deps.supabase
       .from("users")
@@ -306,25 +419,45 @@ export async function handler(
         kind: "ops_transfer",
         ref_id: subscriptionId,
         amount: opsTON,
-        meta: { to: config.ops_treasury, unit: "TON" },
+        meta: {
+          to: config.ops_treasury,
+          unit: "TON",
+          tonTxHash: tx_hash,
+          payer: verify.payerAddress ?? null,
+          blockTime: verify.blockTime ?? null,
+        },
       },
       {
         kind: "buyback",
         ref_id: subscriptionId,
         amount: buyTON,
-        meta: { unit: "TON", dctOut: dctForUser },
+        meta: {
+          unit: "TON",
+          dctOut: dctForUser,
+          tonTxHash: tx_hash,
+          swapTxHash: autoInvestSwap.swapTxHash,
+          routerSwapId: autoInvestSwap.routerSwapId,
+          tonSpent: autoInvestSwap.tonSpent,
+        },
       },
       {
         kind: "burn",
         ref_id: subscriptionId,
         amount: dctForBurn,
-        meta: { unit: "DCT" },
+        meta: {
+          unit: "DCT",
+          tonTxHash: tx_hash,
+          swapTxHash: burnSwap.swapTxHash,
+          routerSwapId: burnSwap.routerSwapId,
+          burnTxHash,
+          tonSpent: burnSwap.tonSpent,
+        },
       },
       {
         kind: "stake_credit",
         ref_id: subscriptionId,
         amount: dctForUser,
-        meta: { unit: "DCT", weight },
+        meta: { unit: "DCT", weight, tonTxHash: tx_hash },
       },
     ]);
 
@@ -334,7 +467,7 @@ export async function handler(
 
     await notifyUser(
       deps.fetch,
-      `✅ *Subscription processed*\n\n• Plan: *${plan}*\n• Paid: *${tonPaid} TON*\n• Auto-invest: *${dctForUser} DCT*\n• Burned: *${dctForBurn} DCT*\n\n👉 Open Mini App: ${appUrl}`,
+      `✅ *Subscription processed*\n\n• Plan: *${plan}*\n• Paid: *${tonPaid} TON*\n• Auto-invest: *${dctForUser} DCT* (swap: ${autoInvestSwap.swapTxHash})\n• Burned: *${dctForBurn} DCT*${burnTxHash ? ` (burn: ${burnTxHash})` : ""}\n\n👉 Open Mini App: ${appUrl}`,
     );
 
     return new Response(JSON.stringify({ ok: true }), {


### PR DESCRIPTION
## Summary
- switch the Telegram mini app to initiate real TonConnect payments, parse transaction hashes from the returned BOC, and expose numeric plan pricing tied to a configured treasury address
- overhaul the Supabase `process-subscription` function to require indexer verification, execute swap/burn flows via the configured router and webhook, and persist detailed ledger entries; extend the associated tests to cover rejection and success paths
- refactor wallet auth surfaces to present TonConnect status (including header actions), reuse the new session API, and document the required TON intake address; commit the mini app lockfile for the added TON dependencies

## Testing
- npm run lint
- npm run typecheck
- deno test dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts *(fails: deno not installed in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c094a754832297c71d514232470e