### PR TITLE
Optimize DigitalOcean build pipeline

### DIFF
--- a/scripts/digitalocean-build.mjs
+++ b/scripts/digitalocean-build.mjs
@@ -1,24 +1,30 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
-import { createSanitizedNpmEnv } from './utils/npm-env.mjs';
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createSanitizedNpmEnv } from "./utils/npm-env.mjs";
+import { hashDirectory } from "./utils/hash-directory.mjs";
 
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const staticDirectory =
+  (process.env.DIGITALOCEAN_STATIC_DIR || "_static").trim() || "_static";
+const cacheFileName = "digitalocean-static-fingerprint.json";
 
 function run(command, args, options = {}) {
   const { env: providedEnv, ...rest } = options;
   const env = createSanitizedNpmEnv(providedEnv ?? {});
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
-      stdio: 'inherit',
+      stdio: "inherit",
       ...rest,
       env,
     });
 
-    child.on('error', (error) => {
+    child.on("error", (error) => {
       reject(error);
     });
 
-    child.on('close', (code, signal) => {
+    child.on("close", (code, signal) => {
       if (signal) {
         resolve(1);
         return;
@@ -32,42 +38,181 @@ function isMissing(value) {
   if (!value) {
     return true;
   }
-  if (typeof value === 'string' && value.trim() === '') {
+  if (typeof value === "string" && value.trim() === "") {
     return true;
   }
   return false;
 }
 
+function parseBoolean(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(normalized);
+}
+
+function resolveCacheBaseDir() {
+  const candidates = [
+    process.env.DIGITALOCEAN_APP_CACHE_DIR,
+    process.env.APP_PLATFORM_CACHE_DIR,
+    process.env.APP_CACHE_DIR,
+    ".do-build-cache",
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    const trimmed = String(candidate).trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    return path.isAbsolute(trimmed) ? trimmed : path.resolve(trimmed);
+  }
+
+  return path.resolve(".do-build-cache");
+}
+
+const cacheFilePath = path.join(resolveCacheBaseDir(), cacheFileName);
+
+async function loadPreviousFingerprint() {
+  try {
+    const raw = await readFile(cacheFilePath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (
+      !parsed || typeof parsed !== "object" || typeof parsed.hash !== "string"
+    ) {
+      console.warn(
+        `DigitalOcean build: ignoring invalid fingerprint cache at ${cacheFilePath}. Expected an object with a string hash.`,
+      );
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
+    console.warn(
+      `DigitalOcean build: unable to read cached fingerprint at ${cacheFilePath}. Proceeding without cache.`,
+      error,
+    );
+    return null;
+  }
+}
+
+async function persistFingerprint(fingerprint) {
+  const payload = {
+    hash: fingerprint.hash,
+    fileCount: fingerprint.fileCount,
+    totalBytes: fingerprint.totalBytes,
+    savedAt: new Date().toISOString(),
+  };
+
+  await mkdir(path.dirname(cacheFilePath), { recursive: true });
+  await writeFile(cacheFilePath, JSON.stringify(payload, null, 2), "utf8");
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return "0 B";
+  }
+
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+
+  const formatted = value >= 10 || index === 0
+    ? value.toFixed(0)
+    : value.toFixed(1);
+  return `${formatted} ${units[index]}`;
+}
+
 async function main() {
-  console.log('DigitalOcean build: running `npm run build`…');
-  const buildCode = await run(npmCommand, ['run', 'build']);
+  console.log("DigitalOcean build: running `npm run build`…");
+  const buildCode = await run(npmCommand, ["run", "build"]);
   if (buildCode !== 0) {
-    console.error('DigitalOcean build: `npm run build` failed. Aborting.');
+    console.error("DigitalOcean build: `npm run build` failed. Aborting.");
     process.exit(buildCode);
   }
 
-  const requiredKeys = ['CDN_BUCKET', 'CDN_ACCESS_KEY', 'CDN_SECRET_KEY'];
+  const fingerprint = await hashDirectory(staticDirectory);
+  if (!fingerprint) {
+    console.warn(
+      `DigitalOcean build: directory "${staticDirectory}" not found after build. Skipping asset upload.`,
+    );
+    return;
+  }
+
+  const forceUpload = parseBoolean(
+    process.env.DIGITALOCEAN_FORCE_UPLOAD ??
+      process.env.FORCE_DIGITALOCEAN_UPLOAD,
+  );
+  const previousFingerprint = await loadPreviousFingerprint();
+
+  if (!forceUpload) {
+    if (previousFingerprint && previousFingerprint.hash === fingerprint.hash) {
+      console.log(
+        "DigitalOcean build: static assets unchanged since last successful upload. Skipping upload and CDN purge.",
+      );
+      return;
+    }
+
+    if (previousFingerprint) {
+      console.log(
+        "DigitalOcean build: static asset fingerprint changed. Preparing to upload updated assets.",
+      );
+    } else {
+      console.log(
+        "DigitalOcean build: no previous asset fingerprint found. Performing full upload.",
+      );
+    }
+  } else {
+    console.log(
+      "DigitalOcean build: forcing static asset upload due to DIGITALOCEAN_FORCE_UPLOAD flag.",
+    );
+  }
+
+  const requiredKeys = ["CDN_BUCKET", "CDN_ACCESS_KEY", "CDN_SECRET_KEY"];
   const missingKeys = requiredKeys.filter((key) => isMissing(process.env[key]));
 
   if (missingKeys.length > 0) {
     console.warn(
-      `DigitalOcean build: skipping static asset upload because credentials are missing (${missingKeys.join(', ')}).`,
+      `DigitalOcean build: skipping static asset upload because credentials are missing (${
+        missingKeys.join(", ")
+      }).`,
     );
-    console.warn('Set CDN_BUCKET, CDN_ACCESS_KEY, and CDN_SECRET_KEY to enable uploads during the build.');
+    console.warn(
+      "Set CDN_BUCKET, CDN_ACCESS_KEY, and CDN_SECRET_KEY to enable uploads during the build.",
+    );
     return;
   }
 
-  console.log('DigitalOcean build: uploading `_static/` assets to Spaces…');
-  const uploadCode = await run(npmCommand, ['run', 'upload-assets']);
+  console.log(
+    `DigitalOcean build: uploading "${staticDirectory}/" assets to Spaces (${fingerprint.fileCount} files, ${
+      formatBytes(fingerprint.totalBytes)
+    }).`,
+  );
+  const uploadCode = await run(npmCommand, ["run", "upload-assets"]);
   if (uploadCode !== 0) {
-    console.error('DigitalOcean build: `npm run upload-assets` failed.');
+    console.error("DigitalOcean build: `npm run upload-assets` failed.");
     process.exit(uploadCode);
   }
 
-  console.log('DigitalOcean build: static asset upload completed successfully.');
+  await persistFingerprint(fingerprint);
+  console.log(
+    "DigitalOcean build: static asset upload completed successfully.",
+  );
 }
 
 main().catch((error) => {
-  console.error('DigitalOcean build: unexpected error while preparing deployment:', error);
+  console.error(
+    "DigitalOcean build: unexpected error while preparing deployment:",
+    error,
+  );
   process.exit(1);
 });

--- a/scripts/utils/hash-directory.mjs
+++ b/scripts/utils/hash-directory.mjs
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+function joinPath(prefix, name) {
+  return prefix ? `${prefix}/${name}` : name;
+}
+
+async function walkDirectory(root, relativePrefix, files, total) {
+  const entries = await readdir(root, { withFileTypes: true });
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const absolutePath = path.join(root, entry.name);
+    const relativePath = joinPath(relativePrefix, entry.name);
+    if (entry.isDirectory()) {
+      await walkDirectory(absolutePath, relativePath, files, total);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const data = await readFile(absolutePath);
+    const fileHash = createHash("sha256").update(data).digest("hex");
+    files.push({ path: relativePath, hash: fileHash, size: data.byteLength });
+    total.bytes += data.byteLength;
+  }
+}
+
+export async function hashDirectory(root) {
+  let details;
+  try {
+    details = await stat(root);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  if (!details.isDirectory()) {
+    throw new Error(
+      `Expected a directory at ${root} to compute asset fingerprint.`,
+    );
+  }
+
+  const files = [];
+  const totals = { bytes: 0 };
+  await walkDirectory(root, "", files, totals);
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+
+  const combined = createHash("sha256");
+  for (const file of files) {
+    combined.update(file.path);
+    combined.update("\0");
+    combined.update(file.hash);
+  }
+
+  const digest = combined.digest("hex");
+  return {
+    hash: digest,
+    fileCount: files.length,
+    totalBytes: totals.bytes,
+    files,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable hashDirectory helper for computing deterministic digests of build asset directories
- enhance the DigitalOcean build script to skip redundant uploads, support a force upload flag, and persist the latest fingerprint in the build cache

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d69743daf88322b8b66c6411abe097