### PR TITLE
feat: orchestrate trading optimization workflow

### DIFF
--- a/algorithms/python/optimization_workflow.py
+++ b/algorithms/python/optimization_workflow.py
@@ -1,0 +1,224 @@
+"""High-level orchestration helpers for optimising the trading stack."""
+
+from __future__ import annotations
+
+import copy
+import statistics
+from dataclasses import dataclass, replace
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .backtesting import BacktestResult
+from .hyperparameter_search import HyperparameterSearch
+from .realtime import BrokerConnector, HealthMonitor, RealtimeExecutor, StateStore
+from .trade_logic import (
+    FeaturePipeline,
+    MarketSnapshot,
+    RiskManager,
+    RiskParameters,
+    TradeConfig,
+    TradeLogic,
+)
+
+try:  # pragma: no cover - optional dependency used for typing only
+    from .grok_advisor import TradeAdvisor
+except Exception:  # pragma: no cover - typing helper when grok advisor deps missing
+    TradeAdvisor = object  # type: ignore[misc, assignment]
+
+
+@dataclass(slots=True)
+class OptimizationInsights:
+    """Aggregated statistics that inform configuration tuning."""
+
+    snapshot_count: int
+    average_correlation: Optional[float]
+    max_correlation: Optional[float]
+    average_seasonal_bias: Optional[float]
+    average_seasonal_confidence: Optional[float]
+    average_range_pips: Optional[float]
+
+
+@dataclass(slots=True)
+class OptimizationPlan:
+    """Results produced by :func:`optimize_trading_stack`."""
+
+    pipeline: FeaturePipeline
+    pipeline_state: Dict[str, object]
+    base_config: TradeConfig
+    tuned_config: TradeConfig
+    best_config: TradeConfig
+    backtest_result: BacktestResult
+    history: List[Tuple[TradeConfig, BacktestResult]]
+    risk_manager: RiskManager
+    trade_logic: TradeLogic
+    realtime_executor: Optional[RealtimeExecutor]
+    insights: OptimizationInsights
+
+
+def _prepare_pipeline(snapshots: Sequence[MarketSnapshot]) -> FeaturePipeline:
+    pipeline = FeaturePipeline()
+    feature_rows = (snapshot.feature_vector() for snapshot in snapshots)
+    pipeline.fit(feature_rows)
+    return pipeline
+
+
+def _aggregate_insights(snapshots: Sequence[MarketSnapshot]) -> OptimizationInsights:
+    correlations: List[float] = []
+    seasonal_bias: List[float] = []
+    seasonal_confidence: List[float] = []
+    ranges: List[float] = []
+
+    for snapshot in snapshots:
+        if snapshot.correlation_scores:
+            correlations.extend(abs(score) for score in snapshot.correlation_scores.values())
+        if snapshot.seasonal_bias is not None:
+            seasonal_bias.append(float(snapshot.seasonal_bias))
+        if snapshot.seasonal_confidence is not None:
+            seasonal_confidence.append(float(snapshot.seasonal_confidence))
+        high = snapshot.daily_high or snapshot.high
+        low = snapshot.daily_low or snapshot.low
+        if high is not None and low is not None and snapshot.pip_size:
+            ranges.append((high - low) / snapshot.pip_size)
+
+    return OptimizationInsights(
+        snapshot_count=len(snapshots),
+        average_correlation=statistics.fmean(correlations) if correlations else None,
+        max_correlation=max(correlations) if correlations else None,
+        average_seasonal_bias=statistics.fmean(seasonal_bias) if seasonal_bias else None,
+        average_seasonal_confidence=(
+            statistics.fmean(seasonal_confidence) if seasonal_confidence else None
+        ),
+        average_range_pips=statistics.fmean(ranges) if ranges else None,
+    )
+
+
+def _tune_trade_config(base: TradeConfig, insights: OptimizationInsights) -> TradeConfig:
+    config = replace(base)
+
+    if insights.average_correlation is not None:
+        config.correlation_threshold = max(
+            base.correlation_threshold, round(insights.average_correlation, 2)
+        )
+        weight_hint = min(
+            base.max_correlation_adjustment,
+            max(base.correlation_weight, insights.average_correlation * 0.5),
+        )
+        config.correlation_weight = round(weight_hint, 3)
+
+    if insights.average_seasonal_confidence is not None:
+        seasonal_weight = min(
+            base.max_seasonal_adjustment,
+            max(
+                base.seasonal_bias_weight,
+                insights.average_seasonal_confidence * base.max_seasonal_adjustment,
+            ),
+        )
+        config.seasonal_bias_weight = round(seasonal_weight, 3)
+
+    if insights.average_range_pips is not None and insights.average_range_pips > 0:
+        neutral_zone = max(base.neutral_zone_pips, insights.average_range_pips * 0.02)
+        config.neutral_zone_pips = round(min(neutral_zone, base.neutral_zone_pips * 2), 3)
+        if base.use_adr:
+            stop_factor = max(base.adr_stop_loss_factor, 0.5)
+            take_factor = max(base.adr_take_profit_factor, 1.0)
+            config.manual_stop_loss_pips = round(
+                max(base.manual_stop_loss_pips, insights.average_range_pips * stop_factor), 3
+            )
+            config.manual_take_profit_pips = round(
+                max(
+                    base.manual_take_profit_pips,
+                    insights.average_range_pips * take_factor,
+                ),
+                3,
+            )
+
+    return config
+
+
+def _calibrate_risk_parameters(
+    snapshots: Sequence[MarketSnapshot], params: Optional[RiskParameters]
+) -> RiskParameters:
+    calibrated = replace(params or RiskParameters())
+    if calibrated.max_daily_drawdown_pct is None:
+        calibrated.max_daily_drawdown_pct = 5.0
+
+    if calibrated.pip_value_per_standard_lot <= 0:
+        pip_values = [snap.pip_value for snap in snapshots if snap.pip_value]
+        if pip_values:
+            calibrated.pip_value_per_standard_lot = statistics.fmean(pip_values)
+
+    return calibrated
+
+
+def optimize_trading_stack(
+    snapshots: Sequence[MarketSnapshot],
+    search_space: Mapping[str, Iterable],
+    *,
+    base_config: Optional[TradeConfig] = None,
+    risk_parameters: Optional[RiskParameters] = None,
+    scoring: Optional[Callable[[BacktestResult], float]] = None,
+    initial_equity: float = 10_000.0,
+    broker: Optional[BrokerConnector] = None,
+    state_store: Optional[StateStore] = None,
+    health_monitor: Optional[HealthMonitor] = None,
+    advisor: "TradeAdvisor" | None = None,
+) -> OptimizationPlan:
+    """Execute the optimisation tasks recommended by the trading playbook."""
+
+    snapshot_list = list(snapshots)
+    if not snapshot_list:
+        raise ValueError("snapshots must be a non-empty sequence")
+
+    pipeline = _prepare_pipeline(snapshot_list)
+    pipeline_state = pipeline.state_dict()
+    insights = _aggregate_insights(snapshot_list)
+
+    base = base_config or TradeConfig()
+    tuned_config = _tune_trade_config(base, insights)
+
+    risk_params = _calibrate_risk_parameters(snapshot_list, risk_parameters)
+
+    search = HyperparameterSearch(
+        snapshot_list,
+        dict(search_space),
+        base_config=tuned_config,
+        scoring=scoring,
+        initial_equity=initial_equity,
+        pipeline_state=pipeline_state,
+    )
+    best_config, best_result, history = search.run()
+
+    risk_manager = RiskManager(risk_params)
+    trade_logic = TradeLogic(config=best_config, risk=risk_manager)
+    trade_logic.strategy.pipeline.load_state_dict(copy.deepcopy(pipeline_state))
+
+    realtime_executor: Optional[RealtimeExecutor] = None
+    if broker is not None:
+        realtime_executor = RealtimeExecutor(
+            trade_logic,
+            broker,
+            state_store=state_store,
+            health_monitor=health_monitor,
+            advisor=advisor,
+        )
+
+    return OptimizationPlan(
+        pipeline=pipeline,
+        pipeline_state=pipeline_state,
+        base_config=base,
+        tuned_config=tuned_config,
+        best_config=best_config,
+        backtest_result=best_result,
+        history=history,
+        risk_manager=risk_manager,
+        trade_logic=trade_logic,
+        realtime_executor=realtime_executor,
+        insights=insights,
+    )
+
+
+__all__ = [
+    "OptimizationInsights",
+    "OptimizationPlan",
+    "optimize_trading_stack",
+]
+

--- a/algorithms/python/tests/test_optimization_workflow.py
+++ b/algorithms/python/tests/test_optimization_workflow.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Sequence
+
+import pytest
+
+from algorithms.python.data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+from algorithms.python.optimization_workflow import (
+    OptimizationPlan,
+    optimize_trading_stack,
+)
+from algorithms.python.realtime import InMemoryStateStore
+from algorithms.python.trade_logic import MarketSnapshot, RiskParameters, TradeConfig
+
+
+def _build_snapshots() -> Sequence[MarketSnapshot]:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    bars = []
+    price = 100.0
+    for idx in range(30):
+        high = price + 0.4
+        low = price - 0.4
+        close = price + (0.25 if idx % 2 == 0 else -0.15)
+        bars.append(
+            RawBar(
+                timestamp=start + timedelta(minutes=idx * 5),
+                open=price,
+                high=high,
+                low=low,
+                close=close,
+            )
+        )
+        price = close
+    job = MarketDataIngestionJob()
+    instrument = InstrumentMeta(symbol="XAUUSD", pip_size=0.1, pip_value=1.0)
+    snapshots = job.run(bars, instrument)
+    assert snapshots, "expected ingestion job to return snapshots"
+    return snapshots
+
+
+class MemoryBroker:
+    def __init__(self) -> None:
+        self.decisions = []
+        self.positions = []
+
+    def fetch_open_positions(self):
+        return list(self.positions)
+
+    def execute(self, decision):
+        self.decisions.append(decision)
+
+
+def test_optimize_trading_stack_produces_plan():
+    snapshots = _build_snapshots()
+    search_space = {"neighbors": [1, 2], "label_lookahead": [2]}
+    broker = MemoryBroker()
+    plan = optimize_trading_stack(
+        snapshots,
+        search_space,
+        base_config=TradeConfig(min_confidence=0.0),
+        risk_parameters=RiskParameters(max_daily_drawdown_pct=None),
+        broker=broker,
+        state_store=InMemoryStateStore(),
+    )
+
+    assert isinstance(plan, OptimizationPlan)
+    assert plan.insights.snapshot_count == len(snapshots)
+    assert "type" in plan.pipeline_state
+    assert plan.best_config.neighbors in {1, 2}
+    assert plan.backtest_result.performance.total_trades >= 0
+    assert plan.risk_manager.params.max_daily_drawdown_pct == pytest.approx(5.0)
+
+    assert plan.realtime_executor is not None
+    first_decisions = plan.realtime_executor.process_snapshot(snapshots[0])
+    assert isinstance(first_decisions, list)
+
+    # Ensure pipeline state can be reused for persistence workflows
+    pipeline_state = plan.pipeline_state
+    restored_plan = optimize_trading_stack(
+        snapshots[:10],
+        {"neighbors": [plan.best_config.neighbors]},
+        base_config=plan.best_config,
+        risk_parameters=plan.risk_manager.params,
+    )
+    assert restored_plan.pipeline_state["type"] == pipeline_state["type"]
+
+
+def test_optimize_trading_stack_requires_snapshots():
+    with pytest.raises(ValueError):
+        optimize_trading_stack([], {"neighbors": [1]})
+


### PR DESCRIPTION
## Summary
- add an optimisation workflow helper that fits the feature pipeline, tunes configuration knobs, runs hyperparameter search, and wires up risk/realtime components
- allow the hyperparameter search harness to reuse pre-fitted feature pipeline state for consistent evaluations
- cover the new workflow with unit tests to validate orchestration behaviour and error handling

## Testing
- pytest algorithms/python/tests -q
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5cbb2ab488322aa0dd5a85966d955