### PR TITLE
Add Loss Recovery Programme section to landing page

### DIFF
--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.module.scss
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.module.scss
@@ -77,6 +77,12 @@
   grid-template-columns: repeat(auto-fit, minmax(21rem, 1fr));
 }
 
+.lossRecoveryGrid {
+  @extend %gridBase;
+  gap: clamp(1.25rem, 3vw, 2.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+}
+
 .card {
   height: 100%;
 }
@@ -151,6 +157,18 @@
   list-style: none;
   padding: 0;
   margin: 0;
+}
+
+.applyFlow {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.applyFlowArrow {
+  display: inline-flex;
+  align-items: center;
 }
 
 @media (max-width: breakpoints.$m) {

--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -25,6 +25,7 @@ import { FxMarketSnapshotSection } from "@/components/magic-portfolio/home/FxMar
 import { HeroExperience } from "@/components/magic-portfolio/home/HeroExperience";
 import { IndexStrengthSection } from "@/components/magic-portfolio/home/IndexStrengthSection";
 import { MentorshipProgramsSection } from "@/components/magic-portfolio/home/MentorshipProgramsSection";
+import { LossRecoveryProgrammeSection } from "@/components/magic-portfolio/home/LossRecoveryProgrammeSection";
 import { Mailchimp } from "@/components/magic-portfolio/Mailchimp";
 import { MarketWatchlist } from "@/components/magic-portfolio/home/MarketWatchlist";
 import { PerformanceInsightsSection } from "@/components/magic-portfolio/home/PerformanceInsightsSection";
@@ -233,6 +234,16 @@ const SERVICES = [
     ctaHref: "#mentorship-programs",
   },
   {
+    id: "loss-recovery",
+    icon: "shield" as const,
+    name: "Loss Recovery Programme",
+    tagline: "Risk-first turnaround plans for disciplined traders.",
+    description:
+      "Submit read-only performance history for an audit, then partner with senior strategists to reset risk and rebuild execution.",
+    ctaLabel: "Explore the programme",
+    ctaHref: "#loss-recovery",
+  },
+  {
     id: "capital-bridge",
     icon: "rocket" as const,
     name: "Capital Bridge",
@@ -348,27 +359,30 @@ export function DynamicCapitalLandingPage() {
         <MentorshipProgramsSection />
       </Section>
       <Section revealDelay={1.2}>
-        <VipPlansPricingSection />
+        <LossRecoveryProgrammeSection />
       </Section>
       <Section revealDelay={1.28}>
-        <VipPackagesSection />
+        <VipPlansPricingSection />
       </Section>
       <Section revealDelay={1.36}>
-        <MentorAndTrustSection />
+        <VipPackagesSection />
       </Section>
       <Section revealDelay={1.44}>
-        <PoolTradingSection />
+        <MentorAndTrustSection />
       </Section>
       <Section revealDelay={1.52}>
-        <ComplianceCertificates />
+        <PoolTradingSection />
       </Section>
       <Section revealDelay={1.6}>
-        <FundingReadinessSection />
+        <ComplianceCertificates />
       </Section>
       <Section revealDelay={1.68}>
-        <CheckoutCallout />
+        <FundingReadinessSection />
       </Section>
       <Section revealDelay={1.76}>
+        <CheckoutCallout />
+      </Section>
+      <Section revealDelay={1.84}>
         <AboutShowcase />
       </Section>
       <Section reveal={false}>

--- a/apps/web/components/magic-portfolio/home/LossRecoveryProgrammeSection.tsx
+++ b/apps/web/components/magic-portfolio/home/LossRecoveryProgrammeSection.tsx
@@ -1,0 +1,234 @@
+import { Fragment } from "react";
+
+import {
+  Column,
+  Heading,
+  Icon,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+
+import styles from "../DynamicCapitalLandingPage.module.scss";
+
+type RecoveryStep = {
+  title: string;
+  description: string;
+  supportingText?: string;
+  bullets?: string[];
+};
+
+const HOW_IT_WORKS: RecoveryStep[] = [
+  {
+    title: "Submit your trading history (read-only)",
+    description:
+      "Share your MT4/MT5 investor password or a Myfxbook/FXBlue read-only link so the desk can audit live data.",
+    supportingText:
+      "We analyze strategy habits, drawdown profile, risk, and execution before prescribing adjustments.",
+  },
+  {
+    title: "Personal review",
+    description:
+      "Book a 1:1 session once the audit is complete for a tailored Recovery Plan covering the core levers.",
+    bullets: [
+      "Risk reset calibrated to your drawdown ceiling",
+      "Position sizing recalculated against current equity",
+      "Session rules optimized around market windows",
+      "Playbook setups prioritized for rebuilding confidence",
+    ],
+  },
+  {
+    title: "Live Q&A with our experts",
+    description:
+      "Join a Zoom or Telegram call to walk through the recovery roadmap, clarify execution steps, and confirm accountability milestones.",
+  },
+];
+
+const HIGH_LOSS_DETAILS = [
+  "Priority access to senior strategists",
+  "Choice of private in-person meeting or executive Zoom",
+  "NDA support available on request",
+] as const;
+
+const SUITABILITY = [
+  "You’re in drawdown or stuck managing hedged positions",
+  "You want a structured path back with accountability checkpoints",
+] as const;
+
+const APPLY_FLOW = [
+  "Submit details",
+  "Book review",
+  "Get your plan",
+  "Implement with support",
+] as const;
+
+export function LossRecoveryProgrammeSection() {
+  return (
+    <Column
+      id="loss-recovery"
+      fillWidth
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      gap="32"
+      shadow="l"
+      style={{ scrollMarginTop: "96px" }}
+    >
+      <Column gap="12" maxWidth={32}>
+        <Heading variant="display-strong-xs">
+          Loss Recovery Programme
+        </Heading>
+        <Text variant="body-default-l" onBackground="neutral-weak">
+          Help disciplined traders turn around drawdowns and rebuild equity with
+          a clear, risk-first plan.
+        </Text>
+      </Column>
+
+      <div className={styles.lossRecoveryGrid}>
+        <Column gap="20">
+          <Column gap="12">
+            <Heading variant="heading-strong-s">How it works</Heading>
+            <Column as="ol" gap="16" className={styles.stepList}>
+              {HOW_IT_WORKS.map((step, index) => (
+                <Column as="li" key={step.title} gap="12">
+                  <Row gap="12" vertical="start">
+                    <Tag size="s" background="brand-alpha-weak">
+                      Step {index + 1}
+                    </Tag>
+                    <Heading variant="heading-strong-s">
+                      {step.title}
+                    </Heading>
+                  </Row>
+                  <Text variant="body-default-m">{step.description}</Text>
+                  {step.supportingText
+                    ? (
+                      <Text
+                        variant="body-default-m"
+                        onBackground="neutral-weak"
+                      >
+                        {step.supportingText}
+                      </Text>
+                    )
+                    : null}
+                  {step.bullets
+                    ? (
+                      <Column as="ul" gap="8">
+                        {step.bullets.map((bullet) => (
+                          <Row key={bullet} gap="8" vertical="center">
+                            <Icon name="check" onBackground="brand-medium" />
+                            <Text as="li" variant="body-default-m">
+                              {bullet}
+                            </Text>
+                          </Row>
+                        ))}
+                      </Column>
+                    )
+                    : null}
+                </Column>
+              ))}
+            </Column>
+          </Column>
+        </Column>
+
+        <Column gap="20">
+          <Column
+            background="brand-alpha-weak"
+            border="brand-alpha-medium"
+            radius="l"
+            padding="l"
+            gap="12"
+          >
+            <Tag size="s" background="brand-alpha-weak" prefixIcon="shield">
+              High-Loss Desk (&gt;$500k)
+            </Tag>
+            <Column as="ul" gap="8">
+              {HIGH_LOSS_DETAILS.map((detail) => (
+                <Row key={detail} gap="8" vertical="center">
+                  <Icon name="users" onBackground="brand-medium" />
+                  <Text as="li" variant="body-default-m">
+                    {detail}
+                  </Text>
+                </Row>
+              ))}
+            </Column>
+          </Column>
+
+          <Column
+            background="page"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="l"
+            gap="8"
+          >
+            <Tag size="s" background="brand-alpha-weak" prefixIcon="sparkles">
+              Fees
+            </Tag>
+            <Text variant="body-default-m">
+              Performance-based options available for eligible cases — no
+              upfront fee for select profiles, subject to assessment.
+            </Text>
+          </Column>
+
+          <Column
+            background="page"
+            border="neutral-alpha-weak"
+            radius="l"
+            padding="l"
+            gap="8"
+          >
+            <Tag size="s" background="brand-alpha-weak" prefixIcon="timer">
+              Availability
+            </Tag>
+            <Text variant="body-default-m">
+              Limited to the first 100 traders this cycle.
+            </Text>
+          </Column>
+        </Column>
+      </div>
+
+      <Column gap="20">
+        <Column gap="12">
+          <Heading variant="heading-strong-s">Who should apply</Heading>
+          <Column as="ul" gap="8">
+            {SUITABILITY.map((item) => (
+              <Row key={item} gap="8" vertical="center">
+                <Icon name="check" onBackground="brand-medium" />
+                <Text as="li" variant="body-default-m">
+                  {item}
+                </Text>
+              </Row>
+            ))}
+          </Column>
+        </Column>
+
+        <Column gap="12">
+          <Heading variant="heading-strong-s">Apply</Heading>
+          <div className={styles.applyFlow}>
+            {APPLY_FLOW.map((step, index) => (
+              <Fragment key={step}>
+                <Tag size="m" background="brand-alpha-weak">
+                  {step}
+                </Tag>
+                {index < APPLY_FLOW.length - 1
+                  ? (
+                    <Text
+                      as="span"
+                      variant="body-default-m"
+                      onBackground="neutral-weak"
+                      className={styles.applyFlowArrow}
+                    >
+                      →
+                    </Text>
+                  )
+                  : null}
+              </Fragment>
+            ))}
+          </div>
+        </Column>
+      </Column>
+    </Column>
+  );
+}
+
+export default LossRecoveryProgrammeSection;

--- a/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
+++ b/apps/web/components/magic-portfolio/home/MentorshipProgramsSection.tsx
@@ -19,9 +19,11 @@ type MentorshipProgram = {
   description: string;
   focus: string;
   features: string[];
-  planId: string;
+  planId?: string;
+  primaryCtaHref?: string;
   primaryCtaLabel: string;
-  secondaryCtaLabel: string;
+  secondaryCtaLabel?: string;
+  secondaryCtaHref?: string;
 };
 
 const PROGRAMS: MentorshipProgram[] = [
@@ -58,6 +60,23 @@ const PROGRAMS: MentorshipProgram[] = [
     planId: "vip-lifetime",
     primaryCtaLabel: "Unlock with lifetime access",
     secondaryCtaLabel: "Talk with the mentorship lead",
+  },
+  {
+    id: "loss-recovery-programme",
+    name: "Loss Recovery Programme",
+    cadence: "Application-based",
+    description:
+      "A structured turnaround plan for disciplined traders facing sustained drawdowns.",
+    focus:
+      "Audit live trading history, reset risk, and rebuild execution habits before scaling back into full size.",
+    features: [
+      "Read-only MT4/MT5 or Myfxbook/FXBlue audit by senior strategists",
+      "Tailored recovery roadmap covering risk reset and position sizing",
+      "Session rules and playbook setups to restore disciplined execution",
+    ],
+    primaryCtaLabel: "Submit details for review",
+    primaryCtaHref: "#loss-recovery",
+    secondaryCtaLabel: "Book the recovery review",
   },
 ];
 
@@ -121,28 +140,50 @@ export function MentorshipProgramsSection() {
                 ))}
               </Column>
               <Row gap="12" s={{ direction: "column" }}>
-                <Button
-                  size="m"
-                  variant="secondary"
-                  data-border="rounded"
-                  prefixIcon="sparkles"
-                  href={`/checkout?plan=${encodeURIComponent(program.planId)}`}
-                >
-                  {program.primaryCtaLabel}
-                </Button>
-                {about.calendar.display && about.calendar.link
-                  ? (
+                {(() => {
+                  const primaryHref = program.primaryCtaHref ??
+                    (program.planId
+                      ? `/checkout?plan=${encodeURIComponent(program.planId)}`
+                      : undefined);
+
+                  return primaryHref
+                    ? (
+                      <Button
+                        size="m"
+                        variant="secondary"
+                        data-border="rounded"
+                        prefixIcon="sparkles"
+                        href={primaryHref}
+                      >
+                        {program.primaryCtaLabel}
+                      </Button>
+                    )
+                    : null;
+                })()}
+                {(() => {
+                  const secondaryHref = program.secondaryCtaHref ??
+                    about.calendar.link;
+
+                  if (
+                    !program.secondaryCtaLabel ||
+                    !about.calendar.display ||
+                    !secondaryHref
+                  ) {
+                    return null;
+                  }
+
+                  return (
                     <Button
                       size="m"
                       variant="secondary"
                       data-border="rounded"
                       prefixIcon="calendar"
-                      href={about.calendar.link}
+                      href={secondaryHref}
                     >
                       {program.secondaryCtaLabel}
                     </Button>
-                  )
-                  : null}
+                  );
+                })()}
               </Row>
             </Column>
             {index < PROGRAMS.length - 1


### PR DESCRIPTION
## Summary
- add a dedicated Loss Recovery Programme section with application flow details and high-loss callouts on the landing page
- extend the mentorship catalogue with the Loss Recovery Programme entry and flexible CTA handling
- surface the new programme in the services roster and adjust layout styling utilities

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d62534e9b883228f06d4014df5f01a