### PR TITLE
Align AwesomeAPI timestamps with desk timezone

### DIFF
--- a/algorithms/python/tests/test_awesome_api.py
+++ b/algorithms/python/tests/test_awesome_api.py
@@ -72,6 +72,7 @@ def test_client_fetch_bars_parses_payload(monkeypatch: pytest.MonkeyPatch) -> No
     bars = client.fetch_bars("EUR-USD", limit=4)
     assert len(bars) == 4
     assert bars[0].timestamp < bars[-1].timestamp
+    assert bars[0].timestamp.tzinfo == module.DESK_TIME_ZONE
     assert pytest.approx(bars[1].open) == bars[0].close
 
 


### PR DESCRIPTION
## Summary
- update AwesomeAPI timestamp parsing to use the desk time zone instead of UTC
- fall back to UTC if the Maldives zoneinfo entry is unavailable and cover the behaviour with a unit test assertion

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_awesome_api.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d618a9fd4c8322bf361e179db36a8f