### PR TITLE
Add dynamic multi-LLM auto sync orchestrator

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -22,6 +22,12 @@ from .loss_recovery_programme import (
     RecoveryPlan,
     RecoveryStep,
 )
+from .auto_sync_multi_llm import (
+    AutoSyncAction,
+    AutoSyncPlan,
+    DynamicAutoSyncOrchestrator,
+    SyncSnapshot,
+)
 from .dct_token_sync import (
     DCTAllocationEngine,
     DCTAllocationResult,
@@ -65,6 +71,10 @@ __all__ = _trade_exports + [
     "LossRecoveryProgramme",
     "RecoveryPlan",
     "RecoveryStep",
+    "AutoSyncAction",
+    "AutoSyncPlan",
+    "DynamicAutoSyncOrchestrator",
+    "SyncSnapshot",
     "DCTAllocationEngine",
     "DCTAllocationResult",
     "DCTAllocationRule",
@@ -105,6 +115,10 @@ globals().update(
         "LossRecoveryProgramme": LossRecoveryProgramme,
         "RecoveryPlan": RecoveryPlan,
         "RecoveryStep": RecoveryStep,
+        "AutoSyncAction": AutoSyncAction,
+        "AutoSyncPlan": AutoSyncPlan,
+        "DynamicAutoSyncOrchestrator": DynamicAutoSyncOrchestrator,
+        "SyncSnapshot": SyncSnapshot,
         "DCTAllocationEngine": DCTAllocationEngine,
         "DCTAllocationResult": DCTAllocationResult,
         "DCTAllocationRule": DCTAllocationRule,

--- a/algorithms/python/auto_sync_multi_llm.py
+++ b/algorithms/python/auto_sync_multi_llm.py
@@ -1,0 +1,531 @@
+"""Dynamic multi-LLM orchestrator for auto-synchronisation workflows."""
+
+from __future__ import annotations
+
+import json
+import math
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+
+from .multi_llm import (
+    LLMConfig,
+    LLMRun,
+    collect_strings,
+    parse_json_response,
+    serialise_runs,
+)
+
+__all__ = [
+    "SyncSnapshot",
+    "AutoSyncAction",
+    "AutoSyncPlan",
+    "DynamicAutoSyncOrchestrator",
+]
+
+
+def _as_dict(mapping: Mapping[str, Any] | None) -> Dict[str, Any]:
+    if not mapping:
+        return {}
+    return {key: value for key, value in mapping.items()}
+
+
+def _normalise_confidence(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(number) or math.isinf(number):
+        return None
+    return max(0.0, min(1.0, number))
+
+
+def _normalise_tags(*candidates: Any) -> tuple[str, ...]:
+    tags: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, (str, bytes)):
+            values: Iterable[Any] = (candidate,)
+        elif isinstance(candidate, Iterable):
+            values = candidate
+        else:
+            values = (candidate,)
+        for value in values:
+            tag = str(value).strip()
+            if not tag or tag in seen:
+                continue
+            seen.add(tag)
+            tags.append(tag)
+    return tuple(tags)
+
+
+@dataclass(slots=True)
+class SyncSnapshot:
+    """State snapshot for an entity that participates in auto-sync."""
+
+    entity_id: str
+    current_state: Mapping[str, Any]
+    desired_state: Mapping[str, Any] = field(default_factory=dict)
+    history: Sequence[Mapping[str, Any] | str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Return a JSON-friendly representation of the snapshot."""
+
+        events: list[Dict[str, Any]] = []
+        for entry in self.history:
+            if isinstance(entry, Mapping):
+                events.append({key: value for key, value in entry.items()})
+            else:
+                text = str(entry).strip()
+                if text:
+                    events.append({"event": text})
+
+        payload: Dict[str, Any] = {
+            "entity_id": self.entity_id,
+            "current_state": _as_dict(self.current_state),
+            "desired_state": _as_dict(self.desired_state),
+            "metadata": _as_dict(self.metadata),
+        }
+        if events:
+            payload["history"] = events
+        return payload
+
+
+@dataclass(slots=True)
+class AutoSyncAction:
+    """Proposed synchronisation action produced by the orchestration pipeline."""
+
+    entity_id: str
+    action: str
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+    confidence: float | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def merge(self, other: "AutoSyncAction") -> "AutoSyncAction":
+        """Combine two actions that target the same entity/action pair."""
+
+        if self.entity_id != other.entity_id or self.action != other.action:
+            raise ValueError("actions can only be merged when entity and action match")
+
+        reasons = tuple(collect_strings(self.reasons, other.reasons))
+        tags = _normalise_tags(self.tags, other.tags)
+
+        confidence: float | None
+        if self.confidence is None:
+            confidence = other.confidence
+        elif other.confidence is None:
+            confidence = self.confidence
+        else:
+            confidence = max(self.confidence, other.confidence)
+
+        metadata: Dict[str, Any] = {}
+        metadata.update(_as_dict(self.metadata))
+        metadata.update(_as_dict(other.metadata))
+
+        return AutoSyncAction(
+            entity_id=self.entity_id,
+            action=self.action,
+            reasons=reasons,
+            confidence=confidence,
+            tags=tags,
+            metadata=metadata,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the action for logging or downstream services."""
+
+        payload: Dict[str, Any] = {
+            "entity_id": self.entity_id,
+            "action": self.action,
+            "reasons": list(self.reasons),
+        }
+        if self.confidence is not None:
+            payload["confidence"] = self.confidence
+        if self.tags:
+            payload["tags"] = list(self.tags)
+        if self.metadata:
+            payload["metadata"] = {key: value for key, value in self.metadata.items()}
+        return payload
+
+
+@dataclass(slots=True)
+class AutoSyncPlan:
+    """Aggregated plan returned by :class:`DynamicAutoSyncOrchestrator`."""
+
+    actions: tuple[AutoSyncAction, ...]
+    anomalies: tuple[str, ...]
+    escalations: tuple[str, ...]
+    summary: str
+    metadata: Mapping[str, Any]
+    runs: tuple[LLMRun, ...]
+    raw_runs: str | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-safe representation of the plan."""
+
+        return {
+            "actions": [action.to_dict() for action in self.actions],
+            "anomalies": list(self.anomalies),
+            "escalations": list(self.escalations),
+            "summary": self.summary,
+            "metadata": {key: value for key, value in self.metadata.items()},
+            "runs": [run.to_dict() for run in self.runs],
+            "raw_runs": self.raw_runs,
+        }
+
+
+class DynamicAutoSyncOrchestrator:
+    """Coordinates multiple LLMs to design an auto-synchronisation plan."""
+
+    def __init__(
+        self,
+        *,
+        detector: LLMConfig,
+        resolver: LLMConfig | None = None,
+        auditor: LLMConfig | None = None,
+    ) -> None:
+        self.detector = detector
+        self.resolver = resolver
+        self.auditor = auditor
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build_plan(
+        self,
+        snapshots: Sequence[SyncSnapshot],
+        *,
+        context: Mapping[str, Any] | None = None,
+        guardrails: Mapping[str, Any] | None = None,
+        goal: str | None = None,
+    ) -> AutoSyncPlan:
+        if not snapshots:
+            raise ValueError("snapshots cannot be empty")
+
+        serialised_snapshots = [snapshot.to_payload() for snapshot in snapshots]
+        context_payload = _as_dict(context)
+        guardrail_payload = _as_dict(guardrails)
+        orchestrator_goal = goal or "Synchronise treasury and membership state consistently across systems."
+
+        runs: list[LLMRun] = []
+        metadata: Dict[str, Any] = {
+            "context": context_payload,
+            "guardrails": guardrail_payload,
+            "goal": orchestrator_goal,
+        }
+
+        detector_prompt = self._build_detector_prompt(
+            orchestrator_goal,
+            serialised_snapshots,
+            context_payload,
+            guardrail_payload,
+        )
+        detector_run = self.detector.run(detector_prompt)
+        runs.append(detector_run)
+        detector_payload = parse_json_response(detector_run.response, fallback_key="narrative") or {}
+        metadata["detector"] = detector_payload
+
+        actions = self._extract_actions(detector_payload)
+        anomalies = tuple(collect_strings(detector_payload.get("anomalies")))
+        escalations = collect_strings(detector_payload.get("escalations"))
+
+        resolver_payload: Dict[str, Any] | None = None
+        if self.resolver is not None:
+            resolver_prompt = self._build_resolver_prompt(
+                orchestrator_goal,
+                serialised_snapshots,
+                context_payload,
+                guardrail_payload,
+                detector_payload,
+                actions,
+            )
+            resolver_run = self.resolver.run(resolver_prompt)
+            runs.append(resolver_run)
+            resolver_payload = parse_json_response(resolver_run.response, fallback_key="narrative") or {}
+            metadata["resolver"] = resolver_payload
+            extra_actions = self._extract_actions(resolver_payload)
+            if extra_actions:
+                actions = self._merge_actions(actions, extra_actions)
+            escalations = collect_strings(escalations, resolver_payload.get("escalations"))
+            anomalies = tuple(collect_strings(anomalies, resolver_payload.get("anomalies")))
+
+        auditor_payload: Dict[str, Any] | None = None
+        if self.auditor is not None:
+            auditor_prompt = self._build_auditor_prompt(
+                orchestrator_goal,
+                serialised_snapshots,
+                context_payload,
+                guardrail_payload,
+                actions,
+                anomalies,
+                escalations,
+            )
+            auditor_run = self.auditor.run(auditor_prompt)
+            runs.append(auditor_run)
+            auditor_payload = parse_json_response(auditor_run.response, fallback_key="narrative") or {}
+            metadata["auditor"] = auditor_payload
+            escalations = collect_strings(escalations, auditor_payload.get("escalations"))
+            anomalies = tuple(collect_strings(anomalies, auditor_payload.get("anomalies")))
+
+        escalations_tuple = tuple(escalations)
+        summary = (
+            f"{len(actions)} sync actions, {len(escalations_tuple)} escalations, "
+            f"{len(anomalies)} anomalies detected"
+        )
+
+        raw_runs = serialise_runs(runs)
+
+        return AutoSyncPlan(
+            actions=tuple(actions),
+            anomalies=anomalies,
+            escalations=escalations_tuple,
+            summary=summary,
+            metadata=metadata,
+            runs=tuple(runs),
+            raw_runs=raw_runs,
+        )
+
+    # ------------------------------------------------------------------
+    # Prompt builders
+    # ------------------------------------------------------------------
+    def _build_detector_prompt(
+        self,
+        goal: str,
+        snapshots: Sequence[Mapping[str, Any]],
+        context: Mapping[str, Any],
+        guardrails: Mapping[str, Any],
+    ) -> str:
+        payload = {
+            "goal": goal,
+            "context": context,
+            "guardrails": guardrails,
+            "snapshots": snapshots,
+        }
+        return textwrap.dedent(
+            f"""
+            You are the anomaly detection model in a dynamic multi-LLM auto synchronisation workflow.
+            Review the provided entity snapshots, highlight anomalies, and draft remediation actions
+            that respect the supplied guardrails.
+
+            Respond strictly in JSON with the shape:
+            {{
+              "anomalies": ["str"...],
+              "actions": [
+                {{
+                  "entity_id": "...",
+                  "action": "...",
+                  "reason": "...",
+                  "confidence": 0-1,
+                  "tags": ["..."]
+                }}
+              ],
+              "escalations": ["str"...]
+            }}
+
+            Input payload:
+            {json.dumps(payload, indent=2, sort_keys=True, default=str)}
+            """
+        ).strip()
+
+    def _build_resolver_prompt(
+        self,
+        goal: str,
+        snapshots: Sequence[Mapping[str, Any]],
+        context: Mapping[str, Any],
+        guardrails: Mapping[str, Any],
+        detector_payload: Mapping[str, Any],
+        actions: Sequence[AutoSyncAction],
+    ) -> str:
+        plan_preview = {
+            "goal": goal,
+            "actions": [action.to_dict() for action in actions],
+            "anomalies": detector_payload.get("anomalies", []),
+            "escalations": detector_payload.get("escalations", []),
+        }
+        payload = {
+            "snapshots": snapshots,
+            "context": context,
+            "guardrails": guardrails,
+            "detector": detector_payload,
+            "plan_preview": plan_preview,
+        }
+        return textwrap.dedent(
+            f"""
+            You are the reconciliation model in a dynamic multi-LLM auto synchronisation workflow.
+            Validate the detector's proposed actions, adjust confidences, add missing steps, and
+            note any cases that should escalate to humans. Respect guardrails and ensure changes align with the goal.
+
+            Respond strictly in JSON with keys: "actions", "anomalies", "escalations".
+
+            Input payload:
+            {json.dumps(payload, indent=2, sort_keys=True, default=str)}
+            """
+        ).strip()
+
+    def _build_auditor_prompt(
+        self,
+        goal: str,
+        snapshots: Sequence[Mapping[str, Any]],
+        context: Mapping[str, Any],
+        guardrails: Mapping[str, Any],
+        actions: Sequence[AutoSyncAction],
+        anomalies: Sequence[str],
+        escalations: Sequence[str],
+    ) -> str:
+        payload = {
+            "goal": goal,
+            "snapshots": snapshots,
+            "context": context,
+            "guardrails": guardrails,
+            "actions": [action.to_dict() for action in actions],
+            "anomalies": list(anomalies),
+            "escalations": list(escalations),
+        }
+        return textwrap.dedent(
+            f"""
+            You are the compliance auditor model in a dynamic multi-LLM auto synchronisation workflow.
+            Review the draft plan, ensure all guardrails are honoured, and surface any outstanding
+            escalations or policy violations. Provide actionable escalations if human review is required.
+
+            Respond strictly in JSON with keys: "escalations" and optionally "anomalies" or "notes".
+
+            Input payload:
+            {json.dumps(payload, indent=2, sort_keys=True, default=str)}
+            """
+        ).strip()
+
+    # ------------------------------------------------------------------
+    # Normalisation helpers
+    # ------------------------------------------------------------------
+    def _extract_actions(self, payload: Mapping[str, Any]) -> list[AutoSyncAction]:
+        candidates: list[Any] = []
+        for key in ("actions", "proposed_actions", "sync_actions"):
+            value = payload.get(key)
+            if value is not None:
+                candidates.append(value)
+
+        actions: list[AutoSyncAction] = []
+        for candidate in candidates:
+            actions.extend(self._normalise_action_candidate(candidate))
+        return actions
+
+    def _normalise_action_candidate(self, candidate: Any) -> list[AutoSyncAction]:
+        actions: list[AutoSyncAction] = []
+        if candidate is None:
+            return actions
+
+        if isinstance(candidate, Mapping):
+            for entity, details in candidate.items():
+                entity_id = str(entity)
+                if isinstance(details, Mapping):
+                    actions.append(self._action_from_mapping(entity_id, details))
+                elif isinstance(details, Sequence) and not isinstance(details, (str, bytes)):
+                    for item in details:
+                        if isinstance(item, Mapping):
+                            actions.append(self._action_from_mapping(entity_id, item))
+                        else:
+                            actions.append(
+                                AutoSyncAction(entity_id=entity_id, action=str(item), reasons=tuple())
+                            )
+                else:
+                    actions.append(
+                        AutoSyncAction(entity_id=entity_id, action=str(details), reasons=tuple())
+                    )
+            return actions
+
+        if isinstance(candidate, Sequence) and not isinstance(candidate, (str, bytes)):
+            for item in candidate:
+                if isinstance(item, Mapping):
+                    entity_id = self._resolve_entity_id(item)
+                    actions.append(self._action_from_mapping(entity_id, item))
+                else:
+                    actions.append(
+                        AutoSyncAction(entity_id="unknown", action=str(item), reasons=tuple())
+                    )
+            return actions
+
+        return [AutoSyncAction(entity_id="unknown", action=str(candidate), reasons=tuple())]
+
+    def _resolve_entity_id(self, mapping: Mapping[str, Any]) -> str:
+        for key in ("entity_id", "entity", "member_id", "member", "user", "target", "id"):
+            if key in mapping and mapping[key] is not None:
+                return str(mapping[key])
+        return "unknown"
+
+    def _action_from_mapping(self, fallback_entity: str, mapping: Mapping[str, Any]) -> AutoSyncAction:
+        entity_id = self._resolve_entity_id(mapping) or fallback_entity
+        action = str(
+            mapping.get("action")
+            or mapping.get("operation")
+            or mapping.get("task")
+            or mapping.get("status")
+            or "review"
+        )
+        reasons = tuple(collect_strings(mapping.get("reason"), mapping.get("reasons"), mapping.get("rationale")))
+        confidence = _normalise_confidence(mapping.get("confidence") or mapping.get("score"))
+        tags = _normalise_tags(mapping.get("tags"), mapping.get("labels"))
+
+        metadata: Dict[str, Any] = {}
+        for key in ("metadata", "details", "extra"):
+            candidate = mapping.get(key)
+            if isinstance(candidate, Mapping):
+                metadata.update(candidate)
+
+        for key, value in mapping.items():
+            if key in {
+                "entity_id",
+                "entity",
+                "member_id",
+                "member",
+                "user",
+                "target",
+                "id",
+                "action",
+                "operation",
+                "task",
+                "status",
+                "reason",
+                "reasons",
+                "rationale",
+                "confidence",
+                "score",
+                "tags",
+                "labels",
+                "metadata",
+                "details",
+                "extra",
+            }:
+                continue
+            metadata.setdefault(key, value)
+
+        return AutoSyncAction(
+            entity_id=entity_id or fallback_entity,
+            action=action,
+            reasons=reasons,
+            confidence=confidence,
+            tags=tags,
+            metadata=metadata,
+        )
+
+    def _merge_actions(
+        self,
+        current: Sequence[AutoSyncAction],
+        additions: Sequence[AutoSyncAction],
+    ) -> list[AutoSyncAction]:
+        merged: Dict[tuple[str, str], AutoSyncAction] = {
+            (action.entity_id, action.action): action for action in current
+        }
+        for action in additions:
+            key = (action.entity_id, action.action)
+            if key in merged:
+                merged[key] = merged[key].merge(action)
+            else:
+                merged[key] = action
+        return list(merged.values())
+

--- a/algorithms/python/tests/test_auto_sync_multi_llm.py
+++ b/algorithms/python/tests/test_auto_sync_multi_llm.py
@@ -1,0 +1,187 @@
+import json
+from typing import Any, Dict, Sequence
+
+import pytest
+
+from algorithms.python.auto_sync_multi_llm import (
+    AutoSyncPlan,
+    DynamicAutoSyncOrchestrator,
+    SyncSnapshot,
+)
+from algorithms.python.multi_llm import LLMConfig
+
+
+class StubClient:
+    def __init__(self, responses: Sequence[str]) -> None:
+        self.responses = list(responses)
+        self.calls: list[Dict[str, Any]] = []
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        temperature: float,
+        max_tokens: int,
+        nucleus_p: float,
+    ) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "nucleus_p": nucleus_p,
+            }
+        )
+        if not self.responses:
+            raise RuntimeError("no responses queued")
+        return self.responses.pop(0)
+
+
+def _config(client: StubClient) -> LLMConfig:
+    return LLMConfig(name="stub", client=client, temperature=0.2, nucleus_p=0.9, max_tokens=512)
+
+
+def test_orchestrator_merges_multi_llm_actions() -> None:
+    detector_payload = {
+        "anomalies": ["user-2 missing token"],
+        "actions": [
+            {
+                "entity_id": "user-1",
+                "action": "grant_token",
+                "reason": "Alpha access minted",
+                "confidence": 0.72,
+                "tags": ["grant"],
+                "metadata": {"source": "detector"},
+            },
+            {
+                "entity_id": "user-2",
+                "action": "revoke_access",
+                "reason": "Subscription inactive",
+                "confidence": 0.85,
+                "tags": ["compliance"],
+            },
+        ],
+    }
+
+    resolver_payload = {
+        "actions": [
+            {
+                "entity_id": "user-1",
+                "action": "grant_token",
+                "reason": "Cross-model consensus",
+                "confidence": 0.9,
+                "tags": ["consensus"],
+                "metadata": {"mode": "auto"},
+            },
+            {
+                "entity_id": "user-3",
+                "action": "flag_review",
+                "reason": "Missing verification",
+                "confidence": 0.6,
+            },
+        ],
+        "escalations": ["user-3 requires manual verification"],
+    }
+
+    auditor_payload = {
+        "escalations": ["Confirm KYC for user-2"],
+        "notes": ["Ensure legal sign-off on revocations"],
+    }
+
+    detector_client = StubClient([json.dumps(detector_payload)])
+    resolver_client = StubClient([json.dumps(resolver_payload)])
+    auditor_client = StubClient([json.dumps(auditor_payload)])
+
+    orchestrator = DynamicAutoSyncOrchestrator(
+        detector=_config(detector_client),
+        resolver=_config(resolver_client),
+        auditor=_config(auditor_client),
+    )
+
+    snapshots = [
+        SyncSnapshot(
+            entity_id="user-1",
+            current_state={"memberships": ["vip"]},
+            desired_state={"memberships": ["vip", "alpha"]},
+            history=[{"event": "joined", "channel": "@alpha"}],
+            metadata={"tier": "vip"},
+        ),
+        SyncSnapshot(
+            entity_id="user-2",
+            current_state={"memberships": ["vip"]},
+            desired_state={"memberships": []},
+            history=["subscription lapsed"],
+            metadata={"tier": "vip"},
+        ),
+    ]
+
+    plan = orchestrator.build_plan(
+        snapshots,
+        context={"runway_months": 24},
+        guardrails={"max_grants_per_day": 200},
+        goal="Synchronise VIP tokens across membership surfaces",
+    )
+
+    assert isinstance(plan, AutoSyncPlan)
+    assert plan.summary.startswith("3 sync actions")
+    assert plan.anomalies == ("user-2 missing token",)
+    assert "user-3 requires manual verification" in plan.escalations
+    assert "Confirm KYC for user-2" in plan.escalations
+
+    actions = {(action.entity_id, action.action): action for action in plan.actions}
+    assert len(actions) == 3
+
+    user1 = actions[("user-1", "grant_token")]
+    assert set(user1.reasons) == {"Alpha access minted", "Cross-model consensus"}
+    assert user1.confidence == pytest.approx(0.9)
+    assert set(user1.tags) == {"grant", "consensus"}
+    assert user1.metadata["mode"] == "auto"
+    assert user1.metadata["source"] == "detector"
+
+    user2 = actions[("user-2", "revoke_access")]
+    assert user2.confidence == pytest.approx(0.85)
+
+    user3 = actions[("user-3", "flag_review")]
+    assert user3.confidence == pytest.approx(0.6)
+    assert "Missing verification" in user3.reasons[0]
+
+    assert "detector" in plan.metadata
+    assert "resolver" in plan.metadata
+    assert "auditor" in plan.metadata
+    assert json.dumps(plan.metadata["detector"])  # round-trip safety
+    assert len(plan.runs) == 3
+    assert plan.raw_runs is not None
+    assert "snapshots" in detector_client.calls[0]["prompt"]
+    assert "plan_preview" in resolver_client.calls[0]["prompt"]
+    assert "compliance auditor" in auditor_client.calls[0]["prompt"]
+
+
+def test_orchestrator_handles_textual_fallbacks() -> None:
+    detector_client = StubClient(["Narrative only response"])
+    resolver_client = StubClient(["Manual review required"])
+
+    orchestrator = DynamicAutoSyncOrchestrator(
+        detector=_config(detector_client),
+        resolver=_config(resolver_client),
+    )
+
+    snapshots = [
+        SyncSnapshot(entity_id="user-1", current_state={"memberships": ["vip"]}),
+    ]
+
+    plan = orchestrator.build_plan(snapshots, context={"runway_months": 12})
+
+    assert plan.actions == ()
+    assert plan.escalations == ()
+    assert plan.anomalies == ()
+    assert plan.metadata["detector"]["narrative"] == "Narrative only response"
+    assert plan.metadata["resolver"]["narrative"] == "Manual review required"
+    assert plan.summary.startswith("0 sync actions")
+
+
+def test_build_plan_requires_snapshots() -> None:
+    detector_client = StubClient(["{}"])
+    orchestrator = DynamicAutoSyncOrchestrator(detector=_config(detector_client))
+
+    with pytest.raises(ValueError):
+        orchestrator.build_plan([])

--- a/docs/treasury-holdings-algorithm.md
+++ b/docs/treasury-holdings-algorithm.md
@@ -1,0 +1,57 @@
+# Treasury Holdings Algorithm (Policy-Driven Rebalancer)
+
+## Purpose
+- Automate treasury portfolio management while honoring governance-approved allocations, guardrails, and escalation paths.
+- Preserve liquidity for operations, maintain runway stability, and scale buybacks/burns within policy thresholds.
+
+## Core Inputs
+- **Configuration**: `app_config` and policy tables defining tranche weights, guardrail bounds, and exception workflows.
+- **Treasury Snapshot**: Categorized balance sheet covering TON reserves, yield vault deposits, and liquidity positions.
+- **Market Telemetry**: TON price, volatility, usage demand, and override flags sourced via the shared `DCTMarketSnapshot`/`DCTPriceCalculator` pipeline.
+- **Governance State**: Token Assembly directives, Contributor Council overrides, and queued policy updates.
+
+## High-Level Flow
+1. **Ingest State**
+   - Pull configuration, treasury inventory, and market telemetry on a fixed cadence (default: hourly, burstable on large inflows).
+   - Normalize data into a shared `TreasuryState` object for downstream consistency and auditing.
+2. **Derive Targets**
+   - Allocate each inflow across operations, investment, and buyback/burn tranches using configured weights and floor constraints (e.g., maintain ≥20 M DCT operations buffer).
+   - Apply time-based multipliers (e.g., increased liquidity provisioning ahead of product launches) before finalizing target weights.
+3. **Validate Guardrails**
+   - Ensure liquidity depth ≥1 M TON inside ±2 % price bands and that ≥65 % of positions remain in-range.
+   - Monitor price drift (±15 % VWAP divergence) and volatility (>40 % annualized) to decide whether to auto-execute or defer for governance review.
+   - Enforce buyback caps (≤20 % of net fees monthly) and burn triggers (route 50 % of penalty fees when runway >24 months).
+4. **Solve Deltas**
+   - Use a weight-based allocator (patterned after `DCTAllocationEngine`) to compute target holdings per bucket.
+   - Derive deltas between current and desired allocations, applying smoothing (e.g., max 10 % circulating supply shift per epoch) similar to `DCTProductionPlanner`.
+   - Persist proposed moves and telemetry into `tx_logs` for auditability.
+5. **Execute Adjustments**
+   - Route TON→DCT conversions through the existing `dexBuyDCT` and burn flows to inherit slippage protections.
+   - Trigger buybacks via rate-limited, venue-scoped executors honoring per-minute and per-market caps.
+   - Sequence liquidity top-ups, runway replenishment, and yield vault deposits according to priority queues, logging each action.
+6. **Governance & Reporting**
+   - Require Contributor Council + Token Assembly approval for operations outside daily policy bands.
+   - Emit weekly/monthly transparency reports summarizing inflows, outflows, buybacks, burns, and guardrail status.
+
+## Data Structures
+- `TreasuryState`: Snapshot of balances, inflows, policy overrides, and telemetry references.
+- `AllocationPlan`: Target weights, floor/ceiling bounds, and staged execution schedule.
+- `ExecutionTask`: Atomic action specification (venue, asset pair, volume, safety checks, logging hooks).
+
+## Telemetry & Alerting
+- Publish metrics for guardrail compliance, execution latency, and policy utilization into the observability pipeline.
+- Trigger alerts when:
+  - Liquidity depth < target or out-of-range share >35 %.
+  - Volatility exceeds tolerance and rebalancing is deferred.
+  - Buyback/burn budgets near monthly caps.
+
+## Implementation Notes
+- Implement allocator and smoothing logic as reusable services to keep policy tuning independent of execution engines.
+- Use idempotent upsert patterns for `tx_logs` and state snapshots to support retries.
+- Version configuration schemas to allow staged rollout of new guardrails without downtime.
+
+## Testing Strategy
+- **Unit Tests**: Validate allocator math, guardrail enforcement, and smoothing heuristics against deterministic fixtures.
+- **Simulation Harness**: Replay historical inflows and market conditions to verify policy adherence and stress behavior.
+- **Integration Tests**: Mock DEX/exchange executors ensuring venue rate limits and slippage protections trigger as expected.
+- **Operational Drills**: Run monthly governance review simulations to ensure escalation paths and reporting pipelines stay functional.


### PR DESCRIPTION
## Summary
- implement a dynamic multi-LLM auto sync orchestrator with JSON-normalised prompts and aggregation helpers
- expose the orchestrator, plan, and snapshot types via the algorithms package
- cover the pipeline with unit tests for action merging and error handling

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_auto_sync_multi_llm.py

------
https://chatgpt.com/codex/tasks/task_e_68d65276115c8322a6ff125adea87623