### PR TITLE
Add recommended TON wallets to mini app connect modal

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/app/page.tsx
+++ b/dynamic-capital-ton/apps/miniapp/app/page.tsx
@@ -5,6 +5,7 @@ import {
   TonConnectUIProvider,
   useTonConnectUI,
 } from "@tonconnect/ui-react";
+import type { WalletsListConfiguration } from "@tonconnect/ui-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
@@ -89,6 +90,38 @@ type LiveIntelState = {
   isSyncing: boolean;
   error?: string;
 };
+
+const RECOMMENDED_WALLETS: NonNullable<
+  WalletsListConfiguration["includeWallets"]
+> = [
+  {
+    appName: "tonkeeper",
+    name: "Tonkeeper",
+    imageUrl: "https://tonkeeper.com/assets/tonconnect-icon.png",
+    aboutUrl: "https://tonkeeper.com",
+    universalLink: "https://app.tonkeeper.com/ton-connect",
+    bridgeUrl: "https://bridge.tonapi.io/bridge",
+    platforms: ["ios", "android", "chrome", "firefox"],
+  },
+  {
+    appName: "tonhub",
+    name: "Tonhub",
+    imageUrl: "https://tonhub.com/tonconnect_logo.png",
+    aboutUrl: "https://tonhub.com",
+    universalLink: "https://tonhub.com/ton-connect",
+    bridgeUrl: "https://connect.tonhubapi.com/tonconnect",
+    platforms: ["ios", "android"],
+  },
+  {
+    appName: "mytonwallet",
+    name: "MyTonWallet",
+    imageUrl: "https://mytonwallet.io/icon-256.png",
+    aboutUrl: "https://mytonwallet.io",
+    universalLink: "https://connect.mytonwallet.org",
+    bridgeUrl: "https://tonconnectbridge.mytonwallet.org/bridge/",
+    platforms: ["chrome", "windows", "macos", "linux"],
+  },
+];
 
 const FALLBACK_PLAN_OPTIONS: PlanOption[] = [
   {
@@ -1478,7 +1511,10 @@ const NAV_ITEMS: NavItem[] = [
 
 export default function Page() {
   return (
-    <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+    <TonConnectUIProvider
+      manifestUrl="/tonconnect-manifest.json"
+      walletsListConfiguration={{ includeWallets: RECOMMENDED_WALLETS }}
+    >
       <HomeInner />
     </TonConnectUIProvider>
   );


### PR DESCRIPTION
## Summary
- add a curated TonConnect wallets list highlighting Tonkeeper, Tonhub, and MyTonWallet
- configure the mini app TonConnect provider to surface the curated wallets in the connect modal

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d644c0b1208322a15213562c94fa81