### PR TITLE
feat: visualize watchlist guidance

### DIFF
--- a/apps/web/types/opentelemetry-instrumentation-fetch.d.ts
+++ b/apps/web/types/opentelemetry-instrumentation-fetch.d.ts
@@ -1,0 +1,15 @@
+declare module "@opentelemetry/instrumentation-fetch" {
+  import {
+    InstrumentationBase,
+    InstrumentationConfig,
+  } from "@opentelemetry/instrumentation";
+
+  export interface FetchInstrumentationConfig extends InstrumentationConfig {
+    clearTimingResources?: boolean;
+  }
+
+  export class FetchInstrumentation
+    extends InstrumentationBase<FetchInstrumentationConfig> {
+    constructor(config?: FetchInstrumentationConfig);
+  }
+}


### PR DESCRIPTION
## Summary
- convert quick takeaway and strategy focus strings into structured insight chips with tone-aware styling
- add helpers to classify price levels, momentum, and automation guidance for the watchlist
- declare the @opentelemetry/instrumentation-fetch module to keep type-checking green

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d63ebcad408322937cc519f59ad4d5