### PR TITLE
feat: sync trading logic with AwesomeAPI feed

### DIFF
--- a/algorithms/README.md
+++ b/algorithms/README.md
@@ -28,6 +28,9 @@ remain in the top-level `supabase/` directory.
 - `python/realtime.py` – wire Grok into `RealtimeExecutor` by supplying an
   advisor instance; decisions surface the returned rationale under the
   `context["advisor"]` key for downstream audit trails.
+- `python/awesome_api.py` – converts AwesomeAPI FX/crypto data into
+  `MarketSnapshot` objects so the Python trading stack and live logic consume
+  the same market feed used by the product surfaces.
 
 To enable Grok feedback in a live service, instantiate a completion client
 (e.g. wrapping the local `grok-1` `InferenceRunner`) and pass a configured

--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -1,6 +1,21 @@
 """Python trading strategy utilities for Dynamic Capital."""
 
 from . import trade_logic as _trade_logic
+from .awesome_api import AwesomeAPIClient, AwesomeAPIError, AwesomeAPISnapshotBuilder
 
-__all__ = getattr(_trade_logic, "__all__", [])  # type: ignore[attr-defined]
-globals().update({name: getattr(_trade_logic, name) for name in __all__})
+_trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
+
+__all__ = _trade_exports + [
+    "AwesomeAPIClient",
+    "AwesomeAPIError",
+    "AwesomeAPISnapshotBuilder",
+]
+
+globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
+globals().update(
+    {
+        "AwesomeAPIClient": AwesomeAPIClient,
+        "AwesomeAPIError": AwesomeAPIError,
+        "AwesomeAPISnapshotBuilder": AwesomeAPISnapshotBuilder,
+    }
+)

--- a/algorithms/python/awesome_api.py
+++ b/algorithms/python/awesome_api.py
@@ -1,0 +1,175 @@
+"""AwesomeAPI market data helpers for Dynamic Capital trading systems."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import List, Mapping, MutableSequence, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+from .trade_logic import MarketSnapshot
+
+LOGGER = logging.getLogger(__name__)
+
+BASE_URL = "https://economia.awesomeapi.com.br"
+USER_AGENT = "DynamicCapitalBot/1.0"
+DEFAULT_HISTORY = 256
+DEFAULT_TIMEOUT = 10.0
+
+
+class AwesomeAPIError(RuntimeError):
+    """Raised when AwesomeAPI responses cannot be converted into market data."""
+
+
+def _parse_float(value: object, *, field_name: str) -> float:
+    if value is None:
+        raise ValueError(f"missing {field_name}")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"invalid {field_name}: {value!r}") from exc
+
+
+def _parse_timestamp(value: object) -> datetime:
+    if value is None:
+        raise ValueError("missing timestamp")
+    try:
+        epoch = int(str(value))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid timestamp: {value!r}") from exc
+    return datetime.fromtimestamp(epoch, tz=UTC)
+
+
+def _extract_close(entry: Mapping[str, object]) -> float:
+    candidates: MutableSequence[float] = []
+    for key in ("bid", "ask", "close"):
+        raw = entry.get(key)
+        if raw in (None, ""):
+            continue
+        try:
+            candidates.append(float(raw))
+        except (TypeError, ValueError):
+            continue
+    if not candidates:
+        raise ValueError("close price missing from AwesomeAPI payload")
+    if len(candidates) == 1:
+        return candidates[0]
+    return sum(candidates) / len(candidates)
+
+
+def _normalise_daily_payload(payload: Sequence[Mapping[str, object]]) -> List[RawBar]:
+    entries = sorted(
+        (entry for entry in payload if entry.get("timestamp") is not None),
+        key=lambda row: int(str(row["timestamp"])),
+    )
+    bars: List[RawBar] = []
+    previous_close: float | None = None
+    for entry in entries:
+        try:
+            timestamp = _parse_timestamp(entry.get("timestamp"))
+            high = _parse_float(entry.get("high"), field_name="high")
+            low = _parse_float(entry.get("low"), field_name="low")
+            close = _extract_close(entry)
+        except ValueError as exc:
+            LOGGER.debug("Skipping AwesomeAPI entry due to error: %s", exc)
+            continue
+        if high < low:
+            high, low = low, high
+        open_price = previous_close if previous_close is not None else close
+        bars.append(
+            RawBar(
+                timestamp=timestamp,
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                volume=0.0,
+            )
+        )
+        previous_close = close
+    return bars
+
+
+@dataclass(slots=True)
+class AwesomeAPIClient:
+    """Lightweight HTTP client for AwesomeAPI FX and crypto endpoints."""
+
+    base_url: str = BASE_URL
+    user_agent: str = USER_AGENT
+    timeout: float = DEFAULT_TIMEOUT
+
+    def fetch_daily(self, pair: str, *, limit: int) -> Sequence[Mapping[str, object]]:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        pair_clean = pair.strip()
+        url = f"{self.base_url}/json/daily/{pair_clean}/{limit}"
+        request = Request(url, headers={"User-Agent": self.user_agent})
+        try:
+            with urlopen(request, timeout=self.timeout) as response:  # type: ignore[arg-type]
+                raw = response.read()
+        except (HTTPError, URLError, TimeoutError) as exc:  # pragma: no cover - network variance
+            raise AwesomeAPIError(f"Failed to fetch AwesomeAPI data for {pair_clean}: {exc}") from exc
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+            raise AwesomeAPIError(f"Invalid AwesomeAPI payload for {pair_clean}: {exc}") from exc
+        if not isinstance(payload, list):
+            raise AwesomeAPIError(
+                f"Unexpected AwesomeAPI response for {pair_clean}: {type(payload).__name__}"
+            )
+        return payload
+
+    def fetch_bars(self, pair: str, *, limit: int) -> List[RawBar]:
+        payload = self.fetch_daily(pair, limit=limit)
+        bars = _normalise_daily_payload(payload)
+        if not bars:
+            raise AwesomeAPIError(f"AwesomeAPI returned no usable bars for {pair}")
+        return bars
+
+
+@dataclass(slots=True)
+class AwesomeAPISnapshotBuilder:
+    """Build :class:`MarketSnapshot` sequences from AwesomeAPI market data."""
+
+    client: AwesomeAPIClient = field(default_factory=AwesomeAPIClient)
+    job: MarketDataIngestionJob = field(default_factory=MarketDataIngestionJob)
+    history: int = DEFAULT_HISTORY
+
+    def fetch_snapshots(
+        self,
+        pair: str,
+        instrument: InstrumentMeta,
+        *,
+        history: int | None = None,
+    ) -> List[MarketSnapshot]:
+        window = self.history if history is None else history
+        if window <= 0:
+            raise ValueError("history must be positive")
+        bars = self.client.fetch_bars(pair, limit=window)
+        snapshots = self.job.run(bars, instrument)
+        if not snapshots:
+            raise AwesomeAPIError(
+                f"Insufficient AwesomeAPI history for {pair}; received {len(bars)} bars"
+            )
+        return snapshots
+
+    def latest_snapshot(
+        self,
+        pair: str,
+        instrument: InstrumentMeta,
+        *,
+        history: int | None = None,
+    ) -> MarketSnapshot:
+        snapshots = self.fetch_snapshots(pair, instrument, history=history)
+        return snapshots[-1]
+
+
+__all__ = [
+    "AwesomeAPIClient",
+    "AwesomeAPIError",
+    "AwesomeAPISnapshotBuilder",
+]

--- a/algorithms/python/tests/test_awesome_api.py
+++ b/algorithms/python/tests/test_awesome_api.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import io
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from algorithms.python.awesome_api import (
+    AwesomeAPIClient,
+    AwesomeAPIError,
+    AwesomeAPISnapshotBuilder,
+)
+from algorithms.python.data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
+
+
+class _DummyResponse(io.BytesIO):
+    def __enter__(self) -> "_DummyResponse":  # pragma: no cover - protocol glue
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - protocol glue
+        self.close()
+
+
+def _payload_entry(timestamp: int, close: float) -> dict[str, str]:
+    high = close + 0.5
+    low = close - 0.5
+    return {
+        "timestamp": str(timestamp),
+        "high": f"{high:.5f}",
+        "low": f"{low:.5f}",
+        "bid": f"{close:.5f}",
+        "ask": f"{(close + 0.0002):.5f}",
+    }
+
+
+def _bars(count: int) -> list[RawBar]:
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    price = 1800.0
+    series: list[RawBar] = []
+    for idx in range(count):
+        timestamp = start + timedelta(hours=idx)
+        close = price + (1.0 if idx % 2 == 0 else -0.8)
+        series.append(
+            RawBar(
+                timestamp=timestamp,
+                open=price,
+                high=price + 2.0,
+                low=price - 2.0,
+                close=close,
+                volume=0.0,
+            )
+        )
+        price = close
+    return series
+
+
+def test_client_fetch_bars_parses_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    from algorithms.python import awesome_api as module
+
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    payload = [
+        _payload_entry(int((base + timedelta(days=idx)).timestamp()), 1.05 + idx * 0.01)
+        for idx in range(4)
+    ]
+
+    def fake_urlopen(request, timeout: float):  # type: ignore[override]
+        return _DummyResponse(json.dumps(list(reversed(payload))).encode("utf-8"))
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    client = AwesomeAPIClient()
+    bars = client.fetch_bars("EUR-USD", limit=4)
+    assert len(bars) == 4
+    assert bars[0].timestamp < bars[-1].timestamp
+    assert pytest.approx(bars[1].open) == bars[0].close
+
+
+def test_client_fetch_bars_raises_for_invalid_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    from algorithms.python import awesome_api as module
+
+    def fake_urlopen(request, timeout: float):  # type: ignore[override]
+        return _DummyResponse(b"{\"invalid\": true}")
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    client = AwesomeAPIClient()
+    with pytest.raises(AwesomeAPIError):
+        client.fetch_bars("EUR-USD", limit=3)
+
+
+def test_snapshot_builder_returns_latest_snapshot() -> None:
+    class StubClient:
+        def fetch_bars(self, pair: str, *, limit: int) -> list[RawBar]:
+            assert pair == "XAU-USD"
+            assert limit == 30
+            return _bars(40)
+
+    builder = AwesomeAPISnapshotBuilder(
+        client=StubClient(),
+        job=MarketDataIngestionJob(rsi_fast=3, rsi_slow=5, adx_fast=3, adx_slow=5),
+        history=30,
+    )
+    instrument = InstrumentMeta(symbol="XAUUSD", pip_size=0.1, pip_value=1.0)
+    snapshot = builder.latest_snapshot("XAU-USD", instrument)
+    assert snapshot.symbol == instrument.symbol
+    assert 0 <= snapshot.rsi_fast <= 100
+    assert 0 <= snapshot.rsi_slow <= 100
+    assert snapshot.close == pytest.approx(_bars(40)[-1].close)
+
+
+def test_snapshot_builder_validates_history() -> None:
+    builder = AwesomeAPISnapshotBuilder()
+    instrument = InstrumentMeta(symbol="EURUSD", pip_size=0.0001, pip_value=10.0)
+    with pytest.raises(ValueError):
+        builder.fetch_snapshots("EUR-USD", instrument, history=0)
+
+
+def test_client_validates_limit() -> None:
+    client = AwesomeAPIClient()
+    with pytest.raises(ValueError):
+        client.fetch_daily("EUR-USD", limit=0)


### PR DESCRIPTION
## Summary
- add an AwesomeAPI client and snapshot builder so the python trading stack can consume the same market feed as the product UI
- allow the backtest data collector to pull bars from AwesomeAPI and export the helpers via the python package entrypoint
- cover the new AwesomeAPI integration with focused unit tests

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_awesome_api.py algorithms/python/tests/test_backtest_data_collector.py

------
https://chatgpt.com/codex/tasks/task_e_68d6159021808322a3c97fb594fe1e05