### PR TITLE
Adjust DCT allocation minimum scaling

### DIFF
--- a/algorithms/python/dct_token_sync.py
+++ b/algorithms/python/dct_token_sync.py
@@ -255,14 +255,40 @@ class DCTAllocationEngine:
 
     def distribute(self, total_dct: float) -> List[DCTAllocationResult]:
         total_dct = max(0.0, total_dct)
-        weight_total = sum(rule.weight for rule in self.rules if rule.weight > 0)
-        results: MutableSequence[DCTAllocationResult] = []
-        if weight_total <= 0:
-            return list(results)
+        if not self.rules:
+            return []
 
-        for rule in self.rules:
-            weight_share = rule.weight / weight_total
-            base_allocation = max(rule.min_allocation, total_dct * weight_share)
+        min_allocations = [max(0.0, rule.min_allocation) for rule in self.rules]
+        total_minimum = sum(min_allocations)
+        results: MutableSequence[DCTAllocationResult] = []
+
+        if total_dct == 0.0:
+            base_allocations = [0.0 for _ in self.rules]
+        elif total_minimum > 0.0 and total_minimum >= total_dct:
+            scale = total_dct / total_minimum
+            base_allocations = [min_alloc * scale for min_alloc in min_allocations]
+        else:
+            remaining = max(0.0, total_dct - total_minimum)
+            weight_total = sum(rule.weight for rule in self.rules if rule.weight > 0)
+            if weight_total > 0:
+                base_allocations = []
+                for rule, min_alloc in zip(self.rules, min_allocations):
+                    share = rule.weight / weight_total if rule.weight > 0 else 0.0
+                    base_allocations.append(min_alloc + remaining * share)
+            elif total_minimum > 0.0:
+                scale = total_dct / total_minimum
+                base_allocations = [min_alloc * scale for min_alloc in min_allocations]
+            else:
+                equal_share = total_dct / len(self.rules)
+                base_allocations = [equal_share for _ in self.rules]
+
+        if base_allocations:
+            discrepancy = total_dct - sum(base_allocations)
+            if abs(discrepancy) > 1e-9:
+                base_allocations[-1] += discrepancy
+
+        for rule, base_allocation in zip(self.rules, base_allocations):
+            base_allocation = max(0.0, base_allocation)
             adjusted_allocation = base_allocation * max(rule.multiplier, 0.0)
             per_member = None
             if rule.member_count and rule.member_count > 0:

--- a/algorithms/python/tests/test_dct_token_sync.py
+++ b/algorithms/python/tests/test_dct_token_sync.py
@@ -125,6 +125,24 @@ def test_allocation_engine_respects_weights_and_multipliers() -> None:
     assert pytest.approx(vip.per_member or 0.0, rel=1e-4) == 720
 
 
+def test_allocation_engine_scales_when_minimums_exceed_budget() -> None:
+    engine = DCTAllocationEngine(
+        rules=[
+            DCTAllocationRule("VIP", weight=3, multiplier=1.0, min_allocation=80_000),
+            DCTAllocationRule("Labs", weight=2, multiplier=1.0, min_allocation=40_000),
+        ]
+    )
+    allocations = engine.distribute(100_000)
+    assert len(allocations) == 2
+    total_base = sum(entry.base_allocation for entry in allocations)
+    assert total_base == pytest.approx(100_000, rel=1e-6)
+    vip_allocation, labs_allocation = allocations
+    expected_vip = 100_000 * (80_000 / 120_000)
+    expected_labs = 100_000 * (40_000 / 120_000)
+    assert vip_allocation.base_allocation == pytest.approx(expected_vip, rel=1e-6)
+    assert labs_allocation.base_allocation == pytest.approx(expected_labs, rel=1e-6)
+
+
 def test_sync_job_compiles_payload_and_writes_to_supabase() -> None:
     calculator = DCTPriceCalculator()
     planner = DCTProductionPlanner()


### PR DESCRIPTION
## Summary
- update the DCT allocation engine to normalise base grants when minimum guarantees exceed the minted supply
- ensure allocation fallbacks cover zero-weight and zero-budget scenarios while keeping totals consistent
- add regression coverage for the scaled minimum allocation behaviour

## Testing
- PYTHONPATH=. pytest algorithms/python/tests/test_dct_token_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d68d2e6fa0832286784f939c875fba