### PR TITLE
Configure Tonkeeper testnet support

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/README.md
+++ b/dynamic-capital-ton/apps/miniapp/README.md
@@ -10,6 +10,9 @@ Create a `.env.local` file with the following values:
 
 ```bash
 NEXT_PUBLIC_APP_URL=https://dynamic-capital-qazf2.ondigitalocean.app
+NEXT_PUBLIC_TON_NETWORK=mainnet
+NEXT_PUBLIC_TONKEEPER_UNIVERSAL_LINK=https://app.tonkeeper.com/ton-connect
+NEXT_PUBLIC_TONKEEPER_BRIDGE_URL=https://bridge.tonapi.io/bridge
 NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_FN_URL=https://<project>.functions.supabase.co
@@ -17,8 +20,11 @@ SUPABASE_FN_URL=https://<project>.functions.supabase.co
 SUPABASE_ANON_KEY=<anon-key>
 ```
 
-The `NEXT_PUBLIC_SUPABASE_*` values enable live subscription plan updates inside
-the Mini App by connecting directly to Supabase Realtime.
+Set `NEXT_PUBLIC_TON_NETWORK=testnet` to point Tonkeeper connections at the
+testnet infrastructure. Override `NEXT_PUBLIC_TONKEEPER_*` if you need custom
+Tonkeeper endpoints (they default to mainnet values). The
+`NEXT_PUBLIC_SUPABASE_*` values enable live subscription plan updates inside the
+Mini App by connecting directly to Supabase Realtime.
 
 ## Key scripts
 

--- a/dynamic-capital-ton/apps/miniapp/app/page.tsx
+++ b/dynamic-capital-ton/apps/miniapp/app/page.tsx
@@ -20,6 +20,43 @@ import type {
 import { DEFAULT_REFRESH_SECONDS } from "../data/live-intel";
 import { getSupabaseClient } from "../lib/supabase-client";
 
+type TonNetwork = "mainnet" | "testnet";
+
+const TONCONNECT_NETWORK: TonNetwork =
+  process.env.NEXT_PUBLIC_TON_NETWORK === "testnet" ? "testnet" : "mainnet";
+
+const TONKEEPER_LINKS: Record<
+  TonNetwork,
+  { universalLink: string; bridgeUrl: string }
+> = {
+  mainnet: {
+    universalLink: "https://app.tonkeeper.com/ton-connect",
+    bridgeUrl: "https://bridge.tonapi.io/bridge",
+  },
+  testnet: {
+    universalLink: "https://testnet.tonkeeper.com/ton-connect",
+    bridgeUrl: "https://testnet.tonapi.io/bridge",
+  },
+};
+
+const tonkeeperDefaults = TONKEEPER_LINKS[TONCONNECT_NETWORK];
+
+const tonkeeperWallet: NonNullable<
+  WalletsListConfiguration["includeWallets"]
+>[number] = {
+  appName: "tonkeeper",
+  name: "Tonkeeper",
+  imageUrl: "https://tonkeeper.com/assets/tonconnect-icon.png",
+  aboutUrl: "https://tonkeeper.com",
+  universalLink:
+    process.env.NEXT_PUBLIC_TONKEEPER_UNIVERSAL_LINK ??
+    tonkeeperDefaults.universalLink,
+  bridgeUrl:
+    process.env.NEXT_PUBLIC_TONKEEPER_BRIDGE_URL ??
+    tonkeeperDefaults.bridgeUrl,
+  platforms: ["ios", "android", "chrome", "firefox"],
+};
+
 const PLAN_IDS = [
   "vip_bronze",
   "vip_silver",
@@ -104,15 +141,7 @@ type LiveIntelState = {
 const RECOMMENDED_WALLETS: NonNullable<
   WalletsListConfiguration["includeWallets"]
 > = [
-  {
-    appName: "tonkeeper",
-    name: "Tonkeeper",
-    imageUrl: "https://tonkeeper.com/assets/tonconnect-icon.png",
-    aboutUrl: "https://tonkeeper.com",
-    universalLink: "https://app.tonkeeper.com/ton-connect",
-    bridgeUrl: "https://bridge.tonapi.io/bridge",
-    platforms: ["ios", "android", "chrome", "firefox"],
-  },
+  tonkeeperWallet,
   {
     appName: "tonhub",
     name: "Tonhub",


### PR DESCRIPTION
## Summary
- derive Tonkeeper wallet configuration from environment variables so the mini app can target testnet endpoints
- document the Tonkeeper network toggle and overrides in the mini app README

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d683dd17c48322a0324aba1063ecfa