### PR TITLE
feat: add adaptive data labeling algorithm

### DIFF
--- a/algorithms/python/data_labeling_algorithm.py
+++ b/algorithms/python/data_labeling_algorithm.py
@@ -1,0 +1,189 @@
+"""Adaptive offline data labelling helpers."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from statistics import pstdev
+from typing import Callable, Dict, Iterable, List, Optional, Sequence
+
+from .trade_logic import FeaturePipeline, LabeledFeature, MarketSnapshot
+
+
+@dataclass(slots=True)
+class AdaptiveLabelingConfig:
+    """Configuration for :class:`AdaptiveLabelingAlgorithm`.
+
+    Attributes
+    ----------
+    lookahead:
+        Number of steps ahead used to generate the ground-truth label.
+    neutral_zone_pips:
+        Baseline neutral zone below which price moves are considered noise.
+    volatility_window:
+        Number of recent price changes to inspect when estimating volatility.
+    min_threshold:
+        Lower bound applied to the dynamic threshold in pip units.
+    max_threshold:
+        Upper bound applied to the dynamic threshold in pip units.
+    confidence_slope:
+        Controls how quickly label confidence increases as the move exceeds the
+        dynamic threshold. Higher values lead to faster saturation towards 1.
+    """
+
+    lookahead: int = 4
+    neutral_zone_pips: float = 2.0
+    volatility_window: int = 20
+    min_threshold: float = 0.5
+    max_threshold: float = 25.0
+    confidence_slope: float = 1.0
+
+
+class AdaptiveLabelingAlgorithm:
+    """Produce labels with a volatility-aware neutral zone."""
+
+    def __init__(self, *, pipeline: Optional[FeaturePipeline] = None) -> None:
+        self.pipeline = pipeline or FeaturePipeline()
+
+    def label(
+        self,
+        snapshots: Sequence[MarketSnapshot],
+        config: Optional[AdaptiveLabelingConfig] = None,
+        *,
+        metadata_fn: Optional[Callable[[MarketSnapshot], Dict[str, object]]] = None,
+    ) -> List[LabeledFeature]:
+        """Return labelled samples derived from ``snapshots``.
+
+        Parameters
+        ----------
+        snapshots:
+            Ordered market snapshots to label.
+        config:
+            Optional configuration object. When omitted the defaults are used.
+        metadata_fn:
+            Callable that receives the current snapshot and returns a metadata
+            dictionary to merge with the automatically populated metadata.
+        """
+
+        if not snapshots:
+            raise ValueError("snapshots sequence must be non-empty")
+
+        cfg = config or AdaptiveLabelingConfig()
+        if cfg.lookahead <= 0:
+            raise ValueError("lookahead must be positive")
+        if cfg.volatility_window < 0:
+            raise ValueError("volatility_window cannot be negative")
+
+        volatility = self._rolling_volatility(snapshots, cfg.volatility_window)
+
+        transformed: List[tuple[MarketSnapshot, tuple[float, ...], float]] = []
+        for idx, snapshot in enumerate(snapshots):
+            features = self.pipeline.transform(snapshot.feature_vector(), update=True)
+            transformed.append((snapshot, features, volatility[idx]))
+
+        labelled: List[LabeledFeature] = []
+        for idx, (snapshot, features, local_vol) in enumerate(transformed):
+            target_idx = idx + cfg.lookahead
+            if target_idx >= len(transformed):
+                break
+            future_snapshot = transformed[target_idx][0]
+            move = (future_snapshot.close - snapshot.close) / snapshot.pip_size
+            magnitude = abs(move)
+            threshold = self._calculate_threshold(cfg, local_vol)
+
+            if magnitude <= threshold:
+                label = 0
+                confidence = 0.0
+            else:
+                label = 1 if move > 0 else -1
+                confidence = self._confidence_from_move(magnitude, threshold, cfg)
+
+            metadata: Dict[str, object] = dict(metadata_fn(snapshot) if metadata_fn else {})
+            metadata.update(
+                {
+                    "threshold_pips": threshold,
+                    "volatility_pips": local_vol,
+                    "move_pips": magnitude,
+                    "raw_move": move,
+                    "confidence": confidence,
+                    "lookahead": cfg.lookahead,
+                    "lookahead_target": future_snapshot.timestamp.isoformat(),
+                    "source_timestamp": snapshot.timestamp.isoformat(),
+                }
+            )
+
+            labelled.append(
+                LabeledFeature(
+                    features=features,
+                    label=label,
+                    close=snapshot.close,
+                    timestamp=snapshot.timestamp,
+                    metadata=metadata,
+                )
+            )
+        return labelled
+
+    @staticmethod
+    def summarise_distribution(samples: Iterable[LabeledFeature]) -> Dict[str, float]:
+        """Return the proportion of each label class in ``samples``."""
+
+        counts = {"positive": 0, "neutral": 0, "negative": 0}
+        total = 0
+        for sample in samples:
+            total += 1
+            if sample.label > 0:
+                counts["positive"] += 1
+            elif sample.label < 0:
+                counts["negative"] += 1
+            else:
+                counts["neutral"] += 1
+        if total == 0:
+            return {key: 0.0 for key in counts}
+        return {key: value / total for key, value in counts.items()}
+
+    @staticmethod
+    def _confidence_from_move(
+        magnitude: float, threshold: float, config: AdaptiveLabelingConfig
+    ) -> float:
+        overshoot = max(0.0, magnitude - threshold)
+        if overshoot == 0.0:
+            return 0.0
+        scale = max(1e-6, threshold / max(1.0, config.confidence_slope))
+        return min(1.0, overshoot / (overshoot + scale))
+
+    @staticmethod
+    def _calculate_threshold(config: AdaptiveLabelingConfig, volatility: float) -> float:
+        base = max(config.neutral_zone_pips, config.min_threshold)
+        if volatility <= 0.0:
+            return min(config.max_threshold, max(config.min_threshold, base))
+        dynamic = base + 0.5 * volatility
+        return min(config.max_threshold, max(config.min_threshold, dynamic))
+
+    @staticmethod
+    def _rolling_volatility(
+        snapshots: Sequence[MarketSnapshot], window: int
+    ) -> List[float]:
+        if window <= 1:
+            return [0.0] * len(snapshots)
+
+        values: deque[float] = deque(maxlen=window)
+        volatilities: List[float] = []
+        previous: Optional[MarketSnapshot] = None
+        for snapshot in snapshots:
+            if previous is None:
+                volatilities.append(0.0)
+                previous = snapshot
+                continue
+
+            pip_move = abs(snapshot.close - previous.close) / snapshot.pip_size
+            values.append(pip_move)
+            if len(values) >= 2:
+                vol = float(pstdev(values))
+            else:
+                vol = 0.0
+            volatilities.append(vol)
+            previous = snapshot
+        return volatilities
+
+
+__all__ = ["AdaptiveLabelingConfig", "AdaptiveLabelingAlgorithm"]

--- a/algorithms/python/tests/test_data_labeling_algorithm.py
+++ b/algorithms/python/tests/test_data_labeling_algorithm.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.data_labeling_algorithm import (  # noqa: E402
+    AdaptiveLabelingAlgorithm,
+    AdaptiveLabelingConfig,
+)
+from algorithms.python.trade_logic import MarketSnapshot  # noqa: E402
+
+
+def _build_snapshots(prices: list[float]) -> list[MarketSnapshot]:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    snapshots: list[MarketSnapshot] = []
+    for idx, price in enumerate(prices):
+        snapshots.append(
+            MarketSnapshot(
+                symbol="XAUUSD",
+                timestamp=base + timedelta(minutes=idx * 5),
+                close=price,
+                rsi_fast=50.0 + idx,
+                adx_fast=20.0,
+                rsi_slow=45.0,
+                adx_slow=18.0,
+                pip_size=0.1,
+                pip_value=1.0,
+            )
+        )
+    return snapshots
+
+
+def test_adaptive_labeling_algorithm_labels_snapshots() -> None:
+    snapshots = _build_snapshots([100.0, 100.2, 100.8, 101.5, 102.5, 101.0])
+    config = AdaptiveLabelingConfig(lookahead=2, neutral_zone_pips=0.5, volatility_window=3)
+    algo = AdaptiveLabelingAlgorithm()
+
+    labelled = algo.label(snapshots, config)
+
+    assert labelled, "algorithm should emit labelled samples"
+    first = labelled[0]
+    assert "threshold_pips" in first.metadata
+    assert first.metadata["lookahead"] == 2
+
+    expected_future = snapshots[2].close
+    assert first.label == (1 if expected_future > snapshots[0].close else -1)
+
+
+def test_adaptive_labeling_respects_neutral_zone() -> None:
+    snapshots = _build_snapshots([100.0, 100.05, 100.1, 100.15, 100.2])
+    config = AdaptiveLabelingConfig(lookahead=1, neutral_zone_pips=5.0, volatility_window=2)
+
+    labelled = AdaptiveLabelingAlgorithm().label(snapshots, config)
+
+    assert all(sample.label == 0 for sample in labelled)
+
+
+def test_dynamic_threshold_tracks_volatility() -> None:
+    snapshots = _build_snapshots([100.0, 105.0, 95.0, 110.0, 90.0, 95.0])
+    config = AdaptiveLabelingConfig(lookahead=1, neutral_zone_pips=1.0, volatility_window=3)
+    algo = AdaptiveLabelingAlgorithm()
+
+    labelled = algo.label(snapshots, config)
+    thresholds = [sample.metadata["threshold_pips"] for sample in labelled]
+
+    assert len(thresholds) >= 3
+    assert thresholds[2] > thresholds[1] >= config.neutral_zone_pips
+
+    distribution = AdaptiveLabelingAlgorithm.summarise_distribution(labelled)
+    assert pytest.approx(sum(distribution.values()), rel=1e-6) == 1.0


### PR DESCRIPTION
## Summary
- add an adaptive offline data labeling algorithm with volatility-aware thresholds and confidence metadata
- cover the new workflow with focused pytest scenarios for labelling behaviour and distribution summaries

## Testing
- pytest algorithms/python/tests/test_data_labeling_algorithm.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a36a57248322bd8571ada1ce5782