### PR TITLE
feat: enable online adaptive labeling

### DIFF
--- a/algorithms/python/data_labeling_algorithm.py
+++ b/algorithms/python/data_labeling_algorithm.py
@@ -1,0 +1,433 @@
+"""Adaptive data labelling helpers for offline and live workflows."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import pstdev
+from typing import (
+    Callable,
+    Deque,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Sequence,
+)
+
+from .trade_logic import FeaturePipeline, LabeledFeature, MarketSnapshot
+
+
+@dataclass(slots=True)
+class AdaptiveLabelingConfig:
+    """Configuration for :class:`AdaptiveLabelingAlgorithm`.
+
+    Attributes
+    ----------
+    lookahead:
+        Number of steps ahead used to generate the ground-truth label.
+    neutral_zone_pips:
+        Baseline neutral zone below which price moves are considered noise.
+    volatility_window:
+        Number of recent price changes to inspect when estimating volatility.
+    min_threshold:
+        Lower bound applied to the dynamic threshold in pip units.
+    max_threshold:
+        Upper bound applied to the dynamic threshold in pip units.
+    confidence_slope:
+        Controls how quickly label confidence increases as the move exceeds the
+        dynamic threshold. Higher values lead to faster saturation towards 1.
+    """
+
+    lookahead: int = 4
+    neutral_zone_pips: float = 2.0
+    volatility_window: int = 20
+    min_threshold: float = 0.5
+    max_threshold: float = 25.0
+    confidence_slope: float = 1.0
+
+
+class AdaptiveLabelingAlgorithm:
+    """Produce labels with a volatility-aware neutral zone."""
+
+    def __init__(self, *, pipeline: Optional[FeaturePipeline] = None) -> None:
+        self.pipeline = pipeline or FeaturePipeline()
+
+    def label(
+        self,
+        snapshots: Sequence[MarketSnapshot],
+        config: Optional[AdaptiveLabelingConfig] = None,
+        *,
+        metadata_fn: Optional[Callable[[MarketSnapshot], Dict[str, object]]] = None,
+    ) -> List[LabeledFeature]:
+        """Return labelled samples derived from ``snapshots``.
+
+        Parameters
+        ----------
+        snapshots:
+            Ordered market snapshots to label.
+        config:
+            Optional configuration object. When omitted the defaults are used.
+        metadata_fn:
+            Callable that receives the current snapshot and returns a metadata
+            dictionary to merge with the automatically populated metadata.
+        """
+
+        if not snapshots:
+            raise ValueError("snapshots sequence must be non-empty")
+
+        cfg = config or AdaptiveLabelingConfig()
+        if cfg.lookahead <= 0:
+            raise ValueError("lookahead must be positive")
+        if cfg.volatility_window < 0:
+            raise ValueError("volatility_window cannot be negative")
+
+        volatility = self._rolling_volatility(snapshots, cfg.volatility_window)
+
+        transformed: List[tuple[MarketSnapshot, tuple[float, ...], float]] = []
+        for idx, snapshot in enumerate(snapshots):
+            features = self.pipeline.transform(snapshot.feature_vector(), update=True)
+            transformed.append((snapshot, features, volatility[idx]))
+
+        labelled: List[LabeledFeature] = []
+        for idx, (snapshot, features, local_vol) in enumerate(transformed):
+            target_idx = idx + cfg.lookahead
+            if target_idx >= len(transformed):
+                break
+            future_snapshot = transformed[target_idx][0]
+            labelled.append(
+                self._build_label(
+                    snapshot,
+                    features,
+                    local_vol,
+                    future_snapshot,
+                    cfg,
+                    metadata_fn=metadata_fn,
+                )
+            )
+        return labelled
+
+    @staticmethod
+    def summarise_distribution(samples: Iterable[LabeledFeature]) -> Dict[str, float]:
+        """Return the proportion of each label class in ``samples``."""
+
+        counts = {"positive": 0, "neutral": 0, "negative": 0}
+        total = 0
+        for sample in samples:
+            total += 1
+            if sample.label > 0:
+                counts["positive"] += 1
+            elif sample.label < 0:
+                counts["negative"] += 1
+            else:
+                counts["neutral"] += 1
+        if total == 0:
+            return {key: 0.0 for key in counts}
+        return {key: value / total for key, value in counts.items()}
+
+    @staticmethod
+    def _confidence_from_move(
+        magnitude: float, threshold: float, config: AdaptiveLabelingConfig
+    ) -> float:
+        overshoot = max(0.0, magnitude - threshold)
+        if overshoot == 0.0:
+            return 0.0
+        scale = max(1e-6, threshold / max(1.0, config.confidence_slope))
+        return min(1.0, overshoot / (overshoot + scale))
+
+    @staticmethod
+    def _calculate_threshold(config: AdaptiveLabelingConfig, volatility: float) -> float:
+        base = max(config.neutral_zone_pips, config.min_threshold)
+        if volatility <= 0.0:
+            return min(config.max_threshold, max(config.min_threshold, base))
+        dynamic = base + 0.5 * volatility
+        return min(config.max_threshold, max(config.min_threshold, dynamic))
+
+    @staticmethod
+    def _build_label(
+        snapshot: MarketSnapshot,
+        features: tuple[float, ...],
+        local_vol: float,
+        future_snapshot: MarketSnapshot,
+        config: AdaptiveLabelingConfig,
+        *,
+        metadata_fn: Optional[Callable[[MarketSnapshot], Dict[str, object]]] = None,
+    ) -> LabeledFeature:
+        move = (future_snapshot.close - snapshot.close) / snapshot.pip_size
+        magnitude = abs(move)
+        threshold = AdaptiveLabelingAlgorithm._calculate_threshold(config, local_vol)
+
+        if magnitude <= threshold:
+            label = 0
+            confidence = 0.0
+        else:
+            label = 1 if move > 0 else -1
+            confidence = AdaptiveLabelingAlgorithm._confidence_from_move(
+                magnitude, threshold, config
+            )
+
+        metadata: Dict[str, object] = dict(metadata_fn(snapshot) if metadata_fn else {})
+        metadata.update(
+            {
+                "threshold_pips": threshold,
+                "volatility_pips": local_vol,
+                "move_pips": magnitude,
+                "raw_move": move,
+                "confidence": confidence,
+                "lookahead": config.lookahead,
+                "lookahead_target": future_snapshot.timestamp,
+                "source_timestamp": snapshot.timestamp,
+                "symbol": snapshot.symbol,
+            }
+        )
+
+        return LabeledFeature(
+            features=features,
+            label=label,
+            close=snapshot.close,
+            timestamp=snapshot.timestamp,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _rolling_volatility(
+        snapshots: Sequence[MarketSnapshot], window: int
+    ) -> List[float]:
+        if window <= 1:
+            return [0.0] * len(snapshots)
+
+        values: deque[float] = deque(maxlen=window)
+        volatilities: List[float] = []
+        previous: Optional[MarketSnapshot] = None
+        for snapshot in snapshots:
+            if previous is None:
+                volatilities.append(0.0)
+                previous = snapshot
+                continue
+
+            pip_move = abs(snapshot.close - previous.close) / snapshot.pip_size
+            values.append(pip_move)
+            if len(values) >= 2:
+                vol = float(pstdev(values))
+            else:
+                vol = 0.0
+            volatilities.append(vol)
+            previous = snapshot
+        return volatilities
+
+
+@dataclass(slots=True)
+class _TransformedSnapshot:
+    snapshot: MarketSnapshot
+    features: tuple[float, ...]
+    volatility: float
+
+
+class OnlineAdaptiveLabeler:
+    """Stream market snapshots and emit labels once lookahead is satisfied."""
+
+    def __init__(
+        self,
+        *,
+        config: Optional[AdaptiveLabelingConfig] = None,
+        pipeline: Optional[FeaturePipeline] = None,
+    ) -> None:
+        self.config = config or AdaptiveLabelingConfig()
+        if self.config.lookahead <= 0:
+            raise ValueError("lookahead must be positive for online labelling")
+        if self.config.volatility_window < 0:
+            raise ValueError("volatility_window cannot be negative")
+        self.pipeline = pipeline or FeaturePipeline()
+        self._buffer: Deque[_TransformedSnapshot] = deque()
+        self._volatility: Optional[Deque[float]] = None
+        if self.config.volatility_window > 1:
+            self._volatility = deque(maxlen=self.config.volatility_window)
+        self._previous_snapshot: Optional[MarketSnapshot] = None
+
+    def reset(self) -> None:
+        """Clear buffered snapshots and volatility history."""
+
+        self._buffer.clear()
+        if self._volatility is not None:
+            self._volatility.clear()
+        self._previous_snapshot = None
+
+    def push(
+        self,
+        snapshot: MarketSnapshot,
+        *,
+        metadata_fn: Optional[Callable[[MarketSnapshot], Dict[str, object]]] = None,
+    ) -> List[LabeledFeature]:
+        """Process a snapshot and emit any labels whose lookahead is satisfied."""
+
+        features = self.pipeline.transform(snapshot.feature_vector(), update=True)
+        local_vol = self._update_volatility(snapshot)
+        self._buffer.append(
+            _TransformedSnapshot(
+                snapshot=snapshot,
+                features=features,
+                volatility=local_vol,
+            )
+        )
+
+        emitted: List[LabeledFeature] = []
+        # Once the buffer holds lookahead + 1 entries we can label the oldest.
+        while len(self._buffer) > self.config.lookahead:
+            base = self._buffer.popleft()
+            target = self._buffer[self.config.lookahead - 1].snapshot
+            emitted.append(
+                AdaptiveLabelingAlgorithm._build_label(
+                    base.snapshot,
+                    base.features,
+                    base.volatility,
+                    target,
+                    self.config,
+                    metadata_fn=metadata_fn,
+                )
+            )
+        return emitted
+
+    def state_dict(self) -> Dict[str, object]:
+        """Serialise the online labeller state for persistence."""
+
+        return {
+            "config": self.config,
+            "pipeline": self.pipeline.state_dict(),
+            "buffer": [
+                {
+                    "snapshot": entry.snapshot,
+                    "features": entry.features,
+                    "volatility": entry.volatility,
+                }
+                for entry in self._buffer
+            ],
+            "volatility": list(self._volatility or []),
+            "previous_snapshot": self._previous_snapshot,
+        }
+
+    def load_state_dict(self, state: Dict[str, object]) -> None:
+        """Restore state previously produced by :meth:`state_dict`."""
+
+        self.reset()
+        pipeline_state = state.get("pipeline")
+        if isinstance(pipeline_state, dict):
+            self.pipeline.load_state_dict(pipeline_state)
+        buffer = state.get("buffer")
+        if isinstance(buffer, list):
+            for entry in buffer:
+                snapshot = entry.get("snapshot")
+                features = entry.get("features")
+                volatility = entry.get("volatility")
+                if not isinstance(snapshot, MarketSnapshot):
+                    continue
+                if not isinstance(features, tuple):
+                    try:
+                        features = tuple(features)  # type: ignore[arg-type]
+                    except TypeError:
+                        continue
+                if not isinstance(volatility, (int, float)):
+                    continue
+                self._buffer.append(
+                    _TransformedSnapshot(
+                        snapshot=snapshot,
+                        features=tuple(float(x) for x in features),
+                        volatility=float(volatility),
+                    )
+                )
+        previous = state.get("previous_snapshot")
+        if isinstance(previous, MarketSnapshot):
+            self._previous_snapshot = previous
+        vol_state = state.get("volatility")
+        if self._volatility is not None and isinstance(vol_state, list):
+            for value in vol_state:
+                try:
+                    self._volatility.append(float(value))
+                except (TypeError, ValueError):
+                    continue
+
+    def _update_volatility(self, snapshot: MarketSnapshot) -> float:
+        if self._volatility is None:
+            self._previous_snapshot = snapshot
+            return 0.0
+
+        previous = self._previous_snapshot
+        self._previous_snapshot = snapshot
+        if previous is None:
+            return 0.0
+
+        pip_move = abs(snapshot.close - previous.close) / snapshot.pip_size
+        self._volatility.append(pip_move)
+        if len(self._volatility) >= 2:
+            return float(pstdev(self._volatility))
+        return 0.0
+
+
+class _Writer(Protocol):  # pragma: no cover - defined by SupabaseTableWriter
+    def upsert(self, rows: Iterable[Mapping[str, object]]) -> int:
+        ...
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class LiveLabelSyncService:
+    """Persists labelled samples to an external table such as Supabase."""
+
+    def __init__(self, writer: _Writer, *, clock: Callable[[], datetime] = _utcnow) -> None:
+        self.writer = writer
+        self.clock = clock
+
+    def sync(self, samples: Sequence[LabeledFeature]) -> int:
+        if not samples:
+            return 0
+        synced_at = self.clock()
+        rows: List[Dict[str, object]] = []
+        for sample in samples:
+            metadata = dict(sample.metadata)
+            rows.append(
+                {
+                    "symbol": metadata.get("symbol"),
+                    "label": int(sample.label),
+                    "confidence": float(metadata.get("confidence", 0.0)),
+                    "threshold_pips": float(metadata.get("threshold_pips", 0.0)),
+                    "volatility_pips": float(metadata.get("volatility_pips", 0.0)),
+                    "move_pips": float(metadata.get("move_pips", 0.0)),
+                    "raw_move": float(metadata.get("raw_move", 0.0)),
+                    "lookahead": int(metadata.get("lookahead", 0)),
+                    "source_timestamp": _coerce_timestamp(
+                        metadata.get("source_timestamp"), sample.timestamp
+                    ),
+                    "lookahead_target": _coerce_timestamp(
+                        metadata.get("lookahead_target"), None
+                    ),
+                    "close": float(sample.close),
+                    "features": [float(value) for value in sample.features],
+                    "timestamp": sample.timestamp,
+                    "metadata": metadata,
+                    "synced_at": synced_at,
+                }
+            )
+        return self.writer.upsert(rows)
+
+
+def _coerce_timestamp(value: object, fallback: Optional[datetime]) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return fallback
+    return fallback
+
+
+__all__ = [
+    "AdaptiveLabelingConfig",
+    "AdaptiveLabelingAlgorithm",
+    "LiveLabelSyncService",
+    "OnlineAdaptiveLabeler",
+]

--- a/algorithms/python/tests/test_data_labeling_algorithm.py
+++ b/algorithms/python/tests/test_data_labeling_algorithm.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+from typing import Iterable, Mapping
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.data_labeling_algorithm import (  # noqa: E402
+    AdaptiveLabelingAlgorithm,
+    AdaptiveLabelingConfig,
+    LiveLabelSyncService,
+    OnlineAdaptiveLabeler,
+)
+from algorithms.python.trade_logic import LabeledFeature, MarketSnapshot  # noqa: E402
+
+
+def _build_snapshots(prices: list[float]) -> list[MarketSnapshot]:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    snapshots: list[MarketSnapshot] = []
+    for idx, price in enumerate(prices):
+        snapshots.append(
+            MarketSnapshot(
+                symbol="XAUUSD",
+                timestamp=base + timedelta(minutes=idx * 5),
+                close=price,
+                rsi_fast=50.0 + idx,
+                adx_fast=20.0,
+                rsi_slow=45.0,
+                adx_slow=18.0,
+                pip_size=0.1,
+                pip_value=1.0,
+            )
+        )
+    return snapshots
+
+
+def test_adaptive_labeling_algorithm_labels_snapshots() -> None:
+    snapshots = _build_snapshots([100.0, 100.2, 100.8, 101.5, 102.5, 101.0])
+    config = AdaptiveLabelingConfig(lookahead=2, neutral_zone_pips=0.5, volatility_window=3)
+    algo = AdaptiveLabelingAlgorithm()
+
+    labelled = algo.label(snapshots, config)
+
+    assert labelled, "algorithm should emit labelled samples"
+    first = labelled[0]
+    assert "threshold_pips" in first.metadata
+    assert first.metadata["lookahead"] == 2
+
+    expected_future = snapshots[2].close
+    assert first.label == (1 if expected_future > snapshots[0].close else -1)
+
+
+def test_adaptive_labeling_respects_neutral_zone() -> None:
+    snapshots = _build_snapshots([100.0, 100.05, 100.1, 100.15, 100.2])
+    config = AdaptiveLabelingConfig(lookahead=1, neutral_zone_pips=5.0, volatility_window=2)
+
+    labelled = AdaptiveLabelingAlgorithm().label(snapshots, config)
+
+    assert all(sample.label == 0 for sample in labelled)
+
+
+def test_dynamic_threshold_tracks_volatility() -> None:
+    snapshots = _build_snapshots([100.0, 105.0, 95.0, 110.0, 90.0, 95.0])
+    config = AdaptiveLabelingConfig(lookahead=1, neutral_zone_pips=1.0, volatility_window=3)
+    algo = AdaptiveLabelingAlgorithm()
+
+    labelled = algo.label(snapshots, config)
+    thresholds = [sample.metadata["threshold_pips"] for sample in labelled]
+
+    assert len(thresholds) >= 3
+    assert thresholds[2] > thresholds[1] >= config.neutral_zone_pips
+
+    distribution = AdaptiveLabelingAlgorithm.summarise_distribution(labelled)
+    assert pytest.approx(sum(distribution.values()), rel=1e-6) == 1.0
+
+
+def test_online_labeler_matches_offline_labels() -> None:
+    snapshots = _build_snapshots([100.0, 100.4, 100.9, 101.6, 102.2, 101.8, 103.0])
+    config = AdaptiveLabelingConfig(lookahead=2, neutral_zone_pips=0.5, volatility_window=4)
+
+    offline = AdaptiveLabelingAlgorithm().label(snapshots, config)
+    online = OnlineAdaptiveLabeler(config=config)
+
+    streamed: list[LabeledFeature] = []
+    for snapshot in snapshots:
+        streamed.extend(online.push(snapshot))
+
+    assert streamed
+    assert len(streamed) == len(offline)
+
+    for offline_sample, online_sample in zip(offline, streamed):
+        assert offline_sample.label == online_sample.label
+        assert offline_sample.metadata["symbol"] == online_sample.metadata["symbol"]
+        assert offline_sample.metadata["lookahead_target"] == online_sample.metadata["lookahead_target"]
+        assert offline_sample.metadata["threshold_pips"] == pytest.approx(
+            online_sample.metadata["threshold_pips"]
+        )
+
+
+def test_live_label_sync_service_persists_rows() -> None:
+    class _RecordingWriter:
+        def __init__(self) -> None:
+            self.rows: list[dict] = []
+
+        def upsert(self, rows: Iterable[Mapping[str, object]]) -> int:
+            payload = list(rows)
+            self.rows.extend(payload)
+            return len(payload)
+
+    snapshots = _build_snapshots([100.0, 100.4, 100.9, 101.6, 102.2])
+    config = AdaptiveLabelingConfig(lookahead=1, neutral_zone_pips=0.3, volatility_window=3)
+    labelled = AdaptiveLabelingAlgorithm().label(snapshots, config)
+    writer = _RecordingWriter()
+    synced_at = datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc)
+    service = LiveLabelSyncService(writer, clock=lambda: synced_at)
+
+    count = service.sync(labelled[:2])
+
+    assert count == 2
+    assert len(writer.rows) == 2
+    row = writer.rows[0]
+    assert row["symbol"] == snapshots[0].symbol
+    assert row["label"] in {-1, 0, 1}
+    assert row["synced_at"] == synced_at
+    assert row["source_timestamp"].tzinfo is not None
+    assert isinstance(row["features"], list)


### PR DESCRIPTION
## Summary
- extend the adaptive labeling helper with shared label construction, symbol-aware metadata, and a live sync service
- add an online labeling engine that streams snapshots, preserves state, and matches offline output
- cover the new streaming and sync flows with pytest cases that validate parity and payload persistence

## Testing
- pytest algorithms/python/tests/test_data_labeling_algorithm.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d6a36a57248322bd8571ada1ce5782