### PR TITLE
Integrate DeepSeek advisor with trading logic

### DIFF
--- a/algorithms/README.md
+++ b/algorithms/README.md
@@ -18,17 +18,19 @@ Refer to the README in each sub-folder for layout details, build commands, and
 handoff expectations between teams. Supabase database migrations and functions
 remain in the top-level `supabase/` directory.
 
-## Grok advisory workflow
+## LLM advisory workflow
 
-- `python/grok_advisor.py` – prompt builder and completion helpers that relay
-  live trade context to Grok-1.
-- `python/trade_logic.py` – accepts an optional Grok advisor during
-  `TradeLogic.on_bar` so Grok can suggest confidence adjustments before trades
+- `python/grok_advisor.py` – shared prompt builder and completion helpers that
+  relay live trade context to a large language model.
+- `python/deepseek_advisor.py` – DeepSeek-V3 specific defaults plus an API
+  client for the OpenAI-compatible endpoint.
+- `python/trade_logic.py` – accepts an optional advisor during
+  `TradeLogic.on_bar` so LLMs can suggest confidence adjustments before trades
   are finalised.
-- `python/realtime.py` – wire Grok into `RealtimeExecutor` by supplying an
-  advisor instance; decisions surface the returned rationale under the
-  `context["advisor"]` key for downstream audit trails.
+- `python/realtime.py` – wire an advisor into `RealtimeExecutor` by supplying an
+  instance; decisions surface the returned rationale under the `context["advisor"]`
+  key for downstream audit trails.
 
-To enable Grok feedback in a live service, instantiate a completion client
-(e.g. wrapping the local `grok-1` `InferenceRunner`) and pass a configured
-`GrokAdvisor` instance into `RealtimeExecutor`.
+To enable feedback in a live service, instantiate a completion client (e.g.
+wrapping the local `grok-1` runner or the DeepSeek API) and pass a configured
+advisor instance into `RealtimeExecutor`.

--- a/algorithms/python/deepseek_advisor.py
+++ b/algorithms/python/deepseek_advisor.py
@@ -1,0 +1,113 @@
+"""DeepSeek-V3 advisor integration for Dynamic Capital trading workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+import json
+
+from .grok_advisor import (
+    AdvisorFeedback,
+    CompletionClient,
+    GrokAdvisor,
+    TradeAdvisor,
+)
+
+
+@dataclass(slots=True)
+class DeepSeekAdvisor(GrokAdvisor):
+    """Specialised advisor tuned for DeepSeek-V3 responses."""
+
+    source: str = "deepseek-v3"
+    temperature: float = 0.15
+    nucleus_p: float = 0.9
+    max_tokens: int = 512
+
+    def _prompt_summary(self) -> str:
+        base = GrokAdvisor._prompt_summary(self)
+        return (
+            f"{base}\n\n"
+            "Leverage DeepSeek-V3's reasoning to stress-test risk controls. "
+            "Return any supporting commentary under an \"analysis\" field when applicable."
+        )
+
+    def _base_metadata(self, prompt: str) -> Dict[str, Any]:
+        metadata = GrokAdvisor._base_metadata(self, prompt)
+        metadata.setdefault("model", "deepseek-v3")
+        return metadata
+
+
+@dataclass(slots=True)
+class DeepSeekAPIClient:
+    """Thin wrapper around the DeepSeek OpenAI-compatible API."""
+
+    api_key: str
+    base_url: str = "https://api.deepseek.com/v1"
+    model: str = "deepseek-chat"
+    system_prompt: str = "You are DeepSeek-V3 assisting the Dynamic Capital trading desk."
+    timeout: float = 30.0
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        temperature: float,
+        max_tokens: int,
+        nucleus_p: float,
+    ) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": temperature,
+            "top_p": nucleus_p,
+            "max_tokens": max_tokens,
+        }
+        request = Request(
+            f"{self.base_url}/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:  # nosec B310
+                body = response.read().decode("utf-8")
+        except HTTPError as exc:  # pragma: no cover - network variability
+            detail = ""
+            if getattr(exc, "fp", None) is not None:
+                try:
+                    detail = exc.read().decode("utf-8", errors="ignore")
+                except Exception:  # pragma: no cover - best-effort diagnostics
+                    detail = ""
+            raise RuntimeError(f"DeepSeek API error {exc.code}: {detail}") from exc
+        except URLError as exc:  # pragma: no cover - network variability
+            raise RuntimeError(f"DeepSeek API request failed: {exc.reason}") from exc
+
+        data = json.loads(body)
+        choices = data.get("choices")
+        if not choices:
+            raise RuntimeError("DeepSeek API returned no choices")
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if not content:
+            raise RuntimeError("DeepSeek API response missing content")
+        reasoning = message.get("reasoning_content")
+        if reasoning:
+            content = f"<think>{reasoning}</think>\n{content}".strip()
+        return content
+
+
+__all__ = [
+    "AdvisorFeedback",
+    "CompletionClient",
+    "DeepSeekAdvisor",
+    "DeepSeekAPIClient",
+    "TradeAdvisor",
+]

--- a/algorithms/python/tests/test_deepseek_advisor.py
+++ b/algorithms/python/tests/test_deepseek_advisor.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timezone
+import json
+
+import pytest
+
+from algorithms.python.deepseek_advisor import DeepSeekAdvisor, DeepSeekAPIClient
+from algorithms.python.grok_advisor import AdvisorFeedback
+from algorithms.python.trade_logic import ActivePosition, MarketSnapshot, TradeSignal
+
+
+class StubClient:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+
+    def complete(self, prompt: str, *, temperature: float, max_tokens: int, nucleus_p: float) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "nucleus_p": nucleus_p,
+            }
+        )
+        return self.response
+
+
+def _snapshot() -> MarketSnapshot:
+    return MarketSnapshot(
+        symbol="GBPUSD",
+        timestamp=datetime(2024, 3, 19, 7, 0, tzinfo=timezone.utc),
+        close=1.2755,
+        rsi_fast=55.0,
+        adx_fast=21.0,
+        rsi_slow=52.0,
+        adx_slow=18.0,
+        pip_size=0.0001,
+        pip_value=10.0,
+        seasonal_bias=0.4,
+        seasonal_confidence=0.7,
+    )
+
+
+def test_deepseek_advisor_normalises_reasoning_blocks() -> None:
+    response = (
+        "<think>Liquidity running on prior highs. Watch USD news.\n</think>"
+        "{\"final\": {\"adjusted_confidence\": 0.58, \"rationale\": \"Favour long setup\", \"alerts\": [\"Tighten stop\"]}}"
+    )
+    client = StubClient(response)
+    advisor = DeepSeekAdvisor(client=client)
+
+    signal = TradeSignal(direction=1, confidence=0.6, votes=5, neighbors_considered=8)
+    feedback = advisor.review(
+        snapshot=_snapshot(),
+        signal=signal,
+        context={"final_confidence": 0.6},
+        open_positions=[ActivePosition(symbol="EURUSD", direction=1, size=0.2, entry_price=1.09)],
+    )
+
+    assert feedback is not None
+    assert isinstance(feedback, AdvisorFeedback)
+    assert feedback.adjusted_signal is not None
+    assert feedback.adjusted_signal.confidence == pytest.approx(0.58)
+    assert feedback.metadata["source"] == "deepseek-v3"
+    assert feedback.metadata["model"] == "deepseek-v3"
+    assert "analysis" in feedback.metadata and "Liquidity" in feedback.metadata["analysis"]
+    assert feedback.metadata["alerts"] == ["Tighten stop"]
+    assert client.calls and client.calls[0]["nucleus_p"] == advisor.nucleus_p
+
+
+def test_deepseek_api_client_merges_reasoning(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": "{\"adjusted_confidence\": 0.51, \"rationale\": \"Align with London flow\"}",
+                    "reasoning_content": "Assessing seasonal bias before confirming entry.",
+                }
+            }
+        ]
+    }
+
+    class DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout):  # type: ignore[override]
+        return DummyResponse()
+
+    monkeypatch.setattr("algorithms.python.deepseek_advisor.urlopen", fake_urlopen)
+
+    client = DeepSeekAPIClient(api_key="test", base_url="https://example.com")
+    result = client.complete("Prompt", temperature=0.2, max_tokens=128, nucleus_p=0.9)
+
+    assert result.startswith("<think>")
+    assert "Assessing seasonal bias" in result
+    assert "adjusted_confidence" in result

--- a/algorithms/python/tests/test_grok_advisor.py
+++ b/algorithms/python/tests/test_grok_advisor.py
@@ -57,6 +57,8 @@ def test_grok_advisor_parses_confidence_adjustment() -> None:
     assert feedback.adjusted_signal is not None
     assert feedback.adjusted_signal.confidence == pytest.approx(0.45)
     assert feedback.metadata["rationale"] == "Macro headwinds"
+    assert feedback.metadata["source"] == "grok"
+    assert "prompt" in feedback.metadata
     assert client.calls and "GBPUSD" in client.calls[0]["prompt"]
 
 
@@ -76,3 +78,4 @@ def test_grok_advisor_handles_text_response() -> None:
     assert feedback.adjusted_signal is None
     assert "Maintain current plan" in feedback.metadata["rationale"]
     assert feedback.raw_response.startswith("Maintain")
+    assert feedback.metadata["source"] == "grok"

--- a/algorithms/python/tests/test_trading_workflow.py
+++ b/algorithms/python/tests/test_trading_workflow.py
@@ -420,7 +420,7 @@ def test_trade_logic_applies_grok_advice():
     decisions = logic.on_bar(snapshot, open_positions=[], advisor=advisor)
     decision = next(dec for dec in decisions if dec.action == "open")
 
-    assert advisor.invocations, "expected Grok advisor to be invoked"
+    assert advisor.invocations, "expected trade advisor to be invoked"
     assert decision.signal is not None
     assert decision.signal.confidence == pytest.approx(0.42)
     assert decision.context["final_confidence"] == pytest.approx(0.42)

--- a/algorithms/python/trade_logic.py
+++ b/algorithms/python/trade_logic.py
@@ -1281,7 +1281,7 @@ class TradeLogic:
                     open_positions=open_positions,
                 )
             except Exception:  # pragma: no cover - advisor failures should not halt trading
-                logger.exception("Grok advisor review failed for %s", snapshot.symbol)
+                logger.exception("Trade advisor review failed for %s", snapshot.symbol)
             else:
                 if advisor_feedback:
                     if advisor_feedback.adjusted_signal is not None:


### PR DESCRIPTION
## Summary
- generalize the Grok advisor so LLM reviews capture metadata, handle `<think>` reasoning blocks, and normalize nested payloads
- add a DeepSeek-V3 advisor plus API client alongside targeted tests for reasoning extraction and API responses
- refresh documentation and log messaging to reflect generic advisors across the trading workflow

## Testing
- pytest algorithms/python/tests
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5ce727ba883228aa5741b9ed75395