### PR TITLE
Align desk trade logic summary with protocol helper

### DIFF
--- a/algorithms/python/dynamic_protocol_planner.py
+++ b/algorithms/python/dynamic_protocol_planner.py
@@ -179,6 +179,12 @@ def _summarise_trade_logic(trade_logic: Any) -> Dict[str, Any]:
     return payload
 
 
+def summarise_trade_logic(trade_logic: Any) -> Dict[str, Any]:
+    """Public helper that mirrors the protocol trade logic summary."""
+
+    return _summarise_trade_logic(trade_logic)
+
+
 def _summarise_optimization_plan(plan: Any) -> Dict[str, Any]:
     if plan is None:
         return {}
@@ -552,5 +558,6 @@ __all__ = [
     "DynamicProtocolPlanner",
     "HORIZON_KEYS",
     "ProtocolDraft",
+    "summarise_trade_logic",
 ]
 

--- a/algorithms/python/tests/test_desk_sync.py
+++ b/algorithms/python/tests/test_desk_sync.py
@@ -14,9 +14,13 @@ from algorithms.python.desk_sync import (
     DeskSyncReport,
     TeamRolePlaybook,
     TeamRoleSyncAlgorithm,
+    summarise_trade_logic,
     TradingDeskSynchroniser,
 )
-from algorithms.python.dynamic_protocol_planner import ProtocolDraft
+from algorithms.python.dynamic_protocol_planner import (
+    ProtocolDraft,
+    summarise_trade_logic as protocol_summarise_trade_logic,
+)
 from algorithms.python.trade_logic import TradeLogic
 
 
@@ -118,3 +122,15 @@ def test_team_role_sync_errors_on_unknown_focus() -> None:
     sync = TeamRoleSyncAlgorithm(_build_playbooks())
     with pytest.raises(KeyError):
         sync.synchronise(focus=("Unknown",))
+
+
+def test_trade_logic_summary_aligns_with_protocol() -> None:
+    trade_logic = TradeLogic()
+
+    desk_summary = summarise_trade_logic(trade_logic)
+    protocol_summary = protocol_summarise_trade_logic(trade_logic)
+
+    assert desk_summary["config"] == protocol_summary["config"]
+    assert desk_summary["adr"] == protocol_summary["adr"]
+    assert desk_summary["smc"] == protocol_summary["smc"]
+    assert "strategy" in desk_summary


### PR DESCRIPTION
## Summary
- expose a public helper in the protocol planner that returns the trade logic summary used by protocol generation
- reuse that helper in the trading desk synchroniser so team reports mirror protocol annotations while preserving desk-specific metrics
- add a regression test that confirms the desk trade logic summary stays aligned with the protocol version

## Testing
- pytest algorithms/python/tests/test_desk_sync.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d65a54baf8832288a062a63921f283