### PR TITLE
feat(algorithms): add dual llm trade advisor

### DIFF
--- a/algorithms/python/tests/test_grok_advisor.py
+++ b/algorithms/python/tests/test_grok_advisor.py
@@ -1,9 +1,10 @@
+import json
 from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 
-from algorithms.python.grok_advisor import AdvisorFeedback, GrokAdvisor
+from algorithms.python.grok_advisor import AdvisorFeedback, DualLLMAdvisor, GrokAdvisor
 from algorithms.python.trade_logic import ActivePosition, MarketSnapshot, TradeSignal
 
 
@@ -76,3 +77,61 @@ def test_grok_advisor_handles_text_response() -> None:
     assert feedback.adjusted_signal is None
     assert "Maintain current plan" in feedback.metadata["rationale"]
     assert feedback.raw_response.startswith("Maintain")
+
+
+def test_dual_llm_advisor_applies_deepseek_modifier() -> None:
+    grok_client = StubClient('{"adjusted_confidence": 0.64, "alerts": ["Liquidity concentration"]}')
+    deepseek_client = StubClient('{"confidence_modifier": 0.75, "alerts": ["Overnight funding risk"], "rationale": "Thin Asia session"}')
+
+    advisor = DualLLMAdvisor(grok_client=grok_client, deepseek_client=deepseek_client)
+
+    signal = TradeSignal(direction=1, confidence=0.7, votes=5, neighbors_considered=8)
+    snapshot = _snapshot()
+    open_positions = [
+        ActivePosition(symbol="EURUSD", direction=-1, size=0.15, entry_price=1.09),
+    ]
+
+    feedback = advisor.review(
+        snapshot=snapshot,
+        signal=signal,
+        context={"final_confidence": 0.7},
+        open_positions=open_positions,
+    )
+
+    assert feedback is not None
+    assert feedback.adjusted_signal is not None
+    assert feedback.adjusted_signal.confidence == pytest.approx(0.48)
+
+    metadata = feedback.metadata
+    assert metadata["grok"]["alerts"] == ["Liquidity concentration"]
+    assert metadata["deepseek"]["applied_modifier"] == pytest.approx(0.75)
+    assert "Overnight funding risk" in metadata["alerts"]
+    assert deepseek_client.calls and "DeepSeek-V3" in deepseek_client.calls[0]["prompt"]
+
+    assert feedback.raw_response is not None
+    payload = json.loads(feedback.raw_response)
+    assert len(payload) == 2
+    assert {entry["model"] for entry in payload} == {"grok", "deepseek"}
+
+
+def test_dual_llm_advisor_handles_textual_deepseek_feedback() -> None:
+    grok_client = StubClient('{"adjusted_confidence": 0.52, "rationale": "Strong momentum"}')
+    deepseek_client = StubClient("Risk high due to overlapping news windows")
+
+    advisor = DualLLMAdvisor(grok_client=grok_client, deepseek_client=deepseek_client, risk_weight=0.4)
+
+    signal = TradeSignal(direction=-1, confidence=0.6, votes=4, neighbors_considered=6)
+    feedback = advisor.review(
+        snapshot=_snapshot(),
+        signal=signal,
+        context={"final_confidence": 0.6},
+        open_positions=[],
+    )
+
+    assert feedback is not None
+    assert feedback.adjusted_signal is not None
+    # DeepSeek does not supply a numeric modifier, so Grok's confidence is preserved.
+    assert feedback.adjusted_signal.confidence == pytest.approx(0.52)
+    assert "Risk high" in feedback.metadata["deepseek"]["rationale"]
+    # Alerts should fall back to Grok-only notes when DeepSeek provides prose.
+    assert feedback.metadata.get("alerts") == feedback.metadata["grok"].get("alerts")


### PR DESCRIPTION
## Summary
- introduce a DualLLMAdvisor that layers DeepSeek-V3 risk guidance on top of the existing Grok-1 confidence review
- capture combined confidence modifiers, alerts, and raw responses so TradeLogic can inspect both models' feedback
- expand unit coverage to exercise DeepSeek-driven adjustments and graceful fallbacks when only prose is returned

## Testing
- npm run format
- npm run lint
- npm run typecheck
- PYTHONPATH=. pytest algorithms/python/tests/test_grok_advisor.py


------
https://chatgpt.com/codex/tasks/task_e_68d5cff692bc83229a7f55631fc272ac