### PR TITLE
feat: add alert notification algorithms and sync helpers

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -1,6 +1,15 @@
 """Python trading strategy utilities for Dynamic Capital."""
 
 from . import trade_logic as _trade_logic
+from .alert_notifications import (
+    AlertEngine,
+    AlertEvent,
+    AlertRule,
+    AlertSyncService,
+    MarketDatum,
+    Notification,
+    NotificationPlanner,
+)
 from .awesome_api import (
     AwesomeAPIAutoCalculator,
     AwesomeAPIAutoMetrics,
@@ -149,6 +158,13 @@ from .time_keeper import (
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]
 
 __all__ = _trade_exports + [
+    "AlertEngine",
+    "AlertEvent",
+    "AlertRule",
+    "AlertSyncService",
+    "MarketDatum",
+    "Notification",
+    "NotificationPlanner",
     "AwesomeAPIAutoCalculator",
     "AwesomeAPIAutoMetrics",
     "AwesomeAPIClient",

--- a/algorithms/python/alert_notifications.py
+++ b/algorithms/python/alert_notifications.py
@@ -1,0 +1,267 @@
+"""Alert generation, notification planning, and Supabase sync helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, Iterable, Mapping, MutableMapping, Protocol, Sequence
+
+__all__ = [
+    "MarketDatum",
+    "LiveDataFeed",
+    "AlertRule",
+    "AlertEvent",
+    "AlertEngine",
+    "Notification",
+    "NotificationPlanner",
+    "AlertSyncService",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+@dataclass(slots=True)
+class MarketDatum:
+    """Represents a live market data snapshot for a tracked instrument."""
+
+    symbol: str
+    price: float
+    change_percent: float
+    updated_at: datetime | None = None
+
+
+class LiveDataFeed(Protocol):  # pragma: no cover - interface definition
+    """Protocol describing a source that can provide live market data."""
+
+    def fetch(self, symbols: Sequence[str]) -> Sequence[MarketDatum]:
+        ...
+
+
+@dataclass(slots=True)
+class AlertRule:
+    """Configuration describing when an alert should be triggered."""
+
+    id: str
+    symbol: str
+    threshold_percent: float
+    direction: str = "above"
+    severity: str = "info"
+    title: str | None = None
+    message_template: str = "{symbol} moved {change_percent:+.2f}% to {price:.2f}"
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class AlertEvent:
+    """Concrete alert generated from a rule evaluation."""
+
+    id: str
+    rule_id: str
+    symbol: str
+    price: float
+    change_percent: float
+    severity: str
+    title: str
+    message: str
+    triggered_at: datetime
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class Notification:
+    """Notification instance targeted to a specific recipient."""
+
+    id: str
+    alert_id: str
+    recipient: str
+    category: str
+    title: str
+    body: str
+    severity: str
+    sent_at: datetime
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+
+
+class _Writer(Protocol):  # pragma: no cover - behaviour defined by SupabaseTableWriter
+    def upsert(self, rows: Iterable[Mapping[str, object]]) -> int:
+        ...
+
+
+@dataclass(slots=True)
+class AlertEngine:
+    """Evaluates live data against rules and produces alert events."""
+
+    feed: LiveDataFeed
+    dedupe_ttl: timedelta | None = timedelta(minutes=5)
+    clock: Callable[[], datetime] = _utcnow
+    _last_triggered: Dict[str, datetime] = field(init=False, default_factory=dict)
+
+    def evaluate(self, rules: Sequence[AlertRule]) -> list[AlertEvent]:
+        if not rules:
+            return []
+        symbols = sorted({rule.symbol.upper() for rule in rules})
+        snapshots = {datum.symbol.upper(): datum for datum in self.feed.fetch(symbols)}
+        events: list[AlertEvent] = []
+        for rule in rules:
+            datum = snapshots.get(rule.symbol.upper())
+            if not datum:
+                continue
+            threshold = abs(rule.threshold_percent)
+            change = float(datum.change_percent)
+            if not self._should_trigger(rule.direction, change, threshold):
+                continue
+            triggered_at = datum.updated_at or self.clock()
+            if self._is_duplicate(rule.id, triggered_at):
+                continue
+            severity = rule.severity
+            title = rule.title or f"{rule.symbol.upper()} Alert"
+            context = {
+                "symbol": datum.symbol,
+                "price": float(datum.price),
+                "change_percent": change,
+                "threshold": threshold,
+                "direction": "up" if change >= 0 else "down",
+                "severity": severity,
+            }
+            message = self._format_message(rule.message_template, context)
+            metadata: MutableMapping[str, object] = {
+                "symbol": datum.symbol,
+                "price": float(datum.price),
+                "change_percent": change,
+                "threshold_percent": threshold,
+                "direction": context["direction"],
+            }
+            if rule.metadata:
+                metadata.update(dict(rule.metadata))
+            event_id = f"{rule.id}:{triggered_at.isoformat()}"
+            events.append(
+                AlertEvent(
+                    id=event_id,
+                    rule_id=rule.id,
+                    symbol=datum.symbol,
+                    price=float(datum.price),
+                    change_percent=change,
+                    severity=severity,
+                    title=title,
+                    message=message,
+                    triggered_at=triggered_at,
+                    metadata=metadata,
+                )
+            )
+            self._last_triggered[rule.id] = triggered_at
+        return events
+
+    def _should_trigger(self, direction: str, change: float, threshold: float) -> bool:
+        if direction == "above":
+            return change >= threshold
+        if direction == "below":
+            return change <= -threshold
+        if direction == "absolute":
+            return abs(change) >= threshold
+        raise ValueError(f"Unsupported alert direction: {direction}")
+
+    def _is_duplicate(self, rule_id: str, triggered_at: datetime) -> bool:
+        last = self._last_triggered.get(rule_id)
+        if last is None or self.dedupe_ttl is None:
+            return False
+        # Treat out-of-order events that are not newer than the last fired timestamp as duplicates.
+        if triggered_at <= last:
+            return True
+        return triggered_at - last <= self.dedupe_ttl
+
+    @staticmethod
+    def _format_message(template: str, context: Mapping[str, object]) -> str:
+        try:
+            return template.format(**context)
+        except KeyError:
+            # Fall back to leaving unknown placeholders untouched.
+            class _DefaultDict(dict):
+                def __missing__(self, key: str) -> str:  # type: ignore[override]
+                    return "{" + key + "}"
+
+            return template.format_map(_DefaultDict(context))
+        except Exception:
+            return template
+
+
+@dataclass(slots=True)
+class NotificationPlanner:
+    """Expands alert events into targeted notification payloads."""
+
+    clock: Callable[[], datetime] = _utcnow
+    category: str = "market-alert"
+
+    def plan(self, alert: AlertEvent, recipients: Sequence[str]) -> list[Notification]:
+        planned: list[Notification] = []
+        sent_at = self.clock()
+        for recipient in recipients:
+            metadata = dict(alert.metadata)
+            metadata["recipient"] = recipient
+            planned.append(
+                Notification(
+                    id=f"{alert.id}:{recipient}",
+                    alert_id=alert.id,
+                    recipient=recipient,
+                    category=self.category,
+                    title=alert.title,
+                    body=alert.message,
+                    severity=alert.severity,
+                    sent_at=sent_at,
+                    metadata=metadata,
+                )
+            )
+        return planned
+
+
+@dataclass(slots=True)
+class AlertSyncService:
+    """Persists alert events and notifications into Supabase tables."""
+
+    alerts_writer: _Writer
+    notifications_writer: _Writer | None = None
+    clock: Callable[[], datetime] = _utcnow
+
+    def sync_alerts(self, alerts: Sequence[AlertEvent]) -> int:
+        if not alerts:
+            return 0
+        synced_at = self.clock()
+        rows = [
+            {
+                "alert_id": alert.id,
+                "rule_id": alert.rule_id,
+                "symbol": alert.symbol,
+                "price": alert.price,
+                "change_percent": alert.change_percent,
+                "severity": alert.severity,
+                "title": alert.title,
+                "message": alert.message,
+                "triggered_at": alert.triggered_at,
+                "metadata": dict(alert.metadata),
+                "synced_at": synced_at,
+            }
+            for alert in alerts
+        ]
+        return self.alerts_writer.upsert(rows)
+
+    def sync_notifications(self, notifications: Sequence[Notification]) -> int:
+        if not notifications:
+            return 0
+        if not self.notifications_writer:
+            raise RuntimeError("notifications_writer is not configured")
+        rows = [
+            {
+                "notification_id": notification.id,
+                "alert_id": notification.alert_id,
+                "recipient": notification.recipient,
+                "category": notification.category,
+                "title": notification.title,
+                "body": notification.body,
+                "severity": notification.severity,
+                "sent_at": notification.sent_at,
+                "metadata": dict(notification.metadata),
+            }
+            for notification in notifications
+        ]
+        return self.notifications_writer.upsert(rows)

--- a/algorithms/python/tests/test_alert_notifications.py
+++ b/algorithms/python/tests/test_alert_notifications.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.alert_notifications import (
+    AlertEngine,
+    AlertEvent,
+    AlertRule,
+    AlertSyncService,
+    MarketDatum,
+    NotificationPlanner,
+)
+
+
+class FeedStub:
+    def __init__(self, datum: MarketDatum):
+        self.datum = datum
+
+    def fetch(self, symbols):
+        # Return the current datum if requested symbol matches, case insensitive.
+        return [self.datum] if self.datum.symbol.upper() in {s.upper() for s in symbols} else []
+
+
+class WriterStub:
+    def __init__(self):
+        self.rows: list[dict[str, object]] = []
+
+    def upsert(self, rows):
+        self.rows.extend(rows)
+        return len(rows)
+
+
+def _ts(hour: int, minute: int = 0) -> datetime:
+    return datetime(2025, 1, 1, hour=hour, minute=minute, tzinfo=timezone.utc)
+
+
+def test_alert_engine_triggers_and_deduplicates():
+    datum = MarketDatum(symbol="XAUUSD", price=2370.5, change_percent=6.2, updated_at=_ts(9, 30))
+    feed = FeedStub(datum)
+    engine = AlertEngine(feed=feed, clock=lambda: _ts(9, 0), dedupe_ttl=timedelta(minutes=5))
+    rule = AlertRule(
+        id="gold-surge",
+        symbol="XAUUSD",
+        threshold_percent=5.0,
+        direction="above",
+        severity="warning",
+        title="Gold breakout",
+        message_template="{symbol} is {direction} {change_percent:+.2f}% at ${price:.1f}",
+    )
+
+    events = engine.evaluate([rule])
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.rule_id == "gold-surge"
+    assert event.symbol == "XAUUSD"
+    assert event.price == pytest.approx(2370.5)
+    assert event.change_percent == pytest.approx(6.2)
+    assert event.severity == "warning"
+    assert event.title == "Gold breakout"
+    assert "Gold breakout" in event.title
+    assert "up" == event.metadata["direction"]
+
+    # Re-evaluating without enough time passing should dedupe the alert
+    repeat = engine.evaluate([rule])
+    assert repeat == []
+
+    # Once the dedupe window expires we should see a new alert
+    feed.datum = MarketDatum(
+        symbol="XAUUSD",
+        price=2380.1,
+        change_percent=5.5,
+        updated_at=_ts(9, 40),
+    )
+    follow_up = engine.evaluate([rule])
+    assert len(follow_up) == 1
+    assert follow_up[0].triggered_at == _ts(9, 40)
+
+
+def test_alert_engine_handles_bearish_direction():
+    feed = FeedStub(MarketDatum(symbol="EURUSD", price=1.075, change_percent=-2.4, updated_at=_ts(10)))
+    engine = AlertEngine(feed=feed, dedupe_ttl=None, clock=lambda: _ts(10))
+    rule = AlertRule(
+        id="eur-drop",
+        symbol="EURUSD",
+        threshold_percent=1.5,
+        direction="below",
+        severity="critical",
+        message_template="{symbol} moved {change_percent:.1f}% {direction}",
+    )
+
+    events = engine.evaluate([rule])
+
+    assert len(events) == 1
+    assert events[0].severity == "critical"
+    assert "down" in events[0].message
+
+
+def test_notification_planning_and_sync():
+    alert = AlertEvent(
+        id="gold-surge:2025-01-01T09:30:00+00:00",
+        rule_id="gold-surge",
+        symbol="XAUUSD",
+        price=2370.5,
+        change_percent=6.2,
+        severity="warning",
+        title="Gold breakout",
+        message="Gold is up",
+        triggered_at=_ts(9, 30),
+        metadata={"direction": "up"},
+    )
+    planner = NotificationPlanner(clock=lambda: _ts(9, 45))
+    notifications = planner.plan(alert, ["alice", "bob"])
+
+    assert len(notifications) == 2
+    assert notifications[0].id.endswith(":alice")
+    assert notifications[0].sent_at == _ts(9, 45)
+    assert notifications[1].metadata["recipient"] == "bob"
+    assert notifications[1].metadata["direction"] == "up"
+
+    alerts_writer = WriterStub()
+    notifications_writer = WriterStub()
+    sync = AlertSyncService(
+        alerts_writer=alerts_writer,
+        notifications_writer=notifications_writer,
+        clock=lambda: _ts(9, 50),
+    )
+
+    alert_count = sync.sync_alerts([alert])
+    notification_count = sync.sync_notifications(notifications)
+
+    assert alert_count == 1
+    assert notification_count == 2
+    assert alerts_writer.rows[0]["alert_id"] == alert.id
+    assert alerts_writer.rows[0]["synced_at"] == _ts(9, 50)
+    assert notifications_writer.rows[0]["notification_id"].endswith(":alice")
+    assert notifications_writer.rows[1]["recipient"] == "bob"


### PR DESCRIPTION
## Summary
- add alert generation, notification planning, and Supabase sync helpers for live market data
- expose the new helpers through the python algorithms package exports
- cover the alert and notification flow with targeted pytest cases

## Testing
- npm run lint
- npm run typecheck
- PYTHONPATH=. pytest algorithms/python/tests/test_alert_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68d6981a53088322b2d5c3bab31bfbb7