### PR TITLE
Fix login page build error by forcing dynamic rendering

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -5,6 +5,9 @@ export const metadata = {
   description: "Access your Dynamic Capital trading dashboard and manage VIP membership settings.",
 };
 
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
 export default function LoginPage() {
   return <AuthForm />;
 }


### PR DESCRIPTION
## Summary
- mark the login route as force-dynamic and disable fetch caching
- prevent Next.js static generation failures that caused the /login page to 404 in production

## Testing
- npm run lint
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5e2b3abf8832298b3cf6637602f02