### PR TITLE
feat: add trading psychology scoring pipeline

### DIFF
--- a/algorithms/README.md
+++ b/algorithms/README.md
@@ -35,3 +35,26 @@ remain in the top-level `supabase/` directory.
 To enable Grok feedback in a live service, instantiate a completion client
 (e.g. wrapping the local `grok-1` `InferenceRunner`) and pass a configured
 `GrokAdvisor` instance into `RealtimeExecutor`.
+
+## Trading psychology scoring inputs
+
+`python/trading_psychology.py` ingests structured observations describing the
+desk's operating rhythm. Each `PsychologyObservation` should include:
+
+- `timestamp` – timezone-aware datetime indicating when the reflection was
+  captured.
+- `plan_adherence` – 0.0–1.0 score covering pre-session planning follow-through.
+- `risk_compliance` – 0.0–1.0 ratio of trades that respected risk parameters.
+- `recovery_rate` – 0.0–1.0 measure of how quickly the trader rebounded from a
+  setback.
+- `emotional_stability` – 0.0–1.0 pulse on emotional regulation during the
+  session.
+- `focus_quality` – 0.0–1.0 assessment of concentration on planned setups.
+- `distraction_events` – integer count of meaningful distractions recorded for
+  the session (used as a penalty against focus).
+- `routine_adherence` – 0.0–1.0 signal for journaling, warm-ups, and recovery
+  routines completed.
+
+The ingestion pipeline should publish the most recent observations (typically
+the last 10–14 sessions) so the model can apply recency-weighted scoring before
+syncing composite readiness into Supabase.

--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -14,6 +14,13 @@ from .economic_catalysts import (
     EconomicCatalystGenerator,
     EconomicCatalystSyncJob,
 )
+from .trading_psychology import (
+    PsychologyObservation,
+    PsychologyScore,
+    TradingPsychologyInsights,
+    TradingPsychologyModel,
+)
+from .jobs.trading_psychology_job import TradingPsychologySyncJob
 
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
 
@@ -28,6 +35,11 @@ __all__ = _trade_exports + [
     "EconomicCatalyst",
     "EconomicCatalystGenerator",
     "EconomicCatalystSyncJob",
+    "PsychologyObservation",
+    "PsychologyScore",
+    "TradingPsychologyModel",
+    "TradingPsychologyInsights",
+    "TradingPsychologySyncJob",
 ]
 
 globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
@@ -43,5 +55,10 @@ globals().update(
         "EconomicCatalyst": EconomicCatalyst,
         "EconomicCatalystGenerator": EconomicCatalystGenerator,
         "EconomicCatalystSyncJob": EconomicCatalystSyncJob,
+        "PsychologyObservation": PsychologyObservation,
+        "PsychologyScore": PsychologyScore,
+        "TradingPsychologyModel": TradingPsychologyModel,
+        "TradingPsychologyInsights": TradingPsychologyInsights,
+        "TradingPsychologySyncJob": TradingPsychologySyncJob,
     }
 )

--- a/algorithms/python/jobs/trading_psychology_job.py
+++ b/algorithms/python/jobs/trading_psychology_job.py
@@ -1,0 +1,56 @@
+"""Supabase sync job for trading psychology scores."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from ..supabase_sync import SupabaseTableWriter
+from ..trading_psychology import TradingPsychologyInsights, TradingPsychologyModel
+
+__all__ = ["TradingPsychologySyncJob"]
+
+
+@dataclass(slots=True)
+class TradingPsychologySyncJob:
+    """Persist the latest trading psychology score into Supabase."""
+
+    model: TradingPsychologyModel
+    writer: SupabaseTableWriter
+    insights: TradingPsychologyInsights | None = None
+    source_model: Optional[str] = None
+    source_run: Optional[str] = None
+
+    def run(self) -> int:
+        score = self.model.evaluate()
+        latest_timestamp = self._resolve_timestamp()
+
+        narrative: Optional[str] = None
+        if self.insights is not None:
+            insight_payload = self.insights.generate(score)
+            narrative = insight_payload.get("narrative") or None
+
+        row: Dict[str, Any] = {
+            "capturedAt": latest_timestamp,
+            "composite": round(score.composite, 4),
+            "discipline": round(score.discipline, 4),
+            "resilience": round(score.resilience, 4),
+            "focus": round(score.focus, 4),
+            "consistency": round(score.consistency, 4),
+            "state": score.state,
+        }
+        if narrative:
+            row["narrative"] = narrative
+        if self.source_model:
+            row["sourceModel"] = self.source_model
+        if self.source_run:
+            row["sourceRun"] = self.source_run
+
+        return self.writer.upsert([row])
+
+    def _resolve_timestamp(self) -> datetime:
+        inputs = self.model.get_inputs()
+        if not inputs:
+            raise ValueError("model has no observations to persist")
+        return inputs[-1].timestamp

--- a/algorithms/python/tests/test_trading_psychology.py
+++ b/algorithms/python/tests/test_trading_psychology.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from algorithms.python.jobs.trading_psychology_job import TradingPsychologySyncJob
+from algorithms.python.trading_psychology import (
+    PsychologyObservation,
+    TradingPsychologyModel,
+)
+
+
+class FakeWriter:
+    def __init__(self) -> None:
+        self.rows = []
+
+    def upsert(self, rows):  # pragma: no cover - behaviour tested via assertions
+        self.rows = list(rows)
+        return len(self.rows)
+
+
+class StubInsights:
+    def __init__(self, narrative: str) -> None:
+        self.narrative = narrative
+        self.calls = 0
+
+    def generate(self, score):  # pragma: no cover - simple stub
+        self.calls += 1
+        return {"score": score, "narrative": self.narrative, "insights": [self.narrative]}
+
+
+@pytest.fixture
+def observation_series():
+    base = datetime(2024, 5, 10, 12, tzinfo=timezone.utc)
+    return [
+        PsychologyObservation(
+            timestamp=base - timedelta(days=2),
+            plan_adherence=0.6,
+            risk_compliance=0.5,
+            recovery_rate=0.4,
+            emotional_stability=0.6,
+            focus_quality=0.7,
+            distraction_events=4,
+            routine_adherence=0.5,
+        ),
+        PsychologyObservation(
+            timestamp=base - timedelta(days=1),
+            plan_adherence=0.8,
+            risk_compliance=0.75,
+            recovery_rate=0.6,
+            emotional_stability=0.7,
+            focus_quality=0.65,
+            distraction_events=3,
+            routine_adherence=0.7,
+        ),
+        PsychologyObservation(
+            timestamp=base,
+            plan_adherence=0.9,
+            risk_compliance=0.85,
+            recovery_rate=0.8,
+            emotional_stability=0.9,
+            focus_quality=0.8,
+            distraction_events=1,
+            routine_adherence=0.8,
+        ),
+    ]
+
+
+def test_trading_psychology_model_scoring_deterministic(observation_series):
+    model = TradingPsychologyModel(observations=observation_series, recency_decay=0.8)
+    score = model.evaluate()
+
+    assert score.state == "caution"
+    assert score.discipline == pytest.approx(0.7570, abs=1e-4)
+    assert score.resilience == pytest.approx(0.6926, abs=1e-4)
+    assert score.focus == pytest.approx(0.6587, abs=1e-4)
+    assert score.consistency == pytest.approx(0.7385, abs=1e-4)
+    assert score.composite == pytest.approx(0.7126, abs=1e-4)
+
+
+def test_trading_psychology_model_applies_window_decay():
+    base = datetime(2024, 5, 1, tzinfo=timezone.utc)
+    observations = []
+    for index in range(10):
+        observations.append(
+            PsychologyObservation(
+                timestamp=base + timedelta(days=index),
+                plan_adherence=0.9 if index >= 5 else 0.3,
+                risk_compliance=0.9 if index >= 5 else 0.3,
+                recovery_rate=0.85 if index >= 5 else 0.35,
+                emotional_stability=0.9 if index >= 5 else 0.4,
+                focus_quality=0.88 if index >= 5 else 0.4,
+                distraction_events=1 if index >= 5 else 6,
+                routine_adherence=0.92 if index >= 5 else 0.35,
+            )
+        )
+    model = TradingPsychologyModel(observations=observations, window=5, recency_decay=0.7)
+    score = model.evaluate()
+
+    assert score.state == "ready"
+    assert score.composite > 0.8
+
+
+def test_trading_psychology_state_transitions(observation_series):
+    model = TradingPsychologyModel(
+        observations=observation_series,
+        recency_decay=0.8,
+        readiness_thresholds={"ready": 0.7, "monitor": 0.6},
+    )
+    score = model.evaluate(force=True)
+    assert score.state == "ready"
+
+    degraded = [
+        PsychologyObservation(
+            timestamp=obs.timestamp,
+            plan_adherence=obs.plan_adherence * 0.92,
+            risk_compliance=obs.risk_compliance * 0.92,
+            recovery_rate=obs.recovery_rate * 0.92,
+            emotional_stability=obs.emotional_stability * 0.92,
+            focus_quality=obs.focus_quality * 0.92,
+            distraction_events=obs.distraction_events + 1,
+            routine_adherence=obs.routine_adherence * 0.92,
+        )
+        for obs in observation_series
+    ]
+    downgraded_model = TradingPsychologyModel(
+        observations=degraded,
+        recency_decay=0.8,
+        readiness_thresholds={"ready": 0.7, "monitor": 0.6},
+    )
+    downgraded_score = downgraded_model.evaluate()
+    assert downgraded_score.state == "caution"
+
+    stressed = [
+        PsychologyObservation(
+            timestamp=obs.timestamp,
+            plan_adherence=0.2,
+            risk_compliance=0.2,
+            recovery_rate=0.2,
+            emotional_stability=0.3,
+            focus_quality=0.3,
+            distraction_events=6,
+            routine_adherence=0.2,
+        )
+        for obs in observation_series
+    ]
+    stressed_model = TradingPsychologyModel(
+        observations=stressed,
+        recency_decay=0.8,
+        readiness_thresholds={"ready": 0.7, "monitor": 0.6},
+    )
+    stressed_score = stressed_model.evaluate()
+    assert stressed_score.state == "recovery"
+
+
+def test_trading_psychology_job_payload_structure(observation_series):
+    model = TradingPsychologyModel(observations=observation_series, recency_decay=0.8)
+    writer = FakeWriter()
+    insights = StubInsights("Maintain focus blocks around macro events.")
+
+    job = TradingPsychologySyncJob(
+        model=model,
+        writer=writer,
+        insights=insights,
+        source_model="psychology-v1",
+        source_run="batch-42",
+    )
+
+    count = job.run()
+
+    assert count == 1
+    assert len(writer.rows) == 1
+    payload = writer.rows[0]
+    assert payload["capturedAt"] == observation_series[-1].timestamp
+    assert payload["state"] == model.evaluate().state
+    assert "narrative" in payload and payload["narrative"].startswith("Maintain")
+    assert payload["sourceModel"] == "psychology-v1"
+    assert payload["sourceRun"] == "batch-42"

--- a/algorithms/python/trading_psychology.py
+++ b/algorithms/python/trading_psychology.py
@@ -1,0 +1,358 @@
+"""Trading psychology scoring and narrative insights helpers."""
+
+from __future__ import annotations
+
+import statistics
+import textwrap
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+
+from .multi_llm import (
+    CompletionClient,
+    LLMConfig,
+    collect_strings,
+    parse_json_response,
+    serialise_runs,
+)
+
+__all__ = [
+    "PsychologyObservation",
+    "PsychologyScore",
+    "TradingPsychologyModel",
+    "TradingPsychologyInsights",
+]
+
+
+def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+@dataclass(slots=True)
+class PsychologyObservation:
+    """Raw intraday wellness telemetry captured from the trading desk."""
+
+    timestamp: datetime
+    plan_adherence: float
+    risk_compliance: float
+    recovery_rate: float
+    emotional_stability: float
+    focus_quality: float
+    distraction_events: int
+    routine_adherence: float
+
+
+@dataclass(slots=True)
+class PsychologyScore:
+    """Aggregated trading psychology readiness score."""
+
+    discipline: float
+    resilience: float
+    focus: float
+    consistency: float
+    composite: float
+    state: str
+    recommendations: list[str] = field(default_factory=list)
+    normalized_history: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "discipline": self.discipline,
+            "resilience": self.resilience,
+            "focus": self.focus,
+            "consistency": self.consistency,
+            "composite": self.composite,
+        }
+
+
+@dataclass(slots=True)
+class TradingPsychologyModel:
+    """Compute readiness of the trading desk based on qualitative telemetry."""
+
+    observations: Sequence[PsychologyObservation]
+    window: int = 14
+    recency_decay: float = 0.85
+    readiness_thresholds: Mapping[str, float] = field(
+        default_factory=lambda: {"ready": 0.75, "monitor": 0.6}
+    )
+    _cached_score: Optional[PsychologyScore] = field(init=False, default=None)
+
+    def evaluate(self, *, force: bool = False) -> PsychologyScore:
+        if self._cached_score is not None and not force:
+            return self._cached_score
+
+        recent = self._select_recent_observations()
+        if not recent:
+            raise ValueError("observations cannot be empty")
+
+        normalised = self._normalise_observations(recent)
+        weights = self._compute_weights(len(normalised))
+        sub_scores = self._aggregate_sub_scores(normalised, weights)
+        composite = self._blend_composite(sub_scores)
+        state = self._determine_state(composite)
+        recommendations = self._build_recommendations(sub_scores, composite, state)
+
+        history: list[Dict[str, Any]] = []
+        for index, obs in enumerate(recent):
+            payload = normalised[index]
+            weight = weights[index]
+            history.append(
+                {
+                    "timestamp": obs.timestamp,
+                    "weight": weight,
+                    "discipline": payload["discipline"],
+                    "resilience": payload["resilience"],
+                    "focus": payload["focus"],
+                    "consistency": payload["consistency"],
+                }
+            )
+
+        self._cached_score = PsychologyScore(
+            discipline=sub_scores["discipline"],
+            resilience=sub_scores["resilience"],
+            focus=sub_scores["focus"],
+            consistency=sub_scores["consistency"],
+            composite=composite,
+            state=state,
+            recommendations=recommendations,
+            normalized_history=tuple(history),
+        )
+        return self._cached_score
+
+    def get_inputs(self) -> Sequence[PsychologyObservation]:
+        return tuple(sorted(self.observations, key=lambda obs: obs.timestamp))
+
+    def get_sub_scores(self) -> Dict[str, float]:
+        score = self.evaluate()
+        return {
+            "discipline": score.discipline,
+            "resilience": score.resilience,
+            "focus": score.focus,
+            "consistency": score.consistency,
+        }
+
+    def get_recommendations(self) -> list[str]:
+        return list(self.evaluate().recommendations)
+
+    def get_normalized_history(self) -> Sequence[Mapping[str, Any]]:
+        return self.evaluate().normalized_history
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _select_recent_observations(self) -> Sequence[PsychologyObservation]:
+        ordered = sorted(self.observations, key=lambda obs: obs.timestamp)
+        if self.window <= 0:
+            return tuple(ordered)
+        return tuple(ordered[-self.window :])
+
+    def _normalise_observations(
+        self, observations: Sequence[PsychologyObservation]
+    ) -> list[Dict[str, float]]:
+        normalised: list[Dict[str, float]] = []
+        for obs in observations:
+            discipline = statistics.fmean([obs.plan_adherence, obs.risk_compliance])
+            resilience = statistics.fmean([obs.recovery_rate, obs.emotional_stability])
+            distraction_penalty = _clamp(obs.distraction_events / 6, 0.0, 1.0)
+            focus = statistics.fmean([
+                obs.focus_quality,
+                1.0 - distraction_penalty,
+            ])
+            consistency = statistics.fmean([
+                obs.routine_adherence,
+                obs.plan_adherence,
+            ])
+            normalised.append(
+                {
+                    "discipline": _clamp(discipline),
+                    "resilience": _clamp(resilience),
+                    "focus": _clamp(focus),
+                    "consistency": _clamp(consistency),
+                }
+            )
+        return normalised
+
+    def _compute_weights(self, count: int) -> list[float]:
+        if count <= 0:
+            return []
+        decay = _clamp(self.recency_decay, 0.1, 0.999)
+        weights = [decay ** (count - index - 1) for index in range(count)]
+        return weights
+
+    def _aggregate_sub_scores(
+        self,
+        normalised: Sequence[Mapping[str, float]],
+        weights: Sequence[float],
+    ) -> Dict[str, float]:
+        totals = {"discipline": 0.0, "resilience": 0.0, "focus": 0.0, "consistency": 0.0}
+        total_weight = sum(weights)
+        if total_weight == 0:
+            raise ValueError("weights cannot sum to zero")
+        for index, payload in enumerate(normalised):
+            weight = weights[index]
+            for key in totals:
+                totals[key] += payload[key] * weight
+        return {key: totals[key] / total_weight for key in totals}
+
+    def _blend_composite(self, scores: Mapping[str, float]) -> float:
+        composite = (
+            scores["discipline"] * 0.3
+            + scores["resilience"] * 0.25
+            + scores["focus"] * 0.25
+            + scores["consistency"] * 0.2
+        )
+        return _clamp(composite)
+
+    def _determine_state(self, composite: float) -> str:
+        ready = self.readiness_thresholds.get("ready", 0.75)
+        monitor = self.readiness_thresholds.get("monitor", 0.6)
+        if composite >= ready:
+            return "ready"
+        if composite >= monitor:
+            return "caution"
+        return "recovery"
+
+    def _build_recommendations(
+        self,
+        scores: Mapping[str, float],
+        composite: float,
+        state: str,
+    ) -> list[str]:
+        recommendations: list[str] = []
+        if composite < 0.5:
+            recommendations.append("Pause discretionary trades until mindset stabilises.")
+        if scores["discipline"] < 0.6:
+            recommendations.append("Revisit risk rules and pre-trade checklists.")
+        if scores["resilience"] < 0.6:
+            recommendations.append("Schedule recovery time and review recent setbacks.")
+        if scores["focus"] < 0.6:
+            recommendations.append("Minimise desk distractions for the next session.")
+        if scores["consistency"] < 0.6:
+            recommendations.append("Reinforce daily routines and journaling cadence.")
+        if not recommendations and state == "ready":
+            recommendations.append("Maintain current routines; readiness remains strong.")
+        return recommendations
+
+
+@dataclass(slots=True)
+class TradingPsychologyInsights:
+    """Optional LLM-assisted narrative builder for psychology scores."""
+
+    model: TradingPsychologyModel
+    grok_client: CompletionClient | None = None
+    deepseek_client: CompletionClient | None = None
+    grok_temperature: float = 0.25
+    grok_nucleus_p: float = 0.85
+    grok_max_tokens: int = 320
+    deepseek_temperature: float = 0.2
+    deepseek_nucleus_p: float = 0.9
+    deepseek_max_tokens: int = 320
+
+    def generate(self, score: Optional[PsychologyScore] = None) -> Dict[str, Any]:
+        score = score or self.model.evaluate()
+        score_summary = textwrap.dedent(
+            f"""
+            Composite readiness: {score.composite:.2%}
+            Discipline: {score.discipline:.2%}
+            Resilience: {score.resilience:.2%}
+            Focus: {score.focus:.2%}
+            Consistency: {score.consistency:.2%}
+            State: {score.state}
+            """
+        ).strip()
+
+        runs = []
+        insights: list[str] = []
+        metadata: Dict[str, Any] = {"score": score.as_dict()}
+        grok_payload: Mapping[str, Any] | None = None
+
+        if self.grok_client is not None:
+            prompt = self._build_grok_prompt(score_summary, score.recommendations)
+            grok_run = LLMConfig(
+                name="grok-1",
+                client=self.grok_client,
+                temperature=self.grok_temperature,
+                nucleus_p=self.grok_nucleus_p,
+                max_tokens=self.grok_max_tokens,
+            ).run(prompt)
+            runs.append(grok_run)
+            grok_payload = parse_json_response(grok_run.response, fallback_key="narrative")
+            metadata["grok"] = grok_payload
+            insights.extend(
+                collect_strings(
+                    grok_payload.get("insights") if isinstance(grok_payload, Mapping) else None,
+                    grok_payload.get("narrative") if isinstance(grok_payload, Mapping) else None,
+                    grok_run.response if not grok_payload else None,
+                )
+            )
+
+        if self.deepseek_client is not None:
+            prompt = self._build_deepseek_prompt(score_summary, insights)
+            deepseek_run = LLMConfig(
+                name="deepseek-v3",
+                client=self.deepseek_client,
+                temperature=self.deepseek_temperature,
+                nucleus_p=self.deepseek_nucleus_p,
+                max_tokens=self.deepseek_max_tokens,
+            ).run(prompt)
+            runs.append(deepseek_run)
+            deepseek_payload = parse_json_response(
+                deepseek_run.response, fallback_key="narrative"
+            )
+            metadata["deepseek"] = deepseek_payload
+            insights.extend(
+                collect_strings(
+                    deepseek_payload.get("insights") if isinstance(deepseek_payload, Mapping) else None,
+                    deepseek_payload.get("narrative") if isinstance(deepseek_payload, Mapping) else None,
+                    deepseek_run.response if not deepseek_payload else None,
+                )
+            )
+
+        narrative = " ".join(insights) if insights else None
+        raw_response = serialise_runs(runs)
+
+        return {
+            "score": score,
+            "insights": insights,
+            "narrative": narrative,
+            "metadata": metadata,
+            "raw_response": raw_response,
+        }
+
+    def _build_grok_prompt(
+        self, score_summary: str, recommendations: Iterable[str]
+    ) -> str:
+        recs = "\n".join(f"- {item}" for item in recommendations) or "- No immediate actions logged."
+        return textwrap.dedent(
+            f"""
+            You are the trading desk psychologist for Dynamic Capital.
+            Review the quantitative readiness summary and craft a JSON object with keys
+            "insights" (array of short sentences), "narrative" (a concise paragraph),
+            and "actions" (array of tactical adjustments).
+
+            Readiness summary:
+            {score_summary}
+
+            Existing recommendations:
+            {recs}
+            """
+        ).strip()
+
+    def _build_deepseek_prompt(self, score_summary: str, insights: Iterable[str]) -> str:
+        prior = "\n".join(f"- {item}" for item in insights) or "- No Grok guidance provided."
+        return textwrap.dedent(
+            f"""
+            You are DeepSeek-V3 acting as a performance coach.
+            Given the readiness summary and the initial Grok insights, produce a JSON
+            response reinforcing the key psychological themes and highlight any
+            emerging risks to monitor over the next session. Use the keys "insights"
+            and "narrative".
+
+            Readiness summary:
+            {score_summary}
+
+            Grok insights to build upon:
+            {prior}
+            """
+        ).strip()


### PR DESCRIPTION
## Summary
- add a trading psychology scoring model with optional LLM insights generator
- create a Supabase sync job and document required observation fields
- cover scoring behaviour and sync payloads with targeted unit tests

## Testing
- `PYTHONPATH=. pytest algorithms/python/tests/test_trading_psychology.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d62c3621ec8322909bda7751bb9232