### PR TITLE
Add treasury growth planner heuristics

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -1,4 +1,10 @@
-"""Python trading strategy utilities for Dynamic Capital."""
+"""Python trading strategy utilities for Dynamic Capital.
+
+The module exposes helper planners that mirror the Dynamic Capital treasury
+and token policy handbooks.  See :mod:`algorithms.python.dct_treasury_growth`
+for the treasury growth heuristics derived from the sustainability
+whitepaper.
+"""
 
 from . import trade_logic as _trade_logic
 from .awesome_api import (
@@ -45,6 +51,12 @@ from .vip_auto_token_sync import (
     VipMembershipSnapshot,
     VipTokenGrant,
     VipTokenisationStrategy,
+)
+from .dct_treasury_growth import (
+    TreasuryGrowthLevers,
+    TreasuryGrowthPlan,
+    TreasuryGrowthPlanner,
+    TreasurySnapshot,
 )
 from .desk_token_hub import (
     CHECKLIST_REFERENCE as DESK_TOKEN_CHECKLIST_REFERENCE,
@@ -98,6 +110,10 @@ __all__ = _trade_exports + [
     "VipMembershipSnapshot",
     "VipTokenGrant",
     "VipTokenisationStrategy",
+    "TreasuryGrowthLevers",
+    "TreasuryGrowthPlan",
+    "TreasuryGrowthPlanner",
+    "TreasurySnapshot",
 ]
 
 globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
@@ -145,5 +161,9 @@ globals().update(
         "VipMembershipSnapshot": VipMembershipSnapshot,
         "VipTokenGrant": VipTokenGrant,
         "VipTokenisationStrategy": VipTokenisationStrategy,
+        "TreasuryGrowthLevers": TreasuryGrowthLevers,
+        "TreasuryGrowthPlan": TreasuryGrowthPlan,
+        "TreasuryGrowthPlanner": TreasuryGrowthPlanner,
+        "TreasurySnapshot": TreasurySnapshot,
     }
 )

--- a/algorithms/python/dct_treasury_growth.py
+++ b/algorithms/python/dct_treasury_growth.py
@@ -1,0 +1,230 @@
+"""DCT treasury growth planning heuristics.
+
+This module implements the high level guard-rails published in the
+``Dynamic Capital Treasury Sustainability Whitepaper`` and the ``2024 DCT
+Governance Addendum``.  Maintainers can use the :class:`TreasuryGrowthPlanner`
+to classify the current treasury posture and to derive a consistent capital
+deployment plan for weekly council reviews.
+
+Typical usage::
+
+    from algorithms.python.dct_treasury_growth import (
+        TreasuryGrowthPlanner,
+        TreasurySnapshot,
+    )
+
+    snapshot = TreasurySnapshot(
+        operations_balance=2_000_000,
+        liquidity_reserve=1_500_000,
+        monthly_burn=120_000,
+        protocol_fees=90_000,
+        penalty_fees=15_000,
+        dct_price=0.92,
+        dct_90d_ma=1.05,
+        volatility=0.38,
+        liquidity_depth=1_200_000,
+        in_range_ratio=0.72,
+    )
+
+    planner = TreasuryGrowthPlanner()
+    plan = planner.build_plan(snapshot)
+
+The returned :class:`TreasuryGrowthPlan` enumerates recommended allocations
+and governance flags, along with justification notes that can be surfaced in
+operational tooling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(slots=True)
+class TreasurySnapshot:
+    """State of the treasury at a point in time.
+
+    Attributes provide enough signal for the planner to derive runway
+    coverage, liquidity sufficiency, and policy-triggered levers.
+    """
+
+    operations_balance: float
+    liquidity_reserve: float
+    monthly_burn: float
+    protocol_fees: float
+    penalty_fees: float
+    dct_price: float
+    dct_90d_ma: float
+    volatility: float
+    liquidity_depth: float
+    in_range_ratio: float
+
+    @property
+    def coverage_months(self) -> float:
+        """Return the operations coverage in months."""
+
+        if self.monthly_burn <= 0:
+            return float("inf")
+        return self.operations_balance / self.monthly_burn
+
+    @property
+    def net_fees(self) -> float:
+        """Return combined protocol and penalty fees."""
+
+        return self.protocol_fees + self.penalty_fees
+
+    @property
+    def price_discount(self) -> float:
+        """Return the percentage discount to the 90-day moving average."""
+
+        if self.dct_90d_ma <= 0:
+            return 0.0
+        return 1 - (self.dct_price / self.dct_90d_ma)
+
+    @property
+    def liquidity_depth_shortfall(self) -> float:
+        """Difference between required and realised liquidity depth."""
+
+        return max(0.0, TreasuryGrowthPlanner.LIQUIDITY_DEPTH_MIN - self.liquidity_depth)
+
+    @property
+    def in_range_shortfall(self) -> float:
+        """Difference between required and realised in-range liquidity ratio."""
+
+        return max(0.0, TreasuryGrowthPlanner.IN_RANGE_MIN - self.in_range_ratio)
+
+
+@dataclass(slots=True)
+class TreasuryGrowthLevers:
+    """Monetary allocations recommended by the planner."""
+
+    operations_top_up: float = 0.0
+    liquidity_reinforcement: float = 0.0
+    buybacks: float = 0.0
+    burns: float = 0.0
+    yield_deployments: float = 0.0
+
+
+@dataclass(slots=True)
+class TreasuryGrowthPlan:
+    """Planner output that describes capital deployment for the period."""
+
+    posture: str
+    levers: TreasuryGrowthLevers
+    throttle_emissions: bool = False
+    emission_throttle_ratio: float = 0.0
+    governance_review_required: bool = False
+    notes: List[str] = field(default_factory=list)
+
+
+class TreasuryGrowthPlanner:
+    """Encapsulates whitepaper policies for treasury growth planning."""
+
+    LIQUIDITY_DEPTH_MIN: float = 1_000_000.0
+    IN_RANGE_MIN: float = 0.65
+    BUYBACK_FEE_RATIO: float = 0.20
+    PENALTY_BURN_RATIO: float = 0.50
+    EMISSION_THROTTLE_MAX: float = 0.25
+    COVERAGE_DEFENSIVE: float = 18.0
+    COVERAGE_STRONG: float = 24.0
+    COVERAGE_EXPANSION: float = 36.0
+    VOLATILITY_ALERT: float = 0.55
+
+    def classify_posture(self, snapshot: TreasurySnapshot) -> str:
+        """Return the treasury posture for the supplied snapshot."""
+
+        coverage = snapshot.coverage_months
+        if coverage < self.COVERAGE_DEFENSIVE:
+            return "defensive"
+        if coverage < self.COVERAGE_EXPANSION:
+            return "balanced"
+        return "expansion"
+
+    def build_plan(self, snapshot: TreasurySnapshot) -> TreasuryGrowthPlan:
+        """Construct a growth plan for the provided snapshot."""
+
+        posture = self.classify_posture(snapshot)
+        levers = TreasuryGrowthLevers()
+        notes: List[str] = []
+
+        required_runway = self.COVERAGE_STRONG if snapshot.coverage_months >= self.COVERAGE_DEFENSIVE else self.COVERAGE_DEFENSIVE
+        target_balance = snapshot.monthly_burn * required_runway
+        operations_gap = max(0.0, target_balance - snapshot.operations_balance)
+        if operations_gap > 0:
+            levers.operations_top_up = operations_gap
+            notes.append(
+                f"Operations runway below {required_runway:.0f} months target; allocating {operations_gap:,.0f} for top-up."
+            )
+
+        liquidity_gap_value = max(
+            snapshot.liquidity_depth_shortfall,
+            snapshot.liquidity_depth * snapshot.in_range_shortfall,
+        )
+        throttle_ratio = 0.0
+        if snapshot.liquidity_depth_shortfall > 0:
+            notes.append(
+                "Liquidity depth below policy minimum; directing reinforcement capital."
+            )
+            throttle_ratio = max(
+                throttle_ratio,
+                snapshot.liquidity_depth_shortfall / self.LIQUIDITY_DEPTH_MIN,
+            )
+        if snapshot.in_range_shortfall > 0:
+            notes.append(
+                "In-range liquidity coverage insufficient; reallocating to restore bands."
+            )
+            throttle_ratio = max(
+                throttle_ratio,
+                snapshot.in_range_shortfall / self.IN_RANGE_MIN,
+            )
+        if liquidity_gap_value > 0:
+            levers.liquidity_reinforcement = liquidity_gap_value
+
+        net_fees = snapshot.net_fees
+        if snapshot.coverage_months >= self.COVERAGE_STRONG and snapshot.dct_price < snapshot.dct_90d_ma:
+            buyback_budget = max(0.0, net_fees) * self.BUYBACK_FEE_RATIO
+            if buyback_budget > 0:
+                levers.buybacks = buyback_budget
+                notes.append(
+                    "DCT trades at a discount with healthy reserves; executing capped buybacks."
+                )
+        else:
+            if posture == "defensive":
+                notes.append("Buybacks suppressed until runway recovers.")
+
+        if snapshot.coverage_months >= self.COVERAGE_STRONG and snapshot.penalty_fees > 0:
+            burn_budget = snapshot.penalty_fees * self.PENALTY_BURN_RATIO
+            levers.burns = burn_budget
+            notes.append("Redirecting 50% of penalty fees to supply burns per policy.")
+
+        yield_budget = max(0.0, net_fees - levers.buybacks - levers.burns)
+        if yield_budget > 0:
+            levers.yield_deployments = yield_budget
+            notes.append("Allocating remaining net fees to strategic yield strategies.")
+
+        throttle_notes = []
+        if snapshot.volatility >= self.VOLATILITY_ALERT:
+            throttle_ratio = max(throttle_ratio, snapshot.volatility - self.VOLATILITY_ALERT)
+            throttle_notes.append("Elevated volatility observed.")
+
+        throttle_ratio = min(self.EMISSION_THROTTLE_MAX, max(0.0, throttle_ratio))
+        throttle_emissions = throttle_ratio > 0
+
+        if throttle_emissions:
+            notes.append(
+                f"Authorising emission throttles up to {throttle_ratio:.0%} to stabilise market conditions."
+            )
+
+        governance_review_required = posture == "defensive" or throttle_emissions
+        if governance_review_required:
+            notes.append("Flagging to governance council for situational awareness.")
+
+        plan = TreasuryGrowthPlan(
+            posture=posture,
+            levers=levers,
+            throttle_emissions=throttle_emissions,
+            emission_throttle_ratio=throttle_ratio,
+            governance_review_required=governance_review_required,
+            notes=notes,
+        )
+        return plan

--- a/algorithms/python/tests/test_dct_treasury_growth.py
+++ b/algorithms/python/tests/test_dct_treasury_growth.py
@@ -1,0 +1,88 @@
+"""Tests for the DCT treasury growth planner heuristics."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.dct_treasury_growth import TreasuryGrowthPlanner, TreasurySnapshot
+
+
+def build_planner() -> TreasuryGrowthPlanner:
+    return TreasuryGrowthPlanner()
+
+
+def test_defensive_posture_prioritises_runway_and_suppresses_buybacks() -> None:
+    planner = build_planner()
+    snapshot = TreasurySnapshot(
+        operations_balance=1_000_000,  # 10 months of runway
+        liquidity_reserve=1_500_000,
+        monthly_burn=100_000,
+        protocol_fees=80_000,
+        penalty_fees=20_000,
+        dct_price=1.02,
+        dct_90d_ma=1.05,
+        volatility=0.30,
+        liquidity_depth=1_200_000,
+        in_range_ratio=0.70,
+    )
+
+    plan = planner.build_plan(snapshot)
+
+    assert plan.posture == "defensive"
+    assert plan.levers.operations_top_up == 800_000  # top-up to 18 month runway
+    assert plan.levers.buybacks == 0
+    assert plan.governance_review_required is True
+    assert any("Buybacks suppressed" in note for note in plan.notes)
+
+
+def test_discounted_price_with_strong_runway_allocates_buybacks_and_burns() -> None:
+    planner = build_planner()
+    snapshot = TreasurySnapshot(
+        operations_balance=3_000_000,  # 30 months of runway
+        liquidity_reserve=2_000_000,
+        monthly_burn=100_000,
+        protocol_fees=100_000,
+        penalty_fees=20_000,
+        dct_price=0.90,
+        dct_90d_ma=1.05,
+        volatility=0.25,
+        liquidity_depth=1_500_000,
+        in_range_ratio=0.80,
+    )
+
+    plan = planner.build_plan(snapshot)
+
+    assert plan.posture == "balanced"
+    assert plan.levers.buybacks == 24_000  # capped at 20% of net fees (120k)
+    assert plan.levers.burns == 10_000  # 50% of penalty fees
+    assert plan.levers.yield_deployments == 86_000  # remainder of net fees
+    assert plan.governance_review_required is False
+
+
+def test_liquidity_shortfalls_trigger_reinforcement_and_throttle() -> None:
+    planner = build_planner()
+    snapshot = TreasurySnapshot(
+        operations_balance=2_800_000,  # 28 months of runway
+        liquidity_reserve=1_100_000,
+        monthly_burn=100_000,
+        protocol_fees=60_000,
+        penalty_fees=10_000,
+        dct_price=1.00,
+        dct_90d_ma=1.02,
+        volatility=0.40,
+        liquidity_depth=800_000,  # below 1M target
+        in_range_ratio=0.50,  # below 65% target
+    )
+
+    plan = planner.build_plan(snapshot)
+
+    assert plan.levers.liquidity_reinforcement == 200_000
+    assert plan.throttle_emissions is True
+    assert 0 < plan.emission_throttle_ratio <= planner.EMISSION_THROTTLE_MAX
+    assert plan.governance_review_required is True
+    assert any("liquidity" in note.lower() for note in plan.notes)


### PR DESCRIPTION
## Summary
- implement a slots-enabled treasury growth planner module with posture classification and allocation logic derived from the treasury policies
- document the planner usage and re-export the new dataclasses from the algorithms.python package
- add unit coverage for defensive, strong runway, and liquidity shortfall scenarios

## Testing
- pytest algorithms/python/tests/test_dct_treasury_growth.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d65e14df8483229a3bfaa4d7233eec