### PR TITLE
feat: align miniapp marketing flows with shared services

### DIFF
--- a/apps/web/app/(miniapp)/miniapp/(tabs)/home/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/(tabs)/home/page.tsx
@@ -1,128 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Sparkles, TrendingUp } from "lucide-react";
-import { Skeleton } from "@/components/miniapp/Skeleton";
-import { Toast } from "@/components/miniapp/Toast";
-import { haptic } from "@/lib/telegram";
-import { track } from "@/lib/metrics";
+import HomeLanding from "@/components/miniapp/HomeLanding";
+import { useTelegramAuth } from "@/hooks/useTelegramAuth";
 
-interface Insight {
-  label: string;
-  value: string;
-  delta: string;
-}
-
-const placeholders: Insight[] = [
-  { label: "Daily ROI", value: "--", delta: "--" },
-  { label: "Signal Accuracy", value: "--", delta: "--" },
-  { label: "VIP Retention", value: "--", delta: "--" },
-];
-
-const readyData: Insight[] = [
-  { label: "Daily ROI", value: "+8.4%", delta: "▲ 1.2% vs yesterday" },
-  { label: "Signal Accuracy", value: "92%", delta: "▲ 4% vs 7d avg" },
-  { label: "VIP Retention", value: "87%", delta: "▲ 2% this month" },
-];
+type HomeLandingTelegramData = {
+  user?: { id: number };
+};
 
 export default function HomeTab() {
-  const [loading, setLoading] = useState(true);
-  const [showToast, setShowToast] = useState(false);
-  const refreshTimeoutRef = useRef<number | null>(null);
+  const { telegramUser } = useTelegramAuth();
 
-  const clearRefreshTimeout = useCallback(() => {
-    if (refreshTimeoutRef.current) {
-      window.clearTimeout(refreshTimeoutRef.current);
-      refreshTimeoutRef.current = null;
-    }
-  }, []);
+  const telegramData: HomeLandingTelegramData = telegramUser
+    ? { user: { id: telegramUser.id } }
+    : {};
 
-  const scheduleLoadingComplete = useCallback(
-    (delay: number) => {
-      clearRefreshTimeout();
-      refreshTimeoutRef.current = window.setTimeout(() => {
-        setLoading(false);
-        refreshTimeoutRef.current = null;
-      }, delay);
-    },
-    [clearRefreshTimeout],
-  );
-
-  useEffect(() => {
-    scheduleLoadingComplete(900);
-    return () => clearRefreshTimeout();
-  }, [clearRefreshTimeout, scheduleLoadingComplete]);
-
-  const data = loading ? placeholders : readyData;
-
-  return (
-    <>
-      <section className="card" style={{ display: "grid", gap: 16 }}>
-        <header style={{ display: "flex", alignItems: "center", gap: 12 }}>
-          <div
-            style={{
-              width: 40,
-              height: 40,
-              borderRadius: 16,
-              display: "grid",
-              placeItems: "center",
-              background: "rgba(48, 194, 242, 0.12)",
-              color: "var(--tg-accent)",
-            }}
-          >
-            <Sparkles size={20} />
-          </div>
-          <div>
-            <h2 style={{ margin: 0 }}>Welcome back</h2>
-            <p className="muted" style={{ margin: 0 }}>
-              Your trading pulse syncs with Telegram in real-time.
-            </p>
-          </div>
-        </header>
-
-        <div style={{ display: "grid", gap: 12 }}>
-          {data.map((insight) => (
-            <div
-              key={insight.label}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "12px 0",
-                borderBottom: "1px solid rgba(255,255,255,0.06)",
-              }}
-            >
-              <div>
-                <div style={{ fontWeight: 600 }}>{insight.label}</div>
-                <p className="muted" style={{ margin: 0, fontSize: 12 }}>
-                  {loading ? <Skeleton h={12} w={120} /> : insight.delta}
-                </p>
-              </div>
-              <div style={{ fontSize: 18, fontWeight: 600 }}>
-                {loading ? <Skeleton h={18} w={72} /> : insight.value}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <button
-          className="btn"
-          onClick={() => {
-            haptic("medium");
-            void track("home_refresh");
-            setShowToast(true);
-            setLoading(true);
-            scheduleLoadingComplete(750);
-          }}
-        >
-          <TrendingUp size={18} /> Refresh insights
-        </button>
-      </section>
-      <Toast
-        text="Insights refreshed"
-        show={showToast}
-        onDismiss={() => setShowToast(false)}
-      />
-    </>
-  );
+  return <HomeLanding telegramData={telegramData} />;
 }

--- a/apps/web/components/miniapp/PlanSection.tsx
+++ b/apps/web/components/miniapp/PlanSection.tsx
@@ -1,30 +1,32 @@
-import { useEffect, useState } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { MotionCard, MotionCardContainer } from "@/components/ui/motion-card";
-import { Interactive3DCard, StaggeredGrid, RippleCard, LiquidCard } from "@/components/ui/interactive-cards";
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { MotionCard } from "@/components/ui/motion-card";
+import {
+  Interactive3DCard,
+  LiquidCard,
+  StaggeredGrid,
+} from "@/components/ui/interactive-cards";
 import { Button } from "@/components/ui/button";
-import { InputField } from "@/components/ui/input-field";
 import { Badge } from "@/components/ui/badge";
-import { CreditCard, Sparkles, Check, Star, TrendingUp } from "lucide-react";
-import { HorizontalSnapScroll } from "@/components/ui/horizontal-snap-scroll";
+import { Check, CreditCard, Sparkles, Star, TrendingUp } from "lucide-react";
 import { FadeInOnView } from "@/components/ui/fade-in-on-view";
 import { CurrencySelector } from "./CurrencySelector";
 import { useCurrency } from "@/hooks/useCurrency";
 import { toast } from "sonner";
-import { motion, AnimatePresence } from "framer-motion";
-import { parentVariants, childVariants, fastParentVariants } from "@/lib/motion-variants";
+import { AnimatePresence, motion } from "framer-motion";
+import { childVariants, parentVariants } from "@/lib/motion-variants";
 import { cn } from "@/lib/utils";
+import type { Plan } from "@/types/plan";
+import { useSubscriptionPlans } from "@/hooks/useSubscriptionPlans";
 import { callEdgeFunction } from "@/config/supabase";
-
-interface Plan {
-  id: string;
-  name: string;
-  price: number;
-  currency: string;
-  duration_months: number;
-  is_lifetime: boolean;
-  features: string[];
-}
 
 interface PromoValidation {
   valid: boolean;
@@ -39,164 +41,253 @@ interface ContentItem {
   content_value: string;
 }
 
-export default function PlanSection() {
-  const [plans, setPlans] = useState<Plan[]>([]);
-  const [loading, setLoading] = useState(true);
-  const { currency, setCurrency, exchangeRate } = useCurrency();
-  const [popularPlanId, setPopularPlanId] = useState<string | null>(null);
-  const [userPreferredPlanId, setUserPreferredPlanId] = useState<string | null>(null);
-  const [promoCode, setPromoCode] = useState(() => {
-    // Pre-fill promo code from URL parameter
-    const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.get('promo') || "";
-  });
-  const [promoValidation, setPromoValidation] = useState<PromoValidation | null>(null);
-  const [validatingPromo, setValidatingPromo] = useState(false);
+const PLAN_SELECTION_STORAGE_KEY = "plan_selection_counts";
 
-  const isInTelegram = typeof window !== 'undefined' && window.Telegram?.WebApp;
+export default function PlanSection() {
+  const {
+    plans,
+    loading: plansLoading,
+    error: plansError,
+  } = useSubscriptionPlans();
+  const { currency, setCurrency, exchangeRate } = useCurrency();
+
+  const [popularPlanId, setPopularPlanId] = useState<string | null>(null);
+  const [userPreferredPlanId, setUserPreferredPlanId] = useState<string | null>(
+    null,
+  );
+  const [promoCode, setPromoCode] = useState("");
+  const [promoValidation, setPromoValidation] = useState<
+    PromoValidation | null
+  >(
+    null,
+  );
+  const [validatingPromo, setValidatingPromo] = useState(false);
+  const [isInTelegram, setIsInTelegram] = useState(false);
+  const [popularPlanLoading, setPopularPlanLoading] = useState(true);
 
   useEffect(() => {
-    // Fetch plans and popular plan
-    const fetchData = async () => {
-      try {
-        const { callEdgeFunction } = await import('@/config/supabase');
-        const [plansResult, contentResult] = await Promise.all([
-          callEdgeFunction('PLANS'),
-          callEdgeFunction('CONTENT_BATCH', {
-            method: 'POST',
-            body: { keys: ["popular_plan_id"] }
-          })
-        ]);
+    if (typeof window === "undefined") {
+      setPopularPlanLoading(false);
+      return;
+    }
 
-        if (plansResult.status !== 200 || contentResult.status !== 200) {
-          throw new Error('Failed to load data');
-        }
+    setIsInTelegram(Boolean(window.Telegram?.WebApp));
 
-        setPlans((plansResult.data as any)?.plans || []);
+    const urlParams = new URLSearchParams(window.location.search);
+    const initialPromo = urlParams.get("promo");
+    if (initialPromo) {
+      setPromoCode(initialPromo.toUpperCase());
+    }
 
-        const contents: ContentItem[] = (contentResult.data as any)?.contents || [];
-        const popularContent = contents.find((c) => c.content_key === 'popular_plan_id');
-
-        if (popularContent) {
-          setPopularPlanId(popularContent.content_value);
-        }
-
-        // Check user's selection history for most preferred plan
-        const selectionCounts: Record<string, number> = JSON.parse(
-          localStorage.getItem('plan_selection_counts') || '{}'
+    try {
+      const stored = window.localStorage.getItem(PLAN_SELECTION_STORAGE_KEY);
+      if (stored) {
+        const selectionCounts = JSON.parse(stored) as Record<string, number>;
+        const mostSelected = Object.entries(selectionCounts).reduce<
+          [string, number]
+        >(
+          (top, entry) => (entry[1] > top[1] ? entry : top),
+          ["", 0],
         );
-        if (Object.keys(selectionCounts).length > 0) {
-          const mostSelected = Object.entries(selectionCounts).reduce(
-            (a, b) => (selectionCounts[a[0]] > selectionCounts[b[0]] ? a : b),
-            ['', 0]
+        if (mostSelected[1] > 0) {
+          setUserPreferredPlanId(mostSelected[0]);
+        }
+      }
+    } catch (error) {
+      console.warn("Failed to read plan selection history", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchPopularPlan = async () => {
+      try {
+        const { data, error, status } = await callEdgeFunction<{
+          contents?: ContentItem[];
+        }>("CONTENT_BATCH", {
+          method: "POST",
+          body: { keys: ["popular_plan_id"] },
+        });
+
+        if (!isMounted) return;
+
+        if (error) {
+          throw new Error(error.message);
+        }
+
+        if (status === 200 && data?.contents) {
+          const popularContent = data.contents.find(
+            (item) => item.content_key === "popular_plan_id",
+          );
+          if (popularContent) {
+            setPopularPlanId(popularContent.content_value);
+          }
+        }
+      } catch (error) {
+        console.warn("Failed to fetch popular plan id", error);
+      } finally {
+        if (isMounted) {
+          setPopularPlanLoading(false);
+        }
+      }
+    };
+
+    void fetchPopularPlan();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (plansError) {
+      toast.error(plansError);
+    }
+  }, [plansError]);
+
+  const validatePromoCode = useCallback(async () => {
+    if (!promoCode.trim()) return;
+    if (plans.length === 0) {
+      toast.error("No plans available");
+      return;
+    }
+
+    setValidatingPromo(true);
+
+    try {
+      let telegramUserId: number | string | null = null;
+      if (isInTelegram && typeof window !== "undefined") {
+        telegramUserId = window.Telegram?.WebApp?.initDataUnsafe?.user?.id ??
+          null;
+      }
+
+      const selectedPlanId = plans[0]?.id;
+      if (!selectedPlanId) {
+        toast.error("No plans available");
+        return;
+      }
+
+      const { data, error, status } = await callEdgeFunction<PromoValidation>(
+        "PROMO_VALIDATE",
+        {
+          method: "POST",
+          body: {
+            code: promoCode,
+            telegram_id: telegramUserId ?? "web-user",
+            plan_id: selectedPlanId,
+          },
+        },
+      );
+
+      if (error || status !== 200 || !data) {
+        throw new Error(error?.message ?? "Network error");
+      }
+
+      setPromoValidation(data);
+
+      if (data.valid) {
+        const hasNumericDiscount = typeof data.discount_value === "number" &&
+          data.discount_value > 0;
+        const value = hasNumericDiscount
+          ? data.discount_type === "percentage"
+            ? `${data.discount_value}%`
+            : `$${data.discount_value}`
+          : null;
+        toast.success(
+          value
+            ? `Promo code applied! ${value} discount`
+            : "Promo code applied!",
+        );
+      } else {
+        toast.error(data.reason || "Invalid promo code");
+      }
+    } catch (error) {
+      console.error("Promo validation error:", error);
+      toast.error("Failed to validate promo code. Please try again.");
+    } finally {
+      setValidatingPromo(false);
+    }
+  }, [isInTelegram, plans, promoCode]);
+
+  useEffect(() => {
+    if (!promoCode.trim() || promoValidation || plans.length === 0) {
+      return;
+    }
+
+    void validatePromoCode();
+  }, [promoCode, promoValidation, plans.length, validatePromoCode]);
+
+  const handleSelectPlan = useCallback(
+    (planId: string) => {
+      if (typeof window !== "undefined") {
+        try {
+          const raw = window.localStorage.getItem(
+            PLAN_SELECTION_STORAGE_KEY,
+          );
+          const selectionCounts = raw
+            ? (JSON.parse(raw) as Record<string, number>)
+            : {};
+          selectionCounts[planId] = (selectionCounts[planId] || 0) + 1;
+          window.localStorage.setItem(
+            PLAN_SELECTION_STORAGE_KEY,
+            JSON.stringify(selectionCounts),
+          );
+
+          const mostSelected = Object.entries(selectionCounts).reduce<
+            [string, number]
+          >(
+            (top, entry) => (entry[1] > top[1] ? entry : top),
+            ["", 0],
           );
           if (mostSelected[1] > 0) {
             setUserPreferredPlanId(mostSelected[0]);
           }
-        }
-      } catch (error) {
-        console.error('Failed to fetch data:', error);
-        toast.error('Failed to load subscription plans');
-      } finally {
-        setLoading(false);
-      }
-    };
 
-    fetchData();
+          const url = new URL(window.location.href);
+          url.searchParams.set("tab", "checkout");
+          url.searchParams.set("plan", planId);
+          if (promoValidation?.valid) {
+            url.searchParams.set("promo", promoCode);
+          }
+          window.history.pushState({}, "", url.toString());
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        } catch (error) {
+          console.error("Failed to persist plan selection", error);
+        }
+      }
+
+      if (!isInTelegram) {
+        toast.info("Proceeding to payment options");
+      }
+    },
+    [isInTelegram, promoCode, promoValidation],
+  );
+
+  const getBasePrice = useCallback((plan: Plan) => {
+    return plan.pricing?.displayPrice ?? plan.price;
   }, []);
 
-  // Auto-validate promo code if pre-filled from URL
-  useEffect(() => {
-    if (promoCode.trim() && plans.length > 0 && !promoValidation) {
-      validatePromoCode();
-    }
-  }, [promoCode, plans.length]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const validatePromoCode = async () => {
-    if (!promoCode.trim()) return;
-    
-    setValidatingPromo(true);
-    try {
-      // For web users without Telegram, we still allow promo validation but with fallback user ID
-      const telegramUserId = isInTelegram ? window.Telegram?.WebApp?.initDataUnsafe?.user?.id : null;
-      const selectedPlanId = plans[0]?.id;
-      
-      if (!selectedPlanId) {
-        toast.error('No plans available');
-        return;
+  const getDisplayPrice = useCallback(
+    (plan: Plan) => {
+      const basePrice = getBasePrice(plan);
+      if (currency === "MVR") {
+        return Math.round(basePrice * exchangeRate);
       }
+      return basePrice;
+    },
+    [currency, exchangeRate, getBasePrice],
+  );
 
-      const { data, status } = await callEdgeFunction('PROMO_VALIDATE', {
-        method: 'POST',
-        body: {
-          code: promoCode,
-          telegram_id: telegramUserId || 'web-user',
-          plan_id: selectedPlanId
-        }
-      });
-
-      if (status !== 200 || !data) {
-        throw new Error('Network error');
-      }
-
-      setPromoValidation(data as PromoValidation);
-
-      if ((data as any).valid) {
-        toast.success(`Promo code applied! ${(data as any).discount_type === 'percentage' ? (data as any).discount_value + '%' : '$' + (data as any).discount_value} discount`);
-      } else {
-        toast.error((data as any).reason || 'Invalid promo code');
-      }
-    } catch (error) {
-      console.error('Promo validation error:', error);
-      toast.error('Failed to validate promo code. Please try again.');
-    } finally {
-      setValidatingPromo(false);
-    }
-  };
-
-  const getDisplayPrice = (plan: Plan) => {
-    const basePrice = plan.price;
-    if (currency === "MVR") {
-      return Math.round(basePrice * exchangeRate);
-    }
-    return basePrice;
-  };
-
-  const handleSelectPlan = (planId: string) => {
-    // Track user's selection for "Most Popular" logic
-    const selectionCounts = JSON.parse(localStorage.getItem('plan_selection_counts') || '{}');
-    selectionCounts[planId] = (selectionCounts[planId] || 0) + 1;
-    localStorage.setItem('plan_selection_counts', JSON.stringify(selectionCounts));
-
-    if (isInTelegram) {
-      // Switch to checkout flow within mini app
-      const url = new URL(window.location.href);
-      url.searchParams.set('tab', 'checkout');
-      url.searchParams.set('plan', planId);
-      if (promoValidation?.valid) {
-        url.searchParams.set('promo', promoCode);
-      }
-      window.history.pushState({}, '', url.toString());
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    } else {
-      // For web users, show enhanced payment section
-      const url = new URL(window.location.href);
-      url.searchParams.set('tab', 'checkout');
-      url.searchParams.set('plan', planId);
-      if (promoValidation?.valid) {
-        url.searchParams.set('promo', promoCode);
-      }
-      window.history.pushState({}, '', url.toString());
-      window.dispatchEvent(new PopStateEvent('popstate'));
-      toast.info('Proceeding to payment options');
-    }
-  };
+  const loading = plansLoading || popularPlanLoading;
 
   if (loading) {
     return (
       <MotionCard variant="glass" animate={true}>
         <CardContent className="p-6">
-          <div className="text-center text-muted-foreground">Loading plans...</div>
+          <div className="text-center text-muted-foreground">
+            Loading plans...
+          </div>
         </CardContent>
       </MotionCard>
     );
@@ -211,10 +302,11 @@ export default function PlanSection() {
               <CreditCard className="icon-sm animate-pulse-glow" />
               VIP Plans
             </CardTitle>
-            <CardDescription className="text-body-sm">Choose your subscription plan and start trading like a pro</CardDescription>
+            <CardDescription className="text-body-sm">
+              Choose your subscription plan and start trading like a pro
+            </CardDescription>
           </CardHeader>
           <CardContent className="ui-stack-base prose">
-            {/* Currency Selector */}
             <FadeInOnView delay={100}>
               <div className="flex justify-between items-center p-4 bg-muted/50 rounded-lg">
                 <div>
@@ -227,47 +319,70 @@ export default function PlanSection() {
               </div>
             </FadeInOnView>
 
-            {/* Promo Code Section */}
             <FadeInOnView delay={200} animation="slide-in-right">
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
                 <div className="flex items-center gap-2">
                   <Sparkles className="h-4 w-4 text-primary" />
-                  <span className="text-sm font-medium">Have a promo code?</span>
+                  <span className="text-sm font-medium">
+                    Have a promo code?
+                  </span>
                   {!isInTelegram && (
                     <Badge variant="outline" className="text-xs">
                       Web Preview
                     </Badge>
                   )}
                 </div>
-                 <div className="flex gap-2">
-                   <input
-                     type="text"
-                     placeholder="Enter promo code"
-                     value={promoCode}
-                     onChange={(e) => setPromoCode(e.target.value.toUpperCase())}
-                     className={cn(
-                       "flex-1 min-h-[44px] px-4 py-2 ui-rounded-lg border transition-all duration-200",
-                       "placeholder:text-muted-foreground font-medium",
-                       promoValidation?.valid === true && "border-green-500 ring-2 ring-green-500/20",
-                      promoValidation?.valid === false && "border-dc-brand ring-2 ring-dc-brand/20",
-                       !promoValidation && "border-border hover:border-border/80 focus:border-primary focus:ring-2 focus:ring-primary/20"
-                     )}
-                   />
-                   <Button 
-                     onClick={validatePromoCode} 
-                     disabled={!promoCode.trim() || validatingPromo}
-                     isLoading={validatingPromo}
-                     className="min-h-[44px] px-6 font-semibold"
-                   >
-                     {validatingPromo ? "..." : "Apply"}
-                   </Button>
-                 </div>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    placeholder="Enter promo code"
+                    value={promoCode}
+                    onChange={(event) => {
+                      setPromoCode(event.target.value.toUpperCase());
+                      setPromoValidation(null);
+                    }}
+                    className={cn(
+                      "flex-1 min-h-[44px] px-4 py-2 ui-rounded-lg border transition-all duration-200",
+                      "placeholder:text-muted-foreground font-medium",
+                      promoValidation?.valid === true &&
+                        "border-green-500 ring-2 ring-green-500/20",
+                      promoValidation?.valid === false &&
+                        "border-dc-brand ring-2 ring-dc-brand/20",
+                      !promoValidation &&
+                        "border-border hover:border-border/80 focus:border-primary focus:ring-2 focus:ring-primary/20",
+                    )}
+                  />
+                  <Button
+                    onClick={validatePromoCode}
+                    disabled={!promoCode.trim() || validatingPromo}
+                    isLoading={validatingPromo}
+                    className="min-h-[44px] px-6 font-semibold"
+                  >
+                    {validatingPromo ? "..." : "Apply"}
+                  </Button>
+                </div>
                 {promoValidation && (
-                  <div className={`text-xs p-2 rounded transition-all duration-300 ${promoValidation.valid ? 'bg-green-500/10 text-green-600' : 'bg-dc-brand/10 text-dc-brand-dark'}`}>
-                    {promoValidation.valid 
-                      ? `${promoValidation.discount_type === 'percentage' ? promoValidation.discount_value + '%' : '$' + promoValidation.discount_value} discount applied!`
-                      : promoValidation.reason
-                    }
+                  <div
+                    className={cn(
+                      "text-xs p-2 rounded transition-all duration-300",
+                      promoValidation.valid
+                        ? "bg-green-500/10 text-green-600"
+                        : "bg-dc-brand/10 text-dc-brand-dark",
+                    )}
+                  >
+                    {promoValidation.valid
+                      ? (() => {
+                        const hasNumericDiscount =
+                          typeof promoValidation.discount_value === "number" &&
+                          promoValidation.discount_value > 0;
+                        if (!hasNumericDiscount) {
+                          return "Discount applied!";
+                        }
+                        return promoValidation.discount_type === "percentage"
+                          ? `${promoValidation.discount_value}% discount applied!`
+                          : `$${promoValidation.discount_value} discount applied!`;
+                      })()
+                      : promoValidation.reason}
                   </div>
                 )}
               </div>
@@ -276,10 +391,11 @@ export default function PlanSection() {
             {!isInTelegram && (
               <div className="p-4 bg-blue-500/10 border border-blue-500/20 rounded-lg">
                 <div className="text-sm text-blue-600 text-center">
-                  💡 For the full experience with instant payments and account management, 
-                  <a 
-                    href="https://t.me/Dynamic_VIP_BOT" 
-                    target="_blank" 
+                  💡 For the full experience with instant payments and account
+                  management,
+                  <a
+                    href="https://t.me/Dynamic_VIP_BOT"
+                    target="_blank"
                     rel="noopener noreferrer"
                     className="underline ml-1 hover:text-blue-800"
                   >
@@ -289,171 +405,234 @@ export default function PlanSection() {
               </div>
             )}
 
-            {/* Plans */}
             <motion.div
               variants={parentVariants}
               initial="hidden"
               animate="visible"
             >
-              <StaggeredGrid columns={1} staggerDelay={0.2} className="!grid-cols-1">
-                {plans.map((plan, index) => (
-                  <Interactive3DCard
-                    key={plan.id}
-                    intensity={0.1}
-                    scale={1.03}
-                    glowEffect={true}
-                    onClick={() => handleSelectPlan(plan.id)}
-                    className="group cursor-pointer"
-                  >
-                    <motion.div 
-                      className="flex justify-between items-start ui-mb-base"
-                      variants={childVariants}
-                    >
-                      <div className="ui-stack-xs">
-                        <div className="flex items-center gap-2">
-                          <motion.h4 
-                            className="font-semibold text-heading font-sf-pro text-foreground"
-                            whileHover={{ scale: 1.05 }}
+              <StaggeredGrid
+                columns={1}
+                staggerDelay={0.2}
+                className="!grid-cols-1"
+              >
+                {plans.length === 0
+                  ? (
+                    <Card className="p-6 text-center text-muted-foreground">
+                      Plans will publish as soon as pricing is live. Check back
+                      shortly.
+                    </Card>
+                  )
+                  : (
+                    plans.map((plan, index) => {
+                      const basePrice = getBasePrice(plan);
+                      const hasDiscount = promoValidation?.valid &&
+                        typeof promoValidation.final_amount === "number" &&
+                        promoValidation.final_amount !== basePrice;
+
+                      return (
+                        <Interactive3DCard
+                          key={plan.id}
+                          intensity={0.1}
+                          scale={1.03}
+                          glowEffect={true}
+                          onClick={() => handleSelectPlan(plan.id)}
+                          className="group cursor-pointer"
+                        >
+                          <motion.div
+                            className="flex justify-between items-start ui-mb-base"
+                            variants={childVariants}
                           >
-                            {plan.name}
-                          </motion.h4>
-                          <AnimatePresence>
-                            {(plan.id === userPreferredPlanId || (plan.id === popularPlanId && !userPreferredPlanId)) && (
-                              <motion.div
-                                initial={{ scale: 0, rotate: -180 }}
-                                animate={{ scale: 1, rotate: 0 }}
-                                exit={{ scale: 0, rotate: 180 }}
-                                transition={{ type: "spring", stiffness: 260, damping: 20 }}
-                              >
-                                <Badge className="bg-gradient-to-r from-orange-500 to-dc-brand text-white text-xs animate-pulse ui-p-xs">
+                            <div className="ui-stack-xs">
+                              <div className="flex items-center gap-2">
+                                <motion.h4
+                                  className="font-semibold text-heading font-sf-pro text-foreground"
+                                  whileHover={{ scale: 1.05 }}
+                                >
+                                  {plan.name}
+                                </motion.h4>
+                                <AnimatePresence>
+                                  {(plan.id === userPreferredPlanId ||
+                                    (plan.id === popularPlanId &&
+                                      !userPreferredPlanId)) && (
+                                    <motion.div
+                                      initial={{ scale: 0, rotate: -180 }}
+                                      animate={{ scale: 1, rotate: 0 }}
+                                      exit={{ scale: 0, rotate: 180 }}
+                                      transition={{
+                                        type: "spring",
+                                        stiffness: 260,
+                                        damping: 20,
+                                      }}
+                                    >
+                                      <Badge className="bg-gradient-to-r from-orange-500 to-dc-brand text-white text-xs animate-pulse ui-p-xs">
+                                        <motion.div
+                                          animate={{ rotate: [0, 15, -15, 0] }}
+                                          transition={{
+                                            duration: 2,
+                                            repeat: Infinity,
+                                          }}
+                                        >
+                                          <Star className="icon-xs ui-mr-xs" />
+                                        </motion.div>
+                                        Most Popular
+                                      </Badge>
+                                    </motion.div>
+                                  )}
+                                </AnimatePresence>
+                                {plan.id !== popularPlanId && index === 0 && (
                                   <motion.div
-                                    animate={{ rotate: [0, 15, -15, 0] }}
-                                    transition={{ duration: 2, repeat: Infinity }}
+                                    initial={{ scale: 0, y: -10 }}
+                                    animate={{ scale: 1, y: 0 }}
+                                    transition={{ delay: 0.5 }}
                                   >
-                                    <Star className="icon-xs ui-mr-xs" />
+                                    <Badge
+                                      variant="outline"
+                                      className="text-xs ui-p-xs"
+                                    >
+                                      <TrendingUp className="icon-xs ui-mr-xs" />
+                                      Best Value
+                                    </Badge>
                                   </motion.div>
-                                  Most Popular
-                                </Badge>
-                              </motion.div>
-                            )}
-                          </AnimatePresence>
-                          {plan.id !== popularPlanId && index === 0 && (
+                                )}
+                              </div>
+                              <motion.p
+                                className="text-body-sm text-muted-foreground font-sf-pro"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                transition={{ delay: index * 0.1 + 0.3 }}
+                              >
+                                {plan.is_lifetime
+                                  ? "Lifetime access"
+                                  : `${plan.duration_months} month${
+                                    plan.duration_months > 1 ? "s" : ""
+                                  }`}
+                              </motion.p>
+                              <motion.p
+                                className="text-body-xs text-muted-foreground mt-1"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                transition={{ delay: index * 0.1 + 0.35 }}
+                              >
+                                Priority signals, VIP chat access & daily
+                                analysis
+                              </motion.p>
+                            </div>
                             <motion.div
-                              initial={{ scale: 0, y: -10 }}
-                              animate={{ scale: 1, y: 0 }}
-                              transition={{ delay: 0.5 }}
-                            >
-                              <Badge variant="outline" className="text-xs ui-p-xs">
-                                <TrendingUp className="icon-xs ui-mr-xs" />
-                                Best Value
-                              </Badge>
-                            </motion.div>
-                          )}
-                        </div>
-                        <motion.p
-                          className="text-body-sm text-muted-foreground font-sf-pro"
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ delay: index * 0.1 + 0.3 }}
-                        >
-                          {plan.is_lifetime ? 'Lifetime access' : `${plan.duration_months} month${plan.duration_months > 1 ? 's' : ''}`}
-                        </motion.p>
-                        <motion.p
-                          className="text-body-xs text-muted-foreground mt-1"
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ delay: index * 0.1 + 0.35 }}
-                        >
-                          Priority signals, VIP chat access & daily analysis
-                        </motion.p>
-                      </div>
-                      <motion.div 
-                        className="text-right ui-stack-xs"
-                        initial={{ opacity: 0, x: 20 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        transition={{ delay: index * 0.1 + 0.2 }}
-                        whileHover={{ scale: 1.05 }}
-                      >
-                        <motion.div 
-                          className="text-title font-bold bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent"
-                          animate={{ 
-                            backgroundPosition: ["0% 50%", "100% 50%", "0% 50%"]
-                          }}
-                          transition={{ 
-                            duration: 3, 
-                            repeat: Infinity,
-                            ease: "linear"
-                          }}
-                          style={{ backgroundSize: "200% 200%" }}
-                        >
-                          {currency === "MVR" ? "Rf" : "$"}{promoValidation?.valid && promoValidation.final_amount ? 
-                            (currency === "MVR" ? Math.round(promoValidation.final_amount * exchangeRate) : promoValidation.final_amount) : 
-                            getDisplayPrice(plan)}
-                        </motion.div>
-                        <AnimatePresence>
-                          {promoValidation?.valid && promoValidation.final_amount !== plan.price && (
-                            <motion.div 
-                              className="text-body-sm text-muted-foreground line-through"
-                              initial={{ opacity: 0, scale: 0.8 }}
-                              animate={{ opacity: 1, scale: 1 }}
-                              exit={{ opacity: 0, scale: 0.8 }}
-                            >
-                              {currency === "MVR" ? "Rf" : "$"}{getDisplayPrice(plan)}
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
-                        <div className="text-caption text-muted-foreground font-medium">{currency}</div>
-                        {currency === "MVR" && (
-                          <div className="text-caption text-muted-foreground">
-                            ≈ ${Math.round(plan.price)} USD
-                          </div>
-                        )}
-                      </motion.div>
-                    </motion.div>
-
-                    {plan.features && plan.features.length > 0 && (
-                      <motion.div 
-                        className="ui-mb-base"
-                        initial={{ opacity: 0, y: 10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ delay: index * 0.1 + 0.4 }}
-                      >
-                        <div className="ui-stack-sm">
-                          {plan.features.slice(0, 3).map((feature, idx) => (
-                            <motion.div 
-                              key={idx} 
-                              className="flex items-center gap-3"
-                              initial={{ opacity: 0, x: -10 }}
+                              className="text-right ui-stack-xs"
+                              initial={{ opacity: 0, x: 20 }}
                               animate={{ opacity: 1, x: 0 }}
-                              transition={{ delay: index * 0.1 + 0.5 + idx * 0.1 }}
-                              whileHover={{ x: 5 }}
+                              transition={{ delay: index * 0.1 + 0.2 }}
+                              whileHover={{ scale: 1.05 }}
                             >
                               <motion.div
-                                whileHover={{ scale: 1.2, rotate: 360 }}
-                                transition={{ duration: 0.3 }}
+                                className="text-title font-bold bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent"
+                                animate={{
+                                  backgroundPosition: [
+                                    "0% 50%",
+                                    "100% 50%",
+                                    "0% 50%",
+                                  ],
+                                }}
+                                transition={{
+                                  duration: 3,
+                                  repeat: Infinity,
+                                  ease: "linear",
+                                }}
+                                style={{ backgroundSize: "200% 200%" }}
                               >
-                                <Check className="icon-xs text-green-500" />
+                                {currency === "MVR" ? "Rf" : "$"}
+                                {promoValidation?.valid &&
+                                    typeof promoValidation.final_amount ===
+                                      "number"
+                                  ? currency === "MVR"
+                                    ? Math.round(
+                                      promoValidation.final_amount *
+                                        exchangeRate,
+                                    )
+                                    : promoValidation.final_amount
+                                  : getDisplayPrice(plan)}
                               </motion.div>
-                              <span className="text-body-sm text-foreground">{feature}</span>
+                              <AnimatePresence>
+                                {hasDiscount && (
+                                  <motion.div
+                                    className="text-body-sm text-muted-foreground line-through"
+                                    initial={{ opacity: 0, scale: 0.8 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    exit={{ opacity: 0, scale: 0.8 }}
+                                  >
+                                    {currency === "MVR" ? "Rf" : "$"}
+                                    {getDisplayPrice(plan)}
+                                  </motion.div>
+                                )}
+                              </AnimatePresence>
+                              <div className="text-caption text-muted-foreground font-medium">
+                                {currency}
+                              </div>
+                              {currency === "MVR" && (
+                                <div className="text-caption text-muted-foreground">
+                                  ≈ ${Math.round(basePrice)} USD
+                                </div>
+                              )}
                             </motion.div>
-                          ))}
-                        </div>
-                      </motion.div>
-                    )}
+                          </motion.div>
 
-                    <motion.div
-                      whileHover={{ scale: 1.05 }}
-                      whileTap={{ scale: 0.95 }}
-                      transition={{ type: "spring", stiffness: 400, damping: 17 }}
-                    >
-                      <Button 
-                        className="w-full liquid-glass-button text-foreground hover:scale-105 transition-all duration-300 ui-rounded-full text-body-sm font-medium font-sf-pro"
-                      >
-                        {isInTelegram ? 'Select Plan' : 'Open in Telegram'}
-                      </Button>
-                    </motion.div>
-                  </Interactive3DCard>
-                ))}
+                          {plan.features && plan.features.length > 0 && (
+                            <motion.div
+                              className="ui-mb-base"
+                              initial={{ opacity: 0, y: 10 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              transition={{ delay: index * 0.1 + 0.4 }}
+                            >
+                              <div className="ui-stack-sm">
+                                {plan.features.slice(0, 3).map((
+                                  feature,
+                                  featureIndex,
+                                ) => (
+                                  <motion.div
+                                    key={featureIndex}
+                                    className="flex items-center gap-3"
+                                    initial={{ opacity: 0, x: -10 }}
+                                    animate={{ opacity: 1, x: 0 }}
+                                    transition={{
+                                      delay: index * 0.1 + 0.5 +
+                                        featureIndex * 0.1,
+                                    }}
+                                    whileHover={{ x: 5 }}
+                                  >
+                                    <motion.div
+                                      whileHover={{ scale: 1.2, rotate: 360 }}
+                                      transition={{ duration: 0.3 }}
+                                    >
+                                      <Check className="icon-xs text-green-500" />
+                                    </motion.div>
+                                    <span className="text-body-sm text-foreground">
+                                      {feature}
+                                    </span>
+                                  </motion.div>
+                                ))}
+                              </div>
+                            </motion.div>
+                          )}
+
+                          <motion.div
+                            whileHover={{ scale: 1.05 }}
+                            whileTap={{ scale: 0.95 }}
+                            transition={{
+                              type: "spring",
+                              stiffness: 400,
+                              damping: 17,
+                            }}
+                          >
+                            <Button className="w-full liquid-glass-button text-foreground hover:scale-105 transition-all duration-300 ui-rounded-full text-body-sm font-medium font-sf-pro">
+                              {isInTelegram
+                                ? "Select Plan"
+                                : "Open in Telegram"}
+                            </Button>
+                          </motion.div>
+                        </Interactive3DCard>
+                      );
+                    })
+                  )}
               </StaggeredGrid>
             </motion.div>
 
@@ -463,10 +642,18 @@ export default function PlanSection() {
                   <Sparkles className="h-8 w-8 text-primary mx-auto mb-2 animate-pulse-glow" />
                   <h3 className="font-semibold mb-2">Why Choose VIP?</h3>
                   <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-                    <div className="hover:text-primary transition-colors">• Premium signals</div>
-                    <div className="hover:text-primary transition-colors">• 24/7 support</div>
-                    <div className="hover:text-primary transition-colors">• Exclusive analysis</div>
-                    <div className="hover:text-primary transition-colors">• Mobile app access</div>
+                    <div className="hover:text-primary transition-colors">
+                      • Premium signals
+                    </div>
+                    <div className="hover:text-primary transition-colors">
+                      • 24/7 support
+                    </div>
+                    <div className="hover:text-primary transition-colors">
+                      • Exclusive analysis
+                    </div>
+                    <div className="hover:text-primary transition-colors">
+                      • Mobile app access
+                    </div>
                   </div>
                 </div>
               </div>

--- a/apps/web/components/miniapp/VIPSubscriptionPlans.tsx
+++ b/apps/web/components/miniapp/VIPSubscriptionPlans.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useState } from "react";
+"use client";
+
+import React, { useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -18,164 +20,103 @@ import {
 } from "lucide-react";
 import { ThreeDEmoticon } from "@/components/ui/three-d-emoticons";
 import { cn } from "@/lib/utils";
-
-interface Plan {
-  id: string;
-  name: string;
-  price: number;
-  currency: string;
-  duration_months: number;
-  is_lifetime: boolean;
-  features: string[];
-  popular?: boolean;
-  savings?: string;
-  base_price?: number;
-  dctAmount?: number;
-  tonAmount?: number | null;
-  lastPricedAt?: string | null;
-}
+import type { Plan } from "@/types/plan";
+import { useSubscriptionPlans } from "@/hooks/useSubscriptionPlans";
 
 interface VIPSubscriptionPlansProps {
   onSelectPlan?: (planId: string) => void;
   compact?: boolean;
 }
 
-export function VIPSubscriptionPlans(
-  { onSelectPlan, compact = false }: VIPSubscriptionPlansProps,
-) {
-  const [plans, setPlans] = useState<Plan[]>([]);
-  const [loading, setLoading] = useState(true);
+const deriveSavings = (plan: Plan): string | undefined => {
+  if (plan.is_lifetime) {
+    return undefined;
+  }
+  if (plan.duration_months >= 6) {
+    return "25% OFF";
+  }
+  if (plan.duration_months >= 3) {
+    return "15% OFF";
+  }
+  return undefined;
+};
 
-  useEffect(() => {
-    fetchPlans();
-  }, []);
+const getPlanIcon = (index: number) => {
+  switch (index) {
+    case 0:
+      return <Star className="h-6 w-6" />;
+    case 1:
+      return <Crown className="h-6 w-6" />;
+    case 2:
+      return <Award className="h-6 w-6" />;
+    default:
+      return <TrendingUp className="h-6 w-6" />;
+  }
+};
 
-  const fetchPlans = async () => {
-    try {
-      setLoading(true);
+const getPlanColor = (index: number, popular: boolean) => {
+  if (popular) return "from-dc-brand to-dc-brand-dark";
+  switch (index) {
+    case 0:
+      return "from-blue-500 to-blue-600";
+    case 1:
+      return "from-dc-brand to-dc-brand-dark";
+    case 2:
+      return "from-red-500 to-red-600";
+    default:
+      return "from-gray-500 to-gray-600";
+  }
+};
 
-      // Import supabase client
-      const { supabase } = await import("@/integrations/supabase/client");
+const formatDuration = (plan: Plan) => {
+  if (plan.is_lifetime) {
+    return "Lifetime Access";
+  }
+  if (plan.duration_months === 1) {
+    return "1 month";
+  }
+  return `${plan.duration_months} months`;
+};
 
-      // Try fetching from the plans edge function first
-      const { data: edgeData, error: edgeError } = await supabase.functions
-        .invoke("plans");
+const getDisplayPrice = (plan: Plan) =>
+  plan.pricing?.displayPrice ?? plan.price;
+const getDctAmount = (plan: Plan) =>
+  plan.pricing?.dctAmount ?? plan.dct_amount ?? plan.price;
+const getTonAmount = (plan: Plan) =>
+  plan.pricing?.tonAmount ?? plan.ton_amount ?? null;
 
-      if (!edgeError && edgeData?.plans) {
-        const mappedPlans = edgeData.plans.map((plan: any, index: number) => {
-          const basePrice = typeof plan.base_price === "number"
-            ? plan.base_price
-            : plan.price;
-          const dctAmount = typeof plan.dct_amount === "number"
-            ? plan.dct_amount
-            : plan.price;
-          const tonAmount = typeof plan.ton_amount === "number"
-            ? plan.ton_amount
-            : null;
+export function VIPSubscriptionPlans({
+  onSelectPlan,
+  compact = false,
+}: VIPSubscriptionPlansProps) {
+  const { plans, loading, error, refresh } = useSubscriptionPlans();
 
-          return {
-            id: plan.id,
-            name: plan.name,
-            price: plan.price,
-            duration_months: plan.duration_months,
-            is_lifetime: plan.is_lifetime || false,
-            currency: plan.currency || "USD",
-            features: plan.features || [],
-            popular: index === 1, // Make second plan popular
-            savings: plan.duration_months >= 6
-              ? "25% OFF"
-              : plan.duration_months >= 3
-              ? "15% OFF"
-              : undefined,
-            base_price: basePrice,
-            dctAmount,
-            tonAmount,
-            lastPricedAt: plan.last_priced_at || null,
-          };
-        });
-        setPlans(mappedPlans);
-        setLoading(false);
-        return;
-      }
-
-      // Fallback to direct Supabase query
-      const { data: plans, error } = await supabase
-        .from("subscription_plans")
-        .select("*")
-        .order("price", { ascending: true });
-
-      if (error) {
-        console.error("Supabase error:", error);
-        throw error;
-      }
-
-      if (plans) {
-        // Add popular and savings info
-        const enhancedPlans = plans.map((plan: any, index: number) => ({
-          ...plan,
-          popular: index === 1, // Make second plan popular
-          savings: plan.duration_months >= 6
-            ? "25% OFF"
-            : plan.duration_months >= 3
-            ? "15% OFF"
-            : undefined,
-          dctAmount: typeof plan.dct_amount === "number"
-            ? plan.dct_amount
-            : plan.price,
-          tonAmount: typeof plan.ton_amount === "number"
-            ? plan.ton_amount
-            : null,
-          base_price: typeof plan.base_price === "number"
-            ? plan.base_price
-            : plan.price,
-        }));
-        setPlans(enhancedPlans);
-      }
-    } catch (error) {
-      console.error("Failed to fetch plans:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const derivedPlans = useMemo(
+    () =>
+      plans.map((plan, index) => ({
+        plan,
+        index,
+        popular: index === 1,
+        savings: deriveSavings(plan),
+      })),
+    [plans],
+  );
 
   const handleSelectPlan = (planId: string) => {
     if (onSelectPlan) {
       onSelectPlan(planId);
-    } else {
-      // Default navigation
-      const url = new URL(window.location.href);
-      url.searchParams.set("tab", "plan");
-      url.searchParams.set("selected", planId);
-      window.history.pushState({}, "", url.toString());
-      window.dispatchEvent(new PopStateEvent("popstate"));
+      return;
     }
-  };
 
-  const getPlanIcon = (index: number) => {
-    switch (index) {
-      case 0:
-        return <Star className="h-6 w-6" />;
-      case 1:
-        return <Crown className="h-6 w-6" />;
-      case 2:
-        return <Award className="h-6 w-6" />;
-      default:
-        return <TrendingUp className="h-6 w-6" />;
+    if (typeof window === "undefined") {
+      return;
     }
-  };
 
-  const getPlanColor = (index: number, popular: boolean) => {
-    if (popular) return "from-dc-brand to-dc-brand-dark";
-    switch (index) {
-      case 0:
-        return "from-blue-500 to-blue-600";
-      case 1:
-        return "from-dc-brand to-dc-brand-dark";
-      case 2:
-        return "from-red-500 to-red-600";
-      default:
-        return "from-gray-500 to-gray-600";
-    }
+    const url = new URL(window.location.href);
+    url.searchParams.set("tab", "plan");
+    url.searchParams.set("selected", planId);
+    window.history.pushState({}, "", url.toString());
+    window.dispatchEvent(new PopStateEvent("popstate"));
   };
 
   if (loading) {
@@ -200,67 +141,90 @@ export function VIPSubscriptionPlans(
     );
   }
 
+  if (error) {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-muted-foreground">
+          {error} Refresh to try loading VIP plans again.
+        </p>
+        <Button variant="secondary" onClick={() => refresh(true)}>
+          Retry loading plans
+        </Button>
+      </div>
+    );
+  }
+
+  if (derivedPlans.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground space-y-2">
+        <p>VIP pricing will publish here as soon as subscriptions go live.</p>
+        <p>Check back shortly or contact support for a concierge onboarding.</p>
+      </div>
+    );
+  }
+
   if (compact) {
     return (
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {plans.slice(0, 3).map((plan, index) => (
-          <Interactive3DCard
-            key={plan.id}
-            intensity={0.1}
-            scale={1.02}
-            className="relative overflow-hidden"
-          >
-            <Card className="h-full border-0">
-              {plan.popular && (
-                <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-dc-brand to-dc-brand-dark text-white text-center py-1 text-xs font-medium">
-                  MOST POPULAR
-                </div>
-              )}
-              <CardHeader className={cn("text-center", plan.popular && "pt-8")}>
-                <div
-                  className={`w-12 h-12 mx-auto rounded-full bg-gradient-to-r ${
-                    getPlanColor(index, plan.popular)
-                  } flex items-center justify-center text-white mb-2`}
-                >
-                  {getPlanIcon(index)}
-                </div>
-                <CardTitle className="text-lg">{plan.name}</CardTitle>
-                <div className="space-y-1">
-                  <div className="text-2xl font-bold text-dc-brand">
-                    ${plan.price}
+        {derivedPlans.slice(0, 3).map(({ plan, index, popular, savings }) => {
+          const displayPrice = getDisplayPrice(plan);
+          const dctAmount = getDctAmount(plan);
+          const tonAmount = getTonAmount(plan);
+
+          return (
+            <Interactive3DCard
+              key={plan.id}
+              intensity={0.1}
+              scale={1.02}
+              className="relative overflow-hidden"
+            >
+              <Card className="h-full border-0">
+                {popular && (
+                  <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-dc-brand to-dc-brand-dark text-white text-center py-1 text-xs font-medium">
+                    MOST POPULAR
                   </div>
-                  <div className="text-sm text-muted-foreground">
-                    ≈ {(plan.dctAmount ?? plan.price).toFixed(2)} DCT
-                    {typeof plan.tonAmount === "number" && plan.tonAmount > 0 &&
-                      (
+                )}
+                <CardHeader className={cn("text-center", popular && "pt-8")}>
+                  <div
+                    className={`w-12 h-12 mx-auto rounded-full bg-gradient-to-r ${
+                      getPlanColor(index, popular)
+                    } flex items-center justify-center text-white mb-2`}
+                  >
+                    {getPlanIcon(index)}
+                  </div>
+                  <CardTitle className="text-lg">{plan.name}</CardTitle>
+                  <div className="space-y-1">
+                    <div className="text-2xl font-bold text-dc-brand">
+                      ${displayPrice}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      ≈ {dctAmount.toFixed(2)} DCT
+                      {typeof tonAmount === "number" && tonAmount > 0 && (
                         <span className="ml-1">
-                          / {plan.tonAmount.toFixed(3)} TON
+                          / {tonAmount.toFixed(3)} TON
                         </span>
                       )}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {formatDuration(plan)}
+                    </div>
                   </div>
-                  <div className="text-sm text-muted-foreground">
-                    {plan.is_lifetime
-                      ? "One-time payment"
-                      : `${plan.duration_months} month${
-                        plan.duration_months > 1 ? "s" : ""
-                      }`}
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <Button
-                  onClick={() => handleSelectPlan(plan.id)}
-                  className={cn(
-                    "w-full",
-                    plan.popular && "bg-dc-brand hover:bg-dc-brand-dark",
-                  )}
-                >
-                  Choose Plan
-                </Button>
-              </CardContent>
-            </Card>
-          </Interactive3DCard>
-        ))}
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <Button
+                    onClick={() => handleSelectPlan(plan.id)}
+                    className={cn(
+                      "w-full",
+                      popular && "bg-dc-brand hover:bg-dc-brand-dark",
+                    )}
+                  >
+                    Choose Plan
+                  </Button>
+                </CardContent>
+              </Card>
+            </Interactive3DCard>
+          );
+        })}
       </div>
     );
   }
@@ -268,207 +232,160 @@ export function VIPSubscriptionPlans(
   return (
     <FadeInOnView delay={100} animation="fade-in-up">
       <div className="space-y-6">
-        {/* Header */}
         <div className="text-center space-y-2">
           <div className="flex items-center justify-center gap-2 mb-4">
-            <ThreeDEmoticon
-              emoji="👑"
-              size={32}
-              intensity={0.4}
-              animate={true}
-            />
+            <ThreeDEmoticon emoji="👑" size={32} intensity={0.4} animate />
             <h2 className="text-2xl font-bold bg-gradient-to-r from-dc-brand to-dc-brand-dark bg-clip-text text-transparent">
               VIP Subscription Plans
             </h2>
-            <ThreeDEmoticon
-              emoji="✨"
-              size={28}
-              intensity={0.3}
-              animate={true}
-            />
+            <ThreeDEmoticon emoji="✨" size={28} intensity={0.3} animate />
           </div>
           <p className="text-muted-foreground">
             Choose the perfect plan to elevate your trading journey
           </p>
         </div>
 
-        {/* Plans Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           <AnimatePresence>
-            {plans.map((plan, index) => (
-              <motion.div
-                key={plan.id}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-              >
-                <Interactive3DCard
-                  intensity={plan.popular ? 0.15 : 0.1}
-                  scale={plan.popular ? 1.03 : 1.02}
-                  glowEffect={plan.popular}
-                  className="relative overflow-hidden group"
+            {derivedPlans.map(({ plan, index, popular, savings }) => {
+              const displayPrice = getDisplayPrice(plan);
+              const dctAmount = getDctAmount(plan);
+              const tonAmount = getTonAmount(plan);
+
+              return (
+                <motion.div
+                  key={plan.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.1 }}
                 >
-                  <Card
-                    className={cn(
-                      "h-full border-2 transition-all duration-300",
-                      plan.popular
-                        ? "border-dc-brand shadow-lg shadow-dc-brand/20"
-                        : "border-border hover:border-dc-brand-light",
-                    )}
+                  <Interactive3DCard
+                    intensity={popular ? 0.15 : 0.1}
+                    scale={popular ? 1.03 : 1.02}
+                    glowEffect={popular}
+                    className="relative overflow-hidden group"
                   >
-                    {/* Popular Badge */}
-                    {plan.popular && (
-                      <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-dc-brand to-dc-brand-dark text-white text-center py-2 font-medium">
-                        <div className="flex items-center justify-center gap-1">
-                          <Crown className="h-4 w-4" />
-                          MOST POPULAR
-                          <Sparkles className="h-4 w-4" />
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Savings Badge */}
-                    {plan.savings && (
-                      <div className="absolute top-2 right-2 z-10">
-                        <Badge className="bg-green-500 text-white">
-                          <Gift className="h-3 w-3 mr-1" />
-                          {plan.savings}
-                        </Badge>
-                      </div>
-                    )}
-
-                    <CardHeader
+                    <Card
                       className={cn(
-                        "text-center relative",
-                        plan.popular && "pt-12",
+                        "h-full border-2 transition-all duration-300",
+                        popular
+                          ? "border-dc-brand shadow-lg shadow-dc-brand/20"
+                          : "border-border hover:border-dc-brand-light",
                       )}
                     >
-                      {/* Plan Icon */}
-                      <motion.div
-                        className={`w-16 h-16 mx-auto rounded-full bg-gradient-to-r ${
-                          getPlanColor(index, plan.popular)
-                        } flex items-center justify-center text-white mb-4 shadow-lg`}
-                        whileHover={{ scale: 1.1, rotate: 5 }}
-                        transition={{
-                          type: "spring",
-                          stiffness: 260,
-                          damping: 20,
-                        }}
-                      >
-                        {getPlanIcon(index)}
-                      </motion.div>
-
-                      <CardTitle className="text-xl font-bold">
-                        {plan.name}
-                      </CardTitle>
-
-                      {/* Pricing */}
-                      <div className="space-y-1">
-                        <div className="text-3xl font-bold text-dc-brand">
-                          ${plan.price}
-                          <span className="text-base text-muted-foreground ml-1">
-                            {plan.currency}
-                          </span>
+                      {popular && (
+                        <div className="absolute top-0 left-0 right-0 bg-gradient-to-r from-dc-brand to-dc-brand-dark text-white text-center py-2 font-medium">
+                          <div className="flex items-center justify-center gap-1">
+                            <Crown className="h-4 w-4" />
+                            MOST POPULAR
+                            <Sparkles className="h-4 w-4" />
+                          </div>
                         </div>
-                        <div className="text-sm text-muted-foreground">
-                          ≈ {(plan.dctAmount ?? plan.price).toFixed(2)} DCT
-                          {typeof plan.tonAmount === "number" &&
-                            plan.tonAmount > 0 && (
-                            <span className="ml-1">
-                              / {plan.tonAmount.toFixed(3)} TON
-                            </span>
-                          )}
-                        </div>
-                        <div className="text-sm text-muted-foreground">
-                          {plan.is_lifetime
-                            ? "Lifetime Access"
-                            : `${plan.duration_months} month${
-                              plan.duration_months > 1 ? "s" : ""
-                            }`}
-                        </div>
-                      </div>
-                    </CardHeader>
+                      )}
 
-                    <CardContent className="space-y-4">
-                      {/* Features */}
-                      <div className="space-y-2">
-                        {plan.features.map((feature, fIndex) => (
-                          <motion.div
-                            key={fIndex}
-                            initial={{ opacity: 0, x: -20 }}
-                            animate={{ opacity: 1, x: 0 }}
-                            transition={{
-                              delay: (index * 0.1) + (fIndex * 0.05),
-                            }}
-                            className="flex items-center gap-2 text-sm"
-                          >
-                            <CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-                            <span>{feature}</span>
-                          </motion.div>
-                        ))}
-                      </div>
+                      {savings && (
+                        <div className="absolute top-2 right-2 z-10">
+                          <Badge className="bg-green-500 text-white">
+                            <Gift className="h-3 w-3 mr-1" />
+                            {savings}
+                          </Badge>
+                        </div>
+                      )}
 
-                      {/* CTA Button */}
-                      <Button
-                        onClick={() => handleSelectPlan(plan.id)}
+                      <CardHeader
                         className={cn(
-                          "w-full font-semibold transition-all duration-300 group-hover:shadow-lg",
-                          plan.popular
-                            ? "bg-dc-brand hover:bg-dc-brand-dark shadow-dc-brand/20"
-                            : "hover:bg-dc-brand hover:text-white",
+                          "text-center relative",
+                          popular && "pt-12",
                         )}
-                        size="lg"
                       >
-                        {plan.popular
-                          ? (
-                            <motion.div
-                              className="flex items-center gap-2"
-                              whileHover={{ scale: 1.05 }}
-                            >
-                              <Crown className="h-4 w-4" />
-                              Choose This Plan
-                              <Zap className="h-4 w-4" />
-                            </motion.div>
-                          )
-                          : (
-                            "Select Plan"
-                          )}
-                      </Button>
-                    </CardContent>
-                  </Card>
-                </Interactive3DCard>
-              </motion.div>
-            ))}
-          </AnimatePresence>
-        </div>
+                        <motion.div
+                          className={`w-16 h-16 mx-auto rounded-full bg-gradient-to-r ${
+                            getPlanColor(index, popular)
+                          } flex items-center justify-center text-white mb-4 shadow-lg`}
+                          whileHover={{ scale: 1.1, rotate: 5 }}
+                          transition={{
+                            type: "spring",
+                            stiffness: 260,
+                            damping: 20,
+                          }}
+                        >
+                          {getPlanIcon(index)}
+                        </motion.div>
 
-        {/* Features Summary */}
-        <div className="mt-8 p-6 bg-gradient-to-r from-dc-brand/10 to-dc-brand-dark/10 rounded-lg border border-dc-brand/20">
-          <div className="text-center space-y-4">
-            <div className="flex items-center justify-center gap-2">
-              <Shield className="h-6 w-6 text-dc-brand" />
-              <h3 className="text-lg font-semibold">All Plans Include</h3>
-              <Shield className="h-6 w-6 text-dc-brand" />
-            </div>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-              <div className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
-                <span>24/7 Support</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
-                <span>Money Back Guarantee</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
-                <span>Instant Access</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
-                <span>No Hidden Fees</span>
-              </div>
-            </div>
-          </div>
+                        <CardTitle className="text-xl font-bold">
+                          {plan.name}
+                        </CardTitle>
+
+                        <div className="space-y-1">
+                          <div className="text-3xl font-bold text-dc-brand">
+                            ${displayPrice}
+                            <span className="text-base text-muted-foreground ml-1">
+                              {plan.currency}
+                            </span>
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            ≈ {dctAmount.toFixed(2)} DCT
+                            {typeof tonAmount === "number" && tonAmount > 0 && (
+                              <span className="ml-1">
+                                / {tonAmount.toFixed(3)} TON
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            {formatDuration(plan)}
+                          </div>
+                        </div>
+                      </CardHeader>
+
+                      <CardContent className="space-y-4">
+                        <div className="space-y-2">
+                          {plan.features.map((feature, featureIndex) => (
+                            <motion.div
+                              key={featureIndex}
+                              initial={{ opacity: 0, x: -20 }}
+                              animate={{ opacity: 1, x: 0 }}
+                              transition={{
+                                delay: featureIndex * 0.08,
+                              }}
+                              className="flex items-center gap-2"
+                            >
+                              <CheckCircle className="h-4 w-4 text-green-500" />
+                              <span className="text-sm text-muted-foreground">
+                                {feature}
+                              </span>
+                            </motion.div>
+                          ))}
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-3 text-sm">
+                          <div className="flex items-center gap-2 text-muted-foreground">
+                            <Shield className="h-4 w-4 text-blue-500" />
+                            Secure checkout
+                          </div>
+                          <div className="flex items-center gap-2 text-muted-foreground">
+                            <Zap className="h-4 w-4 text-yellow-500" />
+                            Instant activation
+                          </div>
+                        </div>
+
+                        <Button
+                          onClick={() => handleSelectPlan(plan.id)}
+                          className={cn(
+                            "w-full transition-transform duration-300",
+                            popular
+                              ? "bg-dc-brand hover:bg-dc-brand-dark"
+                              : "bg-muted hover:bg-muted/80 text-foreground",
+                          )}
+                        >
+                          {popular ? "Join the VIP wave" : "Select plan"}
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  </Interactive3DCard>
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
         </div>
       </div>
     </FadeInOnView>


### PR DESCRIPTION
## Summary
- mark the miniapp marketing components as client safe and harden browser API guards
- reuse the shared subscription plan hook across miniapp pricing surfaces and clean up promo UX
- replace the miniapp home tab placeholders with the shared HomeLanding experience and Telegram context

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6194b2428832296c0c1eef01e03f5