### PR TITLE
Streamline trading data summarisation and dataset exports

### DIFF
--- a/algorithms/python/dataset_builder.py
+++ b/algorithms/python/dataset_builder.py
@@ -1,20 +1,28 @@
-"""Dataset packaging utilities for Dynamic Capital research workflows."""
+"""Dataset packaging utilities for Dynamic Capital research workflows.
+
+Streaming-friendly writers ensure large corpora can be exported without
+materialising every record in memory. Records are shuffled in deterministic
+chunks and flushed incrementally to the target format.
+"""
 
 from __future__ import annotations
 
 import json
 import math
 import random
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Tuple
 
 from .trade_logic import LabeledFeature
 
-try:  # pragma: no cover - optional dependency for parquet output
-    import pandas as _pd  # type: ignore
-except Exception:  # pragma: no cover
-    _pd = None
+
+@dataclass(slots=True)
+class DatasetSplitMetadata:
+    """Summary describing a materialised dataset split."""
+
+    path: Path
+    count: int
 
 
 class DatasetWriter:
@@ -26,11 +34,13 @@ class DatasetWriter:
         *,
         seed: int = 13,
         file_format: str = "parquet",
+        shuffle_chunk_size: int = 2048,
     ) -> None:
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.seed = seed
         self.file_format = file_format.lower()
+        self.shuffle_chunk_size = shuffle_chunk_size
 
     def write(
         self,
@@ -38,52 +48,89 @@ class DatasetWriter:
         *,
         splits: Tuple[float, float, float] = (0.7, 0.15, 0.15),
         metadata: Optional[Dict[str, object]] = None,
-    ) -> Dict[str, List[dict]]:
+    ) -> Dict[str, DatasetSplitMetadata]:
         if not samples:
             raise ValueError("no labelled samples provided")
         if not math.isclose(sum(splits), 1.0, rel_tol=1e-3):
             raise ValueError("dataset splits must sum to 1.0")
         random_gen = random.Random(self.seed)
-        records = [self._to_record(sample) for sample in samples]
-        random_gen.shuffle(records)
-        total = len(records)
+        total = len(samples)
         train_end = int(total * splits[0])
         val_end = train_end + int(total * splits[1])
-        partitions = {
-            "train": records[:train_end],
-            "validation": records[train_end:val_end],
-            "test": records[val_end:],
+
+        record_iter = (self._to_record(sample) for sample in samples)
+        shuffled_records = self._chunked_shuffle(record_iter, random_gen)
+
+        writers = {
+            "train": self._open_split_writer("train"),
+            "validation": self._open_split_writer("validation"),
+            "test": self._open_split_writer("test"),
         }
-        for split_name, split_records in partitions.items():
-            self._write_split(split_name, split_records)
+        counts = {"train": 0, "validation": 0, "test": 0}
+
+        try:
+            for idx, record in enumerate(shuffled_records):
+                if idx < train_end:
+                    split = "train"
+                elif idx < val_end:
+                    split = "validation"
+                else:
+                    split = "test"
+                writers[split].write(record)
+                counts[split] += 1
+        finally:
+            for writer in writers.values():
+                writer.close()
+
+        partitions = {
+            name: DatasetSplitMetadata(path=self._split_path(name), count=count)
+            for name, count in counts.items()
+        }
         meta = metadata or {}
         meta_payload = {
             "seed": self.seed,
             "format": self.file_format,
-            "counts": {key: len(value) for key, value in partitions.items()},
+            "counts": counts,
             "metadata": meta,
         }
         (self.output_dir / "metadata.json").write_text(json.dumps(meta_payload, indent=2))
         return partitions
 
-    def _write_split(self, split: str, records: List[dict]) -> None:
-        if self.file_format == "parquet" and _pd is not None:
-            path = self.output_dir / f"{split}.parquet"
-            frame = _pd.DataFrame.from_records(records)
-            frame.to_parquet(path, index=False)
-            return
+    def _chunked_shuffle(
+        self,
+        records: Iterable[dict],
+        random_gen: random.Random,
+    ) -> Iterator[dict]:
+        chunk: list[dict] = []
+        for record in records:
+            chunk.append(record)
+            if len(chunk) >= self.shuffle_chunk_size:
+                random_gen.shuffle(chunk)
+                yield from chunk
+                chunk.clear()
+        if chunk:
+            random_gen.shuffle(chunk)
+            yield from chunk
+
+    def _open_split_writer(self, split: str) -> "_SplitWriter":
+        path = self._split_path(split)
         if self.file_format == "json":
-            path = self.output_dir / f"{split}.json"
-            with path.open("w") as handle:
-                json.dump(records, handle, indent=2)
-            return
+            return _JsonArrayWriter(path)
         if self.file_format == "jsonl":
-            path = self.output_dir / f"{split}.jsonl"
-            with path.open("w") as handle:
-                for record in records:
-                    handle.write(json.dumps(record) + "\n")
-            return
+            return _JsonLinesWriter(path)
+        if self.file_format == "parquet":
+            return _ParquetWriter(path)
         raise ValueError(f"Unsupported dataset format: {self.file_format}")
+
+    def _split_path(self, split: str) -> Path:
+        suffix = {
+            "json": ".json",
+            "jsonl": ".jsonl",
+            "parquet": ".parquet",
+        }.get(self.file_format)
+        if suffix is None:
+            raise ValueError(f"Unsupported dataset format: {self.file_format}")
+        return self.output_dir / f"{split}{suffix}"
 
     @staticmethod
     def _to_record(sample: LabeledFeature) -> dict:
@@ -92,5 +139,93 @@ class DatasetWriter:
         payload["features"] = list(sample.features)
         return payload
 
+    def _chunked_shuffle_records_for_tests(
+        self,
+        records: Iterable[dict],
+        random_gen: random.Random,
+    ) -> list[dict]:  # pragma: no cover - helper for tests
+        return list(self._chunked_shuffle(records, random_gen))
 
-__all__ = ["DatasetWriter"]
+
+class _SplitWriter:
+    def write(self, record: dict) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def close(self) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class _JsonArrayWriter(_SplitWriter):
+    def __init__(self, path: Path) -> None:
+        self.handle = path.open("w", encoding="utf-8")
+        self.started = False
+
+    def write(self, record: dict) -> None:
+        if not self.started:
+            self.handle.write("[\n")
+            self.started = True
+        else:
+            self.handle.write(",\n")
+        json.dump(record, self.handle)
+
+    def close(self) -> None:
+        if not self.started:
+            self.handle.write("[]\n")
+        else:
+            self.handle.write("\n]\n")
+        self.handle.close()
+
+
+class _JsonLinesWriter(_SplitWriter):
+    def __init__(self, path: Path) -> None:
+        self.handle = path.open("w", encoding="utf-8")
+
+    def write(self, record: dict) -> None:
+        self.handle.write(json.dumps(record) + "\n")
+
+    def close(self) -> None:
+        self.handle.close()
+
+
+class _ParquetWriter(_SplitWriter):
+    def __init__(self, path: Path, chunk_size: int = 512) -> None:
+        try:
+            import pyarrow as pa  # type: ignore
+            import pyarrow.parquet as pq  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+            raise RuntimeError(
+                "pyarrow is required for parquet output; install pyarrow to enable streaming parquet writes"
+            ) from exc
+
+        self.path = path
+        self.chunk_size = chunk_size
+        self._buffer: list[dict] = []
+        self._pa = pa
+        self._pq = pq
+        self._writer: Optional[pq.ParquetWriter] = None
+
+    def write(self, record: dict) -> None:
+        self._buffer.append(record)
+        if len(self._buffer) >= self.chunk_size:
+            self._flush()
+
+    def close(self) -> None:
+        self._flush()
+        if self._writer is not None:
+            self._writer.close()
+        else:
+            empty_table = self._pa.table({})
+            with self._pq.ParquetWriter(self.path, empty_table.schema) as writer:
+                writer.write_table(empty_table)
+
+    def _flush(self) -> None:
+        if not self._buffer:
+            return
+        table = self._pa.Table.from_pylist(self._buffer)
+        if self._writer is None:
+            self._writer = self._pq.ParquetWriter(self.path, table.schema)
+        self._writer.write_table(table)
+        self._buffer.clear()
+
+
+__all__ = ["DatasetWriter", "DatasetSplitMetadata"]

--- a/algorithms/python/tests/test_dataset_builder.py
+++ b/algorithms/python/tests/test_dataset_builder.py
@@ -5,12 +5,19 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import sys
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.dataset_builder import DatasetWriter
 from algorithms.python.trade_logic import LabeledFeature
+
+try:
+    import pyarrow.parquet as _pq  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    _pq = None
 
 
 def _make_samples(count: int) -> list[LabeledFeature]:
@@ -28,11 +35,11 @@ def _make_samples(count: int) -> list[LabeledFeature]:
     return samples
 
 
-def test_dataset_writer_generates_json_and_jsonl(tmp_path: Path):
-    samples = _make_samples(7)
+def test_dataset_writer_generates_json_and_jsonl(tmp_path: Path) -> None:
+    samples = _make_samples(17)
 
     json_dir = tmp_path / "json"
-    json_writer = DatasetWriter(json_dir, file_format="json")
+    json_writer = DatasetWriter(json_dir, file_format="json", shuffle_chunk_size=5)
     json_partitions = json_writer.write(samples)
 
     train_json = json.loads((json_dir / "train.json").read_text())
@@ -40,27 +47,43 @@ def test_dataset_writer_generates_json_and_jsonl(tmp_path: Path):
     test_json = json.loads((json_dir / "test.json").read_text())
     metadata = json.loads((json_dir / "metadata.json").read_text())
 
-    assert train_json == json_partitions["train"]
-    assert validation_json == json_partitions["validation"]
-    assert test_json == json_partitions["test"]
+    assert len(train_json) == json_partitions["train"].count
+    assert len(validation_json) == json_partitions["validation"].count
+    assert len(test_json) == json_partitions["test"].count
+    assert json_partitions["train"].path.name == "train.json"
     assert metadata["format"] == "json"
+    assert metadata["counts"]["train"] == json_partitions["train"].count
 
     jsonl_dir = tmp_path / "jsonl"
-    jsonl_writer = DatasetWriter(jsonl_dir, file_format="jsonl")
+    jsonl_writer = DatasetWriter(jsonl_dir, file_format="jsonl", shuffle_chunk_size=4)
     jsonl_partitions = jsonl_writer.write(samples)
 
-    train_jsonl_path = jsonl_dir / "train.jsonl"
-    validation_jsonl_path = jsonl_dir / "validation.jsonl"
-    test_jsonl_path = jsonl_dir / "test.jsonl"
+    train_lines = [json.loads(line) for line in (jsonl_dir / "train.jsonl").read_text().splitlines()]
+    validation_lines = [
+        json.loads(line) for line in (jsonl_dir / "validation.jsonl").read_text().splitlines()
+    ]
+    test_lines = [json.loads(line) for line in (jsonl_dir / "test.jsonl").read_text().splitlines()]
     metadata_jsonl = json.loads((jsonl_dir / "metadata.json").read_text())
 
-    train_jsonl = [json.loads(line) for line in train_jsonl_path.read_text().splitlines()]
-    validation_jsonl = [
-        json.loads(line) for line in validation_jsonl_path.read_text().splitlines()
-    ]
-    test_jsonl = [json.loads(line) for line in test_jsonl_path.read_text().splitlines()]
-
-    assert train_jsonl == jsonl_partitions["train"]
-    assert validation_jsonl == jsonl_partitions["validation"]
-    assert test_jsonl == jsonl_partitions["test"]
+    assert len(train_lines) == jsonl_partitions["train"].count
+    assert len(validation_lines) == jsonl_partitions["validation"].count
+    assert len(test_lines) == jsonl_partitions["test"].count
     assert metadata_jsonl["format"] == "jsonl"
+    assert metadata_jsonl["counts"]["test"] == jsonl_partitions["test"].count
+
+
+@pytest.mark.skipif(_pq is None, reason="pyarrow is required for parquet output")
+def test_dataset_writer_streams_parquet(tmp_path: Path) -> None:
+    samples = _make_samples(32)
+    parquet_dir = tmp_path / "parquet"
+    writer = DatasetWriter(parquet_dir, file_format="parquet", shuffle_chunk_size=6)
+    partitions = writer.write(samples)
+
+    train_meta = partitions["train"]
+    assert train_meta.path.exists()
+
+    table = _pq.read_table(train_meta.path)  # type: ignore[arg-type]
+    assert table.num_rows == train_meta.count
+
+    metadata = json.loads((parquet_dir / "metadata.json").read_text())
+    assert metadata["counts"]["train"] == train_meta.count

--- a/algorithms/python/tests/test_indicators.py
+++ b/algorithms/python/tests/test_indicators.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from algorithms.python.data_pipeline import _compute_adx, _compute_rsi
+from algorithms.python.data_pipeline import (
+    _compute_adx,
+    _compute_adx_multi,
+    _compute_rsi,
+    _compute_rsi_multi,
+)
 
 
 @pytest.mark.parametrize(
@@ -107,6 +112,14 @@ def test_compute_rsi_matches_reference(period: int, closes: list[float], expecte
 def test_compute_rsi_rejects_non_positive_period() -> None:
     with pytest.raises(ValueError):
         _compute_rsi([1.0, 1.1], 0)
+
+
+def test_compute_rsi_multi_matches_single() -> None:
+    closes = [1.0, 1.05, 1.02, 1.08, 1.1, 1.12, 1.15, 1.09, 1.11, 1.14, 1.16]
+    periods = (3, 5, 7)
+    multi = _compute_rsi_multi(closes, periods)
+    for period in periods:
+        assert multi[period] == _compute_rsi(closes, period)
 
 
 @pytest.mark.parametrize(
@@ -298,3 +311,13 @@ def test_compute_adx_validates_lengths() -> None:
 def test_compute_adx_rejects_non_positive_period() -> None:
     with pytest.raises(ValueError):
         _compute_adx([1.0, 1.1], [0.9, 1.0], [1.0, 1.1], 0)
+
+
+def test_compute_adx_multi_matches_single() -> None:
+    highs = [1.0, 1.1, 1.08, 1.12, 1.15, 1.13, 1.18, 1.2, 1.22]
+    lows = [0.98, 1.05, 1.02, 1.07, 1.1, 1.09, 1.12, 1.14, 1.17]
+    closes = [1.0, 1.08, 1.07, 1.1, 1.12, 1.11, 1.15, 1.18, 1.2]
+    periods = (3, 4)
+    multi = _compute_adx_multi(highs, lows, closes, periods)
+    for period in periods:
+        assert multi[period] == _compute_adx(highs, lows, closes, period)

--- a/algorithms/python/tests/test_training_workflow_module.py
+++ b/algorithms/python/tests/test_training_workflow_module.py
@@ -60,7 +60,11 @@ def test_label_snapshots_and_package_dataset(tmp_path: Path):
         writer=writer,
         pipeline_state_path=tmp_path / "pipeline_state.json",
     )
-    assert result.partitions["train"] or result.partitions["validation"]
+    assert (
+        result.partitions["train"].count > 0
+        or result.partitions["validation"].count > 0
+        or result.partitions["test"].count > 0
+    )
     assert result.state_path is not None and result.state_path.exists()
     assert "pipeline" in result.pipeline_state
 

--- a/algorithms/python/training_workflow.py
+++ b/algorithms/python/training_workflow.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, 
 
 from .backtesting import Backtester, BacktestResult
 from .data_pipeline import InstrumentMeta, MarketDataIngestionJob, RawBar
-from .dataset_builder import DatasetWriter
+from .dataset_builder import DatasetSplitMetadata, DatasetWriter
 from .hyperparameter_search import HyperparameterSearch
 from .offline_labeler import LabelingConfig, OfflineLabeler
 from .optimization_workflow import OptimizationPlan, optimize_trading_stack
@@ -34,7 +34,7 @@ class LabelledDatasetSplits:
     """Payload produced by :func:`label_snapshots_and_package_dataset`."""
 
     labelled: List[LabeledFeature]
-    partitions: Dict[str, List[dict]]
+    partitions: Dict[str, DatasetSplitMetadata]
     pipeline_state: Dict[str, object]
     dataset_dir: Path
     state_path: Optional[Path]


### PR DESCRIPTION
## Summary
- refactor snapshot aggregation in `TradingDataProcessor` to use a single-pass running statistics helper for all numeric telemetry
- share indicator traversals by adding multi-period RSI/ADX helpers and updating the market data ingestion job to reuse them
- make `DatasetWriter` streaming-friendly with chunked shuffling, incremental writers, and richer split metadata while expanding the associated tests

## Testing
- `PYTHONPATH=. pytest algorithms/python/tests/test_trading_data_processor.py algorithms/python/tests/test_indicators.py algorithms/python/tests/test_dataset_builder.py algorithms/python/tests/test_training_workflow_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68d62d61bc788322b14b333d4505be39