### PR TITLE
Refactor DCT auto-invest handling into subscription manager

### DIFF
--- a/supabase/functions/dct-auto-invest/subscription-manager.ts
+++ b/supabase/functions/dct-auto-invest/subscription-manager.ts
@@ -1,0 +1,446 @@
+import { createClient, type SupabaseClient } from "../_shared/client.ts";
+import { optionalEnv } from "../_shared/env.ts";
+
+export type SwapTag = "auto-invest" | "buyback-burn";
+
+export interface SplitConfig {
+  operationsPct: number;
+  autoInvestPct: number;
+  buybackBurnPct: number;
+}
+
+export type VerifiedTonPayment = {
+  ok: true;
+  amountTon: number;
+  blockTime?: string;
+} | {
+  ok: false;
+  error: string;
+};
+
+export interface SwapResult {
+  dctAmount: number;
+  swapTxHash: string;
+  routerSwapId: string;
+  priceSnapshotId: string | null;
+  oraclePrice: number | null;
+  usdNotional: number;
+}
+
+export interface StakeConfig {
+  months: number | null;
+  multiplier: number;
+}
+
+const LOCK_CONFIG: Record<string, StakeConfig> = {
+  "vip_bronze": { months: 3, multiplier: 1.2 },
+  "vip_silver": { months: 6, multiplier: 1.5 },
+  "vip_gold": { months: 12, multiplier: 2.0 },
+  "mentorship": { months: 6, multiplier: 1.35 },
+};
+
+const EARLY_EXIT_PENALTY_BPS = 200;
+
+const ORACLE_SYMBOL = "DCTUSDT";
+
+function resolveStakeConfig(plan: string): StakeConfig {
+  return LOCK_CONFIG[plan] ?? { months: null, multiplier: 1.0 };
+}
+
+function addMonths(date: Date, months: number): Date {
+  const copy = new Date(date.getTime());
+  copy.setUTCMonth(copy.getUTCMonth() + months);
+  return copy;
+}
+
+export function roundTon(value: number): number {
+  return Number(value.toFixed(9));
+}
+
+async function fetchOraclePrice() {
+  const supabase = createClient("service");
+  const { data, error } = await supabase
+    .from("price_snapshots")
+    .select("id, price_usd, signed_at")
+    .eq("symbol", ORACLE_SYMBOL)
+    .order("signed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`Oracle lookup failed: ${error.message}`);
+  }
+  if (!data) {
+    throw new Error("Oracle price unavailable");
+  }
+  const price = Number(data.price_usd);
+  if (!Number.isFinite(price) || price <= 0) {
+    throw new Error("Oracle price invalid");
+  }
+  const signedAt = Date.parse(data.signed_at);
+  if (!Number.isFinite(signedAt)) {
+    throw new Error("Oracle snapshot missing timestamp");
+  }
+  const ageMs = Date.now() - signedAt;
+  if (ageMs > 10 * 60 * 1000) {
+    throw new Error("Oracle price stale");
+  }
+  return { price, snapshotId: data.id as string | null };
+}
+
+async function defaultExecuteSwap(
+  tonAmount: number,
+  tag: SwapTag,
+): Promise<SwapResult> {
+  if (tonAmount <= 0) {
+    return {
+      dctAmount: 0,
+      swapTxHash: "",
+      routerSwapId: "",
+      priceSnapshotId: null,
+      oraclePrice: null,
+      usdNotional: 0,
+    };
+  }
+
+  const tonUsdOverride = optionalEnv("TON_USD_PRICE");
+  const tonUsd = tonUsdOverride ? Number(tonUsdOverride) : 1;
+  if (!Number.isFinite(tonUsd) || tonUsd <= 0) {
+    throw new Error("Invalid TON_USD_PRICE value");
+  }
+
+  const priceOverrideRaw = optionalEnv("DCT_PRICE_OVERRIDE");
+  if (priceOverrideRaw) {
+    const price = Number(priceOverrideRaw);
+    if (!Number.isFinite(price) || price <= 0) {
+      throw new Error("Invalid DCT_PRICE_OVERRIDE value");
+    }
+    const usdNotional = roundTon(tonAmount * tonUsd);
+    const dctAmount = roundTon(usdNotional / price);
+    return {
+      dctAmount,
+      swapTxHash: `simulated-${tag}`,
+      routerSwapId: `sim-${crypto.randomUUID()}`,
+      priceSnapshotId: null,
+      oraclePrice: price,
+      usdNotional,
+    };
+  }
+
+  const oracle = await fetchOraclePrice();
+  const usdNotional = roundTon(tonAmount * tonUsd);
+  const dctAmount = roundTon(usdNotional / oracle.price);
+  return {
+    dctAmount,
+    swapTxHash: `allocator-${tag}-${crypto.randomUUID()}`,
+    routerSwapId: oracle.snapshotId ?? "",
+    priceSnapshotId: oracle.snapshotId ?? null,
+    oraclePrice: oracle.price,
+    usdNotional,
+  };
+}
+
+async function defaultTriggerBurn(
+  amountDct: number,
+  context: Record<string, unknown>,
+): Promise<string | null> {
+  if (amountDct <= 0) return null;
+  const burnHook = optionalEnv("BURN_WEBHOOK_URL");
+  if (!burnHook) return null;
+
+  const response = await fetch(burnHook, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      amount: amountDct,
+      ...context,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Burn webhook error ${response.status}`);
+  }
+
+  const payload = await response.json().catch(
+    () => ({} as Record<string, unknown>),
+  );
+  const burnTxHash = payload.txHash ?? payload.burnTxHash ?? null;
+  return burnTxHash ? String(burnTxHash) : null;
+}
+
+export class SubscriptionManagerError extends Error {}
+
+export class SwapExecutionError extends SubscriptionManagerError {}
+
+export class BurnTriggerError extends SubscriptionManagerError {}
+
+export class PersistenceError extends SubscriptionManagerError {}
+
+export class DuplicateSubscriptionError extends SubscriptionManagerError {}
+
+export interface SubscriptionManagerDependencies {
+  supabase: SupabaseClient;
+  executeSwap?: (
+    tonAmount: number,
+    tag: SwapTag,
+  ) => Promise<SwapResult>;
+  triggerBurn?: (
+    amountDct: number,
+    context: Record<string, unknown>,
+  ) => Promise<string | null>;
+  now?: () => Date;
+}
+
+export interface SubscriptionBeneficiary {
+  telegramId?: number | null;
+  walletAddress: string;
+  tonDomain?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface SubscriptionPaymentDetails {
+  plan: string;
+  tonTxHash: string;
+  tonAmount: number;
+  operationsTon: number;
+  autoInvestTon: number;
+  burnTon: number;
+  splits: SplitConfig;
+  verification: VerifiedTonPayment;
+  operationsWallet: string;
+  dctMaster: string;
+  nextRenewalAt?: string | null;
+  paymentId?: string | null;
+}
+
+export interface SubscriptionReceipt {
+  userId: string;
+  subscriptionId: string;
+  stakeId: string | null;
+  tonAmount: number;
+  splits: SplitConfig;
+  autoInvest: {
+    ton: number;
+    dct: number;
+    swapTxHash: string;
+  };
+  burn: {
+    ton: number;
+    dct: number;
+    swapTxHash: string;
+    burnTxHash: string | null;
+  };
+  operations: {
+    ton: number;
+    wallet: string;
+  };
+  nextRenewalAt: string | null;
+  processedAt: string;
+}
+
+export class SubscriptionManager {
+  private readonly supabase: SupabaseClient;
+  private readonly executeSwapImpl: (
+    tonAmount: number,
+    tag: SwapTag,
+  ) => Promise<SwapResult>;
+  private readonly triggerBurnImpl: (
+    amountDct: number,
+    context: Record<string, unknown>,
+  ) => Promise<string | null>;
+  private readonly nowFn: () => Date;
+
+  constructor(private readonly deps: SubscriptionManagerDependencies) {
+    this.supabase = deps.supabase;
+    this.executeSwapImpl = deps.executeSwap ?? defaultExecuteSwap;
+    this.triggerBurnImpl = deps.triggerBurn ?? defaultTriggerBurn;
+    this.nowFn = deps.now ?? (() => new Date());
+  }
+
+  private now(): Date {
+    return this.nowFn();
+  }
+
+  private async ensureNotDuplicate(txHash: string) {
+    const { data, error } = await this.supabase
+      .from("dct_subscriptions")
+      .select("id")
+      .eq("tx_hash", txHash)
+      .maybeSingle();
+    if (error) {
+      throw new PersistenceError(
+        `Failed to check duplicates: ${error.message}`,
+      );
+    }
+    if (data) {
+      throw new DuplicateSubscriptionError(
+        "Subscription already recorded for this transaction",
+      );
+    }
+  }
+
+  async payFor(
+    beneficiary: SubscriptionBeneficiary,
+    details: SubscriptionPaymentDetails,
+  ): Promise<SubscriptionReceipt> {
+    let autoInvestSwap: SwapResult;
+    let burnSwap: SwapResult;
+    try {
+      autoInvestSwap = await this.executeSwapImpl(
+        details.autoInvestTon,
+        "auto-invest",
+      );
+      burnSwap = await this.executeSwapImpl(details.burnTon, "buyback-burn");
+    } catch (error) {
+      throw new SwapExecutionError(
+        error instanceof Error ? error.message : "Swap failed",
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+
+    let burnTxHash: string | null = null;
+    try {
+      burnTxHash = await this.triggerBurnImpl(burnSwap.dctAmount, {
+        tonTxHash: details.tonTxHash,
+        dctMaster: details.dctMaster,
+      });
+    } catch (error) {
+      throw new BurnTriggerError(
+        error instanceof Error ? error.message : "Burn hook failed",
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+
+    const userPayload = {
+      telegram_id: beneficiary.telegramId ?? null,
+      wallet_address: beneficiary.walletAddress,
+      ton_domain: beneficiary.tonDomain ?? null,
+      metadata: beneficiary.metadata ?? null,
+    } as Record<string, unknown>;
+
+    const { data: user, error: userError } = await this.supabase
+      .from("dct_users")
+      .upsert(userPayload, { onConflict: "wallet_address" })
+      .select()
+      .single();
+
+    if (userError || !user) {
+      throw new PersistenceError(
+        `Failed to upsert user: ${userError?.message ?? "unknown error"}`,
+      );
+    }
+
+    await this.ensureNotDuplicate(details.tonTxHash);
+
+    const subscriptionId = crypto.randomUUID();
+    const processedAt = this.now().toISOString();
+    const stakeConfig = resolveStakeConfig(details.plan);
+    const totalDct = roundTon(autoInvestSwap.dctAmount + burnSwap.dctAmount);
+    const autoInvestDct = roundTon(autoInvestSwap.dctAmount);
+    const burnDct = roundTon(burnSwap.dctAmount);
+
+    const subscriptionRecord = {
+      id: subscriptionId,
+      user_id: user.id,
+      plan: details.plan,
+      ton_paid: roundTon(details.tonAmount),
+      operations_ton: details.operationsTon,
+      auto_invest_ton: details.autoInvestTon,
+      burn_ton: details.burnTon,
+      dct_bought: totalDct,
+      dct_auto_invest: autoInvestDct,
+      dct_burned: burnDct,
+      tx_hash: details.tonTxHash,
+      router_swap_id: autoInvestSwap.routerSwapId || burnSwap.routerSwapId ||
+        null,
+      burn_tx_hash: burnTxHash,
+      split_operations_pct: details.splits.operationsPct,
+      split_auto_invest_pct: details.splits.autoInvestPct,
+      split_burn_pct: details.splits.buybackBurnPct,
+      next_renewal_at: details.nextRenewalAt ?? null,
+      notes: {
+        source: "dct-auto-invest",
+        paymentId: details.paymentId ?? null,
+        verification: details.verification,
+        swaps: {
+          autoInvest: autoInvestSwap,
+          burn: burnSwap,
+        },
+        valuations: {
+          autoInvestUsd: autoInvestSwap.usdNotional,
+          burnUsd: burnSwap.usdNotional,
+          oraclePrice: autoInvestSwap.oraclePrice ?? burnSwap.oraclePrice,
+          priceSnapshotId: autoInvestSwap.priceSnapshotId ??
+            burnSwap.priceSnapshotId ?? null,
+        },
+      },
+    };
+
+    const { error: subscriptionError } = await this.supabase
+      .from("dct_subscriptions")
+      .insert(subscriptionRecord);
+
+    if (subscriptionError) {
+      throw new PersistenceError(
+        `Failed to record subscription: ${subscriptionError.message}`,
+      );
+    }
+
+    let stakeId: string | null = null;
+    if (autoInvestDct > 0) {
+      const weight = roundTon(autoInvestDct * stakeConfig.multiplier);
+      const lockUntil = stakeConfig.months
+        ? addMonths(this.now(), stakeConfig.months)
+        : null;
+      stakeId = crypto.randomUUID();
+      const { error: stakeError } = await this.supabase
+        .from("dct_stakes")
+        .insert({
+          id: stakeId,
+          user_id: user.id,
+          subscription_id: subscriptionId,
+          dct_amount: autoInvestDct,
+          multiplier: stakeConfig.multiplier,
+          weight,
+          lock_months: stakeConfig.months,
+          lock_until: lockUntil ? lockUntil.toISOString() : null,
+          early_exit_penalty_bps: EARLY_EXIT_PENALTY_BPS,
+          status: "active",
+          notes: {
+            plan: details.plan,
+            tonTxHash: details.tonTxHash,
+          },
+        });
+
+      if (stakeError) {
+        throw new PersistenceError(
+          `Failed to create stake: ${stakeError.message}`,
+        );
+      }
+    }
+
+    return {
+      userId: user.id,
+      subscriptionId,
+      stakeId,
+      tonAmount: roundTon(details.tonAmount),
+      splits: details.splits,
+      autoInvest: {
+        ton: details.autoInvestTon,
+        dct: autoInvestDct,
+        swapTxHash: autoInvestSwap.swapTxHash,
+      },
+      burn: {
+        ton: details.burnTon,
+        dct: burnDct,
+        swapTxHash: burnSwap.swapTxHash,
+        burnTxHash,
+      },
+      operations: {
+        ton: details.operationsTon,
+        wallet: details.operationsWallet,
+      },
+      nextRenewalAt: details.nextRenewalAt ?? null,
+      processedAt,
+    };
+  }
+}

--- a/tests/supabase/dct-auto-invest.test.ts
+++ b/tests/supabase/dct-auto-invest.test.ts
@@ -1,0 +1,173 @@
+import test from "node:test";
+import {
+  deepEqual as assertDeepEqual,
+  equal as assertEqual,
+  ok as assertOk,
+  rejects as assertRejects,
+} from "node:assert/strict";
+import { freshImport } from "../utils/freshImport.ts";
+import {
+  __resetSupabaseState,
+  __testSupabaseState,
+  createClient,
+} from "../supabase-client-stub.ts";
+
+const managerModuleUrl = new URL(
+  "../../supabase/functions/dct-auto-invest/subscription-manager.ts",
+  import.meta.url,
+);
+
+test("subscription manager rejects duplicate transactions", async () => {
+  __resetSupabaseState();
+  const managerModule = await freshImport(
+    managerModuleUrl,
+  ) as typeof import("../../supabase/functions/dct-auto-invest/subscription-manager.ts");
+  const {
+    SubscriptionManager,
+    DuplicateSubscriptionError,
+  } = managerModule;
+  type Module = typeof managerModule;
+
+  const supabase = createClient();
+  const executeSwap: Module["SubscriptionManagerDependencies"]["executeSwap"] =
+    async (tonAmount, tag) => ({
+      dctAmount: tag === "auto-invest" ? tonAmount * 2 : tonAmount * 0.5,
+      swapTxHash: `${tag}-swap`,
+      routerSwapId: `${tag}-router`,
+      priceSnapshotId: `${tag}-price`,
+      oraclePrice: 2,
+      usdNotional: tonAmount * 4,
+    });
+  const burnCalls: Array<{ amount: number; context: Record<string, unknown> }> =
+    [];
+  const triggerBurn: Module["SubscriptionManagerDependencies"]["triggerBurn"] =
+    async (amount, context) => {
+      burnCalls.push({ amount, context });
+      return "burn-123";
+    };
+  const now = new Date("2024-01-01T00:00:00.000Z");
+  const manager = new SubscriptionManager({
+    supabase,
+    executeSwap,
+    triggerBurn,
+    now: () => new Date(now),
+  });
+
+  const splits = {
+    operationsPct: 60,
+    autoInvestPct: 30,
+    buybackBurnPct: 10,
+  } satisfies Module["SplitConfig"];
+  const tonAmount = 10;
+  const autoInvestTon = 3;
+  const burnTon = 1;
+  const operationsTon = 6;
+  const verification: Module["VerifiedTonPayment"] = {
+    ok: true,
+    amountTon: tonAmount,
+  };
+
+  const beneficiary: Module["SubscriptionBeneficiary"] = {
+    walletAddress: "wallet-1",
+    telegramId: 123,
+    tonDomain: "alice.ton",
+    metadata: { note: "first" },
+  };
+
+  const details: Module["SubscriptionPaymentDetails"] = {
+    plan: "vip_bronze",
+    tonTxHash: "tx-1",
+    tonAmount,
+    operationsTon,
+    autoInvestTon,
+    burnTon,
+    splits,
+    verification,
+    operationsWallet: "ops-wallet",
+    dctMaster: "dct-master",
+    nextRenewalAt: "2024-02-01T00:00:00.000Z",
+    paymentId: "pay-1",
+  };
+
+  const receipt = await manager.payFor(beneficiary, details);
+  assertOk(receipt.subscriptionId);
+  assertEqual(receipt.tonAmount, tonAmount);
+  assertEqual(burnCalls.length, 1);
+  assertDeepEqual(burnCalls[0].context, {
+    tonTxHash: "tx-1",
+    dctMaster: "dct-master",
+  });
+  assertEqual(__testSupabaseState.dctSubscriptions.size, 1);
+
+  await assertRejects(
+    () => manager.payFor(beneficiary, details),
+    (error) => error instanceof DuplicateSubscriptionError,
+  );
+  assertEqual(__testSupabaseState.dctSubscriptions.size, 1);
+});
+
+test("subscription manager invokes burn hook with swap output", async () => {
+  __resetSupabaseState();
+  const managerModule = await freshImport(
+    managerModuleUrl,
+  ) as typeof import("../../supabase/functions/dct-auto-invest/subscription-manager.ts");
+  const { SubscriptionManager } = managerModule;
+  type Module = typeof managerModule;
+
+  const supabase = createClient();
+  const executeSwap: Module["SubscriptionManagerDependencies"]["executeSwap"] =
+    async (tonAmount, tag) => ({
+      dctAmount: tag === "buyback-burn" ? 5.4321 : 7.6543,
+      swapTxHash: `${tag}-swap`,
+      routerSwapId: `${tag}-router`,
+      priceSnapshotId: null,
+      oraclePrice: 1.5,
+      usdNotional: tonAmount * 3,
+    });
+  const burnCalls: Array<{ amount: number; context: Record<string, unknown> }> =
+    [];
+  const triggerBurn: Module["SubscriptionManagerDependencies"]["triggerBurn"] =
+    async (amount, context) => {
+      burnCalls.push({ amount, context });
+      return "burn-hash";
+    };
+
+  const manager = new SubscriptionManager({
+    supabase,
+    executeSwap,
+    triggerBurn,
+    now: () => new Date("2024-03-01T00:00:00.000Z"),
+  });
+
+  const beneficiary: Module["SubscriptionBeneficiary"] = {
+    walletAddress: "wallet-2",
+  };
+  const details: Module["SubscriptionPaymentDetails"] = {
+    plan: "vip_gold",
+    tonTxHash: "tx-2",
+    tonAmount: 12,
+    operationsTon: 7,
+    autoInvestTon: 3,
+    burnTon: 2,
+    splits: {
+      operationsPct: 60,
+      autoInvestPct: 25,
+      buybackBurnPct: 15,
+    },
+    verification: { ok: true, amountTon: 12 },
+    operationsWallet: "ops-wallet",
+    dctMaster: "dct-master",
+    nextRenewalAt: null,
+    paymentId: null,
+  };
+
+  const receipt = await manager.payFor(beneficiary, details);
+  assertEqual(burnCalls.length, 1);
+  assertEqual(burnCalls[0].amount, 5.4321);
+  assertDeepEqual(burnCalls[0].context, {
+    tonTxHash: "tx-2",
+    dctMaster: "dct-master",
+  });
+  assertEqual(receipt.burn.burnTxHash, "burn-hash");
+  assertEqual(receipt.burn.dct, managerModule.roundTon(5.4321));
+});


### PR DESCRIPTION
## Summary
- extract the DCT auto-invest processing into a dedicated subscription manager that owns swap execution, burn triggering, and database writes
- update the function handler to delegate to the manager while preserving the response payload and error handling
- expand the Supabase client stub and add unit tests covering duplicate detection and burn hook invocation

## Testing
- npm run lint
- npm run typecheck
- npm run test -- tests/supabase/dct-auto-invest.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6373b338c832291bf748babbbbd6d