### PR TITLE
Add Yahoo Finance backtest data collector CLI

### DIFF
--- a/algorithms/python/backtest_data_collector.py
+++ b/algorithms/python/backtest_data_collector.py
@@ -1,0 +1,282 @@
+"""Fetch historical bars and build MarketSnapshot CSVs for backtesting."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+from .data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+from .training_workflow import PreparedSnapshotDataset, prepare_market_snapshot_dataset
+
+YAHOO_BASE_URL = "https://query1.finance.yahoo.com/v7/finance/download/{symbol}"
+SUPPORTED_INTERVALS = {
+    "1m",
+    "5m",
+    "15m",
+    "30m",
+    "60m",
+    "90m",
+    "1h",
+    "1d",
+    "1wk",
+    "1mo",
+}
+
+
+@dataclass(frozen=True)
+class YahooDownloadConfig:
+    """Parameters required to download bars from Yahoo Finance."""
+
+    symbol: str
+    start: datetime
+    end: datetime
+    interval: str = "1h"
+
+    def __post_init__(self) -> None:
+        if self.interval not in SUPPORTED_INTERVALS:
+            raise ValueError(f"Unsupported interval '{self.interval}'")
+        if self.start >= self.end:
+            raise ValueError("start must be earlier than end")
+
+    @property
+    def query(self) -> dict:
+        start_epoch = _to_epoch_seconds(self.start)
+        # Yahoo treats period2 as exclusive; extend slightly to include the final bar.
+        end_epoch = _to_epoch_seconds(self.end + timedelta(seconds=1))
+        return {
+            "period1": str(start_epoch),
+            "period2": str(end_epoch),
+            "interval": "1h" if self.interval == "60m" else self.interval,
+            "events": "history",
+            "includeAdjustedClose": "true",
+        }
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_yahoo_csv(csv_text: str) -> List[RawBar]:
+    """Parse Yahoo Finance CSV payload into :class:`RawBar` instances."""
+
+    reader = csv.DictReader(io.StringIO(csv_text))
+    bars: List[RawBar] = []
+    for row in reader:
+        try:
+            timestamp = _parse_timestamp(row.get("Date", ""))
+            open_price = _parse_float(row.get("Open"))
+            high = _parse_float(row.get("High"))
+            low = _parse_float(row.get("Low"))
+            close = _parse_float(row.get("Close"))
+            volume = _parse_float(row.get("Volume"), allow_null=True)
+        except ValueError:
+            # Skip incomplete or placeholder rows (weekends/holidays).
+            continue
+        bars.append(
+            RawBar(
+                timestamp=timestamp,
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                volume=volume,
+            )
+        )
+    bars.sort(key=lambda bar: bar.timestamp)
+    return bars
+
+
+def download_yahoo_bars(config: YahooDownloadConfig) -> List[RawBar]:
+    """Fetch OHLC data from Yahoo Finance and parse it into bars."""
+
+    url = f"{YAHOO_BASE_URL.format(symbol=config.symbol)}?{urlencode(config.query)}"
+    try:
+        with urlopen(url) as response:  # type: ignore[arg-type]
+            payload = response.read().decode("utf-8")
+    except (HTTPError, URLError) as exc:  # pragma: no cover - network failure
+        raise RuntimeError(f"Failed to download data for {config.symbol}: {exc}") from exc
+    bars = parse_yahoo_csv(payload)
+    if not bars:
+        raise RuntimeError(f"Yahoo Finance returned no usable bars for {config.symbol}")
+    return bars
+
+
+def collect_backtest_data(
+    *,
+    dataset_symbol: str,
+    vendor_symbol: Optional[str],
+    start: datetime,
+    end: datetime,
+    interval: str,
+    pip_size: float,
+    pip_value: float,
+    output_path: Optional[Path] = None,
+    metadata_path: Optional[Path] = None,
+    job: Optional[MarketDataIngestionJob] = None,
+    bars: Optional[Sequence[RawBar]] = None,
+) -> PreparedSnapshotDataset:
+    """Download OHLC data and build a :class:`PreparedSnapshotDataset`."""
+
+    if start >= end:
+        raise ValueError("start must be earlier than end")
+
+    config = YahooDownloadConfig(
+        symbol=vendor_symbol or dataset_symbol,
+        start=start,
+        end=end,
+        interval=interval,
+    )
+
+    series: Sequence[RawBar]
+    if bars is None:
+        series = download_yahoo_bars(config)
+    else:
+        series = list(bars)
+        if not series:
+            raise ValueError("bars must be non-empty when provided explicitly")
+    instrument = InstrumentMeta(symbol=dataset_symbol, pip_size=pip_size, pip_value=pip_value)
+    return prepare_market_snapshot_dataset(
+        series,
+        instrument,
+        job=job,
+        snapshot_path=output_path,
+        metadata_path=metadata_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_epoch_seconds(moment: datetime) -> int:
+    if moment.tzinfo is None:
+        aware = moment.replace(tzinfo=timezone.utc)
+    else:
+        aware = moment.astimezone(timezone.utc)
+    return int(aware.timestamp())
+
+
+def _parse_timestamp(raw: str) -> datetime:
+    cleaned = raw.strip()
+    if not cleaned:
+        raise ValueError("timestamp missing")
+    if cleaned.endswith("Z"):
+        cleaned = cleaned[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        try:
+            parsed = datetime.strptime(cleaned, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError(f"Unrecognised timestamp: {raw}") from exc
+        parsed = parsed.replace(tzinfo=UTC)
+    else:
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        else:
+            parsed = parsed.astimezone(UTC)
+    return parsed
+
+
+def _parse_float(value: Optional[str], *, allow_null: bool = False) -> float:
+    if value is None:
+        raise ValueError("missing numeric value")
+    cleaned = value.strip()
+    if not cleaned or cleaned.lower() == "null":
+        if allow_null:
+            return 0.0
+        raise ValueError("null numeric value")
+    return float(cleaned)
+
+
+def _parse_cli_datetime(raw: str) -> datetime:
+    cleaned = raw.strip()
+    if not cleaned:
+        raise ValueError("datetime argument cannot be empty")
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError:
+        parsed = datetime.strptime(cleaned, "%Y-%m-%d")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Collect Yahoo Finance data for backtesting")
+    parser.add_argument("symbol", help="Instrument symbol to store in the dataset (e.g. XAUUSD)")
+    parser.add_argument("output", type=Path, help="CSV path to write MarketSnapshot rows")
+    parser.add_argument("--vendor-symbol", help="Override vendor symbol if it differs from dataset symbol")
+    parser.add_argument("--start", required=True, help="Start datetime (YYYY-MM-DD or ISO8601)")
+    parser.add_argument("--end", required=True, help="End datetime (YYYY-MM-DD or ISO8601)")
+    parser.add_argument("--interval", default="1h", help="Yahoo Finance interval (default: 1h)")
+    parser.add_argument("--pip-size", type=float, default=0.1, help="Instrument pip size")
+    parser.add_argument("--pip-value", type=float, default=1.0, help="Instrument pip value")
+    parser.add_argument("--metadata", type=Path, help="Optional metadata output path")
+    parser.add_argument("--rsi-fast", type=int, default=9, help="Fast RSI period")
+    parser.add_argument("--rsi-slow", type=int, default=14, help="Slow RSI period")
+    parser.add_argument("--adx-fast", type=int, default=9, help="Fast ADX period")
+    parser.add_argument("--adx-slow", type=int, default=14, help="Slow ADX period")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    start = _parse_cli_datetime(args.start)
+    end = _parse_cli_datetime(args.end)
+    job = MarketDataIngestionJob(
+        rsi_fast=args.rsi_fast,
+        rsi_slow=args.rsi_slow,
+        adx_fast=args.adx_fast,
+        adx_slow=args.adx_slow,
+    )
+
+    result = collect_backtest_data(
+        dataset_symbol=args.symbol,
+        vendor_symbol=args.vendor_symbol,
+        start=start,
+        end=end,
+        interval=args.interval,
+        pip_size=args.pip_size,
+        pip_value=args.pip_value,
+        output_path=args.output,
+        metadata_path=args.metadata,
+        job=job,
+    )
+
+    print(
+        f"Collected {len(result.snapshots)} snapshots for {args.symbol} "
+        f"from {start.isoformat()} to {end.isoformat()}"
+    )
+    if result.snapshot_path:
+        print(f"Snapshots saved to {result.snapshot_path}")
+    if result.metadata_path:
+        print(f"Metadata saved to {result.metadata_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+
+
+__all__ = [
+    "YahooDownloadConfig",
+    "collect_backtest_data",
+    "download_yahoo_bars",
+    "main",
+    "parse_yahoo_csv",
+]

--- a/algorithms/python/tests/test_backtest_data_collector.py
+++ b/algorithms/python/tests/test_backtest_data_collector.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from algorithms.python.backtest_data_collector import (
+    YahooDownloadConfig,
+    collect_backtest_data,
+    parse_yahoo_csv,
+)
+from algorithms.python.data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+
+
+@pytest.fixture
+def sample_csv() -> str:
+    lines = ["Date,Open,High,Low,Close,Adj Close,Volume"]
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    price = 2000.0
+    for idx in range(20):
+        timestamp = start + timedelta(hours=idx)
+        open_price = price
+        high = price + 3.0
+        low = price - 3.0
+        close = price + (1.5 if idx % 2 == 0 else -1.2)
+        volume = 1000 + idx
+        stamp = timestamp.isoformat().replace("+00:00", "Z")
+        lines.append(
+            f"{stamp},{open_price:.2f},{high:.2f},{low:.2f},{close:.2f},{close:.2f},{volume}"
+        )
+        price = close
+    return "\n".join(lines)
+
+
+@pytest.fixture
+def sample_bars(sample_csv: str) -> list[RawBar]:
+    return parse_yahoo_csv(sample_csv)
+
+
+def test_parse_yahoo_csv(sample_csv: str) -> None:
+    bars = parse_yahoo_csv(sample_csv)
+    assert len(bars) == 20
+    assert bars[0].timestamp == datetime(2024, 1, 1, tzinfo=timezone.utc)
+    assert bars[-1].close != 0.0
+
+
+def test_collect_backtest_data(tmp_path: Path, sample_bars: list[RawBar]) -> None:
+    instrument = InstrumentMeta(symbol="XAUUSD", pip_size=0.1, pip_value=1.0)
+    job = MarketDataIngestionJob(rsi_fast=3, rsi_slow=5, adx_fast=3, adx_slow=5)
+    result = collect_backtest_data(
+        dataset_symbol=instrument.symbol,
+        vendor_symbol=None,
+        start=sample_bars[0].timestamp,
+        end=sample_bars[-1].timestamp,
+        interval="1h",
+        pip_size=instrument.pip_size,
+        pip_value=instrument.pip_value,
+        output_path=tmp_path / "snapshots.csv",
+        metadata_path=tmp_path / "snapshots.metadata.json",
+        job=job,
+        bars=sample_bars,
+    )
+    assert result.snapshots
+    assert result.snapshot_path and result.snapshot_path.exists()
+    assert result.metadata_path and result.metadata_path.exists()
+    assert result.metadata["symbol"] == instrument.symbol
+
+
+def test_yahoo_download_config_validates_interval(sample_bars: list[RawBar]) -> None:
+    start = sample_bars[0].timestamp
+    end = sample_bars[-1].timestamp
+    with pytest.raises(ValueError):
+        YahooDownloadConfig(symbol="XAUUSD=X", start=start, end=end, interval="2h")
+
+    with pytest.raises(ValueError):
+        YahooDownloadConfig(symbol="XAUUSD=X", start=end, end=start, interval="1h")

--- a/docs/trading-runbook.md
+++ b/docs/trading-runbook.md
@@ -1,11 +1,12 @@
 # Trading Operations Runbook
 
-This runbook describes the end-to-end operational lifecycle for the Lorentzian k-NN
-strategy that powers Dynamic Capital's discretionary trading stack.
+This runbook describes the end-to-end operational lifecycle for the Lorentzian
+k-NN strategy that powers Dynamic Capital's discretionary trading stack.
 
 ## 1. Daily Data Refresh
 
-1. Export the previous trading day's OHLC candles from the broker or data vendor.
+1. Export the previous trading day's OHLC candles from the broker or data
+   vendor.
 2. Run the historical ingestion job:
    ```python
    from pathlib import Path
@@ -17,6 +18,14 @@ strategy that powers Dynamic Capital's discretionary trading stack.
    instrument = InstrumentMeta(symbol="XAUUSD", pip_size=0.1, pip_value=1.0)
    snapshots = job.run(bars, instrument)
    job.save_csv(snapshots, Path("data/xauusd_snapshots.csv"))
+   ```
+   Alternatively, pull bars directly from Yahoo Finance with the collector CLI:
+   ```bash
+   python -m algorithms.python.backtest_data_collector \
+     XAUUSD data/xauusd_snapshots.csv \
+     --vendor-symbol XAUUSD=X \
+     --start 2024-01-01 --end 2024-01-31 --interval 1h \
+     --metadata data/xauusd_snapshots.metadata.json
    ```
 3. Store the resulting snapshots in the research data lake (e.g. S3 or Supabase
    storage) and update the catalogue entry with the generated metadata file.
@@ -49,8 +58,8 @@ strategy that powers Dynamic Capital's discretionary trading stack.
    ```
 3. Review the resulting `BacktestResult` metrics (hit rate, profit factor,
    drawdown) and promote the best configuration into the staging registry.
-4. Freeze the trained artefacts via `model_artifacts.save_artifacts`, storing the
-   scaler state, neighbour set, and configuration document.
+4. Freeze the trained artefacts via `model_artifacts.save_artifacts`, storing
+   the scaler state, neighbour set, and configuration document.
 
 ## 4. Pre-Deployment Validation
 
@@ -84,4 +93,3 @@ strategy that powers Dynamic Capital's discretionary trading stack.
 4. Trigger the rollback procedure (redeploy the previous artefact version) if
    production performance deviates materially from backtest expectations or if
    risk limits are breached.
-


### PR DESCRIPTION
## Summary
- add a Yahoo Finance-backed collector module that turns downloaded OHLC bars into MarketSnapshot CSVs
- cover the CSV parser and orchestration helper with unit tests
- document the CLI workflow in the trading runbook

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_backtest_data_collector.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d612c6e2608322a29c79bb93703bc3