### PR TITLE
feat(web): add compliance certificate logos

### DIFF
--- a/apps/web/components/magic-portfolio/home/ComplianceCertificates.tsx
+++ b/apps/web/components/magic-portfolio/home/ComplianceCertificates.tsx
@@ -1,4 +1,12 @@
-import { Column, Heading, Icon, Row, Tag, Text } from "@/components/dynamic-ui-system";
+import Image from "next/image";
+
+import {
+  Column,
+  Heading,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
 import { schema } from "@/resources";
 
 interface Certificate {
@@ -6,6 +14,8 @@ interface Certificate {
   description: string;
   certificateId: string;
   issuer: string;
+  logoSrc: string;
+  logoAlt: string;
 }
 
 const CERTIFICATES: Certificate[] = [
@@ -14,36 +24,48 @@ const CERTIFICATES: Certificate[] = [
     description: "Certificate of ISO 27001",
     certificateId: "DC-ISMS-27001-2024",
     issuer: "Apex Assurance Ltd.",
+    logoSrc: "/icons/compliance/iso-27001.svg",
+    logoAlt: "ISO/IEC 27001 certification badge",
   },
   {
     name: "SOC 2 Type II",
     description: "Certificate of SOC 2",
     certificateId: "DC-SOC2-2024-T2",
     issuer: "Langford & Ames, LLP",
+    logoSrc: "/icons/compliance/soc-2-type-ii.svg",
+    logoAlt: "SOC 2 Type II attestation seal",
   },
   {
     name: "PCI DSS Level 1",
     description: "Certificate of PCI DSS",
     certificateId: "DC-PCI-2024-L1",
     issuer: "TrustShield QSA Services",
+    logoSrc: "/icons/compliance/pci-dss.svg",
+    logoAlt: "PCI DSS Level 1 compliance mark",
   },
   {
     name: "HIPAA Security & Privacy",
     description: "Certificate of HIPAA",
     certificateId: "DC-HIPAA-2024",
     issuer: "Veritas Healthcare Assessors",
+    logoSrc: "/icons/compliance/hipaa.svg",
+    logoAlt: "HIPAA compliance shield",
   },
   {
     name: "GDPR Article 27",
     description: "Certificate of GDPR",
     certificateId: "DC-GDPR-2024",
     issuer: "EuroTrust Compliance BV",
+    logoSrc: "/icons/compliance/gdpr-article-27.svg",
+    logoAlt: "GDPR Article 27 badge",
   },
   {
     name: "EU–US Data Privacy Framework",
     description: "Certificate of DPF",
     certificateId: "DPF-EE-2024-8821",
     issuer: "U.S. Department of Commerce",
+    logoSrc: "/icons/compliance/eu-us-dpf.svg",
+    logoAlt: "EU–US Data Privacy Framework shield",
   },
 ];
 
@@ -84,8 +106,14 @@ export function ComplianceCertificates() {
             padding="l"
             gap="12"
           >
-            <Row gap="8" vertical="center">
-              <Icon name="shield" onBackground="brand-medium" />
+            <Row gap="12" vertical="center">
+              <Image
+                src={certificate.logoSrc}
+                alt={certificate.logoAlt}
+                width={48}
+                height={48}
+                style={{ height: "48px", width: "48px", objectFit: "contain" }}
+              />
               <Heading as="h3" variant="heading-strong-m">
                 {certificate.name}
               </Heading>

--- a/apps/web/public/icons/compliance/eu-us-dpf.svg
+++ b/apps/web/public/icons/compliance/eu-us-dpf.svg
@@ -1,0 +1,51 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 120 120"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">EU–US Data Privacy Framework Mark</title>
+  <desc id="desc"
+  >Shield combining European Union stars and United States stripes.</desc>
+  <defs>
+    <linearGradient id="shieldTop" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0052b4" />
+      <stop offset="100%" stop-color="#003087" />
+    </linearGradient>
+    <linearGradient id="shieldBottom" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ef2b2d" />
+      <stop offset="100%" stop-color="#c1121f" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M60 6l40 16v34c0 23.2-15.4 45.2-40 58-24.6-12.8-40-34.8-40-58V22z"
+    fill="#ffffff"
+    stroke="#ccd6f6"
+    stroke-width="4"
+  />
+  <path d="M60 12l32 12v26H28V24z" fill="url(#shieldTop)" />
+  <path
+    d="M28 50h64v6H28zM28 62h64v6H28zM28 74h64v6H28zM28 86h64v6H28z"
+    fill="url(#shieldBottom)"
+  />
+  <g fill="#ffcc00">
+    <circle cx="40" cy="32" r="3" />
+    <circle cx="48" cy="28" r="3" />
+    <circle cx="56" cy="32" r="3" />
+    <circle cx="32" cy="32" r="3" />
+    <circle cx="44" cy="36" r="3" />
+    <circle cx="52" cy="36" r="3" />
+    <circle cx="36" cy="36" r="3" />
+    <circle cx="44" cy="28" r="3" />
+    <circle cx="36" cy="28" r="3" />
+  </g>
+  <text
+    x="50%"
+    y="106"
+    text-anchor="middle"
+    fill="#003087"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="15"
+    font-weight="700"
+  >EU–US DPF</text>
+</svg>

--- a/apps/web/public/icons/compliance/gdpr-article-27.svg
+++ b/apps/web/public/icons/compliance/gdpr-article-27.svg
@@ -1,0 +1,77 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 120 120"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">GDPR Article 27 Seal</title>
+  <desc id="desc">Blue circle with European stars and Article 27 text.</desc>
+  <circle cx="60" cy="60" r="56" fill="#004494" />
+  <g fill="#ffcc00">
+    <polygon
+      points="60,12 62.4,19.2 70,19.2 63.8,23.8 66.2,31 60,26.4 53.8,31 56.2,23.8 50,19.2 57.6,19.2"
+    />
+    <polygon
+      points="82,18 84.4,25.2 92,25.2 85.8,29.8 88.2,37 82,32.4 75.8,37 78.2,29.8 72,25.2 79.6,25.2"
+      transform="rotate(30 82 28)"
+    />
+    <polygon
+      points="98,36 100.4,43.2 108,43.2 101.8,47.8 104.2,55 98,50.4 91.8,55 94.2,47.8 88,43.2 95.6,43.2"
+      transform="rotate(60 98 46)"
+    />
+    <polygon
+      points="104,60 106.4,67.2 114,67.2 107.8,71.8 110.2,79 104,74.4 97.8,79 100.2,71.8 94,67.2 101.6,67.2"
+      transform="rotate(90 104 68)"
+    />
+    <polygon
+      points="98,84 100.4,91.2 108,91.2 101.8,95.8 104.2,103 98,98.4 91.8,103 94.2,95.8 88,91.2 95.6,91.2"
+      transform="rotate(120 98 92)"
+    />
+    <polygon
+      points="82,102 84.4,109.2 92,109.2 85.8,113.8 88.2,121 82,116.4 75.8,121 78.2,113.8 72,109.2 79.6,109.2"
+      transform="rotate(150 82 110)"
+    />
+    <polygon
+      points="60,108 62.4,115.2 70,115.2 63.8,119.8 66.2,127 60,122.4 53.8,127 56.2,119.8 50,115.2 57.6,115.2"
+      transform="rotate(180 60 116)"
+    />
+    <polygon
+      points="38,102 40.4,109.2 48,109.2 41.8,113.8 44.2,121 38,116.4 31.8,121 34.2,113.8 28,109.2 35.6,109.2"
+      transform="rotate(210 38 110)"
+    />
+    <polygon
+      points="22,84 24.4,91.2 32,91.2 25.8,95.8 28.2,103 22,98.4 15.8,103 18.2,95.8 12,91.2 19.6,91.2"
+      transform="rotate(240 22 92)"
+    />
+    <polygon
+      points="16,60 18.4,67.2 26,67.2 19.8,71.8 22.2,79 16,74.4 9.8,79 12.2,71.8 6,67.2 13.6,67.2"
+      transform="rotate(270 16 68)"
+    />
+    <polygon
+      points="22,36 24.4,43.2 32,43.2 25.8,47.8 28.2,55 22,50.4 15.8,55 18.2,47.8 12,43.2 19.6,43.2"
+      transform="rotate(300 22 44)"
+    />
+    <polygon
+      points="38,18 40.4,25.2 48,25.2 41.8,29.8 44.2,37 38,32.4 31.8,37 34.2,29.8 28,25.2 35.6,25.2"
+      transform="rotate(330 38 28)"
+    />
+  </g>
+  <text
+    x="50%"
+    y="68"
+    text-anchor="middle"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="24"
+    font-weight="700"
+  >GDPR</text>
+  <text
+    x="50%"
+    y="90"
+    text-anchor="middle"
+    fill="#ffcc00"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="16"
+    font-weight="600"
+  >ARTICLE 27</text>
+</svg>

--- a/apps/web/public/icons/compliance/hipaa.svg
+++ b/apps/web/public/icons/compliance/hipaa.svg
@@ -1,0 +1,33 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 120 120"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">HIPAA Compliance Badge</title>
+  <desc id="desc">HIPAA compliance logo with shield and caduceus.</desc>
+  <defs>
+    <linearGradient id="hipaaShield" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#5b8def" />
+      <stop offset="100%" stop-color="#2d4d9c" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M60 8l36 12v30c0 20-12.8 38.2-36 50-23.2-11.8-36-30-36-50V20z"
+    fill="url(#hipaaShield)"
+  />
+  <path
+    d="M60 30c7 0 12 5.2 12 12 0 6.2-3.8 10.4-9.6 11.6l5.6 12.4h-6.8l-3.6-8-3.6 8H48l5.6-12.4C47.8 52.4 44 48.2 44 42c0-6.8 5.2-12 12-12zm0 18c3.4 0 6-2.2 6-6s-2.6-6-6-6-6 2.2-6 6 2.6 6 6 6z"
+    fill="#ffffff"
+  />
+  <path d="M60 78c7.2 0 13 5.8 13 13H47c0-7.2 5.8-13 13-13z" fill="#f0f6ff" />
+  <text
+    x="50%"
+    y="108"
+    text-anchor="middle"
+    fill="#1f2a54"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="16"
+    font-weight="700"
+  >HIPAA</text>
+</svg>

--- a/apps/web/public/icons/compliance/iso-27001.svg
+++ b/apps/web/public/icons/compliance/iso-27001.svg
@@ -1,0 +1,49 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 120 120"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">ISO/IEC 27001 Certification Mark</title>
+  <desc id="desc"
+  >Circular ISO 27001 badge with white lettering on a blue globe.</desc>
+  <defs>
+    <linearGradient id="isoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f62fe" />
+      <stop offset="100%" stop-color="#0043ce" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="54" fill="url(#isoGradient)" />
+  <g fill="none" stroke="#ffffff" stroke-width="2.4">
+    <ellipse cx="60" cy="60" rx="38" ry="54" />
+    <ellipse cx="60" cy="60" rx="54" ry="38" />
+    <circle cx="60" cy="60" r="44" />
+  </g>
+  <text
+    x="50%"
+    y="48"
+    text-anchor="middle"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="22"
+    font-weight="700"
+  >ISO/IEC</text>
+  <text
+    x="50%"
+    y="72"
+    text-anchor="middle"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="28"
+    font-weight="700"
+  >27001</text>
+  <text
+    x="50%"
+    y="94"
+    text-anchor="middle"
+    fill="#d0e2ff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="14"
+    font-weight="600"
+  >INFORMATION SECURITY</text>
+</svg>

--- a/apps/web/public/icons/compliance/pci-dss.svg
+++ b/apps/web/public/icons/compliance/pci-dss.svg
@@ -1,0 +1,40 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 160 110"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">PCI DSS Level 1 Mark</title>
+  <desc id="desc">PCI DSS logo with teal badge and white lettering.</desc>
+  <defs>
+    <linearGradient id="pciGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#009c9f" />
+      <stop offset="100%" stop-color="#006b7b" />
+    </linearGradient>
+  </defs>
+  <path d="M12 16h130l6 32-52 46H20L12 16z" fill="url(#pciGradient)" />
+  <path
+    d="M112 30l-28 32-14-16-30 36"
+    fill="none"
+    stroke="#ffffff"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <text
+    x="34"
+    y="52"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="30"
+    font-weight="800"
+  >PCI</text>
+  <text
+    x="34"
+    y="78"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="20"
+    font-weight="600"
+  >DSS</text>
+</svg>

--- a/apps/web/public/icons/compliance/soc-2-type-ii.svg
+++ b/apps/web/public/icons/compliance/soc-2-type-ii.svg
@@ -1,0 +1,69 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 120 120"
+  role="img"
+  aria-labelledby="title desc"
+>
+  <title id="title">SOC 2 Type II Attestation Seal</title>
+  <desc id="desc"
+  >Blue circular SOC 2 Type II logo with AICPA and SOC text.</desc>
+  <defs>
+    <linearGradient id="socOuter" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1f8efa" />
+      <stop offset="100%" stop-color="#0050b5" />
+    </linearGradient>
+    <linearGradient id="socInner" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f6f9ff" />
+      <stop offset="100%" stop-color="#d7e3ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="url(#socOuter)" />
+  <circle cx="60" cy="60" r="44" fill="url(#socInner)" />
+  <circle cx="60" cy="60" r="36" fill="#0050b5" />
+  <text
+    x="50%"
+    y="46"
+    text-anchor="middle"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="24"
+    font-weight="700"
+  >SOC 2</text>
+  <text
+    x="50%"
+    y="66"
+    text-anchor="middle"
+    fill="#9ec9ff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="13"
+    font-weight="600"
+  >SERVICE ORGANIZATION</text>
+  <text
+    x="50%"
+    y="80"
+    text-anchor="middle"
+    fill="#9ec9ff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="13"
+    font-weight="600"
+  >CONTROLS</text>
+  <text
+    x="50%"
+    y="96"
+    text-anchor="middle"
+    fill="#ffffff"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="14"
+    font-weight="700"
+  >TYPE II</text>
+  <text
+    x="50%"
+    y="30"
+    text-anchor="middle"
+    fill="#003b7b"
+    font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+    font-size="12"
+    font-weight="600"
+    letter-spacing="0.24em"
+  >AICPA</text>
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated SVG marks for ISO 27001, SOC 2, PCI DSS, HIPAA, GDPR Article 27, and EU–US DPF in the compliance icon set
- surface certificate-specific branding in the compliance card component by extending the data model and rendering each logo with accessible alt text

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5d167c68c83229d9fdb2fc57daaf8