### PR TITLE
Integrate AwesomeAPI data into economic calendar view

### DIFF
--- a/apps/web/components/magic-portfolio/home/EconomicCalendarSection.stories.tsx
+++ b/apps/web/components/magic-portfolio/home/EconomicCalendarSection.stories.tsx
@@ -9,6 +9,43 @@ const MOCK_EVENTS: EconomicEvent[] = [
     title: "FOMC rate decision & Powell press conference",
     impact: "High",
     marketFocus: ["USD", "Rates", "US Indices"],
+    marketHighlights: [
+      {
+        focus: "USD",
+        instruments: [
+          {
+            instrumentId: "DXY",
+            displaySymbol: "DXY",
+            name: "US Dollar Index",
+            format: {
+              style: "decimal",
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            },
+            last: 104.21,
+            changePercent: 0.32,
+          },
+        ],
+      },
+      { focus: "Rates", instruments: [] },
+      {
+        focus: "US Indices",
+        instruments: [
+          {
+            instrumentId: "SPX500",
+            displaySymbol: "S&P 500",
+            name: "S&P 500",
+            format: {
+              style: "decimal",
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            },
+            last: 5214.5,
+            changePercent: -0.12,
+          },
+        ],
+      },
+    ],
     commentary:
       "We expect policy guidance to lean hawkish until inflation cools materially. Volatility typically spikes across USD crosses as Powell takes the podium.",
     deskPlan: [
@@ -24,6 +61,26 @@ const MOCK_EVENTS: EconomicEvent[] = [
     title: "ECB speakers rotation",
     impact: "Medium",
     marketFocus: ["EUR", "European Banks"],
+    marketHighlights: [
+      {
+        focus: "EUR",
+        instruments: [
+          {
+            instrumentId: "EURUSD",
+            displaySymbol: "EUR/USD",
+            name: "Euro vs US dollar",
+            format: {
+              style: "decimal",
+              minimumFractionDigits: 4,
+              maximumFractionDigits: 4,
+            },
+            last: 1.0832,
+            changePercent: 0.18,
+          },
+        ],
+      },
+      { focus: "European Banks", instruments: [] },
+    ],
     commentary:
       "Lagarde, Villeroy, and Schnabel speak through the session with colour on June easing prospects.",
     deskPlan: [

--- a/apps/web/types/economic-event.ts
+++ b/apps/web/types/economic-event.ts
@@ -1,5 +1,22 @@
 export type ImpactLevel = "High" | "Medium" | "Low";
 
+export interface EconomicEventMarketQuote {
+  instrumentId: string;
+  displaySymbol: string;
+  name: string;
+  format: Intl.NumberFormatOptions;
+  last?: number;
+  changePercent?: number;
+  high?: number;
+  low?: number;
+  lastUpdated?: string | null;
+}
+
+export interface EconomicEventMarketHighlight {
+  focus: string;
+  instruments: EconomicEventMarketQuote[];
+}
+
 export interface EconomicEvent {
   id: string;
   day: string;
@@ -7,6 +24,7 @@ export interface EconomicEvent {
   title: string;
   impact: ImpactLevel;
   marketFocus: string[];
+  marketHighlights: EconomicEventMarketHighlight[];
   commentary: string;
   deskPlan: string[];
 }


### PR DESCRIPTION
## Summary
- pull AwesomeAPI quotes for calendar focuses and merge them into the economic event payload
- expose the market highlight data through the calendar types and component with refreshed UI examples
- expand service tests to cover AwesomeAPI integration and desk-plan fallbacks

## Testing
- npm run lint
- npm run typecheck
- npm run test -- tests/economic-calendar-service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d62088a94083228281bf6b7d373291