### PR TITLE
feat: enrich smc analyzer with discretionary zones

### DIFF
--- a/docs/trading-algo-improvement-checklist.md
+++ b/docs/trading-algo-improvement-checklist.md
@@ -43,6 +43,12 @@ into measurable trading performance.
 
 - [ ] Extend `SMCAnalyzer.observe` with new mitigation block or liquidity
       pattern checks before persisting context to Supabase.
+- [ ] Populate `MarketSnapshot.smc_zones` with discretionary continuation and
+      reversal bases so automated runs reference the same supply/demand map as
+      desk markups.
+- [ ] Calibrate `smc_liquidity_weight` and `smc_bias_weight` after adding new
+      zones to confirm continuation bases boost aligned trades while opposing
+      supply/demand pockets still gate entries.
 - [ ] Add unit or integration tests for each new SMC filter under
       `tests/trading-*` to prevent regressions in BOS/SMS detection.
 - [ ] Log additional analyzer outputs (e.g., swept level IDs, mitigation block


### PR DESCRIPTION
## Summary
- add an `SMCZone` dataclass and extend `MarketSnapshot` so analyst-defined supply/demand bases feed into the signal context
- enhance `SMCAnalyzer` to normalise discretionary zones, balance liquidity boosts/penalties, and surface the richer context to callers
- document the new workflow in the trading algo checklist and add a regression test covering zone-driven adjustments

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- pytest algorithms/python/tests/test_trading_workflow.py::test_trade_logic_smc_zones_balance_support_and_pressure


------
https://chatgpt.com/codex/tasks/task_e_68d66049a7ec832295ae67cd385d31db