### PR TITLE
Add tqdm dependency for DeepSeek inference tools

### DIFF
--- a/third_party/DeepSeek-V3/inference/requirements.txt
+++ b/third_party/DeepSeek-V3/inference/requirements.txt
@@ -2,3 +2,4 @@ torch==2.4.1
 triton==3.0.0
 transformers==4.46.3
 safetensors==0.4.5
+tqdm==4.66.1


### PR DESCRIPTION
## Summary
- add tqdm to the DeepSeek inference requirements so utility scripts can import it
- ensure the requirements file ends with a newline for proper formatting

## Testing
- pip install -r third_party/DeepSeek-V3/inference/requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68d5cde15550832284a1a831e7027887