### PR TITLE
feat: add orchestration core building blocks

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -10,6 +10,21 @@ from .awesome_api import (
 )
 from .elliott_wave import ElliottSwing, ElliottWaveAnalyzer, ElliottWaveReport
 from .mechanical_analysis import MechanicalAnalysisCalculator, MechanicalMetrics
+from .core_orchestration import (
+    ObserverEvent,
+    OrchestrationBuilder,
+    OrchestrationContext,
+    OrchestrationError,
+    OrchestrationExecution,
+    OrchestrationObserver,
+    OrchestrationPlan,
+    OrchestrationStep,
+    StepExecution,
+    StepHandler,
+    StepResult,
+    StepStatus,
+    execute_plan,
+)
 from .economic_catalysts import (
     EconomicCatalyst,
     EconomicCatalystGenerator,
@@ -97,6 +112,14 @@ __all__ = _trade_exports + [
     "MarketAdvisoryEngine",
     "MarketAdvisoryReport",
     "MarketAdvisoryRequest",
+    "ObserverEvent",
+    "OrchestrationBuilder",
+    "OrchestrationContext",
+    "OrchestrationError",
+    "OrchestrationExecution",
+    "OrchestrationObserver",
+    "OrchestrationPlan",
+    "OrchestrationStep",
     "DCTAllocationEngine",
     "DCTAllocationResult",
     "DCTAllocationRule",
@@ -120,6 +143,10 @@ __all__ = _trade_exports + [
     "FAQSource",
     "ProjectFAQGenerator",
     "ProjectFAQPackage",
+    "StepExecution",
+    "StepHandler",
+    "StepResult",
+    "StepStatus",
     "CEO_PLAYBOOK",
     "CFO_PLAYBOOK",
     "COO_PLAYBOOK",
@@ -132,6 +159,7 @@ __all__ = _trade_exports + [
     "VipMembershipSnapshot",
     "VipTokenGrant",
     "VipTokenisationStrategy",
+    "execute_plan",
 ]
 
 globals().update({name: getattr(_trade_logic, name) for name in _trade_exports})
@@ -158,6 +186,14 @@ globals().update(
         "MarketAdvisoryEngine": MarketAdvisoryEngine,
         "MarketAdvisoryReport": MarketAdvisoryReport,
         "MarketAdvisoryRequest": MarketAdvisoryRequest,
+        "ObserverEvent": ObserverEvent,
+        "OrchestrationBuilder": OrchestrationBuilder,
+        "OrchestrationContext": OrchestrationContext,
+        "OrchestrationError": OrchestrationError,
+        "OrchestrationExecution": OrchestrationExecution,
+        "OrchestrationObserver": OrchestrationObserver,
+        "OrchestrationPlan": OrchestrationPlan,
+        "OrchestrationStep": OrchestrationStep,
         "DCTAllocationEngine": DCTAllocationEngine,
         "DCTAllocationResult": DCTAllocationResult,
         "DCTAllocationRule": DCTAllocationRule,
@@ -193,5 +229,10 @@ globals().update(
         "EXECUTIVE_PLAYBOOKS": EXECUTIVE_PLAYBOOKS,
         "build_executive_playbooks": build_executive_playbooks,
         "build_executive_sync_algorithm": build_executive_sync_algorithm,
+        "StepExecution": StepExecution,
+        "StepHandler": StepHandler,
+        "StepResult": StepResult,
+        "StepStatus": StepStatus,
+        "execute_plan": execute_plan,
     }
 )

--- a/algorithms/python/core_orchestration.py
+++ b/algorithms/python/core_orchestration.py
@@ -1,0 +1,488 @@
+"""Composable orchestration primitives for Dynamic Capital workflows."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import time
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+)
+
+
+StepStatus = Literal["pending", "running", "completed", "skipped", "failed"]
+ObserverEvent = Literal["before_step", "after_step", "step_skipped", "step_failed"]
+
+
+class StepHandler(Protocol):
+    """Callable signature required for orchestration steps."""
+
+    def __call__(self, context: "OrchestrationContext") -> "StepResult | None":
+        """Execute a step and optionally return a :class:`StepResult`."""
+
+
+class OrchestrationObserver(Protocol):
+    """Hook invoked around step execution events."""
+
+    def __call__(
+        self,
+        event: ObserverEvent,
+        step: "OrchestrationStep",
+        context: "OrchestrationContext",
+        result: "StepResult | None",
+    ) -> None:
+        """Receive lifecycle notifications for orchestration steps."""
+
+
+class OrchestrationError(RuntimeError):
+    """Raised when orchestration plans are invalid or execution fails."""
+
+
+@dataclass(slots=True)
+class StepResult:
+    """Outcome returned by a single orchestration step."""
+
+    status: StepStatus = "completed"
+    outputs: Mapping[str, Any] = field(default_factory=dict)
+    artifacts: Mapping[str, Any] = field(default_factory=dict)
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+    metrics: Mapping[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        outputs: Optional[Mapping[str, Any]] = None,
+        artifacts: Optional[Mapping[str, Any]] = None,
+        notes: Optional[Iterable[str]] = None,
+        metrics: Optional[Mapping[str, float]] = None,
+    ) -> "StepResult":
+        """Create a successful result with optional metadata."""
+
+        return cls(
+            status="completed",
+            outputs=dict(outputs or {}),
+            artifacts=dict(artifacts or {}),
+            notes=tuple(notes or ()),
+            metrics=dict(metrics or {}),
+        )
+
+    @classmethod
+    def failure(
+        cls,
+        *,
+        notes: Optional[Iterable[str]] = None,
+        outputs: Optional[Mapping[str, Any]] = None,
+        artifacts: Optional[Mapping[str, Any]] = None,
+        metrics: Optional[Mapping[str, float]] = None,
+    ) -> "StepResult":
+        """Create a failed step result."""
+
+        return cls(
+            status="failed",
+            outputs=dict(outputs or {}),
+            artifacts=dict(artifacts or {}),
+            notes=tuple(notes or ()),
+            metrics=dict(metrics or {}),
+        )
+
+    @classmethod
+    def skipped(
+        cls,
+        *,
+        notes: Optional[Iterable[str]] = None,
+    ) -> "StepResult":
+        """Create a skipped step result."""
+
+        return cls(status="skipped", outputs={}, artifacts={}, notes=tuple(notes or ()))
+
+
+@dataclass(slots=True)
+class OrchestrationContext:
+    """Mutable context shared across orchestration steps."""
+
+    state: Dict[str, Any] = field(default_factory=dict)
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def update_state(self, values: Mapping[str, Any]) -> None:
+        """Merge step outputs into the shared state."""
+
+        self.state.update(values)
+
+    def attach_artifacts(self, values: Mapping[str, Any]) -> None:
+        """Store generated artifacts for later inspection."""
+
+        self.artifacts.update(values)
+
+    def attach_artifact(self, name: str, value: Any) -> None:
+        """Attach a single artifact entry."""
+
+        self.artifacts[name] = value
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a value from the state mapping."""
+
+        return self.state.get(key, default)
+
+    def __contains__(self, key: str) -> bool:  # pragma: no cover - convenience
+        return key in self.state
+
+
+@dataclass(slots=True)
+class OrchestrationStep:
+    """Single unit of work within an orchestration plan."""
+
+    name: str
+    summary: str
+    handler: Optional[StepHandler] = None
+    depends_on: Sequence[str] = ()
+    inputs: Sequence[str] = ()
+    provides: Sequence[str] = ()
+    tags: Sequence[str] = ()
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("step name must be a non-empty string")
+        self.depends_on = tuple(dict.fromkeys(self.depends_on))
+        self.inputs = tuple(dict.fromkeys(self.inputs))
+        self.provides = tuple(dict.fromkeys(self.provides))
+        self.tags = tuple(dict.fromkeys(self.tags))
+
+
+@dataclass(slots=True)
+class StepExecution:
+    """Record describing the execution of a step."""
+
+    name: str
+    status: StepStatus
+    outputs: Dict[str, Any]
+    artifacts: Dict[str, Any]
+    notes: Tuple[str, ...]
+    metrics: Dict[str, float]
+    duration: float
+    error: Optional[str] = None
+
+
+@dataclass(slots=True)
+class OrchestrationPlan:
+    """Ordered collection of orchestration steps with dependency awareness."""
+
+    steps: Sequence[OrchestrationStep]
+    name: str = "orchestration_plan"
+    summary: Optional[str] = None
+    _index: Dict[str, OrchestrationStep] = field(init=False, repr=False)
+    _ordered_steps: Tuple[OrchestrationStep, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.steps = tuple(self.steps)
+        self._index: Dict[str, OrchestrationStep] = {step.name: step for step in self.steps}
+        if len(self._index) != len(self.steps):
+            duplicates = self._find_duplicates(step.name for step in self.steps)
+            raise OrchestrationError(
+                f"duplicate step names detected: {', '.join(sorted(duplicates))}"
+            )
+        missing = {
+            dependency
+            for step in self.steps
+            for dependency in step.depends_on
+            if dependency not in self._index
+        }
+        if missing:
+            raise OrchestrationError(
+                f"missing dependencies referenced in plan: {', '.join(sorted(missing))}"
+            )
+        self._ordered_steps = self._resolve_order()
+
+    @staticmethod
+    def _find_duplicates(names: Iterable[str]) -> set[str]:
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for name in names:
+            if name in seen:
+                duplicates.add(name)
+            else:
+                seen.add(name)
+        return duplicates
+
+    def _resolve_order(self) -> Tuple[OrchestrationStep, ...]:
+        indegree: Dict[str, int] = {step.name: 0 for step in self.steps}
+        adjacency: Dict[str, list[str]] = {step.name: [] for step in self.steps}
+        for step in self.steps:
+            for dependency in step.depends_on:
+                indegree[step.name] += 1
+                adjacency[dependency].append(step.name)
+        queue: deque[str] = deque(
+            step.name for step in self.steps if indegree[step.name] == 0
+        )
+        order: list[OrchestrationStep] = []
+        while queue:
+            name = queue.popleft()
+            order.append(self._index[name])
+            for child in adjacency[name]:
+                indegree[child] -= 1
+                if indegree[child] == 0:
+                    queue.append(child)
+        if len(order) != len(self.steps):
+            blocked = [name for name, degree in indegree.items() if degree > 0]
+            raise OrchestrationError(
+                "dependency cycle detected in orchestration plan: "
+                + ", ".join(sorted(blocked))
+            )
+        return tuple(order)
+
+    def __iter__(self) -> Iterator[OrchestrationStep]:  # pragma: no cover - passthrough
+        return iter(self._ordered_steps)
+
+    def ordered_steps(self) -> Tuple[OrchestrationStep, ...]:
+        """Return the steps in a dependency-safe order."""
+
+        return self._ordered_steps
+
+    def get(self, name: str) -> OrchestrationStep:
+        """Return a step by name."""
+
+        try:
+            return self._index[name]
+        except KeyError as error:
+            raise OrchestrationError(f"step '{name}' not found in plan") from error
+
+    def __contains__(self, name: str) -> bool:  # pragma: no cover - convenience
+        return name in self._index
+
+
+@dataclass(slots=True)
+class OrchestrationExecution:
+    """Aggregate execution output for an orchestration plan."""
+
+    plan: OrchestrationPlan
+    context: OrchestrationContext
+    timeline: Tuple[StepExecution, ...]
+    status: StepStatus
+
+    def failures(self) -> Tuple[StepExecution, ...]:
+        """Return the list of failed step executions."""
+
+        return tuple(step for step in self.timeline if step.status == "failed")
+
+    def skipped(self) -> Tuple[StepExecution, ...]:
+        """Return the list of skipped step executions."""
+
+        return tuple(step for step in self.timeline if step.status == "skipped")
+
+
+def execute_plan(
+    plan: OrchestrationPlan,
+    context: Optional[OrchestrationContext] = None,
+    *,
+    strict: bool = True,
+    observers: Optional[Iterable[OrchestrationObserver]] = None,
+) -> OrchestrationExecution:
+    """Execute steps in the provided plan and return an execution summary."""
+
+    ctx = context or OrchestrationContext()
+    observer_list = tuple(observers or ())
+    timeline: list[StepExecution] = []
+    statuses: Dict[str, StepStatus] = {step.name: "pending" for step in plan.ordered_steps()}
+
+    for step in plan.ordered_steps():
+        dependencies = step.depends_on
+        unsatisfied = [name for name in dependencies if statuses.get(name) != "completed"]
+        if unsatisfied:
+            if strict:
+                raise OrchestrationError(
+                    f"step '{step.name}' cannot run because dependencies failed: "
+                    + ", ".join(unsatisfied)
+                )
+            result = StepResult.skipped(
+                notes=(
+                    "skipped because dependencies were not completed",
+                    f"unsatisfied: {', '.join(unsatisfied)}",
+                )
+            )
+            exec_record = StepExecution(
+                name=step.name,
+                status=result.status,
+                outputs={},
+                artifacts={},
+                notes=result.notes,
+                metrics={},
+                duration=0.0,
+                error=None,
+            )
+            timeline.append(exec_record)
+            statuses[step.name] = result.status
+            for observer in observer_list:
+                observer("step_skipped", step, ctx, result)
+            continue
+
+        for observer in observer_list:
+            observer("before_step", step, ctx, None)
+
+        start = time.perf_counter()
+        try:
+            raw_result = step.handler(ctx) if step.handler else None
+        except Exception as exc:  # pragma: no cover - exercised via tests
+            duration = time.perf_counter() - start
+            result = StepResult.failure(notes=(f"exception: {exc!r}",))
+            exec_record = StepExecution(
+                name=step.name,
+                status=result.status,
+                outputs={},
+                artifacts={},
+                notes=result.notes,
+                metrics={},
+                duration=duration,
+                error=repr(exc),
+            )
+            timeline.append(exec_record)
+            statuses[step.name] = result.status
+            for observer in observer_list:
+                observer("step_failed", step, ctx, result)
+            if strict:
+                return OrchestrationExecution(
+                    plan=plan,
+                    context=ctx,
+                    timeline=tuple(timeline),
+                    status="failed",
+                )
+            continue
+
+        result = raw_result or StepResult.success()
+        if result.status not in {"completed", "skipped", "failed", "running", "pending"}:
+            raise OrchestrationError(
+                f"step '{step.name}' returned invalid status '{result.status}'"
+            )
+
+        duration = time.perf_counter() - start
+        outputs = dict(result.outputs)
+        artifacts = dict(result.artifacts)
+        notes = tuple(result.notes)
+        metrics = dict(result.metrics)
+
+        if result.status == "completed":
+            ctx.update_state(outputs)
+            if artifacts:
+                ctx.attach_artifacts(artifacts)
+        elif result.status == "failed" and strict:
+            exec_record = StepExecution(
+                name=step.name,
+                status=result.status,
+                outputs=outputs,
+                artifacts=artifacts,
+                notes=notes,
+                metrics=metrics,
+                duration=duration,
+                error=None,
+            )
+            timeline.append(exec_record)
+            statuses[step.name] = result.status
+            for observer in observer_list:
+                observer("step_failed", step, ctx, result)
+            return OrchestrationExecution(
+                plan=plan,
+                context=ctx,
+                timeline=tuple(timeline),
+                status="failed",
+            )
+
+        exec_record = StepExecution(
+            name=step.name,
+            status=result.status,
+            outputs=outputs,
+            artifacts=artifacts,
+            notes=notes,
+            metrics=metrics,
+            duration=duration,
+            error=None,
+        )
+        timeline.append(exec_record)
+        statuses[step.name] = result.status
+
+        event = "step_failed" if result.status == "failed" else "after_step"
+        for observer in observer_list:
+            observer(event, step, ctx, result)
+
+    status: StepStatus = "completed"
+    if any(record.status == "failed" for record in timeline):
+        status = "failed"
+    elif any(record.status == "skipped" for record in timeline):
+        status = "skipped"
+
+    return OrchestrationExecution(
+        plan=plan,
+        context=ctx,
+        timeline=tuple(timeline),
+        status=status,
+    )
+
+
+class OrchestrationBuilder:
+    """Helper for building orchestration plans fluently."""
+
+    def __init__(self, name: str, *, summary: Optional[str] = None) -> None:
+        self.name = name
+        self.summary = summary
+        self._steps: list[OrchestrationStep] = []
+
+    def add_step(
+        self,
+        name: str,
+        summary: str,
+        *,
+        handler: Optional[StepHandler] = None,
+        depends_on: Sequence[str] = (),
+        inputs: Sequence[str] = (),
+        provides: Sequence[str] = (),
+        tags: Sequence[str] = (),
+    ) -> OrchestrationStep:
+        """Append a new step definition and return it for further inspection."""
+
+        step = OrchestrationStep(
+            name=name,
+            summary=summary,
+            handler=handler,
+            depends_on=depends_on,
+            inputs=inputs,
+            provides=provides,
+            tags=tags,
+        )
+        self._steps.append(step)
+        return step
+
+    def extend(self, steps: Iterable[OrchestrationStep]) -> None:
+        """Extend the builder with externally defined steps."""
+
+        self._steps.extend(steps)
+
+    def build(self) -> OrchestrationPlan:
+        """Produce an :class:`OrchestrationPlan` from the registered steps."""
+
+        return OrchestrationPlan(tuple(self._steps), name=self.name, summary=self.summary)
+
+
+__all__ = [
+    "ObserverEvent",
+    "OrchestrationBuilder",
+    "OrchestrationContext",
+    "OrchestrationError",
+    "OrchestrationExecution",
+    "OrchestrationObserver",
+    "OrchestrationPlan",
+    "OrchestrationStep",
+    "StepExecution",
+    "StepHandler",
+    "StepResult",
+    "StepStatus",
+    "execute_plan",
+]

--- a/algorithms/python/tests/test_core_orchestration.py
+++ b/algorithms/python/tests/test_core_orchestration.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.core_orchestration import (
+    OrchestrationBuilder,
+    OrchestrationContext,
+    OrchestrationError,
+    OrchestrationPlan,
+    OrchestrationStep,
+    StepResult,
+    execute_plan,
+)
+
+
+def test_plan_orders_steps_via_dependencies() -> None:
+    ingest = OrchestrationStep(name="ingest", summary="load raw data")
+    transform = OrchestrationStep(
+        name="transform",
+        summary="prepare features",
+        depends_on=("ingest",),
+    )
+    plan = OrchestrationPlan([transform, ingest])
+
+    assert [step.name for step in plan.ordered_steps()] == ["ingest", "transform"]
+
+
+def test_plan_validation_rejects_missing_dependencies() -> None:
+    with pytest.raises(OrchestrationError):
+        OrchestrationPlan(
+            [
+                OrchestrationStep(
+                    name="train",
+                    summary="train model",
+                    depends_on=("does-not-exist",),
+                )
+            ]
+        )
+
+
+def test_plan_validation_rejects_duplicate_names() -> None:
+    with pytest.raises(OrchestrationError):
+        OrchestrationPlan(
+            [
+                OrchestrationStep(name="prep", summary="first"),
+                OrchestrationStep(name="prep", summary="second"),
+            ]
+        )
+
+
+def test_execute_plan_updates_context_and_notifies_observers() -> None:
+    events: list[tuple[str, str, str | None]] = []
+
+    def observer(event: str, step: OrchestrationStep, context: OrchestrationContext, result: StepResult | None) -> None:
+        events.append((event, step.name, None if result is None else result.status))
+
+    def ingest_handler(context: OrchestrationContext) -> StepResult:
+        return StepResult.success(outputs={"ingested": True})
+
+    def train_handler(context: OrchestrationContext) -> StepResult:
+        assert context.get("ingested") is True
+        return StepResult.success(
+            outputs={"model": "ready"},
+            artifacts={"model_path": "/tmp/model.pkl"},
+            notes=["trained with defaults"],
+        )
+
+    plan = OrchestrationPlan(
+        [
+            OrchestrationStep(name="ingest", summary="load", handler=ingest_handler),
+            OrchestrationStep(name="train", summary="train", handler=train_handler, depends_on=("ingest",)),
+        ]
+    )
+    execution = execute_plan(plan, observers=[observer])
+
+    assert execution.status == "completed"
+    assert execution.context.get("model") == "ready"
+    assert execution.context.artifacts["model_path"] == "/tmp/model.pkl"
+    assert ("before_step", "ingest", None) in events
+    assert ("after_step", "ingest", "completed") in events
+    assert ("after_step", "train", "completed") in events
+
+
+def test_execute_plan_handles_failures_and_skips_dependents() -> None:
+    def failing_handler(context: OrchestrationContext) -> StepResult:
+        raise RuntimeError("boom")
+
+    def downstream_handler(context: OrchestrationContext) -> StepResult:
+        return StepResult.success(outputs={"value": 1})
+
+    plan = OrchestrationPlan(
+        [
+            OrchestrationStep(name="fetch", summary="upstream", handler=failing_handler),
+            OrchestrationStep(
+                name="compute",
+                summary="depends",
+                handler=downstream_handler,
+                depends_on=("fetch",),
+            ),
+        ]
+    )
+
+    execution = execute_plan(plan, strict=False)
+
+    statuses = {record.name: record.status for record in execution.timeline}
+    assert statuses["fetch"] == "failed"
+    assert statuses["compute"] == "skipped"
+    assert execution.status == "failed"
+    assert execution.failures() and execution.failures()[0].name == "fetch"
+
+
+def test_builder_constructs_valid_plan() -> None:
+    builder = OrchestrationBuilder("demo", summary="demo orchestration")
+
+    def prepare(context: OrchestrationContext) -> StepResult:
+        return StepResult.success(outputs={"prepared": True})
+
+    def execute(context: OrchestrationContext) -> StepResult:
+        assert context.get("prepared") is True
+        return StepResult.success(outputs={"executed": True})
+
+    builder.add_step("prepare", "prep", handler=prepare)
+    builder.add_step("execute", "run", handler=execute, depends_on=("prepare",))
+
+    plan = builder.build()
+    execution = execute_plan(plan)
+
+    assert execution.status == "completed"
+    assert execution.context.get("executed") is True


### PR DESCRIPTION
## Summary
- add reusable orchestration primitives, execution helpers, and a builder for composing desk orchestration plans
- expose the orchestration API through the algorithms package exports for downstream consumers
- cover orchestration validation, execution outcomes, and builder flows with focused unit tests

## Testing
- pytest algorithms/python/tests/test_core_orchestration.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d66c154db883228f72c00dd5170fe0