### PR TITLE
Align desk navigation data sources

### DIFF
--- a/apps/web/components/landing/home-navigation-config.ts
+++ b/apps/web/components/landing/home-navigation-config.ts
@@ -71,3 +71,11 @@ export const HOME_NAV_SECTIONS: HomeNavSection[] = [
     href: `/#${HOME_NAV_SECTION_IDS.onboarding}`,
   },
 ];
+
+export const HOME_NAV_SECTION_MAP = HOME_NAV_SECTIONS.reduce(
+  (accumulator, section) => {
+    accumulator[section.id] = section;
+    return accumulator;
+  },
+  {} as Record<HomeNavSectionId, HomeNavSection>,
+);

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -1,13 +1,9 @@
+import { LayoutDashboard, type LucideIcon } from "lucide-react";
+
 import {
-  Bot,
-  Layers,
-  LayoutDashboard,
-  LifeBuoy,
-  type LucideIcon,
-  Shield,
-  TrendingUp,
-  Workflow,
-} from "lucide-react";
+  HOME_NAV_SECTION_MAP,
+  type HomeNavSectionId,
+} from "@/components/landing/home-navigation-config";
 
 export interface NavItem {
   id: string;
@@ -21,84 +17,59 @@ export interface NavItem {
   showOnMobile?: boolean;
 }
 
+const DESK_NAV_SECTION_ORDER: HomeNavSectionId[] = [
+  "overview",
+  "providers",
+  "workflows",
+  "analytics",
+  "security",
+];
+
+const createNavItemFromSection = (
+  sectionId: HomeNavSectionId,
+  stepNumber: number,
+): NavItem | null => {
+  const section = HOME_NAV_SECTION_MAP[sectionId];
+
+  if (!section) {
+    return null;
+  }
+
+  return {
+    id: section.id,
+    step: `Step ${stepNumber}`,
+    label: section.label,
+    description: section.description,
+    icon: section.icon,
+    path: "/",
+    href: section.href,
+    ariaLabel: `Step ${stepNumber}: ${section.label}. ${section.description}`,
+    showOnMobile: true,
+  } satisfies NavItem;
+};
+
+const deskNavItems = DESK_NAV_SECTION_ORDER.map((sectionId, index) =>
+  createNavItemFromSection(sectionId, index + 1)
+).filter((item): item is NavItem => Boolean(item));
+
+const onboardingNavItem = createNavItemFromSection(
+  "onboarding",
+  deskNavItems.length + 2,
+);
+
 export const NAV_ITEMS: NavItem[] = [
-  {
-    id: "overview",
-    step: "Step 1",
-    label: "Workspace",
-    description: "Preview the multi-LLM orchestration hub.",
-    icon: Bot,
-    path: "/",
-    href: "/#overview",
-    ariaLabel: "Step 1: Workspace. Preview the multi-LLM orchestration hub.",
-    showOnMobile: true,
-  },
-  {
-    id: "providers",
-    step: "Step 2",
-    label: "Providers",
-    description: "Compare coverage and context windows.",
-    icon: Layers,
-    path: "/",
-    href: "/#provider-matrix",
-    ariaLabel:
-      "Step 2: Providers. Compare coverage and context windows across vendors.",
-    showOnMobile: true,
-  },
-  {
-    id: "routing",
-    step: "Step 3",
-    label: "Routing",
-    description: "Blend ensembles, fallbacks, and policies.",
-    icon: Workflow,
-    path: "/",
-    href: "/#orchestration",
-    ariaLabel: "Step 3: Routing. Blend ensembles, fallbacks, and policies.",
-    showOnMobile: true,
-  },
-  {
-    id: "analytics",
-    step: "Step 4",
-    label: "Analytics",
-    description: "Inspect latency, quality, and spend traces.",
-    icon: TrendingUp,
-    path: "/",
-    href: "/#analytics",
-    ariaLabel: "Step 4: Analytics. Inspect latency, quality, and spend traces.",
-    showOnMobile: true,
-  },
-  {
-    id: "guardrails",
-    step: "Step 5",
-    label: "Guardrails",
-    description: "Review compliance and escalation workflows.",
-    icon: Shield,
-    path: "/",
-    href: "/#resilience",
-    ariaLabel:
-      "Step 5: Guardrails. Review compliance and escalation workflows.",
-    showOnMobile: true,
-  },
+  ...deskNavItems,
   {
     id: "studio",
-    step: "Step 6",
+    step: `Step ${deskNavItems.length + 1}`,
     label: "LLM studio",
     description: "Run side-by-side provider benchmarks.",
     icon: LayoutDashboard,
     path: "/tools/multi-llm",
-    ariaLabel: "Step 6: LLM studio. Run side-by-side provider benchmarks.",
+    ariaLabel: `Step ${deskNavItems.length + 1}: LLM studio. Run side-by-side provider benchmarks.`,
     showOnMobile: true,
   },
-  {
-    id: "onboarding",
-    step: "Step 7",
-    label: "Onboarding",
-    description: "Activate concierge setup and pricing.",
-    icon: LifeBuoy,
-    path: "/plans",
-    ariaLabel: "Step 7: Onboarding. Activate concierge setup and pricing.",
-    showOnMobile: true,
-  },
+  ...(onboardingNavItem ? [onboardingNavItem] : []),
 ];
 
 export default NAV_ITEMS;


### PR DESCRIPTION
## Summary
- expose a map of desk landing sections for reuse outside the landing rail
- derive the desktop/mobile navigation items from the shared desk section data and keep onboarding anchored to the desk page

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d69aa0f270832284b941407a8620c1