### PR TITLE
Fix timer cleanup and optimize ASCII rendering

### DIFF
--- a/apps/web/components/ui/animated-text.tsx
+++ b/apps/web/components/ui/animated-text.tsx
@@ -24,23 +24,31 @@ export const TypewriterText: React.FC<TypewriterTextProps> = ({
   const [isComplete, setIsComplete] = useState(false);
 
   useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval> | null = null;
     const timer = setTimeout(() => {
       let currentIndex = 0;
-      const interval = setInterval(() => {
+      intervalId = setInterval(() => {
         if (currentIndex <= text.length) {
           setDisplayText(text.slice(0, currentIndex));
           currentIndex++;
         } else {
-          clearInterval(interval);
+          if (intervalId) {
+            clearInterval(intervalId);
+            intervalId = null;
+          }
           setIsComplete(true);
           onComplete?.();
         }
       }, speed);
-
-      return () => clearInterval(interval);
     }, delay);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
   }, [text, delay, speed, onComplete]);
 
   return (


### PR DESCRIPTION
## Summary
- clean up the TypewriterText timer handling to avoid leaking intervals when the component unmounts or restarts
- cache InteractiveAscii font aspect ratio measurements so pointer updates reuse previous results instead of touching the DOM on every move
- update HorizontalSnapScroll to observe element resizes via ResizeObserver (with a window resize fallback) so scroll arrows stay in sync

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5df6456d48322b0c2627cbd65a624