### PR TITLE
feat: add trading desk synchronisation suite

### DIFF
--- a/algorithms/python/desk_sync.py
+++ b/algorithms/python/desk_sync.py
@@ -1,0 +1,240 @@
+"""Trading desk synchronisation utilities.
+
+This module glues together the high level automation pillars that keep
+Dynamic Capital's trading desk aligned.  It provides a lightweight team role
+registry, helpers for reconciling protocol guidance produced by the
+``DynamicProtocolPlanner``, and deterministic summaries of the Lorentzian
+trading logic so downstream systems can validate configuration drift.
+
+The goal is to offer a single coordination point that upstream orchestration
+services (for example, Supabase Edge Functions or Airflow DAGs) can call when
+they need a coherent snapshot of the desk.  The implementation intentionally
+keeps side-effects to a minimum so the algorithms remain fully testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+from .dynamic_protocol_planner import ProtocolDraft
+from .trade_logic import PerformanceMetrics, TradeLogic
+
+__all__ = [
+    "TeamRolePlaybook",
+    "TeamRoleSyncResult",
+    "TeamRoleSyncAlgorithm",
+    "summarise_trade_logic",
+    "DeskSyncReport",
+    "TradingDeskSynchroniser",
+]
+
+
+@dataclass(slots=True)
+class TeamRolePlaybook:
+    """Canonical workflow description for a trading desk role."""
+
+    name: str
+    objectives: Sequence[str]
+    workflow: Sequence[str]
+    outputs: Sequence[str] = field(default_factory=tuple)
+    kpis: Sequence[str] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the playbook."""
+
+        return {
+            "name": self.name,
+            "objectives": list(self.objectives),
+            "workflow": list(self.workflow),
+            "outputs": list(self.outputs),
+            "kpis": list(self.kpis),
+        }
+
+
+@dataclass(slots=True)
+class TeamRoleSyncResult:
+    """Result of running :class:`TeamRoleSyncAlgorithm`."""
+
+    playbooks: Dict[str, TeamRolePlaybook]
+    generated_at: datetime
+    focus: tuple[str, ...]
+    context: Dict[str, Any]
+
+    def summary(self) -> str:
+        """Return a concise human readable summary."""
+
+        roles = ", ".join(self.playbooks)
+        if not roles:
+            return "No roles registered"
+        focus = f" (focus: {', '.join(self.focus)})" if self.focus else ""
+        return f"{len(self.playbooks)} roles synchronised: {roles}{focus}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the synchronisation payload in a JSON-friendly shape."""
+
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "focus": list(self.focus),
+            "context": dict(self.context),
+            "playbooks": {name: playbook.to_dict() for name, playbook in self.playbooks.items()},
+            "summary": self.summary(),
+        }
+
+
+class TeamRoleSyncAlgorithm:
+    """Deterministic registry that exposes trading desk playbooks."""
+
+    def __init__(self, playbooks: Iterable[TeamRolePlaybook]):
+        self._playbooks: Dict[str, TeamRolePlaybook] = {}
+        for playbook in playbooks:
+            if playbook.name in self._playbooks:
+                raise ValueError(f"duplicate playbook registered for {playbook.name}")
+            self._playbooks[playbook.name] = playbook
+        if not self._playbooks:
+            raise ValueError("at least one playbook must be supplied")
+
+    def synchronise(
+        self,
+        *,
+        focus: Optional[Iterable[str]] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> TeamRoleSyncResult:
+        """Return the playbooks that match the optional focus set."""
+
+        focus_tuple: tuple[str, ...] = tuple(focus or ())
+        if focus_tuple:
+            missing = [name for name in focus_tuple if name not in self._playbooks]
+            if missing:
+                raise KeyError(f"Unknown playbook(s): {', '.join(missing)}")
+            selected = {name: self._playbooks[name] for name in focus_tuple}
+        else:
+            selected = dict(sorted(self._playbooks.items()))
+
+        payload_context: Dict[str, Any] = dict(context or {})
+        payload_context.setdefault("role_count", len(selected))
+
+        return TeamRoleSyncResult(
+            playbooks=selected,
+            generated_at=datetime.now(tz=UTC),
+            focus=focus_tuple,
+            context=payload_context,
+        )
+
+
+def summarise_trade_logic(trade_logic: TradeLogic) -> Dict[str, Any]:
+    """Return a lightweight snapshot of the configured trading logic."""
+
+    summary: Dict[str, Any] = {
+        "config": asdict(trade_logic.config),
+    }
+
+    risk = getattr(trade_logic, "risk", None)
+    if risk is not None:
+        params = getattr(risk, "params", None)
+        if params is not None:
+            summary["risk_parameters"] = asdict(params)
+        metrics = None
+        metrics_fn = getattr(risk, "metrics", None)
+        if callable(metrics_fn):
+            try:
+                metrics = metrics_fn()
+            except Exception:  # pragma: no cover - risk metrics are optional
+                metrics = None
+        if isinstance(metrics, PerformanceMetrics):
+            summary["risk_metrics"] = asdict(metrics)
+
+    strategy = getattr(trade_logic, "strategy", None)
+    if strategy is not None:
+        summary["strategy"] = {
+            "neighbors": getattr(strategy, "neighbors", None),
+            "max_rows": getattr(strategy, "max_rows", None),
+            "label_lookahead": getattr(strategy, "label_lookahead", None),
+            "neutral_zone_pips": getattr(strategy, "neutral_zone_pips", None),
+        }
+
+    adr_tracker = getattr(trade_logic, "adr_tracker", None)
+    if adr_tracker is not None:
+        summary["adr"] = {
+            "period": getattr(adr_tracker, "period", None),
+            "value": getattr(adr_tracker, "value", None),
+        }
+
+    return summary
+
+
+@dataclass(slots=True)
+class DeskSyncReport:
+    """Combined synchronisation payload for the trading desk."""
+
+    generated_at: datetime
+    team: TeamRoleSyncResult
+    protocol: ProtocolDraft
+    trade_logic: Dict[str, Any]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the report."""
+
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "team": self.team.to_dict(),
+            "protocol": self.protocol.to_dict(),
+            "trade_logic": self.trade_logic,
+            "metadata": dict(self.metadata),
+        }
+
+
+class TradingDeskSynchroniser:
+    """Orchestrates team, protocol, and trading logic synchronisation."""
+
+    def __init__(
+        self,
+        *,
+        team_sync: TeamRoleSyncAlgorithm,
+        protocol_planner,
+        trade_logic: TradeLogic,
+    ) -> None:
+        self._team_sync = team_sync
+        self._protocol_planner = protocol_planner
+        self._trade_logic = trade_logic
+
+    def build_report(
+        self,
+        *,
+        focus_roles: Optional[Iterable[str]] = None,
+        protocol_context: Optional[Mapping[str, Any]] = None,
+        team_context: Optional[Mapping[str, Any]] = None,
+    ) -> DeskSyncReport:
+        """Run the synchronisation routines and return a :class:`DeskSyncReport`."""
+
+        team_result = self._team_sync.synchronise(focus=focus_roles, context=team_context)
+        protocol = self._protocol_planner.generate_protocol(
+            context=self._merge_context(protocol_context, team_result)
+        )
+        trade_summary = summarise_trade_logic(self._trade_logic)
+        metadata = {
+            "team_summary": team_result.summary(),
+            "protocol_annotations": dict(protocol.annotations),
+        }
+        if protocol_context:
+            metadata["protocol_context"] = dict(protocol_context)
+        return DeskSyncReport(
+            generated_at=datetime.now(tz=UTC),
+            team=team_result,
+            protocol=protocol,
+            trade_logic=trade_summary,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _merge_context(
+        protocol_context: Optional[Mapping[str, Any]],
+        team_result: TeamRoleSyncResult,
+    ) -> MutableMapping[str, Any]:
+        context: MutableMapping[str, Any] = dict(protocol_context or {})
+        context.setdefault("team_roles", list(team_result.playbooks))
+        context.setdefault("team_summary", team_result.summary())
+        context.setdefault("role_count", len(team_result.playbooks))
+        return context

--- a/algorithms/python/tests/test_desk_sync.py
+++ b/algorithms/python/tests/test_desk_sync.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from algorithms.python.desk_sync import (
+    DeskSyncReport,
+    TeamRolePlaybook,
+    TeamRoleSyncAlgorithm,
+    TradingDeskSynchroniser,
+)
+from algorithms.python.dynamic_protocol_planner import ProtocolDraft
+from algorithms.python.trade_logic import TradeLogic
+
+
+def _build_playbooks() -> list[TeamRolePlaybook]:
+    return [
+        TeamRolePlaybook(
+            name="Strategist",
+            objectives=("Align desk objectives", "Surface weekly focus"),
+            workflow=(
+                "Review KPI deltas",
+                "Prioritise initiatives",
+                "Publish strategy brief",
+            ),
+            outputs=("Strategy brief", "Updated risk register"),
+            kpis=("Pipeline velocity", "Budget adherence"),
+        ),
+        TeamRolePlaybook(
+            name="Quant Analyst",
+            objectives=("Maintain trading models", "Validate signals"),
+            workflow=(
+                "Inspect training data",
+                "Backtest parameter updates",
+                "Publish findings to desk",
+            ),
+            outputs=("Model changelog", "Backtest summary"),
+            kpis=("Signal quality", "Deployment latency"),
+        ),
+    ]
+
+
+def test_team_role_sync_filters_and_serialises() -> None:
+    playbooks = _build_playbooks()
+    sync = TeamRoleSyncAlgorithm(playbooks)
+
+    result = sync.synchronise(focus=("Strategist",), context={"shift": "nyc"})
+
+    assert tuple(result.playbooks) == ("Strategist",)
+    assert result.focus == ("Strategist",)
+    assert result.context["role_count"] == 1
+    payload = result.to_dict()
+    assert payload["playbooks"]["Strategist"]["workflow"][0] == "Review KPI deltas"
+    assert payload["focus"] == ["Strategist"]
+    generated = datetime.fromisoformat(payload["generated_at"])
+    assert generated.tzinfo is not None
+
+
+class _StubPlanner:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def generate_protocol(self, *, context=None, trade_logic=None, optimization_plan=None):  # noqa: D401 - signature mirrors planner
+        self.calls.append(dict(context or {}))
+        return ProtocolDraft(
+            plan={
+                "daily": {
+                    "trade_plan": ["Check London session breakouts"],
+                    "review": ["Annotate journal"],
+                }
+            },
+            annotations={"source": "stub"},
+        )
+
+
+def test_trading_desk_synchroniser_builds_report() -> None:
+    playbooks = _build_playbooks()
+    sync = TeamRoleSyncAlgorithm(playbooks)
+    planner = _StubPlanner()
+    trade_logic = TradeLogic()
+
+    orchestrator = TradingDeskSynchroniser(
+        team_sync=sync,
+        protocol_planner=planner,
+        trade_logic=trade_logic,
+    )
+
+    report = orchestrator.build_report(
+        focus_roles=["Strategist"],
+        protocol_context={"market": "fx"},
+        team_context={"shift": "nyc"},
+    )
+
+    assert isinstance(report, DeskSyncReport)
+    assert planner.calls, "expected planner to be invoked"
+    planner_context = planner.calls[0]
+    assert planner_context["team_roles"] == ["Strategist"]
+    assert planner_context["team_summary"].startswith("1 roles synchronised")
+
+    report_payload = report.to_dict()
+    assert report_payload["team"]["summary"].startswith("1 roles synchronised")
+    assert report_payload["protocol"]["daily"]["trade_plan"] == ["Check London session breakouts"]
+    assert report_payload["metadata"]["protocol_annotations"] == {"source": "stub"}
+    assert report_payload["metadata"]["protocol_context"] == {"market": "fx"}
+    assert report_payload["trade_logic"]["config"]["neighbors"] == trade_logic.config.neighbors
+    generated_at = datetime.fromisoformat(report_payload["generated_at"])
+    assert generated_at.tzinfo is not None and generated_at.tzinfo.utcoffset(generated_at) == timezone.utc.utcoffset(generated_at)
+
+
+def test_team_role_sync_errors_on_unknown_focus() -> None:
+    sync = TeamRoleSyncAlgorithm(_build_playbooks())
+    with pytest.raises(KeyError):
+        sync.synchronise(focus=("Unknown",))


### PR DESCRIPTION
## Summary
- add a trading desk synchronisation module that exposes role playbooks, integrates protocol planning, and summarises trade logic state
- cover new orchestration flow with unit tests for role filtering, report generation, and error handling

## Testing
- pytest algorithms/python/tests/test_desk_sync.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d633f31d84832298120ec864cb55f4