### PR TITLE
Update mini app URLs to canonical domain

### DIFF
--- a/dynamic-capital-ton/apps/bot/README.md
+++ b/dynamic-capital-ton/apps/bot/README.md
@@ -1,12 +1,13 @@
 # Dynamic Capital Telegram Bot
 
-A minimal Telegraf bot that welcomes users and links them to the Dynamic Capital mini app.
+A minimal Telegraf bot that welcomes users and links them to the Dynamic Capital
+mini app.
 
 ## Environment variables
 
 ```bash
 TELEGRAM_BOT_TOKEN=xxxxxxxx
-APP_URL=https://dynamic-capital-qazf2.ondigitalocean.app
+APP_URL=https://dynamic-capital.ondigitalocean.app
 ```
 
 Install dependencies with `pnpm install` and run the bot locally using:

--- a/dynamic-capital-ton/apps/miniapp/README.md
+++ b/dynamic-capital-ton/apps/miniapp/README.md
@@ -9,7 +9,7 @@ hooks.
 Create a `.env.local` file with the following values:
 
 ```bash
-NEXT_PUBLIC_APP_URL=https://dynamic-capital-qazf2.ondigitalocean.app
+NEXT_PUBLIC_APP_URL=https://dynamic-capital.ondigitalocean.app
 NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_FN_URL=https://<project>.functions.supabase.co

--- a/dynamic-capital-ton/apps/miniapp/public/tonconnect-manifest.json
+++ b/dynamic-capital-ton/apps/miniapp/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://dynamic-capital-qazf2.ondigitalocean.app",
+  "url": "https://dynamic-capital.ondigitalocean.app",
   "name": "Dynamic Capital",
-  "iconUrl": "https://dynamic-capital-qazf2.ondigitalocean.app/icon.png",
+  "iconUrl": "https://dynamic-capital.ondigitalocean.app/icon.png",
   "termsOfUseUrl": "https://dynamic.capital/terms",
   "privacyPolicyUrl": "https://dynamic.capital/privacy"
 }

--- a/supabase/functions/announce-update/index.ts
+++ b/supabase/functions/announce-update/index.ts
@@ -14,7 +14,7 @@ interface TelegramResponse {
 
 const DEFAULT_VERSION = "v1.0";
 const DEFAULT_FEATURE = "Bug fixes and improvements";
-const DEFAULT_MINI_APP_URL = "https://dynamic-capital-qazf2.ondigitalocean.app";
+const DEFAULT_MINI_APP_URL = "https://dynamic-capital.ondigitalocean.app";
 
 const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Summary
- update TonConnect manifest and developer docs to use dynamic-capital.ondigitalocean.app
- align Supabase announce-update default mini app link with the new canonical host

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d668c2cbc08322bcc989ec3e4ec618