### PR TITLE
Enhance landing and mini app navigation

### DIFF
--- a/apps/web/app/(miniapp)/miniapp/layout.tsx
+++ b/apps/web/app/(miniapp)/miniapp/layout.tsx
@@ -2,18 +2,22 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { AppShell } from "@/components/miniapp/AppShell";
 import { BottomNav } from "@/components/miniapp/BottomNav";
+import { NavigationHeader } from "@/components/miniapp/NavigationHeader";
 import MiniAppProviders from "./providers";
 import "@/styles/theme.css";
 
 export const metadata: Metadata = {
   title: "Dynamic Capital Mini App",
-  description: "Native-feel Telegram experience with tabs, haptics, and telemetry.",
+  description:
+    "Native-feel Telegram experience with tabs, haptics, and telemetry.",
 };
 
 export default function MiniAppLayout({ children }: { children: ReactNode }) {
   return (
     <MiniAppProviders>
-      <AppShell footer={<BottomNav />}>{children}</AppShell>
+      <AppShell header={<NavigationHeader />} footer={<BottomNav />}>
+        {children}
+      </AppShell>
     </MiniAppProviders>
   );
 }

--- a/apps/web/components/landing/HomeNavigationRail.tsx
+++ b/apps/web/components/landing/HomeNavigationRail.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+
+import { cn } from "@/utils";
+
+import {
+  HOME_NAV_SECTIONS,
+  type HomeNavSectionId,
+} from "./home-navigation-config";
+
+const observerOptions: IntersectionObserverInit = {
+  root: null,
+  rootMargin: "-45% 0px -40% 0px",
+  threshold: [0, 0.25, 0.5, 0.75, 1],
+};
+
+export function HomeNavigationRail({ className }: { className?: string }) {
+  const [activeId, setActiveIdState] = useState<HomeNavSectionId | null>(
+    HOME_NAV_SECTIONS[0]?.id ?? null,
+  );
+  const activeIdRef = useRef<HomeNavSectionId | null>(activeId);
+  const reduceMotion = useReducedMotion();
+
+  const setActiveId = useCallback((nextId: HomeNavSectionId) => {
+    if (activeIdRef.current === nextId) {
+      return;
+    }
+
+    activeIdRef.current = nextId;
+    setActiveIdState(nextId);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+      return;
+    }
+
+    const sectionElements = HOME_NAV_SECTIONS.map(({ id }) =>
+      document.querySelector<HTMLElement>(`[data-section-anchor="${id}"]`)
+    ).filter((element): element is HTMLElement => Boolean(element));
+
+    if (!sectionElements.length) {
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const visibleEntries = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+      if (visibleEntries.length > 0) {
+        const latest = visibleEntries[0];
+        const anchor = latest.target.getAttribute("data-section-anchor");
+        if (anchor && anchor !== activeIdRef.current) {
+          setActiveId(anchor as HomeNavSectionId);
+        }
+        return;
+      }
+
+      const nearest = entries
+        .slice()
+        .sort((a, b) =>
+          Math.abs(a.boundingClientRect.top) -
+          Math.abs(b.boundingClientRect.top)
+        )[0];
+
+      if (nearest) {
+        const anchor = nearest.target.getAttribute("data-section-anchor");
+        if (anchor && anchor !== activeIdRef.current) {
+          setActiveId(anchor as HomeNavSectionId);
+        }
+      }
+    }, observerOptions);
+
+    sectionElements.forEach((element) => observer.observe(element));
+
+    return () => observer.disconnect();
+  }, [setActiveId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const hash = window.location.hash?.replace(/^#/, "") as
+      | HomeNavSectionId
+      | undefined;
+
+    if (hash && HOME_NAV_SECTIONS.some((section) => section.id === hash)) {
+      setActiveId(hash);
+    }
+  }, [setActiveId]);
+
+  return (
+    <motion.nav
+      aria-label="Landing page sections"
+      className={cn(
+        "sticky top-4 z-[5] mx-auto w-full max-w-6xl",
+        "rounded-2xl border border-border/50 bg-background/80 backdrop-blur-xl",
+        "shadow-lg shadow-primary/5",
+        "px-4 py-3",
+        className,
+      )}
+      initial={reduceMotion ? false : { opacity: 0, y: -12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: reduceMotion ? 0 : 0.4, ease: "easeOut" }}
+    >
+      <div className="relative flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Explore the desk
+        </div>
+        <div className="relative overflow-hidden">
+          <div
+            className="flex gap-2 overflow-x-auto pb-1"
+            role="tablist"
+            aria-orientation="horizontal"
+          >
+            {HOME_NAV_SECTIONS.map((section, index) => {
+              const Icon = section.icon;
+              const isActive = activeId === section.id;
+
+              return (
+                <motion.div
+                  key={section.id}
+                  className="relative"
+                  initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: reduceMotion ? 0 : 0.3,
+                    delay: reduceMotion ? 0 : index * 0.05,
+                  }}
+                >
+                  <Link
+                    href={section.href}
+                    className={cn(
+                      "group inline-flex items-center gap-2 rounded-full border px-3 py-2",
+                      "text-xs font-semibold transition-colors",
+                      isActive
+                        ? "border-primary/60 bg-primary/10 text-primary"
+                        : "border-border/70 bg-background/60 text-muted-foreground hover:border-primary/40 hover:text-primary",
+                    )}
+                    aria-current={isActive ? "page" : undefined}
+                    role="tab"
+                    aria-selected={isActive}
+                  >
+                    <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-primary">
+                      <Icon className="h-3.5 w-3.5" strokeWidth={2.2} />
+                    </span>
+                    <span className="flex flex-col items-start leading-tight">
+                      <span>{section.label}</span>
+                      <span className="text-[10px] font-normal text-muted-foreground">
+                        {section.description}
+                      </span>
+                    </span>
+                  </Link>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </motion.nav>
+  );
+}
+
+export default HomeNavigationRail;

--- a/apps/web/components/landing/LandingPageShell.tsx
+++ b/apps/web/components/landing/LandingPageShell.tsx
@@ -7,6 +7,7 @@ import { ChatAssistantWidget } from "@/components/shared/ChatAssistantWidget";
 import { cn } from "@/utils";
 import { dynamicUI } from "@/resources";
 import { DynamicCapitalLandingPage } from "@/components/magic-portfolio/DynamicCapitalLandingPage";
+import { HomeNavigationRail } from "@/components/landing/HomeNavigationRail";
 import type {
   ChromaBackgroundProps,
   ChromaBackgroundStyle,
@@ -113,6 +114,7 @@ export function LandingPageShell({
         gap="32"
         horizontal="center"
       >
+        <HomeNavigationRail className="mt-4" />
         <DynamicCapitalLandingPage />
       </Column>
       {showAssistant

--- a/apps/web/components/landing/home-navigation-config.ts
+++ b/apps/web/components/landing/home-navigation-config.ts
@@ -1,0 +1,73 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Compass,
+  Diamond,
+  LineChart,
+  Rocket,
+  ShieldCheck,
+  UsersRound,
+} from "lucide-react";
+
+export interface HomeNavSection {
+  id: HomeNavSectionId;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  href: string;
+}
+
+export const HOME_NAV_SECTION_IDS = {
+  overview: "overview",
+  market: "market-intelligence",
+  mentorship: "mentorship",
+  plans: "vip-plans",
+  trust: "trust-safety",
+  onboarding: "get-started",
+} as const;
+
+export type HomeNavSectionId = keyof typeof HOME_NAV_SECTION_IDS;
+
+export const HOME_NAV_SECTIONS: HomeNavSection[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    description: "Tour automation, playbooks, and desk setup.",
+    icon: Compass,
+    href: `/#${HOME_NAV_SECTION_IDS.overview}`,
+  },
+  {
+    id: "market",
+    label: "Market intel",
+    description: "Scan watchlists, posture maps, and catalysts.",
+    icon: LineChart,
+    href: `/#${HOME_NAV_SECTION_IDS.market}`,
+  },
+  {
+    id: "mentorship",
+    label: "Mentorship",
+    description: "Meet cohort leads and training programmes.",
+    icon: UsersRound,
+    href: `/#${HOME_NAV_SECTION_IDS.mentorship}`,
+  },
+  {
+    id: "plans",
+    label: "Membership",
+    description: "Compare VIP plans and funding unlocks.",
+    icon: Diamond,
+    href: `/#${HOME_NAV_SECTION_IDS.plans}`,
+  },
+  {
+    id: "trust",
+    label: "Trust & safety",
+    description: "Review compliance, guardrails, and audits.",
+    icon: ShieldCheck,
+    href: `/#${HOME_NAV_SECTION_IDS.trust}`,
+  },
+  {
+    id: "onboarding",
+    label: "Get started",
+    description: "Check readiness, checkout, and concierge.",
+    icon: Rocket,
+    href: `/#${HOME_NAV_SECTION_IDS.onboarding}`,
+  },
+];

--- a/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
+++ b/apps/web/components/magic-portfolio/DynamicCapitalLandingPage.tsx
@@ -36,6 +36,7 @@ import { VipPlansPricingSection } from "@/components/magic-portfolio/home/VipPla
 import { cn } from "@/utils";
 import { about, baseURL, home, person, toAbsoluteUrl } from "@/resources";
 import styles from "./DynamicCapitalLandingPage.module.scss";
+import { HOME_NAV_SECTION_IDS } from "@/components/landing/home-navigation-config";
 
 const QUICK_METRICS = [
   {
@@ -322,7 +323,13 @@ export function DynamicCapitalLandingPage() {
       <Section variant="wide" reveal={false}>
         <HeroExperience />
       </Section>
-      <Section revealDelay={0.24}>
+      <Section
+        revealDelay={0.24}
+        anchor={{
+          id: HOME_NAV_SECTION_IDS.overview,
+          ariaLabel: "Platform overview",
+        }}
+      >
         <ValuePropositionSection />
       </Section>
       <Section revealDelay={0.32}>
@@ -337,7 +344,14 @@ export function DynamicCapitalLandingPage() {
       <Section revealDelay={0.56}>
         <AutomationWorkflowSection />
       </Section>
-      <Section variant="wide" revealDelay={0.64}>
+      <Section
+        variant="wide"
+        revealDelay={0.64}
+        anchor={{
+          id: HOME_NAV_SECTION_IDS.market,
+          ariaLabel: "Market intelligence",
+        }}
+      >
         <MarketIntelligenceSection />
       </Section>
       <Section variant="wide" revealDelay={0.72}>
@@ -355,13 +369,25 @@ export function DynamicCapitalLandingPage() {
       <Section revealDelay={1.04}>
         <FundamentalAnalysisSection />
       </Section>
-      <Section revealDelay={1.12}>
+      <Section
+        revealDelay={1.12}
+        anchor={{
+          id: HOME_NAV_SECTION_IDS.mentorship,
+          ariaLabel: "Mentorship programmes",
+        }}
+      >
         <MentorshipProgramsSection />
       </Section>
       <Section revealDelay={1.2}>
         <LossRecoveryProgrammeSection />
       </Section>
-      <Section revealDelay={1.28}>
+      <Section
+        revealDelay={1.28}
+        anchor={{
+          id: HOME_NAV_SECTION_IDS.plans,
+          ariaLabel: "Membership plans",
+        }}
+      >
         <VipPlansPricingSection />
       </Section>
       <Section revealDelay={1.36}>
@@ -373,13 +399,25 @@ export function DynamicCapitalLandingPage() {
       <Section revealDelay={1.52}>
         <PoolTradingSection />
       </Section>
-      <Section revealDelay={1.6}>
+      <Section
+        revealDelay={1.6}
+        anchor={{
+          id: HOME_NAV_SECTION_IDS.trust,
+          ariaLabel: "Trust and compliance",
+        }}
+      >
         <ComplianceCertificates />
       </Section>
       <Section revealDelay={1.68}>
         <FundingReadinessSection />
       </Section>
-      <Section revealDelay={1.76}>
+      <Section
+        revealDelay={1.76}
+        anchor={{
+          id: HOME_NAV_SECTION_IDS.onboarding,
+          ariaLabel: "Get started with Dynamic Capital",
+        }}
+      >
         <CheckoutCallout />
       </Section>
       <Section revealDelay={1.84}>
@@ -394,12 +432,18 @@ export function DynamicCapitalLandingPage() {
 
 type SectionVariant = "compact" | "wide";
 
+interface SectionAnchor {
+  id: string;
+  ariaLabel?: string;
+}
+
 interface SectionProps {
   children: ReactNode;
   className?: string;
   reveal?: boolean;
   revealDelay?: number;
   variant?: SectionVariant;
+  anchor?: SectionAnchor;
 }
 
 function Section({
@@ -408,14 +452,21 @@ function Section({
   reveal = true,
   revealDelay,
   variant = "compact",
+  anchor,
 }: SectionProps) {
   const variantClassName = variant === "wide"
     ? styles.sectionWide
     : styles.sectionCompact;
+  const SectionComponent = (anchor ? "section" : "div") as "section" | "div";
   const section = (
-    <div className={cn(styles.section, variantClassName, className)}>
+    <SectionComponent
+      id={anchor?.id}
+      aria-label={anchor?.ariaLabel}
+      data-section-anchor={anchor?.id}
+      className={cn(styles.section, variantClassName, className)}
+    >
       {children}
-    </div>
+    </SectionComponent>
   );
 
   if (!reveal) {

--- a/apps/web/components/miniapp/AppShell.tsx
+++ b/apps/web/components/miniapp/AppShell.tsx
@@ -14,32 +14,39 @@ const transition: Transition = {
 export function AppShell({
   children,
   footer,
+  header,
 }: {
   children: ReactNode;
   footer: ReactNode;
+  header?: ReactNode;
 }) {
   const pathname = usePathname();
+  const hasHeader = Boolean(header);
 
   return (
     <div className="app-shell">
-      <AnimatePresence initial={false} mode="wait">
-        <motion.main
-          key={pathname}
-          initial={{ y: 24, opacity: 0.4 }}
-          animate={{ y: 0, opacity: 1 }}
-          exit={{ y: -12, opacity: 0 }}
-          transition={transition}
-          style={{
-            padding: "16px",
-            paddingTop: "calc(var(--safe-top) + 8px)",
-            display: "grid",
-            alignContent: "start",
-            gap: "16px",
-          }}
-        >
-          {children}
-        </motion.main>
-      </AnimatePresence>
+      <div className="app-shell-body">
+        {header ?? null}
+        <AnimatePresence initial={false} mode="wait">
+          <motion.main
+            key={pathname}
+            className="app-shell-main"
+            initial={{ y: 24, opacity: 0.4 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -12, opacity: 0 }}
+            transition={transition}
+            style={{
+              padding: "16px",
+              paddingTop: hasHeader ? "12px" : "calc(var(--safe-top) + 8px)",
+              display: "grid",
+              alignContent: "start",
+              gap: "16px",
+            }}
+          >
+            {children}
+          </motion.main>
+        </AnimatePresence>
+      </div>
       {footer}
     </div>
   );

--- a/apps/web/components/miniapp/BottomNav.tsx
+++ b/apps/web/components/miniapp/BottomNav.tsx
@@ -2,26 +2,9 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Activity, Home, PieChart, User } from "lucide-react";
 import { haptic } from "@/lib/telegram";
 import { track } from "@/lib/metrics";
-
-const tabs = [
-  { href: "/miniapp/home", label: "Home", Icon: Home, event: "nav_home" },
-  { href: "/miniapp/fund", label: "Fund", Icon: PieChart, event: "nav_fund" },
-  {
-    href: "/miniapp/signals",
-    label: "Signals",
-    Icon: Activity,
-    event: "nav_signals",
-  },
-  {
-    href: "/miniapp/account",
-    label: "Account",
-    Icon: User,
-    event: "nav_account",
-  },
-] as const;
+import { MINIAPP_TABS } from "./navigation";
 
 export function BottomNav() {
   const pathname = usePathname();
@@ -29,7 +12,7 @@ export function BottomNav() {
   return (
     <nav className="bottom-nav" role="navigation" aria-label="Mini app primary">
       <div className="bottom-nav-inner">
-        {tabs.map(({ href, label, Icon, event }) => {
+        {MINIAPP_TABS.map(({ href, label, Icon, analyticsEvent }) => {
           const active = pathname?.startsWith(href);
           return (
             <Link
@@ -39,7 +22,7 @@ export function BottomNav() {
               aria-current={active ? "page" : undefined}
               onClick={() => {
                 haptic(active ? "light" : "medium");
-                void track(event);
+                void track(analyticsEvent);
               }}
             >
               <span className="bottom-btn-highlight" aria-hidden />

--- a/apps/web/components/miniapp/NavigationHeader.tsx
+++ b/apps/web/components/miniapp/NavigationHeader.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import { haptic } from "@/lib/telegram";
+import { track } from "@/lib/metrics";
+import { cn } from "@/utils";
+
+import { MINIAPP_TABS } from "./navigation";
+
+export function NavigationHeader() {
+  const pathname = usePathname();
+  const reduceMotion = useReducedMotion();
+
+  const activeTab =
+    MINIAPP_TABS.find((tab) => pathname?.startsWith(tab.href)) ??
+      MINIAPP_TABS[0];
+
+  return (
+    <motion.nav
+      aria-label="Mini app section overview"
+      className="miniapp-nav"
+      initial={reduceMotion ? false : { opacity: 0, y: -16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: reduceMotion ? 0 : 0.35, ease: "easeOut" }}
+    >
+      <div className="miniapp-nav-card">
+        <motion.div
+          className="miniapp-nav-card-icon"
+          key={activeTab.id}
+          initial={reduceMotion ? false : { scale: 0.85, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: reduceMotion ? 0 : 0.3, ease: "easeOut" }}
+        >
+          <activeTab.Icon size={20} strokeWidth={2.2} />
+        </motion.div>
+        <div className="miniapp-nav-card-copy">
+          <span className="miniapp-nav-card-subtitle">You're in</span>
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.span
+              key={activeTab.label}
+              className="miniapp-nav-card-title"
+              initial={reduceMotion ? false : { y: 8, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={reduceMotion ? undefined : { y: -8, opacity: 0 }}
+              transition={{
+                duration: reduceMotion ? 0 : 0.25,
+                ease: "easeOut",
+              }}
+            >
+              {activeTab.label}
+            </motion.span>
+          </AnimatePresence>
+          <p className="miniapp-nav-card-description">
+            {activeTab.description}
+          </p>
+        </div>
+      </div>
+      <div className="miniapp-nav-links" role="list">
+        {MINIAPP_TABS.map((tab) => {
+          const isActive = tab.id === activeTab.id;
+          const Icon = tab.Icon;
+
+          return (
+            <Link
+              key={tab.id}
+              href={tab.href}
+              className={cn(
+                "miniapp-nav-chip",
+                isActive && "miniapp-nav-chip-active",
+              )}
+              aria-current={isActive ? "page" : undefined}
+              onClick={() => {
+                haptic(isActive ? "light" : "medium");
+                void track(tab.analyticsEvent);
+              }}
+            >
+              <Icon size={16} strokeWidth={isActive ? 2.4 : 2} />
+              <span>{tab.label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </motion.nav>
+  );
+}
+
+export default NavigationHeader;

--- a/apps/web/components/miniapp/navigation.ts
+++ b/apps/web/components/miniapp/navigation.ts
@@ -1,0 +1,48 @@
+import type { LucideIcon } from "lucide-react";
+import { Activity, Home, PieChart, User } from "lucide-react";
+
+export type MiniAppTabId = "home" | "fund" | "signals" | "account";
+
+export interface MiniAppTab {
+  id: MiniAppTabId;
+  href: string;
+  label: string;
+  Icon: LucideIcon;
+  analyticsEvent: string;
+  description: string;
+}
+
+export const MINIAPP_TABS: MiniAppTab[] = [
+  {
+    id: "home",
+    href: "/miniapp/home",
+    label: "Home",
+    Icon: Home,
+    analyticsEvent: "nav_home",
+    description: "Live agenda, announcements, and quick actions.",
+  },
+  {
+    id: "fund",
+    href: "/miniapp/fund",
+    label: "Fund",
+    Icon: PieChart,
+    analyticsEvent: "nav_fund",
+    description: "Pool performance, funding status, and unlocks.",
+  },
+  {
+    id: "signals",
+    href: "/miniapp/signals",
+    label: "Signals",
+    Icon: Activity,
+    analyticsEvent: "nav_signals",
+    description: "Realtime trade ideas and automation triggers.",
+  },
+  {
+    id: "account",
+    href: "/miniapp/account",
+    label: "Account",
+    Icon: User,
+    analyticsEvent: "nav_account",
+    description: "Membership, billing, and personal settings.",
+  },
+];

--- a/apps/web/styles/theme.css
+++ b/apps/web/styles/theme.css
@@ -43,6 +43,124 @@ html, body {
   background: var(--tg-bg);
 }
 
+.app-shell-body {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell-main {
+  flex: 1;
+  width: 100%;
+}
+
+.miniapp-nav {
+  position: sticky;
+  top: 0;
+  z-index: 24;
+  display: grid;
+  gap: 12px;
+  padding: calc(var(--safe-top) + var(--space-3)) var(--space-4) var(--space-2);
+  background: linear-gradient(
+    180deg,
+    rgba(11, 13, 18, 0.95) 0%,
+    rgba(11, 13, 18, 0.8) 55%,
+    rgba(11, 13, 18, 0)
+  );
+  backdrop-filter: blur(16px);
+}
+
+.miniapp-nav-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(17, 20, 26, 0.92);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.miniapp-nav-card-icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgba(48, 194, 242, 0.15);
+  color: var(--tg-accent);
+}
+
+.miniapp-nav-card-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.miniapp-nav-card-subtitle {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.52);
+}
+
+.miniapp-nav-card-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.miniapp-nav-card-description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.miniapp-nav-links {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 4px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.miniapp-nav-links::-webkit-scrollbar {
+  display: none;
+}
+
+.miniapp-nav-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+}
+
+.miniapp-nav-chip:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.miniapp-nav-chip:focus-visible {
+  outline: 2px solid rgba(48, 194, 242, 0.45);
+  outline-offset: 2px;
+}
+
+.miniapp-nav-chip-active {
+  background: rgba(48, 194, 242, 0.22);
+  color: var(--tg-accent);
+  box-shadow: 0 10px 30px rgba(48, 194, 242, 0.25);
+}
+
 .bottom-nav {
   position: sticky;
   bottom: 0;

--- a/apps/web/types/opentelemetry.d.ts
+++ b/apps/web/types/opentelemetry.d.ts
@@ -1,0 +1,1 @@
+declare module "@opentelemetry/instrumentation-fetch";


### PR DESCRIPTION
## Summary
- add a sticky home navigation rail with shared section metadata on the landing page
- tag key landing page sections with anchors to drive the new navigation experience
- refresh the mini app shell with a contextual header, shared tab config, and updated styling

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d63e09744483228700a4b67bd01b38