### PR TITLE
Sync landing hero metrics with live provider data

### DIFF
--- a/apps/web/hooks/useMultiLlmProviders.ts
+++ b/apps/web/hooks/useMultiLlmProviders.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import type { ProviderSummary } from "@/services/llm/types";
+
+interface ProvidersResponse {
+  providers?: ProviderSummary[] | null;
+}
+
+const QUERY_KEY = ["multi-llm-providers"] as const;
+
+function normalizeProviders(
+  providers: ProvidersResponse["providers"],
+): ProviderSummary[] {
+  if (!Array.isArray(providers)) {
+    return [];
+  }
+
+  return providers.filter((provider): provider is ProviderSummary =>
+    provider !== null && typeof provider === "object" &&
+    typeof provider.id === "string" && provider.id.trim().length > 0
+  );
+}
+
+async function fetchProviders(): Promise<ProviderSummary[]> {
+  const response = await fetch("/api/tools/multi-llm/providers", {
+    method: "GET",
+    headers: { "accept": "application/json" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load provider metadata (${response.status}).`);
+  }
+
+  const payload = (await response.json()) as ProvidersResponse;
+  return normalizeProviders(payload.providers);
+}
+
+export function useMultiLlmProviders() {
+  return useQuery<ProviderSummary[], Error>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchProviders,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
## Summary
- replace the landing hero metrics with values from the live landing metrics edge function and display fallback status messaging
- swap the provider grid to use the multi-LLM providers API, exposing model details and configuration status instead of static copy
- add a `useMultiLlmProviders` hook to share the provider fetch logic across landing and studio experiences

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d68dbf8db08322af84282600d93cf0