### PR TITLE
Replace news scoring with TON DEX scanner algorithm

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -43,6 +43,12 @@ from .economic_catalysts import (
     EconomicCatalystGenerator,
     EconomicCatalystSyncJob,
 )
+from .dex_scanner import (
+    DexPoolSnapshot,
+    DexScannerAlgo,
+    DexScannerSignal,
+    build_scanner_for_tokens,
+)
 from .currency_correlation import (
     CorrelationSeries,
     CurrencyCorrelationCalculator,
@@ -143,6 +149,10 @@ __all__ = _trade_exports + [
     "ElliottWaveReport",
     "MechanicalAnalysisCalculator",
     "MechanicalMetrics",
+    "DexPoolSnapshot",
+    "DexScannerAlgo",
+    "DexScannerSignal",
+    "build_scanner_for_tokens",
     "EconomicCatalyst",
     "EconomicCatalystGenerator",
     "EconomicCatalystSyncJob",
@@ -243,6 +253,10 @@ globals().update(
         "EconomicCatalyst": EconomicCatalyst,
         "EconomicCatalystGenerator": EconomicCatalystGenerator,
         "EconomicCatalystSyncJob": EconomicCatalystSyncJob,
+        "DexPoolSnapshot": DexPoolSnapshot,
+        "DexScannerAlgo": DexScannerAlgo,
+        "DexScannerSignal": DexScannerSignal,
+        "build_scanner_for_tokens": build_scanner_for_tokens,
         "CorrelationSeries": CorrelationSeries,
         "CurrencyCorrelationCalculator": CurrencyCorrelationCalculator,
         "CurrencyCorrelationReport": CurrencyCorrelationReport,

--- a/algorithms/python/dex_scanner.py
+++ b/algorithms/python/dex_scanner.py
@@ -1,0 +1,187 @@
+"""TON-focused DEX scanner scoring utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class DexPoolSnapshot:
+    """Represents a point-in-time view of a TON DEX pool."""
+
+    dex: str
+    pool_address: str
+    base_token: str
+    quote_token: str
+    price_usd: float | None = None
+    liquidity_usd: float | None = None
+    volume_24h_usd: float | None = None
+    price_change_24h_pct: float | None = None
+    transactions_24h: int | None = None
+    fees_24h_usd: float | None = None
+    is_verified: bool = False
+
+
+@dataclass(frozen=True)
+class DexScannerSignal:
+    """Output signal describing the attractiveness of a DEX pool."""
+
+    pool: DexPoolSnapshot
+    score: float
+    tier: str
+    liquidity_score: float
+    volume_score: float
+    activity_score: float
+    momentum_score: float
+    volatility_penalty: float
+    notes: tuple[str, ...]
+
+
+class DexScannerAlgo:
+    """Scores TON DEX pools to help prioritise monitoring."""
+
+    def __init__(
+        self,
+        tracked_tokens: Sequence[str] | None = None,
+        min_liquidity_usd: float = 5_000.0,
+        min_volume_24h_usd: float = 2_000.0,
+        min_transactions_24h: int = 5,
+        high_volatility_threshold_pct: float = 18.0,
+    ) -> None:
+        self.tracked_tokens = tuple(token.upper() for token in (tracked_tokens or ("DCT", "TON")))
+        if not self.tracked_tokens:
+            raise ValueError("tracked_tokens must contain at least one token symbol")
+
+        if min_liquidity_usd < 0 or min_volume_24h_usd < 0:
+            raise ValueError("minimum liquidity and volume thresholds must be non-negative")
+
+        if min_transactions_24h < 0:
+            raise ValueError("minimum transaction threshold must be non-negative")
+
+        self.min_liquidity_usd = float(min_liquidity_usd)
+        self.min_volume_24h_usd = float(min_volume_24h_usd)
+        self.min_transactions_24h = int(min_transactions_24h)
+        self.high_volatility_threshold_pct = float(high_volatility_threshold_pct)
+
+    def score_pool(self, snapshot: DexPoolSnapshot) -> DexScannerSignal:
+        """Scores a single pool snapshot and returns the resulting signal."""
+
+        self._validate_snapshot(snapshot)
+        notes: list[str] = []
+
+        liquidity_score = self._scale(snapshot.liquidity_usd, self.min_liquidity_usd, 250_000.0)
+        volume_score = self._scale(snapshot.volume_24h_usd, self.min_volume_24h_usd, 150_000.0)
+        activity_score = self._scale(snapshot.transactions_24h, self.min_transactions_24h, 500)
+        momentum_score, volatility_penalty = self._compute_momentum(snapshot)
+
+        verification_bonus = 0.05 if snapshot.is_verified else 0.0
+        if snapshot.is_verified:
+            notes.append("Verified pool on TON DEX registry")
+
+        score = (
+            liquidity_score * 0.35
+            + volume_score * 0.3
+            + activity_score * 0.2
+            + momentum_score * 0.15
+            + verification_bonus
+            - volatility_penalty
+        )
+
+        score = max(0.0, min(score, 1.0))
+
+        tier = "caution"
+        if score >= 0.75:
+            tier = "prime"
+        elif score >= 0.5:
+            tier = "watchlist"
+
+        if snapshot.liquidity_usd is None:
+            notes.append("Missing liquidity data")
+        elif snapshot.liquidity_usd < self.min_liquidity_usd:
+            notes.append(
+                f"Liquidity ${snapshot.liquidity_usd:,.0f} below minimum ${self.min_liquidity_usd:,.0f}"
+            )
+
+        if snapshot.volume_24h_usd is None:
+            notes.append("Missing 24h volume data")
+        elif snapshot.volume_24h_usd < self.min_volume_24h_usd:
+            notes.append(
+                f"24h volume ${snapshot.volume_24h_usd:,.0f} below minimum ${self.min_volume_24h_usd:,.0f}"
+            )
+
+        if snapshot.transactions_24h is None:
+            notes.append("Missing transaction count")
+        elif snapshot.transactions_24h < self.min_transactions_24h:
+            notes.append(
+                f"Only {snapshot.transactions_24h} swaps in 24h (min {self.min_transactions_24h})"
+            )
+
+        if volatility_penalty > 0:
+            notes.append(
+                f"Volatility penalty applied ({volatility_penalty:.2f})"
+            )
+
+        return DexScannerSignal(
+            pool=snapshot,
+            score=score,
+            tier=tier,
+            liquidity_score=liquidity_score,
+            volume_score=volume_score,
+            activity_score=activity_score,
+            momentum_score=momentum_score,
+            volatility_penalty=volatility_penalty,
+            notes=tuple(notes),
+        )
+
+    def rank_pools(self, snapshots: Iterable[DexPoolSnapshot]) -> list[DexScannerSignal]:
+        """Score multiple pools and return the results sorted by score."""
+
+        signals = [self.score_pool(snapshot) for snapshot in snapshots]
+        return sorted(signals, key=lambda signal: signal.score, reverse=True)
+
+    def _validate_snapshot(self, snapshot: DexPoolSnapshot) -> None:
+        base = snapshot.base_token.upper()
+        quote = snapshot.quote_token.upper()
+        if base not in self.tracked_tokens and quote not in self.tracked_tokens:
+            raise ValueError(
+                f"Pool {snapshot.pool_address} does not involve tracked tokens {self.tracked_tokens}"
+            )
+
+    def _scale(self, value: float | int | None, minimum: float, target: float) -> float:
+        if value is None:
+            return 0.0
+
+        if minimum <= 0:
+            raise ValueError("minimum must be positive when scaling metrics")
+
+        if target <= minimum:
+            raise ValueError("target must be greater than minimum when scaling metrics")
+
+        normalised = (float(value) - minimum) / (target - minimum)
+        return max(0.0, min(normalised, 1.0))
+
+    def _compute_momentum(self, snapshot: DexPoolSnapshot) -> tuple[float, float]:
+        change_pct = snapshot.price_change_24h_pct
+        if change_pct is None:
+            return 0.5, 0.0
+
+        momentum = 0.5
+        volatility_penalty = 0.0
+
+        if change_pct >= 0:
+            momentum += min(change_pct / 40.0, 0.5)
+        else:
+            momentum += max(change_pct / 30.0, -0.5)
+
+        if abs(change_pct) > self.high_volatility_threshold_pct:
+            volatility_penalty = min((abs(change_pct) - self.high_volatility_threshold_pct) / 50.0, 0.3)
+
+        return max(0.0, min(momentum, 1.0)), volatility_penalty
+
+
+def build_scanner_for_tokens(tokens: Sequence[str]) -> DexScannerAlgo:
+    """Convenience factory for constructing a TON DEX scanner."""
+
+    return DexScannerAlgo(tracked_tokens=tokens)
+

--- a/algorithms/python/tests/test_dex_scanner.py
+++ b/algorithms/python/tests/test_dex_scanner.py
@@ -1,0 +1,133 @@
+"""Tests for the DexScannerAlgo TON DEX scoring engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from algorithms.python.dex_scanner import (
+    DexPoolSnapshot,
+    DexScannerAlgo,
+    build_scanner_for_tokens,
+)
+
+
+def test_prime_pool_scores_high() -> None:
+    algo = DexScannerAlgo()
+    snapshot = DexPoolSnapshot(
+        dex="DeDust",
+        pool_address="0:pool",
+        base_token="DCT",
+        quote_token="TON",
+        price_usd=1.05,
+        liquidity_usd=250_000.0,
+        volume_24h_usd=125_000.0,
+        price_change_24h_pct=12.0,
+        transactions_24h=420,
+        fees_24h_usd=1_400.0,
+        is_verified=True,
+    )
+
+    signal = algo.score_pool(snapshot)
+
+    assert signal.tier == "prime"
+    assert signal.score > 0.8
+    assert "Verified pool" in signal.notes[0]
+
+
+def test_low_liquidity_and_volume_flagged() -> None:
+    algo = DexScannerAlgo(min_liquidity_usd=10_000.0, min_volume_24h_usd=5_000.0, min_transactions_24h=10)
+    snapshot = DexPoolSnapshot(
+        dex="STON.fi",
+        pool_address="0:thin",
+        base_token="TON",
+        quote_token="USDT",
+        price_usd=7.5,
+        liquidity_usd=6_000.0,
+        volume_24h_usd=2_500.0,
+        price_change_24h_pct=1.0,
+        transactions_24h=4,
+    )
+
+    signal = algo.score_pool(snapshot)
+
+    assert signal.tier == "caution"
+    assert any("liquidity" in note.lower() for note in signal.notes)
+    assert any("volume" in note.lower() for note in signal.notes)
+    assert any("swaps" in note.lower() for note in signal.notes)
+
+
+def test_high_volatility_penalty_applied() -> None:
+    algo = DexScannerAlgo(high_volatility_threshold_pct=10.0)
+    snapshot = DexPoolSnapshot(
+        dex="DeDust",
+        pool_address="0:volatile",
+        base_token="DCT",
+        quote_token="USDT",
+        price_usd=0.95,
+        liquidity_usd=80_000.0,
+        volume_24h_usd=45_000.0,
+        price_change_24h_pct=28.0,
+        transactions_24h=200,
+    )
+
+    signal = algo.score_pool(snapshot)
+
+    assert signal.volatility_penalty > 0.0
+    assert any("volatility" in note.lower() for note in signal.notes)
+
+
+def test_untracked_pool_raises_error() -> None:
+    algo = DexScannerAlgo(tracked_tokens=("DCT",))
+    snapshot = DexPoolSnapshot(
+        dex="DeDust",
+        pool_address="0:ignored",
+        base_token="USDT",
+        quote_token="TONCOIN",
+        price_usd=2.1,
+        liquidity_usd=15_000.0,
+        volume_24h_usd=6_000.0,
+        price_change_24h_pct=3.0,
+        transactions_24h=30,
+    )
+
+    with pytest.raises(ValueError):
+        algo.score_pool(snapshot)
+
+
+def test_rank_pools_orders_by_score() -> None:
+    algo = build_scanner_for_tokens(["DCT", "TON"])
+    high = DexPoolSnapshot(
+        dex="DeDust",
+        pool_address="0:high",
+        base_token="DCT",
+        quote_token="TON",
+        liquidity_usd=200_000.0,
+        volume_24h_usd=120_000.0,
+        price_change_24h_pct=9.0,
+        transactions_24h=300,
+    )
+    mid = DexPoolSnapshot(
+        dex="STON.fi",
+        pool_address="0:mid",
+        base_token="TON",
+        quote_token="USDT",
+        liquidity_usd=60_000.0,
+        volume_24h_usd=18_000.0,
+        price_change_24h_pct=4.0,
+        transactions_24h=120,
+    )
+    low = DexPoolSnapshot(
+        dex="STON.fi",
+        pool_address="0:low",
+        base_token="DCT",
+        quote_token="USDT",
+        liquidity_usd=12_000.0,
+        volume_24h_usd=7_000.0,
+        price_change_24h_pct=-6.0,
+        transactions_24h=40,
+    )
+
+    ranked = algo.rank_pools([mid, low, high])
+
+    assert [signal.pool.pool_address for signal in ranked] == ["0:high", "0:mid", "0:low"]
+

--- a/docs/dynamic-capital-ton-whitepaper.md
+++ b/docs/dynamic-capital-ton-whitepaper.md
@@ -114,6 +114,32 @@ when volatility triggers are breached, subject to post-event ratification.
 - Conduct a formal governance review of price structure levers every 30 days,
   with quarterly deep dives that audit performance against guardrail metrics.
 
+### TON DEX Transparency Stack
+
+Dynamic Capital complements internal dashboards with public TON-native scanners
+so that community members can independently verify market health:
+
+1. **DeDust.io Scanner** – The flagship TON DEX interface for reviewing DCT
+   liquidity pools, recent swaps, and aggregated trading volume once the jetton
+   is listed.
+2. **STON.fi Analytics** – Provides TVL, pool depth, and price history for the
+   STON.fi pairs that concentrate treasury-backed liquidity (e.g., DCT/TON and
+   DCT/USDT).
+3. **TONviewer** – A network-wide explorer that surfaces jetton balances and
+   transfer history, helping contributors audit vesting contracts and treasury
+   wallets.
+4. **DexScreener** – Aggregates live market data across TON DEX venues,
+   including DeDust and STON.fi, and auto-generates a public chart once the
+   liquidity pool address is active.
+
+**Operational Workflow.** After deploying the DCT jetton, treasury managers seed
+liquidity on DeDust and STON.fi pairs. DexScreener ingests those pools and
+publishes a shareable analytics page (e.g.,
+`https://dexscreener.com/ton/dct-ton`) that investors can monitor for price
+discovery, market cap, depth, and order flow. These open tools reinforce Dynamic
+Capital’s transparency mandate by making every trade, unlock, and liquidity
+adjustment observable without requiring proprietary access.
+
 ## Token Supply & Emissions
 
 ### Distribution Overview


### PR DESCRIPTION
## Summary
- replace the news-focused module with a DexScannerAlgo that scores TON DEX pool liquidity, volume, momentum, and activity inputs
- expose the new scanner types and factory from the algorithms package for downstream consumers
- cover the pool scoring workflow, volatility penalties, and ranking logic with focused unit tests

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_dex_scanner.py

------
https://chatgpt.com/codex/tasks/task_e_68d67f7b067c8322a1629f1d4cbc933a