### PR TITLE
Add Bitget wallets to the TON mini app

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/app/page.tsx
+++ b/dynamic-capital-ton/apps/miniapp/app/page.tsx
@@ -4,6 +4,7 @@ import {
   TonConnectButton,
   TonConnectUIProvider,
   useTonConnectUI,
+  type UIWallet,
 } from "@tonconnect/ui-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -1476,9 +1477,67 @@ const NAV_ITEMS: NavItem[] = [
   { id: "support", label: "Support", icon: LifebuoyIcon },
 ];
 
+const BITGET_WALLETS: UIWallet[] = [
+  {
+    name: "Bitget Wallet",
+    appName: "bitgetTonWallet",
+    imageUrl:
+      "https://raw.githubusercontent.com/bitgetwallet/download/refs/heads/main/logo/png/bitget_wallet_logo_288_mini.png",
+    aboutUrl: "https://web3.bitget.com",
+    universalLink: "https://bkcode.vip/ton-connect",
+    deepLink: "bitkeep://",
+    bridgeUrl: "https://ton-connect-bridge.bgwapi.io/bridge",
+    platforms: ["ios", "android", "chrome"],
+    features: [
+      {
+        name: "SendTransaction",
+        maxMessages: 4,
+        extraCurrencySupported: false,
+      },
+    ],
+  },
+  {
+    name: "BitgetWeb3",
+    appName: "BitgetWeb3",
+    imageUrl:
+      "https://img.bitgetimg.com/image/third/1731638059795.png",
+    aboutUrl: "https://www.bitget.com",
+    universalLink: "https://t.me/BitgetOfficialBot?attach=wallet",
+    bridgeUrl: "https://ton-connect-bridge.bgwapi.io/bridge",
+    platforms: ["ios", "android", "windows", "macos", "linux"],
+    features: [
+      {
+        name: "SendTransaction",
+        maxMessages: 4,
+        extraCurrencySupported: false,
+      },
+    ],
+  },
+  {
+    name: "Bitget Wallet Lite",
+    appName: "bitgetWalletLite",
+    imageUrl:
+      "https://raw.githubusercontent.com/bitgetwallet/download/refs/heads/main/logo/png/bitget_wallet_lite_logo_288.png",
+    aboutUrl: "https://web3.bitget.com",
+    universalLink: "https://t.me/BitgetWallet_TGBot?attach=wallet",
+    bridgeUrl: "https://ton-connect-bridge.bgwapi.io/bridge",
+    platforms: ["ios", "android", "macos", "windows", "linux"],
+    features: [
+      {
+        name: "SendTransaction",
+        maxMessages: 255,
+        extraCurrencySupported: false,
+      },
+    ],
+  },
+];
+
 export default function Page() {
   return (
-    <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+    <TonConnectUIProvider
+      manifestUrl="/tonconnect-manifest.json"
+      walletsListConfiguration={{ includeWallets: BITGET_WALLETS }}
+    >
       <HomeInner />
     </TonConnectUIProvider>
   );


### PR DESCRIPTION
## Summary
- import the Bitget wallet definitions into the TON mini app
- include Bitget Wallet, BitgetWeb3, and Bitget Wallet Lite in the TonConnect provider configuration

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6453762cc83229529e9e7a4bc7cf2