### PR TITLE
Update whitepaper branding to Dynamic Capital Token

### DIFF
--- a/docs/desk-hub-mini-app-token-hub-checklist.md
+++ b/docs/desk-hub-mini-app-token-hub-checklist.md
@@ -1,6 +1,6 @@
 # Desk Hub Mini App – Token Hub Development Checklist
 
-This checklist translates the Dynamic Capital TON Coin (DCT) whitepaper into actionable tasks for the Desk Hub mini app token hub.
+This checklist translates the Dynamic Capital Token (DCT) whitepaper into actionable tasks for the Desk Hub mini app token hub.
 Use it to coordinate product, engineering, governance, and compliance workstreams.
 
 ## Foundation & Architecture

--- a/docs/dynamic-capital-ton-whitepaper.md
+++ b/docs/dynamic-capital-ton-whitepaper.md
@@ -1,8 +1,8 @@
-# Dynamic Capital TON Coin Whitepaper
+# Dynamic Capital Token (DCT) Whitepaper
 
 ## Abstract
 
-Dynamic Capital TON Coin (DCT) is the on-chain utility token that powers the
+Dynamic Capital Token (DCT) is the on-chain utility token that powers the
 Dynamic Capital ecosystem on The Open Network (TON). The asset enables
 permissionless access to quantitative trading signals, liquidity coordination,
 and governance. DCT is engineered to align incentives between strategy
@@ -203,7 +203,7 @@ shocks.
 
 ## Conclusion
 
-Dynamic Capital TON Coin is the coordination layer connecting intelligence,
+Dynamic Capital Token (DCT) is the coordination layer connecting intelligence,
 liquidity, and governance across the Dynamic Capital stack. The token aligns
 incentives for contributors and capital providers while maintaining strict risk
 oversight. By combining programmable emissions, utility-driven demand, and


### PR DESCRIPTION
## Summary
- rename the whitepaper title and abstract to use the Dynamic Capital Token (DCT) name
- adjust the conclusion to match the updated token branding
- refresh the Desk Hub checklist reference so it points at the new whitepaper naming

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6590e61788322a0ff303ed1d27810