### PR TITLE
Add live Grok/DeepSeek intelligence sync to TON mini app

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/app/api/live-intel/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/live-intel/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+import {
+  DEFAULT_REFRESH_SECONDS,
+  LIVE_INTEL_SNAPSHOTS,
+  resolveSnapshotIndex,
+  snapshotForTimestamp,
+} from "../../../data/live-intel";
+
+function parseIndex(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const indexParam = parseIndex(url.searchParams.get("index"));
+  const now = new Date();
+
+  let report;
+  if (indexParam !== null) {
+    const idx = resolveSnapshotIndex(indexParam, LIVE_INTEL_SNAPSHOTS.length);
+    report = LIVE_INTEL_SNAPSHOTS[idx];
+  } else {
+    report = snapshotForTimestamp(now);
+  }
+
+  const cycleSeconds = DEFAULT_REFRESH_SECONDS;
+  const secondsElapsed = Math.floor((now.getTime() / 1000) % cycleSeconds);
+  const nextUpdateInSeconds = cycleSeconds - secondsElapsed;
+
+  return NextResponse.json({
+    generatedAt: now.toISOString(),
+    nextUpdateInSeconds,
+    report,
+  });
+}

--- a/dynamic-capital-ton/apps/miniapp/app/globals.css
+++ b/dynamic-capital-ton/apps/miniapp/app/globals.css
@@ -44,6 +44,33 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+@keyframes syncPulse {
+  0% {
+    transform: scale(0.85);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.85);
+    opacity: 0.55;
+  }
+}
+
+@keyframes skeletonPulse {
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.6;
+  }
+}
+
 button,
 input,
 select,
@@ -100,6 +127,48 @@ button {
   pointer-events: none;
 }
 
+.sync-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(97, 209, 255, 0.32);
+  background: rgba(97, 209, 255, 0.16);
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+}
+
+.sync-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 8px rgba(97, 209, 255, 0.18);
+}
+
+.sync-indicator--pulse {
+  animation: syncPulse 2.4s ease-in-out infinite;
+}
+
+.sync-text {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.sync-countdown {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.sync-refresh {
+  padding: 8px 14px;
+  font-size: 0.78rem;
+}
+
 .hero-header {
   display: grid;
   gap: 24px;
@@ -153,6 +222,35 @@ button {
 .metric-value {
   font-size: 1.05rem;
   font-weight: 600;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.metric-change {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(97, 209, 255, 0.16);
+  color: var(--accent);
+}
+
+.metric-change--up {
+  background: rgba(74, 222, 128, 0.2);
+  color: var(--success);
+}
+
+.metric-change--down {
+  background: rgba(248, 113, 113, 0.2);
+  color: #f87171;
+}
+
+.metric-change--steady {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-secondary);
 }
 
 .hero-actions {
@@ -368,6 +466,33 @@ button {
   color: var(--text-muted);
 }
 
+.skeleton-group {
+  display: grid;
+  gap: 10px;
+}
+
+.skeleton {
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.16);
+  animation: skeletonPulse 1.6s ease-in-out infinite;
+}
+
+.skeleton--text {
+  height: 14px;
+}
+
+.skeleton--wide {
+  width: 100%;
+}
+
+.skeleton--medium {
+  width: 70%;
+}
+
+.skeleton--block {
+  height: 72px;
+}
+
 .activity-list {
   list-style: none;
   margin: 0;
@@ -426,6 +551,123 @@ button {
   font-size: 0.92rem;
 }
 
+.intel-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.intel-card {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(7, 12, 24, 0.52);
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.intel-card--primary {
+  grid-column: 1 / -1;
+  background: rgba(97, 209, 255, 0.16);
+  border-color: rgba(97, 209, 255, 0.38);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.32);
+}
+
+.intel-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.intel-updated {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.intel-narrative {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+.intel-muted {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.alert-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.alert-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(250, 204, 21, 0.28);
+  background: rgba(250, 204, 21, 0.14);
+  font-size: 0.82rem;
+  color: var(--warning);
+}
+
+.intel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.intel-list li {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.intel-bullet {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  margin-top: 6px;
+  background: var(--accent);
+}
+
+.intel-bullet--opportunity {
+  background: var(--accent);
+}
+
+.intel-bullet--risk {
+  background: rgba(248, 113, 113, 0.92);
+}
+
+.confidence-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(97, 209, 255, 0.32);
+  background: rgba(97, 209, 255, 0.18);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .feature-grid {
   display: grid;
   gap: 16px;
@@ -480,6 +722,85 @@ button {
   line-height: 1.45;
 }
 
+.model-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.model-card {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(6, 11, 24, 0.6);
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.model-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.model-name {
+  font-weight: 600;
+}
+
+.model-tag {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+
+.model-risk {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(250, 204, 21, 0.24);
+  background: rgba(250, 204, 21, 0.14);
+  color: var(--warning);
+}
+
+.model-risk--low {
+  border-color: rgba(74, 222, 128, 0.28);
+  background: rgba(74, 222, 128, 0.18);
+  color: var(--success);
+}
+
+.model-risk--high {
+  border-color: rgba(248, 113, 113, 0.32);
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.model-summary {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.model-highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.model-highlights li::before {
+  content: "•";
+  color: var(--accent);
+  margin-right: 6px;
+}
+
 .status-banner {
   padding: 16px 18px;
   border-radius: 18px;
@@ -488,6 +809,12 @@ button {
   color: var(--text-primary);
   font-size: 0.92rem;
   line-height: 1.4;
+}
+
+.status-banner--error {
+  border-color: rgba(248, 113, 113, 0.32);
+  background: rgba(248, 113, 113, 0.14);
+  color: #fecaca;
 }
 
 .bottom-nav {
@@ -540,6 +867,11 @@ button {
     padding: 28px 22px 24px;
   }
 
+  .sync-banner {
+    padding: 10px 14px;
+    gap: 10px;
+  }
+
   .section-card {
     padding: 22px;
   }
@@ -551,6 +883,11 @@ button {
   .plan-grid,
   .support-grid,
   .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .intel-grid,
+  .model-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -597,6 +934,16 @@ button {
     border: 1px solid rgba(148, 163, 184, 0.2);
   }
 
+  .sync-banner {
+    background: rgba(97, 209, 255, 0.14);
+    border: 1px solid rgba(37, 99, 235, 0.22);
+    color: rgba(15, 23, 42, 0.7);
+  }
+
+  .sync-countdown {
+    color: #0f172a;
+  }
+
   .plan-card {
     background: rgba(255, 255, 255, 0.86);
     border: 1px solid rgba(148, 163, 184, 0.28);
@@ -617,6 +964,27 @@ button {
     border: 1px solid rgba(148, 163, 184, 0.24);
   }
 
+  .intel-card {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+  }
+
+  .intel-card--primary {
+    background: rgba(97, 209, 255, 0.16);
+    border-color: rgba(37, 99, 235, 0.28);
+  }
+
+  .alert-pill {
+    background: rgba(250, 204, 21, 0.14);
+    color: #b45309;
+    border-color: rgba(234, 179, 8, 0.26);
+  }
+
+  .model-card {
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+  }
+
   .bottom-nav {
     background: rgba(255, 255, 255, 0.92);
     border: 1px solid rgba(148, 163, 184, 0.24);
@@ -624,5 +992,11 @@ button {
 
   .nav-button--active {
     background: rgba(97, 209, 255, 0.22);
+  }
+
+  .status-banner--error {
+    background: rgba(248, 113, 113, 0.12);
+    border-color: rgba(248, 113, 113, 0.32);
+    color: #b91c1c;
   }
 }

--- a/dynamic-capital-ton/apps/miniapp/data/live-intel.ts
+++ b/dynamic-capital-ton/apps/miniapp/data/live-intel.ts
@@ -1,0 +1,331 @@
+export type LiveMetric = {
+  label: string;
+  value: string;
+  change?: string;
+  trend?: "up" | "down" | "steady";
+};
+
+export type LiveTimelineEntry = {
+  title: string;
+  status: "complete" | "pending" | "upcoming";
+  timestamp: string;
+  description: string;
+};
+
+export type ModelInsight = {
+  summary: string;
+  highlights: string[];
+  focus: string;
+  model: "grok-1" | "deepseek-v2";
+  riskScore?: number;
+};
+
+export type LiveIntelSnapshot = {
+  id: string;
+  timestamp: string;
+  narrative: string;
+  confidence?: number;
+  alerts: string[];
+  opportunities: string[];
+  risks: string[];
+  recommendedActions: string[];
+  metrics: LiveMetric[];
+  timeline: LiveTimelineEntry[];
+  models: {
+    grok: ModelInsight;
+    deepseek: ModelInsight;
+  };
+};
+
+export const DEFAULT_REFRESH_SECONDS = 45;
+
+export const LIVE_INTEL_SNAPSHOTS: LiveIntelSnapshot[] = [
+  {
+    id: "asia-open",
+    timestamp: "2025-03-05T08:00:00Z",
+    narrative:
+      "Grok-1 spots capital rotating back into TON majors as Asian desks reopen. Funding costs reset lower and momentum screens tilt risk-on.",
+    confidence: 0.74,
+    alerts: [
+      "DeepSeek-V2 Sentinel flags thinner liquidity from 18:00-20:00 UTC as US session winds down.",
+    ],
+    opportunities: [
+      "Scale into TON/USDT ladder while funding spreads remain compressed.",
+      "Express upside via delta-neutral vault overlay to capture basis without directional drag.",
+      "Shadow the desk's structured product basket; Grok-1 sees 1.2x Sharpe uplift vs. passive staking.",
+    ],
+    risks: [
+      "Overnight rollover may re-introduce 35-40 bps of funding slippage if liquidity stays thin.",
+      "Macro: CPI flash due in 14 hours, DeepSeek-V2 recommends keeping risk budgets 15% below ceiling.",
+    ],
+    recommendedActions: [
+      "Allocate 30% of auto-invest buffer to TON/USDT momentum sleeve before European open.",
+      "Queue hedges on BTC pairs in case macro data flips broader crypto beta negative.",
+      "Stage withdrawals through sequencer by 16:30 UTC to avoid the thin liquidity window.",
+    ],
+    metrics: [
+      {
+        label: "Desk yield runway",
+        value: "21.4% APY",
+        change: "+0.6%",
+        trend: "up",
+      },
+      {
+        label: "Live TON signals",
+        value: "14 active",
+        change: "2 new",
+        trend: "steady",
+      },
+      {
+        label: "Settlement latency",
+        value: "3m 12s",
+        change: "-24s",
+        trend: "down",
+      },
+    ],
+    timeline: [
+      {
+        title: "Desk sync complete",
+        status: "complete",
+        timestamp: "Live",
+        description: "Wallet handshake verified. Desk now mirroring Grok-1 allocations in real time.",
+      },
+      {
+        title: "Momentum sleeve deployment",
+        status: "pending",
+        timestamp: "Next cycle",
+        description: "Auto-invest queue will deploy into TON/USDT ladder at the 30-minute bar close.",
+      },
+      {
+        title: "Liquidity caution window",
+        status: "upcoming",
+        timestamp: "18:00 UTC",
+        description: "DeepSeek-V2 recommends trimming leverage ahead of the thin liquidity band.",
+      },
+    ],
+    models: {
+      grok: {
+        model: "grok-1",
+        focus: "Momentum + vault overlay",
+        summary:
+          "Signal deck favors high-conviction TON rotations with reduced funding drag. Expects carry premium to persist for 2-3 cycles.",
+        highlights: [
+          "Momentum breadth +14% versus 7-day average.",
+          "Vault overlay adds projected 0.8 Sharpe uplift.",
+          "Desk bias: maintain 30% buffer for macro surprises.",
+        ],
+      },
+      deepseek: {
+        model: "deepseek-v2",
+        focus: "Risk arbitration",
+        summary:
+          "DeepSeek-V2 Sentinel keeps risk dialled to medium. Recommends staggering entries and keeping hedge inventory warm ahead of CPI.",
+        highlights: [
+          "Liquidity gap flagged 18:00-20:00 UTC.",
+          "Max leverage suggestion: 1.8x core sleeve.",
+          "Macro risk budget trimmed by 15% pre-data.",
+        ],
+        riskScore: 0.42,
+      },
+    },
+  },
+  {
+    id: "eu-session",
+    timestamp: "2025-03-05T12:30:00Z",
+    narrative:
+      "Grok-1 reads a rotation into cross-chain yield as European desks chase basis. DeepSeek-V2 softens risk posture but keeps drawdown guardrails engaged.",
+    confidence: 0.68,
+    alerts: [
+      "Cross-chain bridge latency elevated by 11%. Monitor TON ↔ ETH lanes before sizing into new vaults.",
+    ],
+    opportunities: [
+      "Deploy idle USDT into the dynamic vault ladder capturing 180-220 bps of excess yield.",
+      "Mirror desk OTC block to access discounted TON borrow for structured carry.",
+      "Redirect mentorship cohort to follow Grok-1's live workshop at 15:00 UTC covering the rotation.",
+    ],
+    risks: [
+      "Bridge congestion can delay large ticket withdrawals by up to 6 minutes.",
+      "DeepSeek-V2 notes elevated counterparty variance on two OTC venues—route via desk rails only.",
+      "Macro: US data heavy session later; keep optionality for fast hedging.",
+    ],
+    recommendedActions: [
+      "Top up the cross-chain vault sleeve before latency decays the basis opportunity.",
+      "Keep 10% of capital liquid to pivot into post-data reversals.",
+      "Join the live workshop to align mentorship cohort execution with desk timing.",
+    ],
+    metrics: [
+      {
+        label: "Vault coverage",
+        value: "92% allocated",
+        change: "+5%",
+        trend: "up",
+      },
+      {
+        label: "Bridge latency",
+        value: "5m 48s",
+        change: "+38s",
+        trend: "up",
+      },
+      {
+        label: "Active cohorts",
+        value: "6 live rooms",
+        change: "Mentorship now",
+        trend: "steady",
+      },
+    ],
+    timeline: [
+      {
+        title: "Cross-chain vault top-up",
+        status: "complete",
+        timestamp: "12:20",
+        description: "Desk executed vault rebalance; Grok-1 confirmatory ping received.",
+      },
+      {
+        title: "Mentorship workshop",
+        status: "pending",
+        timestamp: "15:00 UTC",
+        description: "Live playbook review walking through the rotation with cohort leaders.",
+      },
+      {
+        title: "Data risk window",
+        status: "upcoming",
+        timestamp: "18:00 UTC",
+        description: "DeepSeek-V2 to re-run stress test immediately after macro print.",
+      },
+    ],
+    models: {
+      grok: {
+        model: "grok-1",
+        focus: "Cross-chain carry",
+        summary:
+          "Strategy leans into vault carry where basis remains fat. Suggests recycling profits into mentorship-led live trades for cohesion.",
+        highlights: [
+          "Carry spread +210 bps vs. baseline.",
+          "OTC desk offers 0.9% borrow discount if filled before US open.",
+          "Mentorship sync ensures consistent execution cadence.",
+        ],
+      },
+      deepseek: {
+        model: "deepseek-v2",
+        focus: "Counterparty & latency",
+        summary:
+          "DeepSeek-V2 keeps a cautious tone: emphasises routing through trusted rails and staging exits across multiple bridges.",
+        highlights: [
+          "Latency up 11% on TON ↔ ETH lanes.",
+          "Counterparty variance 1.4σ above mean on two OTC books.",
+          "Suggest staging withdrawal tickets to avoid congestion.",
+        ],
+        riskScore: 0.56,
+      },
+    },
+  },
+  {
+    id: "us-close",
+    timestamp: "2025-03-05T21:00:00Z",
+    narrative:
+      "Desk winds down US session exposure. Grok-1 favours locking gains while DeepSeek-V2 watches liquidity cliffs around the close.",
+    confidence: 0.62,
+    alerts: [
+      "DeepSeek-V2 flags widening spreads on TON/ETH during the close—expect up to 45 bps slippage if trading size.",
+      "Monitor sequencer backlog; withdrawals above 50k TON should be pre-scheduled.",
+    ],
+    opportunities: [
+      "Rotate excess yield into short-dated vault to hold gains overnight.",
+      "Mirror desk protective put overlay to guard against post-close gap risk.",
+      "Queue tomorrow's Asia session entries now while Grok-1 precomputes scenarios.",
+    ],
+    risks: [
+      "Slippage widens sharply on large TON/ETH blocks after 21:15 UTC.",
+      "Sequencer backlog risk as VIP cohort batches exit instructions.",
+      "Macro fatigue—VIX futures pricing in 1.3x normal overnight move.",
+    ],
+    recommendedActions: [
+      "Lock current cycle gains via the overnight vault sleeve.",
+      "Hold protective options overlay through the macro data window.",
+      "Ping concierge if planning withdrawals above 50k TON to pre-clear lanes.",
+    ],
+    metrics: [
+      {
+        label: "Cycle PnL locked",
+        value: "+4.6%",
+        change: "Settled",
+        trend: "steady",
+      },
+      {
+        label: "Sequencer load",
+        value: "63%",
+        change: "+12%",
+        trend: "up",
+      },
+      {
+        label: "Overnight risk budget",
+        value: "1.1x",
+        change: "Within guardrails",
+        trend: "steady",
+      },
+    ],
+    timeline: [
+      {
+        title: "Cycle wrap",
+        status: "complete",
+        timestamp: "20:45",
+        description: "Desk captured profits and redistributed into the overnight vault.",
+      },
+      {
+        title: "Protective overlay",
+        status: "pending",
+        timestamp: "21:10 UTC",
+        description: "DeepSeek-V2 verifying hedge coverage before the close.",
+      },
+      {
+        title: "Asia prep",
+        status: "upcoming",
+        timestamp: "23:30 UTC",
+        description: "Grok-1 running new playbooks for tomorrow's Asia session entries.",
+      },
+    ],
+    models: {
+      grok: {
+        model: "grok-1",
+        focus: "Cycle reset",
+        summary:
+          "Prioritise locking in gains and staging Asia session plans. Keep optionality to re-enter if volatility fades overnight.",
+        highlights: [
+          "PnL locked at +4.6% for the cycle.",
+          "Asia prep scenarios seeded across three volatility regimes.",
+          "Desk bias: run lighter through macro window, add risk after recalibration.",
+        ],
+      },
+      deepseek: {
+        model: "deepseek-v2",
+        focus: "Liquidity & execution",
+        summary:
+          "DeepSeek-V2 emphasises execution discipline—avoid chasing late prints and stagger exits to sidestep sequencer queues.",
+        highlights: [
+          "Spreads on TON/ETH widening post 21:15 UTC.",
+          "Sequencer load trending 12% above baseline.",
+          "Maintain overnight risk budget at 1.1x until macro clears.",
+        ],
+        riskScore: 0.61,
+      },
+    },
+  },
+];
+
+export function resolveSnapshotIndex(index: number, total: number): number {
+  if (!Number.isFinite(index)) {
+    return 0;
+  }
+  if (total <= 0) {
+    return 0;
+  }
+  const mod = index % total;
+  return mod < 0 ? mod + total : mod;
+}
+
+export function snapshotForTimestamp(date: Date): LiveIntelSnapshot {
+  const total = LIVE_INTEL_SNAPSHOTS.length;
+  const cycle = Math.floor(date.getTime() / (DEFAULT_REFRESH_SECONDS * 1000));
+  const index = resolveSnapshotIndex(cycle, total);
+  return LIVE_INTEL_SNAPSHOTS[index];
+}


### PR DESCRIPTION
## Summary
- add a polling hook, sync banner, and live intelligence view so the TON mini app stays current with Grok-1 and DeepSeek-V2 guidance
- publish curated Grok/DeepSeek snapshot data and expose a `/api/live-intel` endpoint that rotates snapshots and reports next refresh timing
- refresh mini app styling with sync indicators, skeleton states, and model breakdown cards highlighting strategist vs risk officer insights

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5df0319308322afcce60fed4554da