### PR TITLE
Add market data ingestion jobs

### DIFF
--- a/algorithms/python/jobs/ccxt_price_snapshots_job.py
+++ b/algorithms/python/jobs/ccxt_price_snapshots_job.py
@@ -1,0 +1,160 @@
+"""Entrypoint for capturing price snapshots from CCXT exchanges."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Sequence
+
+from ..supabase_sync import SupabaseTableWriter
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _Snapshot:
+    symbol: str
+    quote_currency: str
+    price_usd: float
+    signature: str
+    signed_at: datetime
+
+
+def _load_ccxt() -> object:
+    try:
+        return importlib.import_module("ccxt")
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment guard
+        raise RuntimeError(
+            "ccxt library is required to run the price snapshot job"
+        ) from exc
+
+
+def _initialise_exchange(module: object, exchange_id: str) -> object:
+    try:
+        factory = getattr(module, exchange_id)
+    except AttributeError as exc:  # pragma: no cover - misconfiguration guard
+        raise RuntimeError(f"Unknown CCXT exchange '{exchange_id}'") from exc
+    exchange = factory()
+    return exchange
+
+
+def _normalise_symbol(market: str) -> tuple[str, str]:
+    if "/" in market:
+        base, quote = market.split("/", 1)
+        return f"{base}{quote}", quote
+    return market.replace("-", ""), "USD"
+
+
+def _normalise_snapshot(
+    *,
+    market: str,
+    exchange: str,
+    ticker: Mapping[str, object],
+) -> _Snapshot | None:
+    last = ticker.get("last")
+    close = ticker.get("close")
+    price_raw = last if isinstance(last, (int, float)) else close
+    if not isinstance(price_raw, (int, float)):
+        LOGGER.debug("Skipping %s due to missing price field", market)
+        return None
+
+    timestamp = ticker.get("timestamp")
+    if isinstance(timestamp, (int, float)):
+        signed_at = datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
+    else:
+        signed_at = datetime.now(tz=timezone.utc)
+
+    symbol, quote = _normalise_symbol(market)
+    signature = f"{exchange}:{market}:{int(signed_at.timestamp())}"
+
+    return _Snapshot(
+        symbol=symbol,
+        quote_currency=quote,
+        price_usd=float(price_raw),
+        signature=signature,
+        signed_at=signed_at,
+    )
+
+
+def _serialise_rows(snapshots: Iterable[_Snapshot]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for snapshot in snapshots:
+        rows.append(
+            {
+                "symbol": snapshot.symbol,
+                "quote_currency": snapshot.quote_currency,
+                "price_usd": snapshot.price_usd,
+                "signature": snapshot.signature,
+                "signed_at": snapshot.signed_at,
+            }
+        )
+    return rows
+
+
+def sync_ccxt_price_snapshots(
+    *,
+    markets: Sequence[str] | None = None,
+    exchange_id: str = "binance",
+    base_url: str | None = None,
+    service_role_key: str | None = None,
+) -> int:
+    markets = markets or (
+        "BTC/USDT",
+        "ETH/USDT",
+        "SOL/USDT",
+        "XRP/USDT",
+        "DOGE/USDT",
+    )
+
+    module = _load_ccxt()
+    exchange = _initialise_exchange(module, exchange_id)
+
+    snapshots: list[_Snapshot] = []
+    for market in markets:
+        try:
+            ticker = exchange.fetch_ticker(market)
+        except Exception as exc:  # pragma: no cover - defensive network guard
+            LOGGER.warning("Failed to fetch ticker for %s: %s", market, exc)
+            continue
+        snapshot = _normalise_snapshot(
+            market=market,
+            exchange=exchange_id,
+            ticker=ticker,
+        )
+        if snapshot:
+            snapshots.append(snapshot)
+
+    close = getattr(exchange, "close", None)
+    if callable(close):  # pragma: no cover - external resource cleanup
+        try:
+            close()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            LOGGER.debug("Failed to close CCXT exchange %s", exchange_id)
+
+    writer = SupabaseTableWriter(
+        table="price_snapshots",
+        conflict_column="symbol,signed_at",
+        base_url=base_url,
+        service_role_key=service_role_key,
+    )
+
+    rows = _serialise_rows(snapshots)
+    return writer.upsert(rows)
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    logging.basicConfig(level=logging.INFO)
+    base_url = os.getenv("SUPABASE_URL")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    count = sync_ccxt_price_snapshots(
+        base_url=base_url,
+        service_role_key=service_key,
+    )
+    LOGGER.info("Synced %s CCXT price snapshots", count)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/algorithms/python/jobs/cryptofeed_orderbook_job.py
+++ b/algorithms/python/jobs/cryptofeed_orderbook_job.py
@@ -1,0 +1,194 @@
+"""Entrypoint for capturing order book depth snapshots via Cryptofeed."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Sequence
+
+from ..supabase_sync import SupabaseTableWriter
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _OrderBookSnapshot:
+    symbol: str
+    bid_price: float
+    ask_price: float
+    mid_price: float
+    spread_bps: float
+    depth_usd: float
+    observed_at: datetime
+    source: str
+
+
+def _load_cryptofeed() -> object:
+    try:
+        return importlib.import_module("cryptofeed")
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment guard
+        raise RuntimeError(
+            "cryptofeed library is required to run the order book job"
+        ) from exc
+
+
+def _initialise_rest_client(module: object, exchange_id: str) -> object:
+    rest = getattr(module, "rest", None)
+    if rest is None:
+        raise RuntimeError("cryptofeed installation is missing rest clients")
+    try:
+        factory = getattr(rest, exchange_id)
+    except AttributeError as exc:
+        raise RuntimeError(f"Unknown cryptofeed exchange '{exchange_id}'") from exc
+    return factory()
+
+
+def _normalise_symbol(symbol: str) -> str:
+    return symbol.replace("/", "").replace("-", "")
+
+
+def _best_price(levels: Sequence[Sequence[object]]) -> float | None:
+    if not levels:
+        return None
+    price = levels[0][0]
+    return float(price) if isinstance(price, (int, float)) else None
+
+
+def _depth_notional(levels: Sequence[Sequence[object]], depth: int) -> float:
+    notionals = []
+    for price, size in levels[:depth]:
+        if isinstance(price, (int, float)) and isinstance(size, (int, float)):
+            notionals.append(float(price) * float(size))
+    return sum(notionals)
+
+
+def _normalise_orderbook(
+    *,
+    symbol: str,
+    exchange_id: str,
+    depth: int,
+    payload: Mapping[str, object],
+) -> _OrderBookSnapshot | None:
+    bids = payload.get("bids") or payload.get("bid")
+    asks = payload.get("asks") or payload.get("ask")
+    if not isinstance(bids, Sequence) or not isinstance(asks, Sequence):
+        LOGGER.debug("Skipping %s due to missing depth data", symbol)
+        return None
+
+    bid_price = _best_price(bids)
+    ask_price = _best_price(asks)
+    if bid_price is None or ask_price is None:
+        LOGGER.debug("Skipping %s due to incomplete best prices", symbol)
+        return None
+
+    mid_price = (bid_price + ask_price) / 2
+    spread_bps = ((ask_price - bid_price) / mid_price * 10_000) if mid_price else 0.0
+    depth_usd = _depth_notional(bids, depth) + _depth_notional(asks, depth)
+
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, (int, float)):
+        observed_at = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    else:
+        observed_at = datetime.now(tz=timezone.utc)
+
+    return _OrderBookSnapshot(
+        symbol=_normalise_symbol(symbol),
+        bid_price=bid_price,
+        ask_price=ask_price,
+        mid_price=mid_price,
+        spread_bps=spread_bps,
+        depth_usd=depth_usd,
+        observed_at=observed_at,
+        source=exchange_id,
+    )
+
+
+def _serialise_rows(
+    snapshots: Iterable[_OrderBookSnapshot],
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for snapshot in snapshots:
+        rows.append(
+            {
+                "symbol": snapshot.symbol,
+                "bid_price": snapshot.bid_price,
+                "ask_price": snapshot.ask_price,
+                "mid_price": snapshot.mid_price,
+                "spread_bps": snapshot.spread_bps,
+                "depth_usd": snapshot.depth_usd,
+                "observed_at": snapshot.observed_at,
+                "source": snapshot.source,
+            }
+        )
+    return rows
+
+
+def sync_cryptofeed_orderbooks(
+    *,
+    markets: Sequence[str] | None = None,
+    exchange_id: str = "Binance",
+    depth: int = 5,
+    base_url: str | None = None,
+    service_role_key: str | None = None,
+) -> int:
+    markets = markets or (
+        "BTC-USDT",
+        "ETH-USDT",
+        "SOL-USDT",
+    )
+
+    module = _load_cryptofeed()
+    client = _initialise_rest_client(module, exchange_id)
+
+    snapshots: list[_OrderBookSnapshot] = []
+    for market in markets:
+        try:
+            payload = client.l2_book(symbol=market, depth=depth)
+        except AttributeError:
+            payload = client.book(symbol=market, depth=depth)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            LOGGER.warning("Failed to fetch order book for %s: %s", market, exc)
+            continue
+        snapshot = _normalise_orderbook(
+            symbol=market,
+            exchange_id=exchange_id,
+            depth=depth,
+            payload=payload,
+        )
+        if snapshot:
+            snapshots.append(snapshot)
+
+    shutdown = getattr(client, "close", None)
+    if callable(shutdown):  # pragma: no cover - external resource cleanup
+        try:
+            shutdown()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            LOGGER.debug("Failed to close cryptofeed client %s", exchange_id)
+
+    writer = SupabaseTableWriter(
+        table="orderbook_snapshots",
+        conflict_column="symbol,observed_at",
+        base_url=base_url,
+        service_role_key=service_role_key,
+    )
+
+    rows = _serialise_rows(snapshots)
+    return writer.upsert(rows)
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    logging.basicConfig(level=logging.INFO)
+    base_url = os.getenv("SUPABASE_URL")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    count = sync_cryptofeed_orderbooks(
+        base_url=base_url,
+        service_role_key=service_key,
+    )
+    LOGGER.info("Synced %s cryptofeed order books", count)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/algorithms/python/jobs/econopy_macro_job.py
+++ b/algorithms/python/jobs/econopy_macro_job.py
@@ -1,0 +1,206 @@
+"""Entrypoint for syncing macroeconomic series from EconoPy."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Sequence
+
+from ..supabase_sync import SupabaseTableWriter
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _MacroPoint:
+    indicator: str
+    region: str
+    actual: float | None
+    forecast: float | None
+    previous: float | None
+    unit: str | None
+    released_at: datetime
+    source: str
+
+
+def _load_econopy() -> object:
+    for module_name in ("econopy", "EconoPy"):
+        try:
+            return importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            continue
+    raise RuntimeError("EconoPy library is required to run the macro sync job")
+
+
+def _initialise_client(module: object) -> object:
+    for attr in ("EconoPy", "Client", "API"):
+        factory = getattr(module, attr, None)
+        if callable(factory):
+            return factory()
+    raise RuntimeError("Unable to locate an EconoPy client constructor")
+
+
+def _to_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if isinstance(value, str):
+        cleaned = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(cleaned)
+        except ValueError:
+            parsed = datetime.strptime(cleaned, "%Y-%m-%d")
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return datetime.now(tz=timezone.utc)
+
+
+def _extract_series(
+    client: object,
+    indicator: str,
+    region: str,
+) -> Mapping[str, object] | None:
+    fetchers = (
+        ("indicator", {"name": indicator, "region": region}),
+        ("fetch_indicator", {"indicator": indicator, "region": region}),
+        ("get_indicator", {"indicator": indicator, "region": region}),
+        ("series", {"indicator": indicator, "region": region}),
+    )
+    series: Sequence[Mapping[str, object]] | None = None
+    for method_name, kwargs in fetchers:
+        method = getattr(client, method_name, None)
+        if callable(method):
+            try:
+                result = method(**kwargs)
+            except TypeError:
+                continue
+            if isinstance(result, Mapping):
+                return result
+            if isinstance(result, Sequence) and result:
+                series = result  # type: ignore[assignment]
+                break
+    if not series:
+        return None
+    # Prefer the latest entry
+    latest = max(
+        series,
+        key=lambda row: _parse_datetime(row.get("released_at") or row.get("date")),
+    )
+    return latest
+
+
+def _normalise_point(
+    *,
+    indicator: str,
+    region: str,
+    source: str,
+    payload: Mapping[str, object],
+) -> _MacroPoint:
+    actual = _to_float(payload.get("actual") or payload.get("value"))
+    forecast = _to_float(payload.get("forecast"))
+    previous = _to_float(payload.get("previous"))
+    unit = payload.get("unit") or payload.get("units")
+    released_at = _parse_datetime(
+        payload.get("released_at")
+        or payload.get("release_date")
+        or payload.get("date")
+        or payload.get("timestamp")
+    )
+    resolved_region = payload.get("region") or payload.get("country") or region
+    return _MacroPoint(
+        indicator=indicator,
+        region=str(resolved_region),
+        actual=actual,
+        forecast=forecast,
+        previous=previous,
+        unit=str(unit) if unit is not None else None,
+        released_at=released_at,
+        source=source,
+    )
+
+
+def _serialise_rows(points: Iterable[_MacroPoint]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for point in points:
+        rows.append(
+            {
+                "indicator": point.indicator,
+                "region": point.region,
+                "actual": point.actual,
+                "forecast": point.forecast,
+                "previous": point.previous,
+                "unit": point.unit,
+                "released_at": point.released_at,
+                "source": point.source,
+            }
+        )
+    return rows
+
+
+def sync_econopy_macro_series(
+    *,
+    indicators: Sequence[str] | None = None,
+    region: str = "US",
+    base_url: str | None = None,
+    service_role_key: str | None = None,
+    source: str = "econopy",
+) -> int:
+    indicators = indicators or (
+        "CPI",
+        "Unemployment Rate",
+        "Retail Sales",
+    )
+
+    module = _load_econopy()
+    client = _initialise_client(module)
+
+    points: list[_MacroPoint] = []
+    for indicator in indicators:
+        payload = _extract_series(client, indicator, region)
+        if not payload:
+            LOGGER.debug("No data returned for indicator %s", indicator)
+            continue
+        point = _normalise_point(
+            indicator=indicator,
+            region=region,
+            source=source,
+            payload=payload,
+        )
+        points.append(point)
+
+    writer = SupabaseTableWriter(
+        table="macro_indicators",
+        conflict_column="indicator,released_at",
+        base_url=base_url,
+        service_role_key=service_role_key,
+    )
+
+    rows = _serialise_rows(points)
+    return writer.upsert(rows)
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    logging.basicConfig(level=logging.INFO)
+    base_url = os.getenv("SUPABASE_URL")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    count = sync_econopy_macro_series(
+        base_url=base_url,
+        service_role_key=service_key,
+    )
+    LOGGER.info("Synced %s macro indicators", count)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/algorithms/python/tests/test_ccxt_price_snapshots_job.py
+++ b/algorithms/python/tests/test_ccxt_price_snapshots_job.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from algorithms.python.jobs import ccxt_price_snapshots_job as job
+
+
+def test_sync_ccxt_price_snapshots_normalises_and_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyExchange:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def fetch_ticker(self, market: str) -> dict[str, object]:
+            assert market == "BTC/USDT"
+            return {
+                "last": 26123.45,
+                "timestamp": 1_700_000_000_000,
+                "info": {},
+            }
+
+        def close(self) -> None:
+            self.closed = True
+
+    class DummyCcxtModule:
+        def __init__(self, exchange: DummyExchange) -> None:
+            self._exchange = exchange
+
+        def __getattr__(self, name: str):
+            if name == "binance":
+                return lambda: self._exchange
+            raise AttributeError(name)
+
+    exchange = DummyExchange()
+    monkeypatch.setattr(job, "_load_ccxt", lambda: DummyCcxtModule(exchange))
+
+    captured: dict[str, object] = {}
+
+    class DummyWriter:
+        def __init__(self, *, table: str, conflict_column: str, **_: object) -> None:
+            captured["table"] = table
+            captured["conflict_column"] = conflict_column
+
+        def upsert(self, rows: list[dict[str, object]]) -> int:
+            captured["rows"] = rows
+            return len(rows)
+
+    monkeypatch.setattr(job, "SupabaseTableWriter", DummyWriter)  # type: ignore[arg-type]
+
+    count = job.sync_ccxt_price_snapshots(markets=["BTC/USDT"], exchange_id="binance")
+
+    assert count == 1
+    assert captured["table"] == "price_snapshots"
+    assert captured["conflict_column"] == "symbol,signed_at"
+
+    rows = captured["rows"]
+    assert isinstance(rows, list)
+    row = rows[0]
+    assert row["symbol"] == "BTCUSDT"
+    assert row["quote_currency"] == "USDT"
+    assert row["price_usd"] == pytest.approx(26123.45)
+    assert isinstance(row["signed_at"], datetime)
+    assert row["signed_at"].tzinfo is timezone.utc
+    assert row["signature"].startswith("binance:BTC/USDT:")
+

--- a/algorithms/python/tests/test_cryptofeed_orderbook_job.py
+++ b/algorithms/python/tests/test_cryptofeed_orderbook_job.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from algorithms.python.jobs import cryptofeed_orderbook_job as job
+
+
+def test_sync_cryptofeed_orderbooks_normalises(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "bids": [(27000.0, 1.5), (26990.0, 2.0)],
+        "asks": [(27010.0, 1.2), (27020.0, 0.5)],
+        "timestamp": 1_700_000_000,
+    }
+
+    class DummyClient:
+        def l2_book(self, *, symbol: str, depth: int) -> dict[str, object]:
+            assert symbol == "BTC-USDT"
+            assert depth == 5
+            return payload
+
+        def close(self) -> None:
+            pass
+
+    class DummyModule:
+        def __init__(self, client: DummyClient) -> None:
+            class RestNamespace:
+                def __init__(self, client: DummyClient) -> None:
+                    self.Binance = lambda: client
+
+            self.rest = RestNamespace(client)
+
+    client = DummyClient()
+    monkeypatch.setattr(job, "_load_cryptofeed", lambda: DummyModule(client))
+
+    captured: dict[str, object] = {}
+
+    class DummyWriter:
+        def __init__(self, *, table: str, conflict_column: str, **_: object) -> None:
+            captured["table"] = table
+            captured["conflict_column"] = conflict_column
+
+        def upsert(self, rows: list[dict[str, object]]) -> int:
+            captured["rows"] = rows
+            return len(rows)
+
+    monkeypatch.setattr(job, "SupabaseTableWriter", DummyWriter)  # type: ignore[arg-type]
+
+    count = job.sync_cryptofeed_orderbooks(markets=["BTC-USDT"], exchange_id="Binance")
+
+    assert count == 1
+    assert captured["table"] == "orderbook_snapshots"
+    assert captured["conflict_column"] == "symbol,observed_at"
+
+    rows = captured["rows"]
+    assert isinstance(rows, list)
+    row = rows[0]
+    assert row["symbol"] == "BTCUSDT"
+    assert row["bid_price"] == pytest.approx(27000.0)
+    assert row["ask_price"] == pytest.approx(27010.0)
+    assert row["mid_price"] == pytest.approx(27005.0)
+    assert row["spread_bps"] == pytest.approx((27010 - 27000) / 27005 * 10_000)
+    assert row["depth_usd"] == pytest.approx(
+        27000.0 * 1.5 + 26990.0 * 2.0 + 27010.0 * 1.2 + 27020.0 * 0.5
+    )
+    assert isinstance(row["observed_at"], datetime)
+    assert row["observed_at"].tzinfo is timezone.utc
+    assert row["source"] == "Binance"
+

--- a/algorithms/python/tests/test_econopy_macro_job.py
+++ b/algorithms/python/tests/test_econopy_macro_job.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from algorithms.python.jobs import econopy_macro_job as job
+
+
+def test_sync_econopy_macro_series_normalises(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyClient:
+        def indicator(self, *, name: str, region: str) -> list[dict[str, object]]:
+            assert name == "CPI"
+            assert region == "US"
+            return [
+                {
+                    "released_at": "2024-04-01T12:30:00Z",
+                    "actual": "3.1",
+                    "forecast": "3.0",
+                    "previous": 2.9,
+                    "unit": "%",
+                    "region": "United States",
+                },
+                {
+                    "released_at": "2024-05-01T12:30:00Z",
+                    "actual": 3.4,
+                    "forecast": 3.3,
+                    "previous": "3.1",
+                    "unit": "%",
+                    "region": "United States",
+                },
+            ]
+
+    class DummyModule:
+        def __init__(self, client: DummyClient) -> None:
+            self._client = client
+
+        def EconoPy(self) -> DummyClient:
+            return self._client
+
+    client = DummyClient()
+    monkeypatch.setattr(job, "_load_econopy", lambda: DummyModule(client))
+
+    captured: dict[str, object] = {}
+
+    class DummyWriter:
+        def __init__(self, *, table: str, conflict_column: str, **_: object) -> None:
+            captured["table"] = table
+            captured["conflict_column"] = conflict_column
+
+        def upsert(self, rows: list[dict[str, object]]) -> int:
+            captured["rows"] = rows
+            return len(rows)
+
+    monkeypatch.setattr(job, "SupabaseTableWriter", DummyWriter)  # type: ignore[arg-type]
+
+    count = job.sync_econopy_macro_series(indicators=["CPI"], region="US")
+
+    assert count == 1
+    assert captured["table"] == "macro_indicators"
+    assert captured["conflict_column"] == "indicator,released_at"
+
+    rows = captured["rows"]
+    assert isinstance(rows, list)
+    row = rows[0]
+    assert row["indicator"] == "CPI"
+    assert row["region"] == "United States"
+    assert row["actual"] == pytest.approx(3.4)
+    assert row["forecast"] == pytest.approx(3.3)
+    assert row["previous"] == pytest.approx(3.1)
+    assert row["unit"] == "%"
+    assert isinstance(row["released_at"], datetime)
+    assert row["released_at"].tzinfo is timezone.utc
+    assert row["source"] == "econopy"
+


### PR DESCRIPTION
## Summary
- add a CCXT-backed job that normalizes spot prices and upserts them into the `price_snapshots` table
- add a Cryptofeed order book job that converts depth payloads into deterministic Supabase upserts
- add an EconoPy macro data job plus focused tests that validate normalization logic and writer invocations

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_ccxt_price_snapshots_job.py algorithms/python/tests/test_cryptofeed_orderbook_job.py algorithms/python/tests/test_econopy_macro_job.py

------
https://chatgpt.com/codex/tasks/task_e_68d6373f7d5c8322b5932eb08385b6dd