### PR TITLE
Fix analytics revenue parsing

### DIFF
--- a/supabase/functions/analytics-data/index.ts
+++ b/supabase/functions/analytics-data/index.ts
@@ -130,8 +130,10 @@ export const handler = registerHandler(async (req) => {
     }
 
     // Calculate total revenue
-    const totalRevenue = revenueData?.reduce((sum, payment) =>
-      sum + (payment.amount || 0), 0) || 0;
+    const totalRevenue = (revenueData ?? []).reduce((sum, payment) => {
+      const amount = Number(payment.amount ?? 0);
+      return sum + (Number.isFinite(amount) ? amount : 0);
+    }, 0);
     logStep("Total revenue calculated", { totalRevenue });
 
     // Calculate package performance
@@ -143,15 +145,17 @@ export const handler = registerHandler(async (req) => {
         sub.plan_id === plan.id
       ) || [];
 
-      const revenue = planPayments.reduce((sum, payment) =>
-        sum + (payment.amount || 0), 0);
+      const revenue = planPayments.reduce((sum, payment) => {
+        const amount = Number(payment.amount ?? 0);
+        return sum + (Number.isFinite(amount) ? amount : 0);
+      }, 0);
       const sales = planSubscriptions.length;
 
       return {
         id: plan.id,
         name: plan.name,
         sales,
-        revenue: revenue / 100, // Convert from cents
+        revenue,
         currency: plan.currency || "USD",
       };
     }) || [];
@@ -168,7 +172,7 @@ export const handler = registerHandler(async (req) => {
 
     const analyticsData = {
       timeframe,
-      total_revenue: totalRevenue / 100, // Convert from cents
+      total_revenue: totalRevenue,
       currency: "USD",
       comparison: comparisonData,
       package_performance: packagePerformance,

--- a/tests/analytics-data-supabase-stub.ts
+++ b/tests/analytics-data-supabase-stub.ts
@@ -1,0 +1,215 @@
+interface PaymentRow extends Record<string, unknown> {
+  amount?: string | number | null;
+  status?: string | null;
+  created_at?: string | null;
+  plan_id?: string | null;
+  currency?: string | null;
+}
+
+interface SubscriptionRow extends Record<string, unknown> {
+  plan_id?: string | null;
+  payment_status?: string | null;
+  created_at?: string | null;
+}
+
+interface PlanRow extends Record<string, unknown> {
+  id?: string | null;
+  name?: string | null;
+  price?: number | string | null;
+  currency?: string | null;
+}
+
+interface CountableRow extends Record<string, unknown> {
+  created_at?: string | null;
+}
+
+interface SelectOptions {
+  count?: "exact";
+  head?: boolean;
+}
+
+interface QueryResult<T> {
+  data: T[];
+  error: { message: string } | null;
+  count?: number;
+}
+
+interface AnalyticsDataStubState {
+  payments: PaymentRow[];
+  userSubscriptions: SubscriptionRow[];
+  subscriptionPlans: PlanRow[];
+  botUsers: CountableRow[];
+  currentVip: CountableRow[];
+}
+
+const state: AnalyticsDataStubState = {
+  payments: [],
+  userSubscriptions: [],
+  subscriptionPlans: [],
+  botUsers: [],
+  currentVip: [],
+};
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function toComparable(value: unknown): { kind: "number" | "string"; value: number | string } | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") {
+    return { kind: "number", value };
+  }
+  if (typeof value === "string") {
+    return { kind: "string", value };
+  }
+  if (value instanceof Date) {
+    return { kind: "string", value: value.toISOString() };
+  }
+  return { kind: "string", value: String(value) };
+}
+
+function compareValues(left: unknown, right: unknown): number | null {
+  const a = toComparable(left);
+  const b = toComparable(right);
+  if (!a || !b) return null;
+  if (a.kind === "number" && b.kind === "number") {
+    return a.value - b.value;
+  }
+  const as = String(a.value);
+  const bs = String(b.value);
+  return as.localeCompare(bs);
+}
+
+class QueryBuilder<T extends Record<string, unknown>> {
+  private readonly filters: ((row: T) => boolean)[] = [];
+
+  constructor(
+    private readonly rows: T[],
+    private readonly options: SelectOptions = {},
+  ) {}
+
+  eq(field: string, value: unknown): QueryBuilder<T> {
+    this.filters.push((row) => row[field] === value);
+    return this;
+  }
+
+  gte(field: string, value: unknown): QueryBuilder<T> {
+    this.filters.push((row) => {
+      const cmp = compareValues(row[field], value);
+      return cmp !== null && cmp >= 0;
+    });
+    return this;
+  }
+
+  lte(field: string, value: unknown): QueryBuilder<T> {
+    this.filters.push((row) => {
+      const cmp = compareValues(row[field], value);
+      return cmp !== null && cmp <= 0;
+    });
+    return this;
+  }
+
+  private applyFilters(): T[] {
+    return this.rows.filter((row) => this.filters.every((fn) => fn(row)));
+  }
+
+  private buildResult(): QueryResult<T> {
+    const filtered = this.applyFilters().map((row) => clone(row));
+    const payload: QueryResult<T> = {
+      data: this.options.head ? [] : filtered,
+      error: null,
+    };
+    if (this.options.count === "exact") {
+      payload.count = filtered.length;
+    }
+    return payload;
+  }
+
+  async maybeSingle(): Promise<{ data: T | null; error: { message: string } | null }> {
+    const filtered = this.applyFilters().map((row) => clone(row));
+    return { data: filtered[0] ?? null, error: null };
+  }
+
+  async single(): Promise<{ data: T | null; error: { message: string } | null }> {
+    const filtered = this.applyFilters().map((row) => clone(row));
+    if (filtered.length === 1) {
+      return { data: filtered[0], error: null };
+    }
+    if (filtered.length === 0) {
+      return { data: null, error: { message: "no rows" } };
+    }
+    return { data: null, error: { message: "multiple rows" } };
+  }
+
+  then<TResult1 = QueryResult<T>, TResult2 = never>(
+    onfulfilled?: ((value: QueryResult<T>) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    const promise = Promise.resolve(this.buildResult());
+    return promise.then(onfulfilled ?? (value => value as unknown as TResult1), onrejected ?? undefined);
+  }
+}
+
+function createTableHandler<T extends Record<string, unknown>>(
+  getRows: () => T[],
+) {
+  return {
+    select(_columns?: string, options?: SelectOptions) {
+      const rows = getRows().map((row) => clone(row));
+      return new QueryBuilder(rows, options);
+    },
+  };
+}
+
+class AnalyticsDataSupabaseClient {
+  from(table: string) {
+    switch (table) {
+      case "payments":
+        return createTableHandler(() => state.payments);
+      case "user_subscriptions":
+        return createTableHandler(() => state.userSubscriptions);
+      case "subscription_plans":
+        return createTableHandler(() => state.subscriptionPlans);
+      case "bot_users":
+        return createTableHandler(() => state.botUsers);
+      case "current_vip":
+        return createTableHandler(() => state.currentVip);
+      default:
+        return createTableHandler(() => []);
+    }
+  }
+}
+
+export function createClient(): AnalyticsDataSupabaseClient {
+  return new AnalyticsDataSupabaseClient();
+}
+
+export function __resetAnalyticsDataStubState() {
+  state.payments = [];
+  state.userSubscriptions = [];
+  state.subscriptionPlans = [];
+  state.botUsers = [];
+  state.currentVip = [];
+}
+
+export function __setAnalyticsDataStubState(
+  partial: Partial<AnalyticsDataStubState>,
+) {
+  if (partial.payments) {
+    state.payments = partial.payments.map((row) => clone(row));
+  }
+  if (partial.userSubscriptions) {
+    state.userSubscriptions = partial.userSubscriptions.map((row) => clone(row));
+  }
+  if (partial.subscriptionPlans) {
+    state.subscriptionPlans = partial.subscriptionPlans.map((row) => clone(row));
+  }
+  if (partial.botUsers) {
+    state.botUsers = partial.botUsers.map((row) => clone(row));
+  }
+  if (partial.currentVip) {
+    state.currentVip = partial.currentVip.map((row) => clone(row));
+  }
+}
+
+export type { AnalyticsDataStubState };

--- a/tests/analytics-data.test.ts
+++ b/tests/analytics-data.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import {
+  strictEqual as assertStrictEqual,
+  ok as assert,
+} from 'node:assert/strict';
+import { freshImport } from './utils/freshImport.ts';
+import {
+  __resetAnalyticsDataStubState,
+  __setAnalyticsDataStubState,
+} from './analytics-data-supabase-stub.ts';
+
+function isoMinutesAgo(minutes: number) {
+  return new Date(Date.now() - minutes * 60 * 1000).toISOString();
+}
+
+test('analytics-data aggregates string payment amounts without scaling', async () => {
+  __resetAnalyticsDataStubState();
+  const createdAt = isoMinutesAgo(5);
+
+  __setAnalyticsDataStubState({
+    payments: [
+      {
+        id: 'pay-basic',
+        amount: '123.45',
+        status: 'completed',
+        created_at: createdAt,
+        plan_id: 'basic',
+        currency: 'USD',
+      },
+      {
+        id: 'pay-pro',
+        amount: '200',
+        status: 'completed',
+        created_at: createdAt,
+        plan_id: 'pro',
+        currency: 'USD',
+      },
+      {
+        id: 'pay-pending',
+        amount: '50.5',
+        status: 'pending',
+        created_at: createdAt,
+        plan_id: 'basic',
+        currency: 'USD',
+      },
+    ],
+    userSubscriptions: [
+      { plan_id: 'basic', payment_status: 'completed', created_at: createdAt },
+      { plan_id: 'pro', payment_status: 'completed', created_at: createdAt },
+    ],
+    subscriptionPlans: [
+      { id: 'basic', name: 'Basic Plan', currency: 'USD' },
+      { id: 'pro', name: 'Pro Plan', currency: 'USD' },
+    ],
+    botUsers: [{ id: 'user-1', created_at: createdAt }],
+    currentVip: [{ telegram_id: 'vip-1', is_vip: true, created_at: createdAt }],
+  });
+
+  let patched: URL | undefined;
+  try {
+    const original = new URL('../supabase/functions/analytics-data/index.ts', import.meta.url);
+    patched = new URL('../supabase/functions/analytics-data/index.test.ts', import.meta.url);
+    let source = await Deno.readTextFile(original);
+    source = source.replace('../_shared/client.ts', '../../../tests/analytics-data-supabase-stub.ts');
+    source = source.replace('../_shared/serve.ts', '../../../tests/serve-stub.ts');
+    await Deno.writeTextFile(patched, source);
+
+    const { handler } = await freshImport(patched);
+    const request = new Request('http://localhost/analytics-data', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ timeframe: 'today' }),
+    });
+
+    const response = await handler(request);
+    assertStrictEqual(response.status, 200);
+    const payload = await response.json();
+
+    assertStrictEqual(typeof payload.total_revenue, 'number');
+    assertStrictEqual(payload.total_revenue, 323.45);
+    assertStrictEqual(payload.pending_payments, 1);
+
+    const performance = payload.package_performance;
+    assert(Array.isArray(performance));
+    const revenueByPlan = new Map(performance.map((plan: { id: string; revenue: number }) => [plan.id, plan.revenue]));
+    assert(revenueByPlan.has('basic'));
+    assert(revenueByPlan.has('pro'));
+    assertStrictEqual(revenueByPlan.get('basic'), 123.45);
+    assertStrictEqual(revenueByPlan.get('pro'), 200);
+    assertStrictEqual(
+      payload.total_revenue,
+      Number(revenueByPlan.get('basic')) + Number(revenueByPlan.get('pro')),
+    );
+  } finally {
+    if (patched) {
+      await Deno.remove(patched).catch(() => {});
+    }
+    __resetAnalyticsDataStubState();
+  }
+});


### PR DESCRIPTION
## Summary
- ensure the analytics-data edge function coerces payment amounts to numbers before aggregation and stop dividing values by 100
- add a lightweight Supabase client stub that supports the analytics-data queries and expose helpers to configure stub state for tests
- cover analytics-data with a regression test that seeds string payment amounts and verifies totals and per-plan revenue

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5e2c529288322a6037e252879ae2a