### PR TITLE
feat: add vip auto sync tokenisation algorithm

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -28,6 +28,14 @@ from .dct_token_sync import (
     DCTProductionPlanner,
     DCTSyncJob,
 )
+from .vip_auto_token_sync import (
+    VipAutoSyncJob,
+    VipAutoSyncReport,
+    VipMembershipProvider,
+    VipMembershipSnapshot,
+    VipTokenGrant,
+    VipTokenisationStrategy,
+)
 
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
 
@@ -56,6 +64,12 @@ __all__ = _trade_exports + [
     "DCTProductionPlan",
     "DCTProductionPlanner",
     "DCTSyncJob",
+    "VipAutoSyncJob",
+    "VipAutoSyncReport",
+    "VipMembershipProvider",
+    "VipMembershipSnapshot",
+    "VipTokenGrant",
+    "VipTokenisationStrategy",
 ]
 
 globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
@@ -85,5 +99,11 @@ globals().update(
         "DCTProductionPlan": DCTProductionPlan,
         "DCTProductionPlanner": DCTProductionPlanner,
         "DCTSyncJob": DCTSyncJob,
+        "VipAutoSyncJob": VipAutoSyncJob,
+        "VipAutoSyncReport": VipAutoSyncReport,
+        "VipMembershipProvider": VipMembershipProvider,
+        "VipMembershipSnapshot": VipMembershipSnapshot,
+        "VipTokenGrant": VipTokenGrant,
+        "VipTokenisationStrategy": VipTokenisationStrategy,
     }
 )

--- a/algorithms/python/tests/test_vip_auto_token_sync.py
+++ b/algorithms/python/tests/test_vip_auto_token_sync.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Sequence
+
+import pytest
+
+from algorithms.python.vip_auto_token_sync import (
+    VipAutoSyncJob,
+    VipMembershipSnapshot,
+    VipTokenisationStrategy,
+)
+
+
+class StubWriter:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def upsert(self, rows: Iterable[Mapping[str, Any]]) -> int:
+        batch = [dict(row) for row in rows]
+        self.rows.extend(batch)
+        return len(batch)
+
+
+class StaticProvider:
+    def __init__(self, snapshots: Sequence[VipMembershipSnapshot]) -> None:
+        self._snapshots = list(snapshots)
+
+    def fetch(self) -> Sequence[VipMembershipSnapshot]:
+        return list(self._snapshots)
+
+
+def test_auto_sync_job_updates_memberships_and_tokens() -> None:
+    provider = StaticProvider(
+        [
+            VipMembershipSnapshot(
+                telegram_user_id=111,
+                username="alpha",
+                memberships={"@vip": True, "@alpha": True},
+                subscription_active=True,
+                trailing_spend=200.0,
+            ),
+            VipMembershipSnapshot(
+                telegram_user_id=222,
+                username="beta",
+                memberships={"@vip": False, "@alpha": True},
+                subscription_active=False,
+                trailing_spend=0.0,
+            ),
+        ]
+    )
+    membership_writer = StubWriter()
+    token_writer = StubWriter()
+    strategy = VipTokenisationStrategy(
+        base_reward=12.0,
+        channel_reward=3.0,
+        subscription_bonus=20.0,
+        spend_ratio=0.02,
+        max_reward=80.0,
+    )
+
+    job = VipAutoSyncJob(
+        provider=provider,
+        membership_writer=membership_writer,
+        token_writer=token_writer,
+        tokenisation=strategy,
+    )
+
+    report = job.run()
+
+    assert report.memberships_synced == 2
+    assert report.tokens_synced == 2
+    assert pytest.approx(report.total_tokens_issued, rel=1e-6) == 57.0
+    assert len(membership_writer.rows) == 2
+    assert membership_writer.rows[0]["activeChannels"] == ["@alpha", "@vip"]
+    assert membership_writer.rows[0]["membershipScore"] == 2
+    assert membership_writer.rows[1]["activeChannels"] == ["@alpha"]
+    assert token_writer.rows[0]["tokens"] == pytest.approx(42.0)
+    assert token_writer.rows[1]["tokens"] == pytest.approx(15.0)
+    summary = report.summary()
+    assert "2 memberships" in summary
+    assert "57.00" in summary
+
+
+def test_tokenisation_strategy_applies_cap_and_breakdown() -> None:
+    snapshot = VipMembershipSnapshot(
+        telegram_user_id=333,
+        username="gamma",
+        memberships={"@vip": True, "@elite": True, "@macro": True},
+        subscription_active=True,
+        trailing_spend=1000.0,
+        last_activity_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    strategy = VipTokenisationStrategy(
+        base_reward=10.0,
+        channel_reward=5.0,
+        subscription_bonus=10.0,
+        spend_ratio=0.2,
+        max_reward=60.0,
+    )
+
+    grant = strategy.tokenise(snapshot)
+
+    assert grant.tokens == pytest.approx(60.0)
+    assert grant.breakdown["cap_reduction"] == pytest.approx(175.0)
+
+    synced_at = datetime(2024, 2, 1, tzinfo=timezone.utc)
+    row = snapshot.to_membership_row(synced_at)
+    token_row = grant.to_row(synced_at)
+
+    assert row["lastActivityAt"] == snapshot.last_activity_at
+    assert row["syncedAt"] == synced_at
+    assert token_row["syncedAt"] == synced_at
+    assert token_row["breakdown"]["cap_reduction"] == pytest.approx(175.0)

--- a/algorithms/python/vip_auto_token_sync.py
+++ b/algorithms/python/vip_auto_token_sync.py
@@ -1,0 +1,222 @@
+"""VIP membership auto synchronisation and tokenisation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Protocol, Sequence
+
+from .supabase_sync import SupabaseTableWriter
+
+__all__ = [
+    "TableWriter",
+    "VipMembershipSnapshot",
+    "VipMembershipProvider",
+    "VipTokenGrant",
+    "VipTokenisationStrategy",
+    "VipAutoSyncReport",
+    "VipAutoSyncJob",
+]
+
+
+class TableWriter(Protocol):
+    """Protocol describing the table writer dependency."""
+
+    def upsert(self, rows: Iterable[Mapping[str, Any]]) -> int:
+        """Persist the supplied rows, returning the number of rows written."""
+
+
+@dataclass(slots=True)
+class VipMembershipSnapshot:
+    """Current VIP membership state for a Telegram user."""
+
+    telegram_user_id: int
+    username: str | None
+    memberships: Mapping[str, bool]
+    subscription_active: bool
+    trailing_spend: float = 0.0
+    last_activity_at: datetime | None = None
+
+    def active_channels(self) -> tuple[str, ...]:
+        """Return the channels where the member is currently active."""
+
+        return tuple(sorted(channel for channel, active in self.memberships.items() if active))
+
+    def inactive_channels(self) -> tuple[str, ...]:
+        """Return the channels where the member is no longer active."""
+
+        return tuple(sorted(channel for channel, active in self.memberships.items() if not active))
+
+    def to_membership_row(self, synced_at: datetime) -> MutableMapping[str, Any]:
+        """Convert the snapshot into a Supabase compatible row."""
+
+        trailing_spend = max(0.0, round(self.trailing_spend, 2))
+        last_activity = None
+        if self.last_activity_at is not None:
+            last_activity = self.last_activity_at.astimezone(timezone.utc)
+        return {
+            "telegramUserId": self.telegram_user_id,
+            "username": self.username,
+            "activeChannels": list(self.active_channels()),
+            "inactiveChannels": list(self.inactive_channels()),
+            "membershipScore": len(self.active_channels()),
+            "subscriptionActive": self.subscription_active,
+            "trailingSpend": trailing_spend,
+            "lastActivityAt": last_activity,
+            "syncedAt": synced_at,
+        }
+
+
+class VipMembershipProvider(Protocol):  # pragma: no cover - interface definition
+    """Interface for providers that surface VIP membership snapshots."""
+
+    def fetch(self) -> Sequence[VipMembershipSnapshot]:
+        """Return the current snapshots for users that require synchronisation."""
+
+
+@dataclass(slots=True)
+class VipTokenGrant:
+    """Token distribution calculated for a VIP user."""
+
+    telegram_user_id: int
+    username: str | None
+    tokens: float
+    breakdown: Mapping[str, float]
+    active_channels: int
+    subscription_active: bool
+
+    def to_row(self, synced_at: datetime) -> MutableMapping[str, Any]:
+        """Return a Supabase row capturing the token grant."""
+
+        rounded_breakdown = {key: round(value, 6) for key, value in self.breakdown.items()}
+        return {
+            "telegramUserId": self.telegram_user_id,
+            "username": self.username,
+            "tokens": round(self.tokens, 6),
+            "breakdown": rounded_breakdown,
+            "activeChannels": self.active_channels,
+            "subscriptionActive": self.subscription_active,
+            "syncedAt": synced_at,
+        }
+
+
+@dataclass(slots=True)
+class VipTokenisationStrategy:
+    """Deterministic strategy that converts membership into token grants."""
+
+    base_reward: float = 10.0
+    channel_reward: float = 2.5
+    subscription_bonus: float = 15.0
+    spend_ratio: float = 0.05
+    max_reward: float = 120.0
+
+    def tokenise(self, snapshot: VipMembershipSnapshot) -> VipTokenGrant:
+        """Return the calculated token grant for ``snapshot``."""
+
+        active_channels = len(snapshot.active_channels())
+        base_component = max(0.0, self.base_reward)
+        subscription_component = self.subscription_bonus if snapshot.subscription_active else 0.0
+        channel_component = active_channels * max(0.0, self.channel_reward)
+        spend_component = max(0.0, snapshot.trailing_spend) * max(0.0, self.spend_ratio)
+
+        raw_total = base_component + subscription_component + channel_component + spend_component
+        capped_total = min(max(0.0, self.max_reward), raw_total)
+        cap_reduction = max(0.0, raw_total - capped_total)
+
+        breakdown: dict[str, float] = {
+            "base": base_component,
+            "subscription": subscription_component,
+            "channels": channel_component,
+            "spend": spend_component,
+        }
+        if cap_reduction > 0:
+            breakdown["cap_reduction"] = cap_reduction
+
+        return VipTokenGrant(
+            telegram_user_id=snapshot.telegram_user_id,
+            username=snapshot.username,
+            tokens=capped_total,
+            breakdown=breakdown,
+            active_channels=active_channels,
+            subscription_active=snapshot.subscription_active,
+        )
+
+
+@dataclass(slots=True)
+class VipAutoSyncReport:
+    """Summary of a completed auto synchronisation run."""
+
+    synced_at: datetime
+    memberships_synced: int
+    tokens_synced: int
+    total_tokens_issued: float
+    grants: Sequence[VipTokenGrant] = field(default_factory=tuple)
+
+    def summary(self) -> str:
+        """Return a concise string describing the run outcome."""
+
+        return (
+            f"{self.memberships_synced} memberships synced, "
+            f"{self.tokens_synced} token grants ({self.total_tokens_issued:.2f} DCT)"
+        )
+
+    def to_dict(self) -> MutableMapping[str, Any]:
+        """Return a JSON friendly representation of the report."""
+
+        return {
+            "syncedAt": self.synced_at.isoformat(),
+            "membershipsSynced": self.memberships_synced,
+            "tokensSynced": self.tokens_synced,
+            "totalTokensIssued": round(self.total_tokens_issued, 6),
+            "grants": [
+                {
+                    "telegramUserId": grant.telegram_user_id,
+                    "username": grant.username,
+                    "tokens": round(grant.tokens, 6),
+                    "breakdown": {key: round(value, 6) for key, value in grant.breakdown.items()},
+                    "activeChannels": grant.active_channels,
+                    "subscriptionActive": grant.subscription_active,
+                }
+                for grant in self.grants
+            ],
+        }
+
+
+@dataclass(slots=True)
+class VipAutoSyncJob:
+    """Synchronise VIP memberships and persist token grants."""
+
+    provider: VipMembershipProvider
+    membership_writer: TableWriter
+    token_writer: TableWriter
+    tokenisation: VipTokenisationStrategy = field(default_factory=VipTokenisationStrategy)
+
+    def run(self) -> VipAutoSyncReport:
+        """Execute the synchronisation pipeline and return a report."""
+
+        snapshots = list(self.provider.fetch())
+        synced_at = datetime.now(tz=timezone.utc)
+
+        membership_rows = [snapshot.to_membership_row(synced_at) for snapshot in snapshots]
+        memberships_synced = 0
+        if membership_rows:
+            memberships_synced = self.membership_writer.upsert(membership_rows)
+
+        grants = [self.tokenisation.tokenise(snapshot) for snapshot in snapshots]
+        token_rows = [grant.to_row(synced_at) for grant in grants]
+        tokens_synced = 0
+        if token_rows:
+            tokens_synced = self.token_writer.upsert(token_rows)
+
+        total_tokens_issued = sum(grant.tokens for grant in grants)
+        return VipAutoSyncReport(
+            synced_at=synced_at,
+            memberships_synced=memberships_synced,
+            tokens_synced=tokens_synced,
+            total_tokens_issued=total_tokens_issued,
+            grants=tuple(grants),
+        )
+
+
+if TYPE_CHECKING:  # pragma: no cover - import-time type assertion only
+    _supabase_writer: TableWriter = SupabaseTableWriter(table="", conflict_column="")

--- a/docs/vip-membership-audit.md
+++ b/docs/vip-membership-audit.md
@@ -1,0 +1,14 @@
+# Audit: Telegram VIP Membership Workflow
+
+## Scope
+This review verifies the prior summary describing how Dynamic Capital checks Telegram channel membership, records it, and recomputes VIP status.
+
+## Findings
+- **Channel list resolution** – `getVipChannels` first reads the `VIP_CHANNELS` environment variable and otherwise queries `bot_settings` for the `vip_channels` entry, which matches the summary’s reference to a configurable channel list.
+- **Membership checks** – `checkUserAcrossChannels` iterates over each configured channel and calls `getChatMemberStatus`, which invokes Telegram’s `getChatMember` API endpoint, confirming the summary’s description of querying Telegram for membership status.
+- **Persistence & VIP recompute** – `upsertMemberships` writes the per-channel membership flags into the `channel_memberships` table and `recomputeVipFlag` combines channel membership with subscription data before updating `bot_users.is_vip` and `subscription_expires_at`, aligning with the prior explanation.
+- **Webhook-driven updates** – `handleMembershipUpdate` responds to `chat_member` and `my_chat_member` webhook updates for VIP channels by upserting the membership row, rerunning `recomputeVipFlag`, and logging the action, which is consistent with the summary’s claim about immediate join/leave handling.
+- **Manual resync** – The `vip-sync` edge function exposes `/one`, `/batch`, and `/all` routes that call `recomputeVipForUser` and emit admin log entries, substantiating the described manual resync capability.
+
+## Conclusion
+All reviewed statements from the earlier summary are accurate with respect to the current codebase.


### PR DESCRIPTION
## Summary
- add a VIP auto synchronisation module that computes membership rows and deterministic token grants
- export the new helpers through the python algorithms package for reuse
- cover the sync and tokenisation flow with focused pytest cases

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_vip_auto_token_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d63aa7ba9c8322ac28784a688ab3bf