### PR TITLE
Add ASCII shader effect to market quotes and tips

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,6 @@
-@import './styles/mobile.css';
-@import '../resources/custom.css';
-@import '../resources/brand-tokens.css';
+@import "./styles/mobile.css";
+@import "../resources/custom.css";
+@import "../resources/brand-tokens.css";
 @reference "./theme.css";
 @tailwind base;
 @tailwind components;
@@ -163,6 +163,100 @@
       radial-gradient(circle at 10px 10px, currentColor 2px, transparent 2px);
     background-size: 40px 40px, 40px 40px, 40px 40px;
     background-position: 0 0, 0 0, 0 0;
+  }
+
+  .ascii-shader-text {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: inherit;
+    isolation: isolate;
+    min-width: 0;
+  }
+
+  .ascii-shader-text__content {
+    position: relative;
+    z-index: 2;
+  }
+
+  .ascii-shader-text::before,
+  .ascii-shader-text::after {
+    content: "";
+    position: absolute;
+    inset: -8%;
+    pointer-events: none;
+    border-radius: inherit;
+    transition: opacity 0.35s ease;
+  }
+
+  .ascii-shader-text::before {
+    z-index: 0;
+    background:
+      radial-gradient(
+        circle at 15% 20%,
+        hsl(var(--brand) / 0.18),
+        transparent 55%
+      ),
+      radial-gradient(
+      circle at 80% 30%,
+      hsl(var(--accent) / 0.16),
+      transparent 60%
+    );
+    filter: blur(10px);
+    opacity: 0.4;
+  }
+
+  .ascii-shader-text::after {
+    z-index: 1;
+    background-image: linear-gradient(
+      125deg,
+      rgba(56, 189, 248, 0.45),
+      rgba(147, 51, 234, 0.45),
+      rgba(249, 115, 22, 0.4)
+    );
+    background-size: 220% 100%;
+    mix-blend-mode: screen;
+    opacity: 0.52;
+    animation: ascii-shader-pan 14s linear infinite;
+    mask-image: var(--ascii-shader-texture);
+    mask-repeat: repeat;
+    mask-size: var(--ascii-mask-size, 260px 140%);
+    -webkit-mask-image: var(--ascii-shader-texture);
+    -webkit-mask-repeat: repeat;
+    -webkit-mask-size: var(--ascii-mask-size, 260px 140%);
+    filter: saturate(1.25) contrast(1.05);
+  }
+
+  .ascii-shader-text[data-ascii-intensity="subtle"]::before {
+    opacity: 0.25;
+  }
+
+  .ascii-shader-text[data-ascii-intensity="bold"]::before {
+    opacity: 0.6;
+  }
+
+  .ascii-shader-text[data-ascii-intensity="subtle"]::after {
+    opacity: 0.32;
+  }
+
+  .ascii-shader-text[data-ascii-intensity="bold"]::after {
+    opacity: 0.72;
+  }
+
+  @keyframes ascii-shader-pan {
+    0% {
+      background-position: 0% 50%;
+    }
+    100% {
+      background-position: -200% 50%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ascii-shader-text::after {
+      animation-duration: 0.01s;
+      animation-iteration-count: 1;
+    }
   }
 
   .pattern-hexagon {

--- a/apps/web/components/magic-portfolio/home/FxMarketSnapshotSection.tsx
+++ b/apps/web/components/magic-portfolio/home/FxMarketSnapshotSection.tsx
@@ -17,6 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { AsciiShaderText } from "@/components/ui/AsciiShaderText";
 import { formatIsoTime } from "@/utils/isoFormat";
 import {
   type ComponentProps,
@@ -1147,24 +1148,32 @@ function MoversTable({ title, data, tone }: MoversSection) {
                   </Column>
                 </TableCell>
                 <TableCell className="text-right">
-                  <Text variant="body-strong-s">
-                    {formatPercent(item.changePercent)}
-                  </Text>
+                  <AsciiShaderText asChild intensity="bold">
+                    <Text variant="body-strong-s">
+                      {formatPercent(item.changePercent)}
+                    </Text>
+                  </AsciiShaderText>
                 </TableCell>
                 <TableCell className="text-right">
-                  <Text variant="body-default-s" onBackground="neutral-weak">
-                    {formatChange(item.change)}
-                  </Text>
+                  <AsciiShaderText asChild intensity="balanced">
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      {formatChange(item.change)}
+                    </Text>
+                  </AsciiShaderText>
                 </TableCell>
                 <TableCell className="text-right">
-                  <Text variant="body-default-s" onBackground="neutral-weak">
-                    {formatPips(item.pips)}
-                  </Text>
+                  <AsciiShaderText asChild intensity="balanced">
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      {formatPips(item.pips)}
+                    </Text>
+                  </AsciiShaderText>
                 </TableCell>
                 <TableCell className="text-right">
-                  <Text variant="body-default-s" onBackground="neutral-weak">
-                    {formatPrice(item.lastPrice)}
-                  </Text>
+                  <AsciiShaderText asChild intensity="bold">
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      {formatPrice(item.lastPrice)}
+                    </Text>
+                  </AsciiShaderText>
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/web/components/magic-portfolio/home/MarketWatchlist.tsx
+++ b/apps/web/components/magic-portfolio/home/MarketWatchlist.tsx
@@ -11,6 +11,7 @@ import {
   Tag,
   Text,
 } from "@/components/dynamic-ui-system";
+import { AsciiShaderText } from "@/components/ui/AsciiShaderText";
 import type { IconName } from "@/resources/icons";
 import { formatIsoTime } from "@/utils/isoFormat";
 import {
@@ -1066,15 +1067,19 @@ export function MarketWatchlist() {
                 </Column>
                 <Column gap="8" horizontal="end" align="end">
                   <Row gap="12" vertical="center">
-                    <Text variant="heading-strong-m" align="right">
-                      {formatNumber(quote?.last, item.format)}
-                    </Text>
+                    <AsciiShaderText asChild intensity="bold">
+                      <Text variant="heading-strong-m" align="right">
+                        {formatNumber(quote?.last, item.format)}
+                      </Text>
+                    </AsciiShaderText>
                     <Tag
                       size="s"
                       background={changeBackground}
                       onBackground={changeForeground}
                     >
-                      {formatChangePercent(changeValue)}
+                      <AsciiShaderText intensity="balanced">
+                        {formatChangePercent(changeValue)}
+                      </AsciiShaderText>
                     </Tag>
                   </Row>
                   <Text
@@ -1100,9 +1105,11 @@ export function MarketWatchlist() {
                   <Text variant="label-default-s" onBackground="neutral-weak">
                     Intraday range
                   </Text>
-                  <Text variant="body-default-m">
-                    {formatRange(quote, item.format)}
-                  </Text>
+                  <AsciiShaderText asChild intensity="subtle">
+                    <Text variant="body-default-m">
+                      {formatRange(quote, item.format)}
+                    </Text>
+                  </AsciiShaderText>
                 </Column>
                 <Column
                   flex={1}
@@ -1132,22 +1139,26 @@ export function MarketWatchlist() {
                               name={insight.icon}
                               onBackground={tone.icon}
                             />
-                            <Text
-                              variant="body-default-s"
-                              onBackground={tone.text}
-                            >
-                              {insight.label}
-                            </Text>
+                            <AsciiShaderText asChild intensity="subtle">
+                              <Text
+                                variant="body-default-s"
+                                onBackground={tone.text}
+                              >
+                                {insight.label}
+                              </Text>
+                            </AsciiShaderText>
                           </Row>
                         );
                       })
                       : (
-                        <Text
-                          variant="body-default-s"
-                          onBackground="brand-strong"
-                        >
-                          No quick insights available.
-                        </Text>
+                        <AsciiShaderText asChild intensity="subtle">
+                          <Text
+                            variant="body-default-s"
+                            onBackground="brand-strong"
+                          >
+                            No quick insights available.
+                          </Text>
+                        </AsciiShaderText>
                       )}
                   </Column>
                 </Column>
@@ -1172,17 +1183,23 @@ export function MarketWatchlist() {
                               name={insight.icon}
                               onBackground={tone.icon}
                             />
-                            <Text
-                              variant="body-default-m"
-                              onBackground={tone.text}
-                            >
-                              {insight.label}
-                            </Text>
+                            <AsciiShaderText asChild intensity="subtle">
+                              <Text
+                                variant="body-default-m"
+                                onBackground={tone.text}
+                              >
+                                {insight.label}
+                              </Text>
+                            </AsciiShaderText>
                           </Row>
                         );
                       })
                       : (
-                        <Text variant="body-default-m">No focus guidance.</Text>
+                        <AsciiShaderText asChild intensity="subtle">
+                          <Text variant="body-default-m">
+                            No focus guidance.
+                          </Text>
+                        </AsciiShaderText>
                       )}
                   </Column>
                 </Column>

--- a/apps/web/components/ui/AsciiShaderText.tsx
+++ b/apps/web/components/ui/AsciiShaderText.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+
+import { cn } from "@/lib/utils";
+
+const ASCII_PATTERN = "@#&%$/=+*";
+const ASCII_LINES = Array.from({ length: 4 }, (_, index) => {
+  const y = 14 + index * 9;
+  return `<text x="0" y="${y}" font-family="'IBM Plex Mono','Roboto Mono',ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace" font-size="12" letter-spacing="4" fill="white" fill-opacity="0.9">${
+    ASCII_PATTERN.repeat(6)
+  }</text>`;
+}).join("");
+
+const ASCII_TEXTURE = `url("data:image/svg+xml,${
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='320' height='48' viewBox='0 0 320 48'>${ASCII_LINES}</svg>`,
+  )
+}")`;
+
+type Intensity = "subtle" | "balanced" | "bold";
+
+type CSSCustomProperties = React.CSSProperties & {
+  "--ascii-shader-texture"?: string;
+};
+
+export interface AsciiShaderTextProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+  children: React.ReactNode;
+  /**
+   * Render the child element directly instead of a nested span.
+   * Useful when composing with typography components that control semantics.
+   */
+  asChild?: boolean;
+  /**
+   * Controls how strong the overlay appears.
+   */
+  intensity?: Intensity;
+}
+
+export const AsciiShaderText = React.forwardRef<
+  HTMLSpanElement,
+  AsciiShaderTextProps
+>(
+  (
+    {
+      asChild = false,
+      children,
+      className,
+      intensity = "balanced",
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const Component = asChild ? Slot : "span";
+    const baseStyle = (style ?? {}) as CSSCustomProperties;
+    const mergedStyle: CSSCustomProperties = {
+      ...baseStyle,
+      "--ascii-shader-texture": ASCII_TEXTURE,
+    };
+
+    return (
+      <span
+        ref={ref}
+        className={cn("ascii-shader-text", className)}
+        data-ascii-intensity={intensity}
+        style={mergedStyle}
+        {...props}
+      >
+        <Component className="ascii-shader-text__content">{children}</Component>
+      </span>
+    );
+  },
+);
+
+AsciiShaderText.displayName = "AsciiShaderText";


### PR DESCRIPTION
## Summary
- add a reusable `AsciiShaderText` wrapper and global styling for the ASCII shader overlay
- apply the shader treatment to FX snapshot prices and market watchlist quotes/tips

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d67a65adfc8322a7b93e50587bd9fb