### PR TITLE
feat: add loop orchestration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ import { FiActivity, FiHome, FiUser } from "react-icons/fi";
 - **Multi-LLM Studio tool** (`apps/web/app/tools/multi-llm`) for comparing
   OpenAI, Anthropic, and Groq chat completions side by side with configurable
   temperature and token limits directly inside the main Next.js app.
+- Step through the [Dynamic Multi-LLM & Trading Algo Enhancement Roadmap](docs/multi-llm-algo-enhancement-roadmap.md)
+  to align provider orchestration with the trading automation stack.
 
 ## Dynamic Theme System
 

--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -136,6 +136,20 @@ from .time_keeper import (
     TimeKeeperSyncResult,
     TradingSession,
 )
+from .loop_algorithms import (
+    LoopExecutionSummary,
+    LoopRun,
+    StopCondition,
+    run_plan_loop,
+)
+from .trading_algo_enhancement import (
+    EnhancementProgress,
+    EnhancementRoadmap,
+    EnhancementTask,
+    build_default_roadmap,
+    build_trading_algo_enhancement_plan,
+    loop_trading_algo_enhancement_plan,
+)
 
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
 
@@ -239,6 +253,16 @@ __all__ = _trade_exports + [
     "TimeKeeperAlgorithm",
     "TimeKeeperSyncResult",
     "TradingSession",
+    "EnhancementTask",
+    "EnhancementRoadmap",
+    "EnhancementProgress",
+    "build_default_roadmap",
+    "build_trading_algo_enhancement_plan",
+    "loop_trading_algo_enhancement_plan",
+    "LoopExecutionSummary",
+    "LoopRun",
+    "StopCondition",
+    "run_plan_loop",
     "VipAutoSyncJob",
     "VipAutoSyncReport",
     "VipMembershipProvider",
@@ -342,6 +366,16 @@ globals().update(
         "ElementSignal": ElementSignal,
         "PsychologyTelemetry": PsychologyTelemetry,
         "score_elements": score_elements,
+        "EnhancementProgress": EnhancementProgress,
+        "EnhancementRoadmap": EnhancementRoadmap,
+        "EnhancementTask": EnhancementTask,
+        "build_default_roadmap": build_default_roadmap,
+        "build_trading_algo_enhancement_plan": build_trading_algo_enhancement_plan,
+        "loop_trading_algo_enhancement_plan": loop_trading_algo_enhancement_plan,
+        "LoopExecutionSummary": LoopExecutionSummary,
+        "LoopRun": LoopRun,
+        "StopCondition": StopCondition,
+        "run_plan_loop": run_plan_loop,
         "StepExecution": StepExecution,
         "StepHandler": StepHandler,
         "StepResult": StepResult,

--- a/algorithms/python/loop_algorithms.py
+++ b/algorithms/python/loop_algorithms.py
@@ -1,0 +1,105 @@
+"""Utilities for executing orchestration plans in feedback loops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Protocol, Sequence, Tuple
+
+from .core_orchestration import (
+    OrchestrationContext,
+    OrchestrationExecution,
+    OrchestrationObserver,
+    OrchestrationPlan,
+    StepStatus,
+    execute_plan,
+)
+
+
+class StopCondition(Protocol):
+    """Callable signature used for loop termination."""
+
+    def __call__(self, iteration: int, execution: OrchestrationExecution) -> bool:
+        """Return ``True`` to halt the loop after the provided iteration."""
+
+
+@dataclass(slots=True)
+class LoopRun:
+    """Represents a single iteration of a looping orchestration plan."""
+
+    iteration: int
+    execution: OrchestrationExecution
+
+
+@dataclass(slots=True)
+class LoopExecutionSummary:
+    """Aggregate details for executing an orchestration plan in a loop."""
+
+    plan: OrchestrationPlan
+    runs: Tuple[LoopRun, ...]
+    context: OrchestrationContext
+    status: StepStatus
+
+    def iterations(self) -> int:
+        """Return the number of completed iterations."""
+
+        return len(self.runs)
+
+    def failures(self) -> Tuple[LoopRun, ...]:
+        """Return iterations that ended in failure."""
+
+        return tuple(run for run in self.runs if run.execution.status == "failed")
+
+
+def run_plan_loop(
+    plan: OrchestrationPlan,
+    *,
+    iterations: int,
+    context: Optional[OrchestrationContext] = None,
+    strict: bool = True,
+    observers: Optional[Iterable[OrchestrationObserver]] = None,
+    break_on_failure: bool = True,
+    stop_condition: Optional[StopCondition] = None,
+) -> LoopExecutionSummary:
+    """Execute an orchestration plan repeatedly until completion or stop."""
+
+    if iterations <= 0:
+        raise ValueError("iterations must be a positive integer")
+
+    ctx = context or OrchestrationContext()
+    observer_list: Sequence[OrchestrationObserver] = tuple(observers or ())
+    runs: list[LoopRun] = []
+    status: StepStatus = "completed"
+
+    for index in range(1, iterations + 1):
+        execution = execute_plan(
+            plan,
+            context=ctx,
+            strict=strict,
+            observers=observer_list,
+        )
+        run = LoopRun(iteration=index, execution=execution)
+        runs.append(run)
+
+        if execution.status == "failed":
+            status = "failed"
+            if break_on_failure:
+                break
+        else:
+            status = execution.status
+
+        if stop_condition and stop_condition(index, execution):
+            break
+
+    if runs and status != "failed":
+        status = runs[-1].execution.status
+
+    return LoopExecutionSummary(
+        plan=plan,
+        runs=tuple(runs),
+        context=ctx,
+        status=status,
+    )
+
+
+__all__ = ["LoopExecutionSummary", "LoopRun", "StopCondition", "run_plan_loop"]
+

--- a/algorithms/python/tests/test_loop_algorithms.py
+++ b/algorithms/python/tests/test_loop_algorithms.py
@@ -1,0 +1,108 @@
+"""Tests for orchestration plan looping utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from algorithms.python.core_orchestration import (
+    OrchestrationBuilder,
+    OrchestrationContext,
+    OrchestrationPlan,
+    StepResult,
+)
+from algorithms.python.loop_algorithms import (
+    LoopExecutionSummary,
+    LoopRun,
+    run_plan_loop,
+)
+
+
+def _build_counter_plan() -> OrchestrationPlan:
+    builder = OrchestrationBuilder("counter_plan")
+
+    def _increment(context: OrchestrationContext) -> StepResult:
+        current = int(context.state.get("count", 0))
+        return StepResult.success(outputs={"count": current + 1})
+
+    builder.add_step(
+        name="increment",
+        summary="increase counter",
+        handler=_increment,
+    )
+    return builder.build()
+
+
+def _build_unstable_plan(*, fail_on: Iterable[int]) -> OrchestrationPlan:
+    failure_iterations = set(fail_on)
+    builder = OrchestrationBuilder("unstable_plan")
+
+    def _maybe_fail(context: OrchestrationContext) -> StepResult:
+        iteration = int(context.metadata.get("loop_iteration", 0)) + 1
+        context.metadata["loop_iteration"] = iteration
+        if iteration in failure_iterations:
+            return StepResult.failure(notes=("forced failure",))
+        return StepResult.success()
+
+    builder.add_step(
+        name="unstable_step",
+        summary="conditionally fails",
+        handler=_maybe_fail,
+    )
+    return builder.build()
+
+
+def test_run_plan_loop_increments_state_and_applies_stop_condition() -> None:
+    plan = _build_counter_plan()
+    context = OrchestrationContext(metadata={})
+
+    summary = run_plan_loop(
+        plan,
+        iterations=5,
+        context=context,
+        stop_condition=lambda iteration, execution: execution.context.get("count", 0) >= 2,
+    )
+
+    assert isinstance(summary, LoopExecutionSummary)
+    assert summary.iterations() == 2
+    assert summary.status == "completed"
+    assert context.get("count") == 2
+    assert all(isinstance(run, LoopRun) for run in summary.runs)
+
+
+def test_run_plan_loop_breaks_on_failure_when_requested() -> None:
+    plan = _build_unstable_plan(fail_on=(1,))
+    context = OrchestrationContext(metadata={})
+    summary = run_plan_loop(plan, iterations=3, context=context, break_on_failure=True)
+
+    assert summary.status == "failed"
+    assert summary.iterations() == 1
+    assert summary.failures()
+
+
+def test_run_plan_loop_allows_continuation_after_failure() -> None:
+    plan = _build_unstable_plan(fail_on=(1,))
+    context = OrchestrationContext(metadata={})
+
+    summary = run_plan_loop(
+        plan,
+        iterations=3,
+        context=context,
+        break_on_failure=False,
+    )
+
+    assert summary.iterations() == 3
+    # First iteration fails, remaining ones succeed.
+    statuses = [run.execution.status for run in summary.runs]
+    assert statuses[0] == "failed"
+    assert statuses[1:] == ["completed", "completed"]
+
+
+def test_run_plan_loop_requires_positive_iterations() -> None:
+    plan = _build_counter_plan()
+    try:
+        run_plan_loop(plan, iterations=0)
+    except ValueError as exc:  # pragma: no cover - exercised via assertion
+        assert "iterations" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError when iterations <= 0")
+

--- a/algorithms/python/tests/test_trading_algo_enhancement.py
+++ b/algorithms/python/tests/test_trading_algo_enhancement.py
@@ -1,0 +1,62 @@
+"""Tests for the trading algo enhancement roadmap utilities."""
+
+from __future__ import annotations
+
+from algorithms.python.trading_algo_enhancement import (
+    EnhancementProgress,
+    build_default_roadmap,
+    build_trading_algo_enhancement_plan,
+    loop_trading_algo_enhancement_plan,
+)
+
+
+def test_default_roadmap_category_order() -> None:
+    roadmap = build_default_roadmap()
+    assert roadmap.categories() == (
+        "telemetry",
+        "orchestration",
+        "integration",
+        "experimentation",
+        "governance",
+    )
+
+
+def test_plan_dependency_integrity() -> None:
+    plan = build_trading_algo_enhancement_plan()
+    steps = {step.name: step for step in plan.steps}
+
+    assert steps["telemetry.instrumentation"].depends_on == ("telemetry.asset_inventory",)
+    assert steps["telemetry.outcome_capture"].depends_on == ("telemetry.instrumentation",)
+    assert steps["integration.guardrails"].depends_on == ("integration.shadow_deployments",)
+    assert steps["orchestration.human_override"].depends_on == ("orchestration.ensemble_scoring",)
+
+
+def test_recommendations_respect_dependencies_and_filters() -> None:
+    roadmap = build_default_roadmap()
+    progress = EnhancementProgress()
+
+    progress.mark_done("telemetry.asset_inventory")
+    recommendations = [task.key for task in roadmap.recommend_next_tasks(progress.task_status)]
+    assert recommendations[0] == "telemetry.instrumentation"
+
+    progress.mark_done("telemetry.instrumentation")
+    progress.mark_done("telemetry.outcome_capture")
+    recommendations = [task.key for task in roadmap.recommend_next_tasks(progress.task_status)]
+    assert recommendations[0] == "orchestration.capability_matrix"
+
+    governance_next = roadmap.recommend_next_tasks(progress.task_status, category="governance")
+    assert governance_next and governance_next[0].key == "governance.vendor_assessment"
+
+    limited = roadmap.recommend_next_tasks(progress.task_status, limit=2)
+    assert [task.key for task in limited] == [
+        "orchestration.capability_matrix",
+        "experimentation.replay_harness",
+    ]
+
+
+def test_loop_trading_algo_enhancement_plan_executes_iterations() -> None:
+    summary = loop_trading_algo_enhancement_plan(iterations=1)
+
+    assert summary.iterations() == 1
+    assert summary.plan.name == "trading_algo_enhancement"
+    assert summary.status in {"completed", "failed", "skipped"}

--- a/algorithms/python/trading_algo_enhancement.py
+++ b/algorithms/python/trading_algo_enhancement.py
@@ -1,0 +1,364 @@
+"""Trading algo enhancement roadmap orchestration utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, Literal, Mapping, MutableMapping, Optional, Tuple
+
+from .core_orchestration import (
+    OrchestrationBuilder,
+    OrchestrationContext,
+    OrchestrationObserver,
+    OrchestrationPlan,
+    OrchestrationStep,
+)
+from .loop_algorithms import LoopExecutionSummary, StopCondition, run_plan_loop
+
+Category = Literal[
+    "telemetry",
+    "orchestration",
+    "integration",
+    "experimentation",
+    "governance",
+]
+Status = Literal["not_started", "in_progress", "blocked", "done"]
+
+
+@dataclass(slots=True)
+class EnhancementTask:
+    """Represents a single actionable roadmap item."""
+
+    key: str
+    title: str
+    summary: str
+    category: Category
+    depends_on: Tuple[str, ...] = ()
+    deliverables: Tuple[str, ...] = ()
+    metrics: Tuple[str, ...] = ()
+
+    def to_step(self) -> OrchestrationStep:
+        """Convert the task definition into an orchestration step."""
+
+        return OrchestrationStep(
+            name=self.key,
+            summary=self.summary,
+            depends_on=self.depends_on,
+            provides=self.deliverables,
+            tags=(self.category, *self.metrics),
+        )
+
+
+@dataclass(slots=True)
+class EnhancementRoadmap:
+    """Collection of roadmap tasks with dependency awareness."""
+
+    tasks: Tuple[EnhancementTask, ...]
+    _index: Dict[str, EnhancementTask] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._index = {task.key: task for task in self.tasks}
+        counts: Dict[str, int] = {}
+        for task in self.tasks:
+            counts[task.key] = counts.get(task.key, 0) + 1
+        duplicates = sorted(key for key, count in counts.items() if count > 1)
+        if duplicates:
+            raise ValueError(f"duplicate task keys detected: {', '.join(duplicates)}")
+
+    def as_plan(self, *, name: str = "trading_algo_enhancement", summary: Optional[str] = None) -> OrchestrationPlan:
+        """Render the roadmap as an orchestration plan."""
+
+        builder = OrchestrationBuilder(name, summary=summary)
+        for task in self.tasks:
+            builder.add_step(
+                name=task.key,
+                summary=task.summary,
+                depends_on=task.depends_on,
+                provides=task.deliverables,
+                tags=(task.category, *task.metrics),
+            )
+        return builder.build()
+
+    def iter_by_category(self, category: Category) -> Iterator[EnhancementTask]:
+        """Yield tasks for the requested category in declaration order."""
+
+        for task in self.tasks:
+            if task.category == category:
+                yield task
+
+    def categories(self) -> Tuple[Category, ...]:
+        """Return an ordered tuple of categories used in the roadmap."""
+
+        seen: list[Category] = []
+        for task in self.tasks:
+            if task.category not in seen:
+                seen.append(task.category)
+        return tuple(seen)
+
+    def recommend_next_tasks(
+        self,
+        progress: Mapping[str, Status] | None = None,
+        *,
+        limit: Optional[int] = None,
+        category: Optional[Category] = None,
+    ) -> list[EnhancementTask]:
+        """Return tasks whose dependencies are complete and not yet finished."""
+
+        status = dict(progress or {})
+        recommendations: list[EnhancementTask] = []
+
+        for task in self.tasks:
+            if category is not None and task.category != category:
+                continue
+            state = status.get(task.key, "not_started")
+            if state in {"done", "blocked"}:
+                continue
+            if any(status.get(dep, "not_started") != "done" for dep in task.depends_on):
+                continue
+            recommendations.append(task)
+            if limit is not None and len(recommendations) >= limit:
+                break
+        return recommendations
+
+
+@dataclass(slots=True)
+class EnhancementProgress:
+    """Mutable tracking structure for roadmap execution."""
+
+    task_status: MutableMapping[str, Status] = field(default_factory=dict)
+
+    def status_for(self, task_key: str) -> Status:
+        """Return the stored status for the task or ``"not_started"``."""
+
+        return self.task_status.get(task_key, "not_started")
+
+    def update(self, task_key: str, status: Status) -> None:
+        """Set the status for a task."""
+
+        self.task_status[task_key] = status
+
+    def mark_done(self, task_key: str) -> None:
+        """Convenience helper for marking a task as completed."""
+
+        self.update(task_key, "done")
+
+
+def build_default_roadmap() -> EnhancementRoadmap:
+    """Create the default enhancement roadmap aligned to the documentation."""
+
+    tasks: Tuple[EnhancementTask, ...] = (
+        # Telemetry foundation
+        EnhancementTask(
+            key="telemetry.asset_inventory",
+            title="Catalogue trading and LLM assets",
+            summary="Map all multi-LLM studio, algorithm, and worker assets that consume or emit model output.",
+            category="telemetry",
+            deliverables=("asset_catalogue",),
+            metrics=("coverage_ratio",),
+        ),
+        EnhancementTask(
+            key="telemetry.instrumentation",
+            title="Instrument provider usage",
+            summary="Add latency, token, error, and cost metrics for every provider in Supabase analytics and trading pipelines.",
+            category="telemetry",
+            depends_on=("telemetry.asset_inventory",),
+            deliverables=("telemetry_dashboards",),
+            metrics=("latency_ms", "error_rate"),
+        ),
+        EnhancementTask(
+            key="telemetry.outcome_capture",
+            title="Capture trade outcomes",
+            summary="Link trade decisions to provider mixes, prompt templates, and algo parameters for post-trade analysis.",
+            category="telemetry",
+            depends_on=("telemetry.instrumentation",),
+            deliverables=("trade_outcome_log",),
+            metrics=("attribution_coverage",),
+        ),
+        # Orchestration
+        EnhancementTask(
+            key="orchestration.capability_matrix",
+            title="Build provider capability matrix",
+            summary="Score providers on latency, cost, reasoning depth, and domain accuracy to inform routing decisions.",
+            category="orchestration",
+            depends_on=("telemetry.outcome_capture",),
+            deliverables=("provider_matrix",),
+            metrics=("latency_ms", "accuracy_score"),
+        ),
+        EnhancementTask(
+            key="orchestration.prompt_library",
+            title="Curate provider-aware prompt templates",
+            summary="Maintain versioned prompts tuned to provider strengths and compliant with glossary checkpoints.",
+            category="orchestration",
+            depends_on=("orchestration.capability_matrix",),
+            deliverables=("prompt_library",),
+            metrics=("template_pass_rate",),
+        ),
+        EnhancementTask(
+            key="orchestration.routing_policy",
+            title="Design routing and fallback policy",
+            summary="Implement rules engine to route research, execution, and fallback traffic across providers.",
+            category="orchestration",
+            depends_on=("orchestration.capability_matrix",),
+            deliverables=("routing_policy",),
+            metrics=("policy_coverage",),
+        ),
+        EnhancementTask(
+            key="orchestration.ensemble_scoring",
+            title="Introduce ensemble scoring",
+            summary="Develop reranking heuristics that evaluate multi-provider outputs before trading consumption.",
+            category="orchestration",
+            depends_on=("orchestration.routing_policy",),
+            deliverables=("ensemble_scoring",),
+            metrics=("confidence_score", "agreement_rate"),
+        ),
+        EnhancementTask(
+            key="orchestration.human_override",
+            title="Enable human-in-the-loop overrides",
+            summary="Expose low-confidence outputs for analyst review in the studio and feed overrides back into weights.",
+            category="orchestration",
+            depends_on=("orchestration.ensemble_scoring",),
+            deliverables=("override_workflow",),
+            metrics=("override_latency",),
+        ),
+        # Integration
+        EnhancementTask(
+            key="integration.glossary_alignment",
+            title="Align glossary checkpoints",
+            summary="Ensure prompts emit terminology compatible with MarketSnapshot and analyzer expectations.",
+            category="integration",
+            depends_on=("orchestration.prompt_library",),
+            deliverables=("glossary_checks",),
+            metrics=("glossary_compliance",),
+        ),
+        EnhancementTask(
+            key="integration.shadow_deployments",
+            title="Run shadow deployments",
+            summary="Evaluate multi-LLM assisted strategies alongside existing automation before full cutover.",
+            category="integration",
+            depends_on=(
+                "integration.glossary_alignment",
+                "orchestration.ensemble_scoring",
+            ),
+            deliverables=("shadow_reports",),
+            metrics=("performance_delta",),
+        ),
+        EnhancementTask(
+            key="integration.guardrails",
+            title="Automate guardrails for live orders",
+            summary="Gate execution on ensemble consensus thresholds before Supabase workers or EAs submit orders.",
+            category="integration",
+            depends_on=("integration.shadow_deployments",),
+            deliverables=("guardrail_rules",),
+            metrics=("false_positive_rate",),
+        ),
+        # Experimentation
+        EnhancementTask(
+            key="experimentation.replay_harness",
+            title="Build historical replay harness",
+            summary="Replay market sessions through the multi-LLM stack to benchmark signal precision and recall.",
+            category="experimentation",
+            depends_on=("telemetry.outcome_capture",),
+            deliverables=("replay_suite",),
+            metrics=("precision", "recall"),
+        ),
+        EnhancementTask(
+            key="experimentation.ab_pipeline",
+            title="Launch A/B pipeline",
+            summary="Randomise signal batches between baseline and enhanced stacks and measure performance deltas.",
+            category="experimentation",
+            depends_on=(
+                "experimentation.replay_harness",
+                "integration.guardrails",
+            ),
+            deliverables=("ab_reports",),
+            metrics=("win_rate", "drawdown"),
+        ),
+        EnhancementTask(
+            key="experimentation.closed_loop",
+            title="Activate closed-loop learning",
+            summary="Feed tagged outcomes into prompt and weight tuning jobs to reinforce profitable behaviours.",
+            category="experimentation",
+            depends_on=("experimentation.ab_pipeline",),
+            deliverables=("tuning_jobs",),
+            metrics=("profit_factor",),
+        ),
+        # Governance
+        EnhancementTask(
+            key="governance.vendor_assessment",
+            title="Complete vendor and regulatory assessment",
+            summary="Document provider data policies and align controls with global and Maldivian regulatory requirements.",
+            category="governance",
+            depends_on=("telemetry.asset_inventory",),
+            deliverables=("vendor_risk_register",),
+            metrics=("risk_score",),
+        ),
+        EnhancementTask(
+            key="governance.secrets_management",
+            title="Enforce secrets governance",
+            summary="Centralise provider API keys with environment-specific rotation and access reviews.",
+            category="governance",
+            depends_on=("governance.vendor_assessment",),
+            deliverables=("secrets_runbook",),
+            metrics=("rotation_cadence",),
+        ),
+        EnhancementTask(
+            key="governance.incident_response",
+            title="Harden incident response playbooks",
+            summary="Update trading runbooks with escalation, rollback, and provider outage handling procedures.",
+            category="governance",
+            depends_on=(
+                "integration.guardrails",
+                "governance.secrets_management",
+            ),
+            deliverables=("incident_runbook",),
+            metrics=("mttr",),
+        ),
+    )
+
+    return EnhancementRoadmap(tasks)
+
+
+def build_trading_algo_enhancement_plan() -> OrchestrationPlan:
+    """Create the orchestration plan for the default enhancement roadmap."""
+
+    roadmap = build_default_roadmap()
+    summary = (
+        "Telemetry, orchestration, integration, experimentation, and governance "
+        "steps for evolving the multi-LLM ensemble and trading stack."
+    )
+    return roadmap.as_plan(summary=summary)
+
+
+def loop_trading_algo_enhancement_plan(
+    iterations: int,
+    *,
+    context: Optional[OrchestrationContext] = None,
+    strict: bool = True,
+    observers: Optional[Iterable[OrchestrationObserver]] = None,
+    break_on_failure: bool = True,
+    stop_condition: Optional[StopCondition] = None,
+) -> LoopExecutionSummary:
+    """Execute the trading algo enhancement plan repeatedly as a loop."""
+
+    plan = build_trading_algo_enhancement_plan()
+    return run_plan_loop(
+        plan,
+        iterations=iterations,
+        context=context,
+        strict=strict,
+        observers=observers,
+        break_on_failure=break_on_failure,
+        stop_condition=stop_condition,
+    )
+
+
+__all__ = [
+    "Category",
+    "Status",
+    "EnhancementTask",
+    "EnhancementRoadmap",
+    "EnhancementProgress",
+    "build_default_roadmap",
+    "build_trading_algo_enhancement_plan",
+    "loop_trading_algo_enhancement_plan",
+]
+

--- a/docs/multi-llm-algo-enhancement-roadmap.md
+++ b/docs/multi-llm-algo-enhancement-roadmap.md
@@ -1,0 +1,106 @@
+# Dynamic Multi-LLM & Trading Algo Enhancement Roadmap
+
+This roadmap breaks the multi-LLM studio, trading automation stack, and
+analytics surfaces into staged workstreams. Follow each step in order—the
+actions progressively reduce risk while layering in new capabilities.
+
+## 1. Baseline Inventory & Telemetry
+
+1. **Catalogue assets** – Map `apps/web/app/tools/multi-llm`,
+   `algorithms/python`, `algorithms/pine-script`, Supabase functions, and queue
+   workers that already consume model output. Flag undocumented consumers.
+2. **Instrument usage** – Add request/response logging with latency, token,
+   and error metrics per provider into Supabase analytics tables. Mirror the
+   logging inside the trading algo pipelines (`RealtimeExecutor`,
+   `TradeLogic.on_bar`).
+3. **Capture outcomes** – Tie each trade decision to the originating provider
+   mix, prompt template, and algorithm parameters so post-trade analysis can
+   quantify model impact.
+
+## 2. Provider Capability Matrix
+
+1. **Define evaluation axes** – Latency, cost-per-1K tokens, reasoning depth,
+   tool-use support, and domain accuracy (SMC vocabulary, trading risk).
+2. **Benchmark providers** – Use Multi-LLM Studio to run scripted evaluations
+   across providers on shared prompts; export results to a Supabase table.
+3. **Curate prompt templates** – Maintain a versioned prompt library aligned to
+   each provider’s strengths (e.g., structured JSON for deterministic models,
+   narrative rationale for reasoning-heavy models).
+
+## 3. Orchestration Architecture
+
+1. **Design routing policy** – Start with a rules engine: route research
+   queries to reasoning-optimized models, execution guardrails to deterministic
+   ones, and fallback logic for degraded providers.
+2. **Introduce ensemble scoring** – Implement a reranker that compares
+   multi-provider outputs, scores them via heuristics (signal alignment,
+   confidence tags), and selects the best response for downstream trading
+   logic.
+3. **Enable human-in-the-loop overrides** – Surface conflicting or low-confidence
+   outputs to analysts via the studio UI with quick-approve/reject flows that
+   feed back into the scoring weights.
+
+## 4. Trading Algo Integration
+
+1. **Align glossary checkpoints** – Ensure prompt outputs respect SMC
+   terminology so they plug directly into `MarketSnapshot` and analyzer
+   expectations.
+2. **Shadow deployments** – Run multi-LLM assisted strategies in parallel with
+   existing automation, comparing BOS/SMS detection, risk metrics, and fill
+   quality before cutting over.
+3. **Automated guardrails** – Gate live orders on consensus thresholds from the
+   ensemble (e.g., require two providers to agree or have a combined confidence
+   score above a target) before the EA or Supabase worker executes.
+
+## 5. Experimentation & Feedback Loops
+
+1. **Replay harness** – Build notebooks or scripts that replay historical
+   market sessions through the multi-LLM stack to score precision/recall on
+   liquidity sweeps and mitigation blocks.
+2. **A/B pipeline** – Randomly assign signal batches to baseline vs. enhanced
+   pipelines; capture performance diffs (win rate, R-multiples, drawdown).
+3. **Closed-loop learning** – Feed tagged outcomes (profitable, flat, loss)
+   into prompt/weight tuning jobs so future runs prioritize successful patterns.
+
+## 6. Compliance, Risk & Security
+
+1. **Vendor assessment** – Document provider data handling policies; align with
+   SOC/GDPR controls already tracked in the repo and extend to Maldivian
+   regulations as legal counsel dictates.
+2. **Secrets governance** – Centralize API keys in the existing secrets
+   management workflows (`docs/SECRETS.md`), ensuring environment-specific
+   rotations and access reviews.
+3. **Incident response** – Update trading runbooks with escalation steps for
+   provider outages, quality regressions, or hallucinated signals. Include
+   rollback instructions for algorithm parameter changes tied to the ensemble.
+
+## 7. Delivery & Communication
+
+1. **UI evolution** – Extend Multi-LLM Studio with comparison charts, provider
+   status badges, and replay exports so stakeholders understand routing choices.
+2. **Stakeholder updates** – Publish sprint notes summarizing experiments,
+   routing adjustments, and trading performance impact in the team’s shared
+   tracker.
+3. **Training modules** – Add onboarding material that teaches analysts how to
+   interpret ensemble confidence, override flows, and log feedback.
+
+## 8. Milestone Timeline
+
+| Phase | Duration | Key Deliverables |
+|-------|----------|------------------|
+| Foundations | Weeks 1-2 | Telemetry pipelines, provider matrix, prompt library |
+| Orchestration | Weeks 3-4 | Routing engine, ensemble scoring prototype |
+| Integration | Weeks 5-6 | Shadow trading runs, guardrail automation |
+| Scale-Up | Weeks 7-8 | A/B reporting, incident runbooks, studio enhancements |
+| Continuous | Ongoing | Quarterly audits, prompt/weight refresh cadence |
+
+Treat each phase as reviewable iteration; do not advance without metrics and
+risk sign-off from trading, compliance, and platform engineering leads.
+
+## Automation Support
+
+Use the `algorithms/python/trading_algo_enhancement.py` module to materialise
+this roadmap as an executable orchestration plan. The helper exposes default
+tasks, dependency-aware recommendations, and an `OrchestrationPlan` builder so
+engineering, trading, and compliance teams can track telemetry, orchestration,
+integration, experimentation, and governance milestones programmatically.


### PR DESCRIPTION
## Summary
- add a loop_algorithms utility that re-executes orchestration plans with stop conditions and failure tracking
- expose the loop runner through the algorithms package and the trading algo enhancement helper to support iterative roadmaps
- cover the looping behaviour with focused unit tests for both the new utilities and the trading roadmap helper

## Testing
- python -m pytest algorithms/python/tests/test_loop_algorithms.py algorithms/python/tests/test_trading_algo_enhancement.py

------
https://chatgpt.com/codex/tasks/task_e_68d68ff612848322806f799c645e0c7d