### PR TITLE
Rename FX market snapshot heading

### DIFF
--- a/apps/web/components/magic-portfolio/home/FxMarketSnapshotSection.tsx
+++ b/apps/web/components/magic-portfolio/home/FxMarketSnapshotSection.tsx
@@ -752,7 +752,7 @@ export function FxMarketSnapshotSection() {
     >
       <Column gap="12" maxWidth={32}>
         <Row gap="12" vertical="center">
-          <Heading variant="display-strong-xs">FX market snapshot</Heading>
+          <Heading variant="display-strong-xs">Dynamic market snapshot</Heading>
           <Tag size="s" background={statusTone} prefixIcon="clock">
             {statusLabel}
           </Tag>


### PR DESCRIPTION
## Summary
- update the FX market snapshot heading copy to read "Dynamic market snapshot"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d618ebaae08322a74b2e0a92b52417