### PR TITLE
feat(algorithms): add AwesomeAPI auto calculation pipeline

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -1,11 +1,19 @@
 """Python trading strategy utilities for Dynamic Capital."""
 
 from . import trade_logic as _trade_logic
-from .awesome_api import AwesomeAPIClient, AwesomeAPIError, AwesomeAPISnapshotBuilder
+from .awesome_api import (
+    AwesomeAPIAutoCalculator,
+    AwesomeAPIAutoMetrics,
+    AwesomeAPIClient,
+    AwesomeAPIError,
+    AwesomeAPISnapshotBuilder,
+)
 
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
 
 __all__ = _trade_exports + [
+    "AwesomeAPIAutoCalculator",
+    "AwesomeAPIAutoMetrics",
     "AwesomeAPIClient",
     "AwesomeAPIError",
     "AwesomeAPISnapshotBuilder",
@@ -14,6 +22,8 @@ __all__ = _trade_exports + [
 globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
 globals().update(
     {
+        "AwesomeAPIAutoCalculator": AwesomeAPIAutoCalculator,
+        "AwesomeAPIAutoMetrics": AwesomeAPIAutoMetrics,
         "AwesomeAPIClient": AwesomeAPIClient,
         "AwesomeAPIError": AwesomeAPIError,
         "AwesomeAPISnapshotBuilder": AwesomeAPISnapshotBuilder,

--- a/algorithms/python/awesome_api.py
+++ b/algorithms/python/awesome_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import statistics
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import List, Mapping, MutableSequence, Sequence
@@ -131,6 +132,111 @@ class AwesomeAPIClient:
         return bars
 
 
+@dataclass(frozen=True, slots=True)
+class AwesomeAPIAutoMetrics:
+    """Derived analytics from an AwesomeAPI price history."""
+
+    pair: str
+    sample_size: int
+    latest_close: float
+    previous_close: float
+    absolute_change: float
+    percentage_change: float
+    average_close: float
+    high: float
+    low: float
+    price_range: float
+    cumulative_return: float
+    average_daily_change: float
+    volatility: float
+    trend_strength: float
+
+
+@dataclass(slots=True)
+class AwesomeAPIAutoCalculator:
+    """Automatically summarise AwesomeAPI bars into actionable metrics."""
+
+    client: AwesomeAPIClient = field(default_factory=AwesomeAPIClient)
+    history: int = DEFAULT_HISTORY
+
+    def compute_metrics(
+        self,
+        pair: str,
+        *,
+        history: int | None = None,
+        bars: Sequence[RawBar] | None = None,
+    ) -> AwesomeAPIAutoMetrics:
+        """Fetch AwesomeAPI bars (or use supplied data) and compute analytics."""
+
+        if bars is None:
+            window = self.history if history is None else history
+            if window <= 1:
+                raise ValueError("history must be at least 2 to compute metrics")
+            series = self.client.fetch_bars(pair, limit=window)
+        else:
+            series = list(bars)
+            if not series:
+                raise ValueError("bars must be non-empty when provided explicitly")
+
+        return self._summarise(pair, series)
+
+    def _summarise(
+        self, pair: str, bars: Sequence[RawBar]
+    ) -> AwesomeAPIAutoMetrics:
+        if len(bars) < 2:
+            raise AwesomeAPIError(
+                f"AwesomeAPI returned insufficient history for {pair}; need at least 2 bars"
+            )
+
+        closes = [bar.close for bar in bars]
+        highs = [bar.high for bar in bars]
+        lows = [bar.low for bar in bars]
+
+        latest_close = closes[-1]
+        previous_close = closes[-2]
+        absolute_change = latest_close - previous_close
+        percentage_change = (
+            (absolute_change / previous_close) * 100.0 if previous_close else 0.0
+        )
+        average_close = sum(closes) / len(closes)
+        high = max(highs)
+        low = min(lows)
+        price_range = high - low
+        cumulative_return = (
+            (latest_close - closes[0]) / closes[0] if closes[0] else 0.0
+        )
+        deltas = [closes[idx] - closes[idx - 1] for idx in range(1, len(closes))]
+        average_daily_change = sum(deltas) / len(deltas) if deltas else 0.0
+        volatility = statistics.pstdev(closes) if len(closes) > 1 else 0.0
+
+        half = len(closes) // 2
+        if half:
+            first_avg = sum(closes[:half]) / half
+            second_avg = sum(closes[-half:]) / half
+        else:
+            first_avg = second_avg = average_close
+        trend_strength = (
+            (second_avg - first_avg) / first_avg if first_avg else 0.0
+        )
+
+        return AwesomeAPIAutoMetrics(
+            pair=pair,
+            sample_size=len(bars),
+            latest_close=latest_close,
+            previous_close=previous_close,
+            absolute_change=absolute_change,
+            percentage_change=percentage_change,
+            average_close=average_close,
+            high=high,
+            low=low,
+            price_range=price_range,
+            cumulative_return=cumulative_return,
+            average_daily_change=average_daily_change,
+            volatility=volatility,
+            trend_strength=trend_strength,
+        )
+
+
 @dataclass(slots=True)
 class AwesomeAPISnapshotBuilder:
     """Build :class:`MarketSnapshot` sequences from AwesomeAPI market data."""
@@ -172,4 +278,6 @@ __all__ = [
     "AwesomeAPIClient",
     "AwesomeAPIError",
     "AwesomeAPISnapshotBuilder",
+    "AwesomeAPIAutoCalculator",
+    "AwesomeAPIAutoMetrics",
 ]

--- a/algorithms/python/tests/test_awesome_api_calculator.py
+++ b/algorithms/python/tests/test_awesome_api_calculator.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from algorithms.python.awesome_api import (
+    AwesomeAPIAutoCalculator,
+    AwesomeAPIAutoMetrics,
+    AwesomeAPIError,
+)
+from algorithms.python.data_pipeline import RawBar
+
+
+@pytest.fixture
+def sample_bars() -> list[RawBar]:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    closes = [100.0, 102.0, 101.0, 105.0, 107.0]
+    bars: list[RawBar] = []
+    for idx, close in enumerate(closes):
+        moment = start + timedelta(days=idx)
+        bars.append(
+            RawBar(
+                timestamp=moment,
+                open=close - 1.0,
+                high=close + 3.0,
+                low=close - 2.0,
+                close=close,
+                volume=1_000 + idx,
+            )
+        )
+    return bars
+
+
+def test_auto_calculator_computes_metrics(sample_bars: list[RawBar]) -> None:
+    class StubClient:
+        def fetch_bars(self, pair: str, *, limit: int) -> list[RawBar]:
+            assert pair == "XAU-USD"
+            assert limit == 5
+            return list(sample_bars)
+
+    calculator = AwesomeAPIAutoCalculator(client=StubClient(), history=5)
+
+    metrics = calculator.compute_metrics("XAU-USD")
+
+    assert isinstance(metrics, AwesomeAPIAutoMetrics)
+    assert metrics.pair == "XAU-USD"
+    assert metrics.sample_size == len(sample_bars)
+    assert metrics.latest_close == pytest.approx(107.0)
+    assert metrics.previous_close == pytest.approx(105.0)
+    assert metrics.absolute_change == pytest.approx(2.0)
+    assert metrics.percentage_change == pytest.approx(1.9047619, rel=1e-6)
+    assert metrics.average_close == pytest.approx(103.0)
+    assert metrics.high == pytest.approx(110.0)
+    assert metrics.low == pytest.approx(98.0)
+    assert metrics.price_range == pytest.approx(12.0)
+    assert metrics.cumulative_return == pytest.approx(0.07)
+    assert metrics.average_daily_change == pytest.approx(1.75)
+    assert metrics.volatility == pytest.approx(2.607680962, rel=1e-6)
+    assert metrics.trend_strength == pytest.approx(0.04950495, rel=1e-6)
+
+
+def test_auto_calculator_respects_history_override(sample_bars: list[RawBar]) -> None:
+    class TrackingClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int]] = []
+
+        def fetch_bars(self, pair: str, *, limit: int) -> list[RawBar]:
+            self.calls.append((pair, limit))
+            return list(sample_bars[:limit])
+
+    client = TrackingClient()
+    calculator = AwesomeAPIAutoCalculator(client=client, history=10)
+
+    metrics = calculator.compute_metrics("EUR-USD", history=3)
+
+    assert client.calls == [("EUR-USD", 3)]
+    assert metrics.sample_size == 3
+    assert metrics.latest_close == pytest.approx(101.0)
+    assert metrics.previous_close == pytest.approx(102.0)
+    assert metrics.absolute_change == pytest.approx(-1.0)
+    assert metrics.percentage_change == pytest.approx(-0.98039215, rel=1e-6)
+    assert metrics.cumulative_return == pytest.approx(0.01)
+    assert metrics.average_daily_change == pytest.approx(0.5)
+    assert metrics.volatility == pytest.approx(0.81649658, rel=1e-6)
+    assert metrics.trend_strength == pytest.approx(0.01)
+
+
+def test_auto_calculator_accepts_explicit_bars(sample_bars: list[RawBar]) -> None:
+    class GuardedClient:
+        def fetch_bars(self, pair: str, *, limit: int) -> list[RawBar]:  # pragma: no cover - defensive
+            raise AssertionError("fetch_bars should not be called when bars are supplied")
+
+    calculator = AwesomeAPIAutoCalculator(client=GuardedClient())
+
+    metrics = calculator.compute_metrics("BTC-USD", bars=sample_bars)
+
+    assert metrics.sample_size == len(sample_bars)
+    assert metrics.latest_close == pytest.approx(sample_bars[-1].close)
+
+
+def test_auto_calculator_validates_inputs(sample_bars: list[RawBar]) -> None:
+    class SparseClient:
+        def fetch_bars(self, pair: str, *, limit: int) -> list[RawBar]:
+            return [sample_bars[0]]
+
+    calculator = AwesomeAPIAutoCalculator(client=SparseClient(), history=2)
+
+    with pytest.raises(AwesomeAPIError):
+        calculator.compute_metrics("XAU-USD")
+
+    with pytest.raises(ValueError):
+        calculator.compute_metrics("XAU-USD", history=1)
+
+    with pytest.raises(ValueError):
+        calculator.compute_metrics("XAU-USD", bars=[])


### PR DESCRIPTION
## Summary
- add an auto-calculation helper that derives price analytics from AwesomeAPI bars
- export the new calculator and metrics types through the algorithms package
- cover AwesomeAPI processing workflow with targeted unit tests

## Testing
- python -m pytest algorithms/python/tests/test_awesome_api_calculator.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d619149f208322a7dfdc9f735c447c