### PR TITLE
Add adaptive weighting and memory to multi-LLM orchestration

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -57,6 +57,8 @@ from .desk_token_hub import (
     TokenHubDevelopmentOrchestrator,
     TokenHubSyncReport,
 )
+from .multi_llm import AdaptiveParameterScheduler
+from .multi_llm_memory import MemoryStore, MultiLLMMemoryStore
 from .project_faq_generator import (
     FAQEntry,
     FAQRequest,
@@ -89,6 +91,7 @@ __all__ = _trade_exports + [
     "MarketAdvisoryEngine",
     "MarketAdvisoryReport",
     "MarketAdvisoryRequest",
+    "AdaptiveParameterScheduler",
     "DCTAllocationEngine",
     "DCTAllocationResult",
     "DCTAllocationRule",
@@ -112,6 +115,8 @@ __all__ = _trade_exports + [
     "FAQSource",
     "ProjectFAQGenerator",
     "ProjectFAQPackage",
+    "MemoryStore",
+    "MultiLLMMemoryStore",
     "VipAutoSyncJob",
     "VipAutoSyncReport",
     "VipMembershipProvider",
@@ -173,5 +178,8 @@ globals().update(
         "FAQSource": FAQSource,
         "ProjectFAQGenerator": ProjectFAQGenerator,
         "ProjectFAQPackage": ProjectFAQPackage,
+        "AdaptiveParameterScheduler": AdaptiveParameterScheduler,
+        "MemoryStore": MemoryStore,
+        "MultiLLMMemoryStore": MultiLLMMemoryStore,
     }
 )

--- a/algorithms/python/multi_llm_memory.py
+++ b/algorithms/python/multi_llm_memory.py
@@ -1,0 +1,125 @@
+"""Persistence helpers for sharing multi-LLM artefacts across runs."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableMapping, Protocol, Sequence
+from urllib.parse import urlencode
+
+from .supabase_sync import SupabaseRestError, SupabaseTableWriter
+
+__all__ = [
+    "MemoryStore",
+    "MultiLLMMemoryStore",
+]
+
+
+class MemoryStore(Protocol):  # pragma: no cover - interface definition
+    """Minimal protocol implemented by memory stores."""
+
+    def store(self, namespace: str, key: str, artefact: Mapping[str, Any]) -> None:
+        """Persist the artefact for the supplied namespace/key combination."""
+
+    def retrieve(
+        self,
+        namespace: str,
+        key: str,
+        *,
+        limit: int | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return prior artefacts ordered from newest to oldest."""
+
+
+@dataclass(slots=True)
+class MultiLLMMemoryStore:
+    """Supabase-backed memory store for sharing lessons between orchestrators.
+
+    The store keeps the latest ``retention_limit`` artefacts per ``(namespace, key)``
+    pair. Older entries are purged on insertion to avoid unbounded growth and to keep
+    the retrieved context concise enough for prompt composition.
+    """
+
+    writer: SupabaseTableWriter
+    retention_limit: int = 5
+
+    def store(self, namespace: str, key: str, artefact: Mapping[str, Any]) -> None:
+        serialised = json.loads(
+            json.dumps(dict(artefact), default=SupabaseTableWriter._json_default)
+        )
+        payload = {
+            "memory_id": str(uuid.uuid4()),
+            "namespace": namespace,
+            "memory_key": key,
+            "payload": serialised,
+            "created_at": datetime.now(timezone.utc),
+        }
+        self.writer.upsert([payload])
+        self._enforce_retention(namespace, key)
+
+    def retrieve(
+        self,
+        namespace: str,
+        key: str,
+        *,
+        limit: int | None = None,
+    ) -> Sequence[Mapping[str, Any]]:
+        rows = self._fetch_rows(namespace, key, limit=limit)
+        return [row.get("payload", {}) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _enforce_retention(self, namespace: str, key: str) -> None:
+        limit = max(self.retention_limit, 1)
+        rows = self._fetch_rows(namespace, key, limit=limit + 5)
+        if len(rows) <= limit:
+            return
+        stale = rows[limit:]
+        identifiers = [row["memory_id"] for row in stale if row.get("memory_id")]
+        if not identifiers:
+            return
+        params = {
+            "memory_id": "in.(" + ",".join(identifiers) + ")",
+            "namespace": f"eq.{namespace}",
+            "memory_key": f"eq.{key}",
+        }
+        self._dispatch("DELETE", params)
+
+    def _fetch_rows(
+        self,
+        namespace: str,
+        key: str,
+        *,
+        limit: int | None,
+    ) -> Sequence[MutableMapping[str, Any]]:
+        params = {
+            "namespace": f"eq.{namespace}",
+            "memory_key": f"eq.{key}",
+            "order": "created_at.desc",
+        }
+        if limit is not None:
+            params["limit"] = str(max(limit, 1))
+        status, body = self._dispatch("GET", params)
+        if status < 200 or status >= 300:
+            raise SupabaseRestError(status, body)
+        if not body:
+            return []
+        return json.loads(body)
+
+    def _dispatch(self, method: str, params: Mapping[str, str]) -> tuple[int, bytes | None]:
+        base_url = self.writer._resolve_base_url()  # type: ignore[attr-defined]
+        key = self.writer._resolve_service_role_key()  # type: ignore[attr-defined]
+        query = urlencode(params)
+        url = f"{base_url}/rest/v1/{self.writer.table}?{query}"
+        headers = {
+            "content-type": "application/json",
+            "apikey": key,
+            "authorization": f"Bearer {key}",
+        }
+        body = b""
+        if method not in {"GET", "HEAD"}:
+            body = b"{}"
+        return self.writer.dispatcher(method, url, headers=headers, body=body)

--- a/algorithms/python/tests/test_multi_llm.py
+++ b/algorithms/python/tests/test_multi_llm.py
@@ -1,0 +1,89 @@
+import pytest
+
+from algorithms.python.multi_llm import AdaptiveParameterScheduler, LLMConfig
+
+
+class StubClient:
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, float | str]] = []
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        temperature: float,
+        max_tokens: int,
+        nucleus_p: float,
+    ) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "nucleus_p": nucleus_p,
+            }
+        )
+        if not self.responses:
+            raise RuntimeError("No responses queued")
+        return self.responses.pop(0)
+
+
+class RecordingScheduler:
+    def __init__(self, response: dict[str, float | int]) -> None:
+        self.response = response
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def __call__(self, run, feedback):  # type: ignore[no-untyped-def]
+        self.calls.append((run.name, dict(feedback)))
+        return dict(self.response)
+
+
+def test_llm_config_scheduler_updates_parameters() -> None:
+    scheduler = RecordingScheduler({"temperature": 0.3, "max_tokens": 200})
+    client = StubClient(["{""result"": ""ok""}"])
+    config = LLMConfig(
+        name="stub",
+        client=client,
+        temperature=0.5,
+        nucleus_p=0.92,
+        max_tokens=128,
+        parameter_scheduler=scheduler,
+    )
+
+    run = config.run("Prompt", feedback={"custom": True})
+
+    assert config.temperature == pytest.approx(0.3, rel=1e-6)
+    assert config.max_tokens == 200
+    assert scheduler.calls[0][1]["custom"] is True
+
+    config.apply_feedback(run, {"parse_success": False})
+    assert len(scheduler.calls) == 2
+    assert scheduler.calls[1][1]["parse_success"] is False
+
+
+def test_adaptive_scheduler_adjusts_on_parse_failure() -> None:
+    client = StubClient(["{""value"": 1}"])
+    scheduler = AdaptiveParameterScheduler(
+        min_temperature=0.1,
+        max_temperature=1.3,
+        temperature_step=0.1,
+        min_nucleus_p=0.2,
+        max_tokens_step=64,
+        max_tokens_floor=128,
+    )
+    config = LLMConfig(
+        name="adaptive",
+        client=client,
+        temperature=0.6,
+        nucleus_p=0.9,
+        max_tokens=256,
+        parameter_scheduler=scheduler,
+    )
+
+    run = config.run("Some prompt")
+    config.apply_feedback(run, {"parse_success": False, "response_length": 255, "truncated": True})
+
+    assert config.temperature == pytest.approx(0.5, rel=1e-6)
+    assert config.nucleus_p == pytest.approx(0.85, rel=1e-6)
+    assert config.max_tokens == 320


### PR DESCRIPTION
## Summary
- introduce reinforcement-weighted aggregation and persistent weight feedback for the DCT multi-LLM optimiser, exposing current weights in sync payloads
- add a Supabase-backed multi-LLM memory store and wire previous artefacts into the FAQ generator and protocol planner prompts and metadata persistence
- enable adaptive decoding schedules in LLMConfig, provide a default scheduler, and cover the new behaviour with targeted tests

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_dct_token_sync.py algorithms/python/tests/test_project_faq_generator.py algorithms/python/tests/test_dynamic_protocol_planner.py algorithms/python/tests/test_multi_llm.py


------
https://chatgpt.com/codex/tasks/task_e_68d66311fb308322b17518d0331e864c