### PR TITLE
Add AwesomeAPI-backed sentiment and COT Supabase sync jobs

### DIFF
--- a/algorithms/python/cot_report_sync.py
+++ b/algorithms/python/cot_report_sync.py
@@ -1,0 +1,189 @@
+"""AwesomeAPI Commitments of Traders report ingestion."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Mapping, MutableSequence, Protocol, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from .awesome_api import BASE_URL, DEFAULT_TIMEOUT, USER_AGENT
+from .supabase_sync import SupabaseTableWriter
+
+__all__ = [
+    "CotMarketConfig",
+    "CotReportSnapshot",
+    "CotReportProvider",
+    "AwesomeAPICotClient",
+    "AwesomeAPICotProvider",
+    "CotReportSyncJob",
+]
+
+
+class AwesomeAPICotError(RuntimeError):
+    """Raised when AwesomeAPI COT responses cannot be parsed."""
+
+
+@dataclass(slots=True)
+class CotMarketConfig:
+    """Mapping between Supabase market name and AwesomeAPI identifier."""
+
+    market: str
+    code: str
+
+
+@dataclass(slots=True)
+class CotReportSnapshot:
+    """Parsed COT report values ready for persistence."""
+
+    market: str
+    commercial_long: int
+    commercial_short: int
+    noncommercial_long: int
+    noncommercial_short: int
+    date: date
+
+
+class CotReportProvider(Protocol):  # pragma: no cover - interface definition
+    """Interface for providers that return COT report snapshots."""
+
+    def fetch(self) -> Sequence[CotReportSnapshot]:
+        """Return the latest report snapshot for each configured market."""
+
+
+@dataclass(slots=True)
+class AwesomeAPICotClient:
+    """Minimal HTTP client for AwesomeAPI COT endpoints."""
+
+    base_url: str = f"{BASE_URL}/cot"
+    user_agent: str = USER_AGENT
+    timeout: float = DEFAULT_TIMEOUT
+
+    def fetch_series(self, code: str) -> Sequence[Mapping[str, object]]:
+        code_clean = code.strip()
+        url = f"{self.base_url}/{code_clean}"
+        request = Request(url, headers={"User-Agent": self.user_agent})
+        try:
+            with urlopen(request, timeout=self.timeout) as response:  # type: ignore[arg-type]
+                raw = response.read()
+        except (HTTPError, URLError, TimeoutError) as exc:  # pragma: no cover - network variance
+            raise AwesomeAPICotError(
+                f"Failed to fetch AwesomeAPI COT data for {code_clean}: {exc}"
+            ) from exc
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise AwesomeAPICotError(
+                f"Invalid AwesomeAPI COT payload for {code_clean}: {exc}"
+            ) from exc
+        if isinstance(payload, list):
+            return payload
+        if isinstance(payload, Mapping):
+            return [payload]
+        raise AwesomeAPICotError(
+            f"Unexpected AwesomeAPI COT response for {code_clean}: {type(payload).__name__}"
+        )
+
+
+def _coerce_date(value: object) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            raise ValueError("empty date value")
+        try:
+            return datetime.fromisoformat(raw).date()
+        except ValueError:
+            if len(raw) == 8 and raw.isdigit():
+                return date(int(raw[:4]), int(raw[4:6]), int(raw[6:]))
+    raise ValueError(f"invalid date value: {value!r}")
+
+
+def _extract_report_date(entry: Mapping[str, object]) -> date:
+    for key in ("date", "report_date", "reportDate"):
+        if key in entry:
+            try:
+                return _coerce_date(entry[key])
+            except ValueError as exc:
+                raise AwesomeAPICotError(f"Invalid COT report date: {entry[key]!r}") from exc
+    raise AwesomeAPICotError("AwesomeAPI COT payload missing report date")
+
+
+def _parse_int(value: object, *, field: str) -> int:
+    if value is None:
+        raise AwesomeAPICotError(f"AwesomeAPI COT payload missing {field}")
+    try:
+        # Some AwesomeAPI payloads serialise numeric fields as strings.
+        return int(float(str(value)))
+    except (TypeError, ValueError) as exc:
+        raise AwesomeAPICotError(f"Invalid COT value for {field}: {value!r}") from exc
+
+
+@dataclass(slots=True)
+class AwesomeAPICotProvider:
+    """Provider that converts AwesomeAPI responses into COT snapshots."""
+
+    markets: Sequence[CotMarketConfig]
+    client: AwesomeAPICotClient = field(default_factory=AwesomeAPICotClient)
+
+    def fetch(self) -> Sequence[CotReportSnapshot]:
+        snapshots: MutableSequence[CotReportSnapshot] = []
+        for config in self.markets:
+            series = self.client.fetch_series(config.code)
+            latest_entry = self._select_latest(series)
+            snapshots.append(
+                CotReportSnapshot(
+                    market=config.market,
+                    commercial_long=_parse_int(latest_entry["commercial_long"], field="commercial_long"),
+                    commercial_short=_parse_int(latest_entry["commercial_short"], field="commercial_short"),
+                    noncommercial_long=_parse_int(
+                        latest_entry["noncommercial_long"], field="noncommercial_long"
+                    ),
+                    noncommercial_short=_parse_int(
+                        latest_entry["noncommercial_short"], field="noncommercial_short"
+                    ),
+                    date=_extract_report_date(latest_entry),
+                )
+            )
+        return list(snapshots)
+
+    @staticmethod
+    def _select_latest(series: Sequence[Mapping[str, object]]) -> Mapping[str, object]:
+        dated_entries: MutableSequence[tuple[date, Mapping[str, object]]] = []
+        for entry in series:
+            try:
+                report_date = _extract_report_date(entry)
+            except AwesomeAPICotError:
+                continue
+            dated_entries.append((report_date, entry))
+        if not dated_entries:
+            raise AwesomeAPICotError("AwesomeAPI COT series contained no dated entries")
+        dated_entries.sort(key=lambda item: item[0])
+        return dated_entries[-1][1]
+
+
+@dataclass(slots=True)
+class CotReportSyncJob:
+    """Persist COT report snapshots into Supabase."""
+
+    provider: CotReportProvider
+    writer: SupabaseTableWriter
+
+    def run(self) -> int:
+        rows = [
+            {
+                "market": snapshot.market,
+                "commercialLong": snapshot.commercial_long,
+                "commercialShort": snapshot.commercial_short,
+                "noncommercialLong": snapshot.noncommercial_long,
+                "noncommercialShort": snapshot.noncommercial_short,
+                "date": snapshot.date,
+            }
+            for snapshot in self.provider.fetch()
+        ]
+        return self.writer.upsert(rows)

--- a/algorithms/python/market_sentiment_sync.py
+++ b/algorithms/python/market_sentiment_sync.py
@@ -1,0 +1,126 @@
+"""AwesomeAPI-backed market sentiment synchronisation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Protocol, Sequence
+
+from .awesome_api import AwesomeAPIAutoCalculator, AwesomeAPIAutoMetrics
+from .supabase_sync import SupabaseTableWriter
+
+__all__ = [
+    "SentimentInstrument",
+    "MarketSentimentSnapshot",
+    "MarketSentimentProvider",
+    "AwesomeAPIMarketSentimentProvider",
+    "MarketSentimentSyncJob",
+]
+
+
+@dataclass(slots=True)
+class SentimentInstrument:
+    """Configuration describing how to fetch sentiment for a market."""
+
+    symbol: str
+    pair: str
+    source: str | None = None
+
+
+@dataclass(slots=True)
+class MarketSentimentSnapshot:
+    """Calculated market sentiment snapshot ready for persistence."""
+
+    source: str
+    symbol: str
+    sentiment: float
+    long_percent: float
+    short_percent: float
+    created_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+
+class MarketSentimentProvider(Protocol):  # pragma: no cover - interface definition
+    """Interface for adapters that provide sentiment snapshots."""
+
+    def fetch(self) -> Sequence[MarketSentimentSnapshot]:
+        """Return the latest snapshots for configured instruments."""
+
+
+@dataclass(slots=True)
+class AwesomeAPIMarketSentimentProvider:
+    """Compute sentiment metrics using AwesomeAPI analytics."""
+
+    instruments: Sequence[SentimentInstrument]
+    calculator: AwesomeAPIAutoCalculator = field(default_factory=AwesomeAPIAutoCalculator)
+    default_source: str = "awesomeapi"
+
+    def fetch(self) -> Sequence[MarketSentimentSnapshot]:
+        snapshots = []
+        for instrument in self.instruments:
+            metrics = self.calculator.compute_metrics(instrument.pair)
+            sentiment, long_percent, short_percent = self._derive_sentiment(metrics)
+            snapshots.append(
+                MarketSentimentSnapshot(
+                    source=instrument.source or self.default_source,
+                    symbol=instrument.symbol,
+                    sentiment=sentiment,
+                    long_percent=long_percent,
+                    short_percent=short_percent,
+                )
+            )
+        return snapshots
+
+    def _derive_sentiment(
+        self, metrics: AwesomeAPIAutoMetrics
+    ) -> tuple[float, float, float]:
+        if metrics.average_close:
+            average_bias = (metrics.latest_close - metrics.average_close) / metrics.average_close
+        else:  # pragma: no cover - guard against zero values from API
+            average_bias = 0.0
+        momentum = metrics.percentage_change / 100.0
+        trend = metrics.trend_strength
+        if metrics.latest_close:
+            volatility_penalty = min(metrics.volatility / metrics.latest_close, 1.0)
+        else:  # pragma: no cover - guard against zero values from API
+            volatility_penalty = 0.0
+
+        raw_score = (
+            0.55 * average_bias
+            + 0.3 * momentum
+            + 0.25 * trend
+            - 0.2 * volatility_penalty
+        )
+        raw_score = max(min(raw_score, 1.0), -1.0)
+
+        long_ratio = (raw_score + 1.0) / 2.0
+        long_percent = max(min(long_ratio * 100.0, 100.0), 0.0)
+        short_percent = max(min((1.0 - long_ratio) * 100.0, 100.0), 0.0)
+        sentiment = long_percent
+
+        return (
+            round(sentiment, 4),
+            round(long_percent, 4),
+            round(short_percent, 4),
+        )
+
+
+@dataclass(slots=True)
+class MarketSentimentSyncJob:
+    """Fetch sentiment snapshots and upsert them into Supabase."""
+
+    provider: MarketSentimentProvider
+    writer: SupabaseTableWriter
+
+    def run(self) -> int:
+        rows = [
+            {
+                "source": snapshot.source,
+                "symbol": snapshot.symbol,
+                "sentiment": round(snapshot.sentiment, 4),
+                "longPercent": round(snapshot.long_percent, 4),
+                "shortPercent": round(snapshot.short_percent, 4),
+                "createdAt": snapshot.created_at,
+            }
+            for snapshot in self.provider.fetch()
+        ]
+        return self.writer.upsert(rows)

--- a/algorithms/python/tests/test_cot_report_sync.py
+++ b/algorithms/python/tests/test_cot_report_sync.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import date
+
+from algorithms.python.cot_report_sync import (
+    AwesomeAPICotProvider,
+    CotMarketConfig,
+    CotReportSnapshot,
+    CotReportSyncJob,
+)
+
+
+class FakeCotClient:
+    def __init__(self, payloads):
+        self._payloads = payloads
+
+    def fetch_series(self, code):  # pragma: no cover - simple stub
+        return list(self._payloads[code])
+
+
+class MemoryWriter:
+    def __init__(self):
+        self.rows = []
+
+    def upsert(self, rows):
+        self.rows = list(rows)
+        return len(self.rows)
+
+
+def test_cot_provider_selects_latest_report():
+    client = FakeCotClient(
+        {
+            "6E": [
+                {
+                    "reportDate": "20240507",
+                    "commercial_long": "1000",
+                    "commercial_short": "800",
+                    "noncommercial_long": "1200",
+                    "noncommercial_short": "900",
+                },
+                {
+                    "date": "2024-05-14",
+                    "commercial_long": 1100,
+                    "commercial_short": 750,
+                    "noncommercial_long": 1300,
+                    "noncommercial_short": 880,
+                },
+            ]
+        }
+    )
+    provider = AwesomeAPICotProvider(
+        markets=[CotMarketConfig(market="EUR Futures", code="6E")],
+        client=client,
+    )
+
+    snapshots = provider.fetch()
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.market == "EUR Futures"
+    assert snapshot.date == date(2024, 5, 14)
+    assert snapshot.commercial_long == 1100
+    assert snapshot.commercial_short == 750
+    assert snapshot.noncommercial_long == 1300
+    assert snapshot.noncommercial_short == 880
+
+
+def test_cot_sync_job_upserts_payload():
+    provider = DummyCotProvider()
+    writer = MemoryWriter()
+    job = CotReportSyncJob(provider=provider, writer=writer)
+
+    count = job.run()
+
+    assert count == 1
+    row = writer.rows[0]
+    assert row["market"] == "S&P Futures"
+    assert row["commercialLong"] == 4000
+    assert row["commercialShort"] == 2500
+    assert row["noncommercialLong"] == 1800
+    assert row["noncommercialShort"] == 2200
+    assert row["date"] == date(2024, 5, 7)
+
+
+class DummyCotProvider:
+    def fetch(self):  # pragma: no cover - simple stub
+        return [
+            CotReportSnapshot(
+                market="S&P Futures",
+                commercial_long=4000,
+                commercial_short=2500,
+                noncommercial_long=1800,
+                noncommercial_short=2200,
+                date=date(2024, 5, 7),
+            )
+        ]

--- a/algorithms/python/tests/test_market_sentiment_sync.py
+++ b/algorithms/python/tests/test_market_sentiment_sync.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from algorithms.python.awesome_api import AwesomeAPIAutoMetrics
+from algorithms.python.market_sentiment_sync import (
+    AwesomeAPIMarketSentimentProvider,
+    MarketSentimentSnapshot,
+    MarketSentimentSyncJob,
+    SentimentInstrument,
+)
+
+
+class DummyCalculator:
+    def compute_metrics(self, pair, history=None, bars=None):  # pragma: no cover - simple stub
+        assert pair == "USD-BRL"
+        return AwesomeAPIAutoMetrics(
+            pair=pair,
+            sample_size=5,
+            latest_close=102.0,
+            previous_close=100.0,
+            absolute_change=2.0,
+            percentage_change=2.0,
+            average_close=100.5,
+            high=105.0,
+            low=95.0,
+            price_range=10.0,
+            cumulative_return=0.05,
+            average_daily_change=0.4,
+            volatility=1.25,
+            trend_strength=0.05,
+        )
+
+
+class MemoryWriter:
+    def __init__(self):
+        self.rows = []
+
+    def upsert(self, rows):
+        self.rows = list(rows)
+        return len(self.rows)
+
+
+def test_awesomeapi_sentiment_provider_derives_percentages():
+    provider = AwesomeAPIMarketSentimentProvider(
+        instruments=[SentimentInstrument(symbol="USDBRL", pair="USD-BRL")],
+        calculator=DummyCalculator(),
+        default_source="awesome",
+    )
+
+    snapshots = provider.fetch()
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.source == "awesome"
+    assert snapshot.symbol == "USDBRL"
+    assert snapshot.sentiment == snapshot.long_percent
+    assert snapshot.sentiment == 51.2129
+    assert snapshot.short_percent == 48.7871
+
+
+def test_market_sentiment_sync_job_persists_rows():
+    provider = DummyProvider()
+    writer = MemoryWriter()
+    job = MarketSentimentSyncJob(provider=provider, writer=writer)
+
+    count = job.run()
+
+    assert count == 1
+    assert writer.rows[0]["symbol"] == "EURUSD"
+    assert writer.rows[0]["sentiment"] == 60.0
+    assert writer.rows[0]["longPercent"] == 60.0
+    assert writer.rows[0]["shortPercent"] == 40.0
+    assert writer.rows[0]["createdAt"].isoformat() == "2024-05-01T12:00:00+00:00"
+
+
+class DummyProvider:
+    def fetch(self):  # pragma: no cover - simple stub
+        return [
+            MarketSentimentSnapshot(
+                source="awesome",
+                symbol="EURUSD",
+                sentiment=60.0,
+                long_percent=60.0,
+                short_percent=40.0,
+                created_at=datetime(2024, 5, 1, 12, tzinfo=timezone.utc),
+            )
+        ]


### PR DESCRIPTION
## Summary
- add a market sentiment pipeline that derives long/short splits from AwesomeAPI metrics and writes them to Supabase
- introduce a Commitments of Traders ingestion workflow with AwesomeAPI parsing, validation, and Supabase persistence
- cover the new providers and sync jobs with focused unit tests

## Testing
- npm run lint
- npm run typecheck
- PYTHONPATH=. pytest algorithms/python/tests/test_market_sentiment_sync.py algorithms/python/tests/test_cot_report_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d622fa42ec83228e972cc6e5cb76a5