### PR TITLE
feat: add AwesomeAPI economic catalyst sync job

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -8,6 +8,11 @@ from .awesome_api import (
     AwesomeAPIError,
     AwesomeAPISnapshotBuilder,
 )
+from .economic_catalysts import (
+    EconomicCatalyst,
+    EconomicCatalystGenerator,
+    EconomicCatalystSyncJob,
+)
 
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
 
@@ -17,6 +22,9 @@ __all__ = _trade_exports + [
     "AwesomeAPIClient",
     "AwesomeAPIError",
     "AwesomeAPISnapshotBuilder",
+    "EconomicCatalyst",
+    "EconomicCatalystGenerator",
+    "EconomicCatalystSyncJob",
 ]
 
 globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
@@ -27,5 +35,8 @@ globals().update(
         "AwesomeAPIClient": AwesomeAPIClient,
         "AwesomeAPIError": AwesomeAPIError,
         "AwesomeAPISnapshotBuilder": AwesomeAPISnapshotBuilder,
+        "EconomicCatalyst": EconomicCatalyst,
+        "EconomicCatalystGenerator": EconomicCatalystGenerator,
+        "EconomicCatalystSyncJob": EconomicCatalystSyncJob,
     }
 )

--- a/algorithms/python/economic_catalysts.py
+++ b/algorithms/python/economic_catalysts.py
@@ -1,0 +1,210 @@
+"""Automated economic catalyst generation from AwesomeAPI price history."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from .awesome_api import (
+    AwesomeAPIAutoCalculator,
+    AwesomeAPIAutoMetrics,
+    AwesomeAPIError,
+)
+from .supabase_sync import SupabaseTableWriter
+
+LOGGER = logging.getLogger(__name__)
+
+ImpactLevel = str  # Aliased for clarity when constructing catalyst payloads
+
+
+@dataclass(frozen=True, slots=True)
+class EconomicCatalyst:
+    """Represents an automatically generated market catalyst."""
+
+    pair: str
+    observed_at: datetime
+    headline: str
+    impact: ImpactLevel
+    market_focus: tuple[str, ...]
+    commentary: str
+    metrics: Mapping[str, float]
+    source: str = "awesomeapi"
+
+
+@dataclass(slots=True)
+class EconomicCatalystGenerator:
+    """Translate AwesomeAPI analytics into catalyst payloads."""
+
+    source: str = "awesomeapi"
+
+    def build(
+        self,
+        pair: str,
+        metrics: AwesomeAPIAutoMetrics,
+        observed_at: datetime,
+        *,
+        market_focus: Sequence[str] | None = None,
+    ) -> EconomicCatalyst:
+        impact = self._classify_impact(metrics)
+        headline = self._build_headline(metrics, impact)
+        commentary = self._build_commentary(metrics)
+        focus = tuple(self._normalise_focus(market_focus or (), pair))
+        payload_metrics = self._select_metrics(metrics)
+        return EconomicCatalyst(
+            pair=pair,
+            observed_at=observed_at,
+            headline=headline,
+            impact=impact,
+            market_focus=focus,
+            commentary=commentary,
+            metrics=payload_metrics,
+            source=self.source,
+        )
+
+    @staticmethod
+    def _classify_impact(metrics: AwesomeAPIAutoMetrics) -> ImpactLevel:
+        move = abs(metrics.percentage_change)
+        trend = abs(metrics.trend_strength) * 100.0
+        range_ratio = (
+            (metrics.price_range / metrics.average_close * 100.0)
+            if metrics.average_close
+            else 0.0
+        )
+        if move >= 1.75 or trend >= 5.0 or (range_ratio >= 3.0 and move >= 0.5):
+            return "High"
+        if move >= 0.75 or trend >= 2.5 or (range_ratio >= 1.5 and move >= 0.25):
+            return "Medium"
+        return "Low"
+
+    @staticmethod
+    def _build_headline(metrics: AwesomeAPIAutoMetrics, impact: ImpactLevel) -> str:
+        magnitude = abs(metrics.percentage_change)
+        if magnitude < 0.05:
+            direction = "flat"
+        elif metrics.absolute_change > 0:
+            direction = "higher"
+        elif metrics.absolute_change < 0:
+            direction = "lower"
+        else:
+            direction = "flat"
+        return (
+            f"{metrics.pair} closes {direction} {magnitude:.2f}% – {impact} impact risk signal"
+        )
+
+    @staticmethod
+    def _build_commentary(metrics: AwesomeAPIAutoMetrics) -> str:
+        direction = "gain" if metrics.absolute_change > 0 else "pullback" if metrics.absolute_change < 0 else "unchanged"
+        change = abs(metrics.absolute_change)
+        change_pct = abs(metrics.percentage_change)
+        range_pct = (
+            metrics.price_range / metrics.average_close * 100.0
+            if metrics.average_close
+            else 0.0
+        )
+        trend_pct = metrics.trend_strength * 100.0
+        volatility_pct = (
+            metrics.volatility / metrics.average_close * 100.0
+            if metrics.average_close
+            else 0.0
+        )
+        return (
+            f"Latest close at {metrics.latest_close:.4f} marks a {direction} of "
+            f"{change:.4f} ({change_pct:.2f}%). Two-sided range spans {range_pct:.2f}% "
+            f"with average close {metrics.average_close:.4f}. Trend strength prints "
+            f"{trend_pct:+.2f}% and realised volatility sits near {volatility_pct:.2f}% of price."
+        )
+
+    @staticmethod
+    def _normalise_focus(market_focus: Sequence[str], pair: str) -> Iterable[str]:
+        if market_focus:
+            for token in market_focus:
+                token_clean = token.strip()
+                if token_clean:
+                    yield token_clean
+        if pair:
+            components = [component.strip() for component in pair.split("-") if component.strip()]
+            for component in components:
+                if component not in market_focus:
+                    yield component
+            yield pair
+
+    @staticmethod
+    def _select_metrics(metrics: AwesomeAPIAutoMetrics) -> Mapping[str, float]:
+        return {
+            "latest_close": round(float(metrics.latest_close), 6),
+            "percentage_change": round(float(metrics.percentage_change), 6),
+            "absolute_change": round(float(metrics.absolute_change), 6),
+            "cumulative_return": round(float(metrics.cumulative_return), 6),
+            "trend_strength": round(float(metrics.trend_strength), 6),
+            "volatility": round(float(metrics.volatility), 6),
+            "average_daily_change": round(float(metrics.average_daily_change), 6),
+        }
+
+
+@dataclass(slots=True)
+class EconomicCatalystSyncJob:
+    """Fetch AwesomeAPI history and persist catalyst snapshots to Supabase."""
+
+    pairs: Mapping[str, Sequence[str]]
+    writer: SupabaseTableWriter
+    calculator: AwesomeAPIAutoCalculator = field(default_factory=AwesomeAPIAutoCalculator)
+    generator: EconomicCatalystGenerator = field(default_factory=EconomicCatalystGenerator)
+    history: int = 64
+
+    def run(self) -> int:
+        rows: list[MutableMapping[str, object]] = []
+        for pair, focus in self.pairs.items():
+            try:
+                bars = self.calculator.client.fetch_bars(pair, limit=self.history)
+            except AwesomeAPIError as exc:
+                LOGGER.warning("Failed to fetch AwesomeAPI history for %s: %s", pair, exc)
+                continue
+            except Exception as exc:  # pragma: no cover - defensive guard
+                LOGGER.warning("Unexpected error fetching AwesomeAPI data for %s: %s", pair, exc)
+                continue
+
+            if len(bars) < 2:
+                LOGGER.warning("Insufficient AwesomeAPI history for %s", pair)
+                continue
+
+            try:
+                metrics = self.calculator.compute_metrics(pair, bars=bars)
+            except (AwesomeAPIError, ValueError) as exc:
+                LOGGER.warning("Unable to compute AwesomeAPI metrics for %s: %s", pair, exc)
+                continue
+
+            observed_at = bars[-1].timestamp
+            catalyst = self.generator.build(
+                pair,
+                metrics,
+                observed_at,
+                market_focus=focus,
+            )
+            rows.append(self._normalise(catalyst))
+
+        if not rows:
+            return 0
+        return self.writer.upsert(rows)
+
+    @staticmethod
+    def _normalise(catalyst: EconomicCatalyst) -> MutableMapping[str, object]:
+        payload: MutableMapping[str, object] = {
+            "pair": catalyst.pair,
+            "observed_at": catalyst.observed_at,
+            "headline": catalyst.headline,
+            "impact": catalyst.impact,
+            "market_focus": list(catalyst.market_focus),
+            "commentary": catalyst.commentary,
+            "metrics": dict(catalyst.metrics),
+            "source": catalyst.source,
+        }
+        return payload
+
+
+__all__ = [
+    "EconomicCatalyst",
+    "EconomicCatalystGenerator",
+    "EconomicCatalystSyncJob",
+]

--- a/algorithms/python/jobs/economic_catalysts_job.py
+++ b/algorithms/python/jobs/economic_catalysts_job.py
@@ -1,0 +1,63 @@
+"""Entrypoint for syncing automated economic catalysts via AwesomeAPI."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping, Sequence
+
+from ..awesome_api import AwesomeAPIAutoCalculator
+from ..economic_catalysts import (
+    EconomicCatalystGenerator,
+    EconomicCatalystSyncJob,
+)
+from ..supabase_sync import SupabaseTableWriter
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PAIRS: Mapping[str, Sequence[str]] = {
+    "USD-BRL": ("USD", "BRL"),
+    "EUR-USD": ("EUR", "USD"),
+    "USD-JPY": ("USD", "JPY"),
+    "GBP-USD": ("GBP", "USD"),
+}
+
+
+def sync_economic_catalysts(
+    *,
+    pairs: Mapping[str, Sequence[str]] | None = None,
+    history: int = 96,
+    base_url: str | None = None,
+    service_role_key: str | None = None,
+) -> int:
+    calculator = AwesomeAPIAutoCalculator()
+    generator = EconomicCatalystGenerator()
+    writer = SupabaseTableWriter(
+        table="economic_catalysts",
+        conflict_column="pair",
+        base_url=base_url,
+        service_role_key=service_role_key,
+    )
+    job = EconomicCatalystSyncJob(
+        pairs=pairs or DEFAULT_PAIRS,
+        writer=writer,
+        calculator=calculator,
+        generator=generator,
+        history=history,
+    )
+    return job.run()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    base_url = os.getenv("SUPABASE_URL")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    count = sync_economic_catalysts(
+        base_url=base_url,
+        service_role_key=service_key,
+    )
+    LOGGER.info("Synced %s economic catalysts", count)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/algorithms/python/tests/test_economic_catalysts.py
+++ b/algorithms/python/tests/test_economic_catalysts.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from algorithms.python.awesome_api import AwesomeAPIAutoCalculator
+from algorithms.python.data_pipeline import RawBar
+from algorithms.python.economic_catalysts import (
+    EconomicCatalystGenerator,
+    EconomicCatalystSyncJob,
+)
+
+
+@pytest.fixture
+def sample_bars() -> list[RawBar]:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    closes = [5.0, 5.1, 5.05, 5.3, 5.4, 5.6]
+    bars: list[RawBar] = []
+    for idx, close in enumerate(closes):
+        moment = start + timedelta(hours=idx)
+        bars.append(
+            RawBar(
+                timestamp=moment,
+                open=close - 0.05,
+                high=close + 0.07,
+                low=close - 0.09,
+                close=close,
+                volume=1_000 + idx,
+            )
+        )
+    return bars
+
+
+def test_generator_builds_high_impact_catalyst(sample_bars: list[RawBar]) -> None:
+    calculator = AwesomeAPIAutoCalculator()
+    metrics = calculator.compute_metrics("USD-BRL", bars=sample_bars)
+    generator = EconomicCatalystGenerator()
+
+    observed_at = sample_bars[-1].timestamp
+    catalyst = generator.build(
+        "USD-BRL",
+        metrics,
+        observed_at,
+        market_focus=("LatAm FX",),
+    )
+
+    assert catalyst.impact == "High"
+    assert "USD-BRL" in catalyst.headline
+    assert "LatAm FX" in catalyst.market_focus
+    assert "USD-BRL" in catalyst.market_focus
+    assert catalyst.metrics["percentage_change"] == pytest.approx(metrics.percentage_change)
+
+
+def test_generator_handles_muted_move(sample_bars: list[RawBar]) -> None:
+    flat_bars = [bar for bar in sample_bars[:3]]
+    flat_bars.append(
+        RawBar(
+            timestamp=flat_bars[-1].timestamp + timedelta(hours=1),
+            open=flat_bars[-1].close,
+            high=flat_bars[-1].close + 0.01,
+            low=flat_bars[-1].close - 0.01,
+            close=flat_bars[-1].close + 0.001,
+            volume=1_500,
+        )
+    )
+    calculator = AwesomeAPIAutoCalculator()
+    metrics = calculator.compute_metrics("EUR-USD", bars=flat_bars)
+    generator = EconomicCatalystGenerator()
+
+    catalyst = generator.build(
+        "EUR-USD",
+        metrics,
+        flat_bars[-1].timestamp,
+    )
+
+    assert catalyst.impact == "Low"
+    assert "flat" in catalyst.headline.lower()
+
+
+def test_sync_job_upserts_rows(sample_bars: list[RawBar]) -> None:
+    class StubClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int]] = []
+
+        def fetch_bars(self, pair: str, *, limit: int) -> list[RawBar]:
+            self.calls.append((pair, limit))
+            assert pair == "USD-BRL"
+            assert limit == 32
+            return list(sample_bars)
+
+    class StubWriter:
+        def __init__(self) -> None:
+            self.rows: list[dict[str, object]] | None = None
+
+        def upsert(self, rows):
+            self.rows = [dict(row) for row in rows]
+            return len(self.rows)
+
+    calculator = AwesomeAPIAutoCalculator(client=StubClient())
+    writer = StubWriter()
+    job = EconomicCatalystSyncJob(
+        pairs={"USD-BRL": ("USD", "BRL")},
+        writer=writer,
+        calculator=calculator,
+        history=32,
+    )
+
+    count = job.run()
+
+    assert count == 1
+    assert writer.rows is not None
+    payload = writer.rows[0]
+    assert payload["pair"] == "USD-BRL"
+    assert payload["observed_at"] == sample_bars[-1].timestamp
+    assert payload["market_focus"] == ["USD", "BRL", "USD-BRL"]
+    assert "awesomeapi" == payload["source"]
+
+
+def test_sync_job_handles_fetch_errors() -> None:
+    class FailingClient:
+        def fetch_bars(self, pair: str, *, limit: int):  # pragma: no cover - defensive
+            raise RuntimeError("boom")
+
+    class StubWriter:
+        def upsert(self, rows):  # pragma: no cover - defensive
+            raise AssertionError("upsert should not be called")
+
+    calculator = AwesomeAPIAutoCalculator(client=FailingClient())
+    job = EconomicCatalystSyncJob(
+        pairs={"USD-BRL": ("USD", "BRL")},
+        writer=StubWriter(),
+        calculator=calculator,
+        history=16,
+    )
+
+    assert job.run() == 0

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -159,6 +159,26 @@ export const marketMovers = pgTable("market_movers", {
 export type MarketMover = typeof marketMovers.$inferSelect;
 export type NewMarketMover = typeof marketMovers.$inferInsert;
 
+export const economicCatalysts = pgTable("economic_catalysts", {
+  pair: text("pair").primaryKey(),
+  observedAt: timestamp("observed_at", { withTimezone: true }).notNull(),
+  headline: text("headline").notNull(),
+  impact: text("impact").notNull(),
+  marketFocus: jsonb("market_focus").$type<string[]>().notNull()
+    .default([] as string[]),
+  commentary: text("commentary"),
+  metrics: jsonb("metrics").$type<Record<string, number>>().notNull()
+    .default({} as Record<string, number>),
+  source: text("source").notNull().default("awesomeapi"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull()
+    .defaultNow(),
+});
+
+export type EconomicCatalystRow = typeof economicCatalysts.$inferSelect;
+export type NewEconomicCatalystRow = typeof economicCatalysts.$inferInsert;
+
 type FundamentalMetric = {
   label: string;
   value: string;


### PR DESCRIPTION
## Summary
- add automated EconomicCatalyst generator and sync job that derive catalysts from AwesomeAPI price history
- expose the new automation through the algorithms package and a runnable job, and expand the schema with an `economic_catalysts` table
- cover the generator and sync behaviour with dedicated pytest cases

## Testing
- PYTHONPATH=. pytest algorithms/python/tests
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d621fc33608322a9a305f404db4b27