### PR TITLE
Add investor dashboard page with Supabase metrics

### DIFF
--- a/apps/web/app/investor/page.tsx
+++ b/apps/web/app/investor/page.tsx
@@ -1,0 +1,75 @@
+import { redirect } from "next/navigation";
+
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
+import { InvestorMetricsPanel } from "@/components/investor/InvestorMetricsPanel";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { fetchInvestorOverview } from "@/lib/investor-metrics";
+
+export const metadata = {
+  title: "Investor Dashboard – Dynamic Capital",
+  description:
+    "Review your private fund equity, track buyback burns, and confirm subscription health in one place.",
+};
+
+export default async function InvestorPage() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/login?redirect=${encodeURIComponent("/investor")}`);
+  }
+
+  try {
+    const overview = await fetchInvestorOverview(supabase, user.id);
+
+    return (
+      <Column
+        gap="24"
+        paddingY="32"
+        align="center"
+        horizontal="center"
+        fillWidth
+      >
+        <Column maxWidth={28} gap="12" align="center" horizontal="center">
+          <Heading variant="display-strong-s" align="center">
+            Investor overview
+          </Heading>
+          <Text
+            variant="body-default-m"
+            onBackground="neutral-weak"
+            align="center"
+          >
+            Live metrics for your Dynamic Capital allocation, token burns, and
+            subscription cadence.
+          </Text>
+        </Column>
+        <InvestorMetricsPanel overview={overview} />
+      </Column>
+    );
+  } catch (error) {
+    console.error("Failed to load investor metrics", error);
+    return (
+      <Column
+        gap="16"
+        paddingY="32"
+        align="center"
+        horizontal="center"
+        fillWidth
+      >
+        <Heading variant="heading-strong-m">
+          Investor metrics unavailable
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          We could not load your investor metrics right now. Refresh the page or
+          contact support if the issue persists.
+        </Text>
+      </Column>
+    );
+  }
+}

--- a/apps/web/components/investor/InvestorMetricsPanel.tsx
+++ b/apps/web/components/investor/InvestorMetricsPanel.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import type { InvestorOverview } from "@/lib/investor-metrics";
+
+interface InvestorMetricsPanelProps {
+  overview: InvestorOverview;
+}
+
+interface MetricCardProps {
+  title: string;
+  value: ReactNode;
+  children?: ReactNode;
+}
+
+function MetricCard({ title, value, children }: MetricCardProps) {
+  return (
+    <Card className="border border-white/10 bg-white/5 backdrop-blur">
+      <CardHeader className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+          {title}
+        </p>
+        <div className="text-3xl font-semibold text-white">{value}</div>
+      </CardHeader>
+      {children
+        ? (
+          <CardContent className="space-y-2 text-sm text-white/70">
+            {children}
+          </CardContent>
+        )
+        : null}
+    </Card>
+  );
+}
+
+export function InvestorMetricsPanel(
+  { overview }: InvestorMetricsPanelProps,
+) {
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 2,
+      }),
+    [],
+  );
+
+  const tokenFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    [],
+  );
+
+  const formatDateTime = useCallback((value: string | null) => {
+    if (!value) return "—";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+    return new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(date);
+  }, []);
+
+  const profitLossValue = overview.equity.profitLossUsd;
+  const profitLossClass = profitLossValue >= 0
+    ? "text-emerald-300"
+    : "text-rose-300";
+
+  const subscription = overview.subscription;
+  const subscriptionStatusLabel = subscription
+    ? subscription.status.toUpperCase()
+    : "NO SUBSCRIPTION";
+  const subscriptionBadgeVariant = subscription
+    ? subscription.isPaused
+      ? "warning"
+      : subscription.status === "active"
+      ? "success"
+      : "secondary"
+    : "outline";
+
+  const burnTotals = overview.burnTotals;
+  const lastBuyback = overview.lastBuyback;
+
+  return (
+    <div className="w-full max-w-5xl">
+      <div className="grid gap-6 md:grid-cols-2">
+        <MetricCard
+          title="Marked Equity"
+          value={currencyFormatter.format(overview.equity.markedEquityUsd)}
+        >
+          <div className="flex flex-wrap items-center gap-2 text-white/70">
+            <span>
+              Contribution{" "}
+              {currencyFormatter.format(overview.equity.contributionUsd)}
+            </span>
+            <span className="hidden h-1 w-1 rounded-full bg-white/20 md:inline-flex" />
+            <span className={profitLossClass}>
+              P/L {currencyFormatter.format(profitLossValue)}
+            </span>
+          </div>
+          <p>
+            Last valuation {formatDateTime(overview.equity.lastValuationAt)}
+          </p>
+        </MetricCard>
+
+        <MetricCard
+          title="Treasury Burn Totals"
+          value={`${tokenFormatter.format(burnTotals.burnTon)} TON`}
+        >
+          <p>
+            {tokenFormatter.format(burnTotals.dctBurned)} DCT destroyed overall.
+          </p>
+          <p>
+            Ops split {tokenFormatter.format(burnTotals.operationsTon)}{" "}
+            TON · Auto-invest {tokenFormatter.format(burnTotals.autoInvestTon)}
+            {" "}
+            TON.
+          </p>
+          <p>Updated {formatDateTime(burnTotals.updatedAt)}</p>
+        </MetricCard>
+
+        <MetricCard
+          title="Subscription Status"
+          value={
+            <div className="flex items-center gap-2">
+              <Badge variant={subscriptionBadgeVariant}>
+                {subscriptionStatusLabel}
+              </Badge>
+              <span className="text-base font-medium text-white/70">
+                {subscription?.planName || "—"}
+              </span>
+            </div>
+          }
+        >
+          {subscription
+            ? (
+              <div className="space-y-1">
+                <p>
+                  Next renewal {formatDateTime(subscription.nextRenewalAt)}
+                </p>
+                <p>
+                  Last payment {formatDateTime(subscription.lastPaymentAt)}
+                </p>
+                {subscription.isPaused
+                  ? <p className="text-amber-200">Auto-renew paused</p>
+                  : null}
+              </div>
+            )
+            : <p>No active subscription linked to your profile.</p>}
+        </MetricCard>
+
+        <MetricCard
+          title="Latest Buyback"
+          value={lastBuyback
+            ? `${tokenFormatter.format(lastBuyback.burnTon)} TON`
+            : "—"}
+        >
+          {lastBuyback
+            ? (
+              <div className="space-y-1">
+                <p>
+                  Burned {tokenFormatter.format(lastBuyback.dctBurned)} DCT
+                </p>
+                <p>Executed {formatDateTime(lastBuyback.executedAt)}</p>
+                {lastBuyback.burnTxHash
+                  ? (
+                    <p className="truncate text-xs text-white/60">
+                      Burn tx {lastBuyback.burnTxHash}
+                    </p>
+                  )
+                  : null}
+              </div>
+            )
+            : <p>No buyback activity recorded yet.</p>}
+        </MetricCard>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/investor-metrics.test.ts
+++ b/apps/web/lib/investor-metrics.test.ts
@@ -1,0 +1,59 @@
+function assertEquals<T>(actual: T, expected: T): void {
+  if (actual !== expected) {
+    throw new Error(`Expected ${expected} but received ${actual}`);
+  }
+}
+
+function assertThrows(fn: () => unknown): void {
+  let thrown = false;
+  try {
+    fn();
+  } catch {
+    thrown = true;
+  }
+
+  if (!thrown) {
+    throw new Error("Expected function to throw");
+  }
+}
+
+import {
+  assertProfileAccess,
+  normalizeEquityRow,
+  normalizeNumeric,
+} from "./investor-metrics.ts";
+
+declare const Deno: {
+  test: (name: string, fn: () => void | Promise<void>) => void;
+};
+
+Deno.test("normalizeNumeric parses numeric strings and guards NaN", () => {
+  assertEquals(normalizeNumeric("120.42"), 120.42);
+  assertEquals(normalizeNumeric(" 0.0001"), 0.0001);
+  assertEquals(normalizeNumeric("not-a-number"), 0);
+  assertEquals(normalizeNumeric(null), 0);
+});
+
+Deno.test("normalizeEquityRow converts raw equity payloads", () => {
+  const result = normalizeEquityRow({
+    contribution_usdt: "1500.50",
+    marked_equity_usdt: 1725.75,
+    profit_loss_usdt: "225.25",
+    last_valuation_at: "2025-01-15T00:00:00Z",
+  });
+
+  assertEquals(result.contributionUsd, 1500.5);
+  assertEquals(result.markedEquityUsd, 1725.75);
+  assertEquals(result.profitLossUsd, 225.25);
+  assertEquals(result.lastValuationAt, "2025-01-15T00:00:00Z");
+});
+
+Deno.test("assertProfileAccess rejects missing identifiers", () => {
+  assertThrows(() => assertProfileAccess(undefined));
+  assertThrows(() => assertProfileAccess(""));
+  assertThrows(() => assertProfileAccess("   "));
+});
+
+Deno.test("assertProfileAccess accepts valid identifiers", () => {
+  assertEquals(assertProfileAccess("user-123"), undefined);
+});

--- a/apps/web/lib/investor-metrics.ts
+++ b/apps/web/lib/investor-metrics.ts
@@ -1,0 +1,279 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/types/supabase";
+
+const INVESTOR_EQUITY_VIEW = "investor_equity_overview" as const;
+const BURN_TOTALS_VIEW = "dct_burn_totals" as const;
+const SUBSCRIPTION_STATUS_VIEW = "investor_subscription_status" as const;
+const BUYBACK_EVENTS_VIEW = "dct_buyback_events" as const;
+
+type RawEquityRow = {
+  profile_id?: string | null;
+  contribution_usdt?: number | string | null;
+  marked_equity_usdt?: number | string | null;
+  profit_loss_usdt?: number | string | null;
+  last_valuation_at?: string | null;
+};
+
+type RawBurnTotalsRow = {
+  burn_ton?: number | string | null;
+  dct_burned?: number | string | null;
+  operations_ton?: number | string | null;
+  auto_invest_ton?: number | string | null;
+  updated_at?: string | null;
+};
+
+type RawSubscriptionStatusRow = {
+  profile_id?: string | null;
+  plan_name?: string | null;
+  status?: string | null;
+  next_renewal_at?: string | null;
+  last_payment_at?: string | null;
+  is_paused?: boolean | null;
+};
+
+type RawBuybackRow = {
+  executed_at?: string | null;
+  burn_ton?: number | string | null;
+  dct_burned?: number | string | null;
+  burn_tx_hash?: string | null;
+  router_swap_id?: string | null;
+};
+
+type InvestorView<Row> = {
+  Row: Row;
+  Insert: never;
+  Update: never;
+  Relationships: [];
+};
+
+type InvestorViews = {
+  investor_equity_overview: InvestorView<RawEquityRow>;
+  dct_burn_totals: InvestorView<RawBurnTotalsRow>;
+  investor_subscription_status: InvestorView<RawSubscriptionStatusRow>;
+  dct_buyback_events: InvestorView<RawBuybackRow>;
+};
+
+type InvestorSchema = Omit<Database["public"], "Views"> & {
+  Views: Database["public"]["Views"] & InvestorViews;
+};
+
+type InvestorDatabase = Omit<Database, "public"> & {
+  public: InvestorSchema;
+};
+
+type SupabaseServerClient = SupabaseClient<InvestorDatabase>;
+
+export type { InvestorDatabase };
+
+export interface InvestorEquity {
+  contributionUsd: number;
+  markedEquityUsd: number;
+  profitLossUsd: number;
+  lastValuationAt: string | null;
+}
+
+export interface BurnTotals {
+  burnTon: number;
+  dctBurned: number;
+  operationsTon: number;
+  autoInvestTon: number;
+  updatedAt: string | null;
+}
+
+export interface SubscriptionStatus {
+  planName: string;
+  status: string;
+  nextRenewalAt: string | null;
+  lastPaymentAt: string | null;
+  isPaused: boolean;
+}
+
+export interface BuybackEvent {
+  executedAt: string | null;
+  burnTon: number;
+  dctBurned: number;
+  burnTxHash: string | null;
+  routerSwapId: string | null;
+}
+
+export interface InvestorOverview {
+  equity: InvestorEquity;
+  burnTotals: BurnTotals;
+  subscription: SubscriptionStatus | null;
+  lastBuyback: BuybackEvent | null;
+}
+
+export function normalizeNumeric(
+  value: number | string | null | undefined,
+): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return 0;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+export function assertProfileAccess(
+  profileId: string | null | undefined,
+): asserts profileId is string {
+  if (typeof profileId !== "string" || profileId.trim().length === 0) {
+    throw new Error("Authentication required to access investor data.");
+  }
+}
+
+export function normalizeEquityRow(row: RawEquityRow | null): InvestorEquity {
+  return {
+    contributionUsd: normalizeNumeric(row?.contribution_usdt),
+    markedEquityUsd: normalizeNumeric(row?.marked_equity_usdt),
+    profitLossUsd: normalizeNumeric(row?.profit_loss_usdt),
+    lastValuationAt: row?.last_valuation_at ?? null,
+  };
+}
+
+export function normalizeBurnTotals(
+  row: RawBurnTotalsRow | null,
+): BurnTotals {
+  return {
+    burnTon: normalizeNumeric(row?.burn_ton),
+    dctBurned: normalizeNumeric(row?.dct_burned),
+    operationsTon: normalizeNumeric(row?.operations_ton),
+    autoInvestTon: normalizeNumeric(row?.auto_invest_ton),
+    updatedAt: row?.updated_at ?? null,
+  };
+}
+
+export function normalizeSubscription(
+  row: RawSubscriptionStatusRow | null,
+): SubscriptionStatus | null {
+  if (!row) return null;
+
+  const planName = typeof row.plan_name === "string" ? row.plan_name : "";
+  const status = typeof row.status === "string" ? row.status : "unknown";
+
+  return {
+    planName,
+    status,
+    nextRenewalAt: row.next_renewal_at ?? null,
+    lastPaymentAt: row.last_payment_at ?? null,
+    isPaused: row.is_paused === true,
+  };
+}
+
+export function normalizeBuyback(
+  row: RawBuybackRow | null,
+): BuybackEvent | null {
+  if (!row) return null;
+  return {
+    executedAt: row.executed_at ?? null,
+    burnTon: normalizeNumeric(row.burn_ton),
+    dctBurned: normalizeNumeric(row.dct_burned),
+    burnTxHash: row.burn_tx_hash ?? null,
+    routerSwapId: row.router_swap_id ?? null,
+  };
+}
+
+export async function fetchInvestorEquity(
+  client: SupabaseServerClient,
+  profileId: string,
+): Promise<InvestorEquity> {
+  assertProfileAccess(profileId);
+
+  const { data, error } = await client
+    .from(INVESTOR_EQUITY_VIEW)
+    .select(
+      "contribution_usdt, marked_equity_usdt, profit_loss_usdt, last_valuation_at",
+    )
+    .eq("profile_id", profileId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || "Failed to load investor equity.");
+  }
+
+  return normalizeEquityRow(data as RawEquityRow | null);
+}
+
+export async function fetchBurnTotals(
+  client: SupabaseServerClient,
+): Promise<BurnTotals> {
+  const { data, error } = await client
+    .from(BURN_TOTALS_VIEW)
+    .select(
+      "burn_ton, dct_burned, operations_ton, auto_invest_ton, updated_at",
+    )
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || "Failed to load burn totals.");
+  }
+
+  return normalizeBurnTotals(data as RawBurnTotalsRow | null);
+}
+
+export async function fetchSubscriptionStatus(
+  client: SupabaseServerClient,
+  profileId: string,
+): Promise<SubscriptionStatus | null> {
+  assertProfileAccess(profileId);
+
+  const { data, error } = await client
+    .from(SUBSCRIPTION_STATUS_VIEW)
+    .select(
+      "plan_name, status, next_renewal_at, last_payment_at, is_paused",
+    )
+    .eq("profile_id", profileId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || "Failed to load subscription status.");
+  }
+
+  return normalizeSubscription(data as RawSubscriptionStatusRow | null);
+}
+
+export async function fetchLastBuyback(
+  client: SupabaseServerClient,
+): Promise<BuybackEvent | null> {
+  const { data, error } = await client
+    .from(BUYBACK_EVENTS_VIEW)
+    .select(
+      "executed_at, burn_ton, dct_burned, burn_tx_hash, router_swap_id",
+    )
+    .order("executed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message || "Failed to load buyback history.");
+  }
+
+  return normalizeBuyback(data as RawBuybackRow | null);
+}
+
+export async function fetchInvestorOverview(
+  client: SupabaseServerClient,
+  profileId: string,
+): Promise<InvestorOverview> {
+  assertProfileAccess(profileId);
+
+  const [equity, burnTotals, subscription, lastBuyback] = await Promise.all([
+    fetchInvestorEquity(client, profileId),
+    fetchBurnTotals(client),
+    fetchSubscriptionStatus(client, profileId),
+    fetchLastBuyback(client),
+  ]);
+
+  return {
+    equity,
+    burnTotals,
+    subscription,
+    lastBuyback,
+  };
+}

--- a/apps/web/lib/supabase-server.ts
+++ b/apps/web/lib/supabase-server.ts
@@ -1,0 +1,29 @@
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "@/config/supabase-runtime";
+import type { InvestorDatabase } from "@/lib/investor-metrics";
+
+export type ServerSupabaseClient = SupabaseClient<InvestorDatabase>;
+
+export async function createServerSupabaseClient(): Promise<
+  ServerSupabaseClient
+> {
+  const cookieStore = await cookies();
+
+  return createServerClient<InvestorDatabase>(
+    SUPABASE_URL,
+    SUPABASE_ANON_KEY,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll().map((cookie) => ({
+            name: cookie.name,
+            value: cookie.value,
+          }));
+        },
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add an /investor route that requires auth and fetches Supabase-backed investor overview data
- create investor metrics utilities plus a server-side Supabase client helper for the new views
- ship a client dashboard component and Deno tests covering numeric formatting and access checks

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d63741ceb48322baa1718c14435076