### PR TITLE
Fix navigation links to satisfy Next.js Link child requirement

### DIFF
--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -65,8 +65,10 @@ const RESOURCE_LINKS = [
     action: (
       <Button asChild variant="link" className="mt-6 text-telegram">
         <Link href="/blog">
-          Explore guides
-          <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+          <span className="contents">
+            Explore guides
+            <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+          </span>
         </Link>
       </Button>
     ),
@@ -87,7 +89,9 @@ export default function SupportPage() {
               Concierge support for every VIP member
             </h1>
             <p className="text-lg text-muted-foreground md:text-xl">
-              Tap a path below to connect with a human instantly, review onboarding resources, or hand off a desk task to the Dynamic Capital team.
+              Tap a path below to connect with a human instantly, review
+              onboarding resources, or hand off a desk task to the Dynamic
+              Capital team.
             </p>
           </div>
         </header>
@@ -121,13 +125,20 @@ export default function SupportPage() {
                 Need the operations console?
               </CardTitle>
               <CardDescription className="text-base text-muted-foreground">
-                Admins can still access the Telegram Bot Dashboard for automation and analytics.
+                Admins can still access the Telegram Bot Dashboard for
+                automation and analytics.
               </CardDescription>
             </div>
-            <Button asChild variant="outline" className="border-white/20 text-foreground">
+            <Button
+              asChild
+              variant="outline"
+              className="border-white/20 text-foreground"
+            >
               <Link href="/telegram">
-                Open bot dashboard
-                <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                <span className="contents">
+                  Open bot dashboard
+                  <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </span>
               </Link>
             </Button>
           </CardHeader>

--- a/apps/web/components/landing/HomeNavigationRail.tsx
+++ b/apps/web/components/landing/HomeNavigationRail.tsx
@@ -243,34 +243,36 @@ export function HomeNavigationRail({ className }: { className?: string }) {
                     role="tab"
                     aria-selected={isActive}
                   >
-                    <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-primary sm:h-7 sm:w-7">
-                      <Icon
-                        className="h-3.5 w-3.5 sm:h-4 sm:w-4"
-                        strokeWidth={2.1}
-                      />
-                    </span>
-                    <span className="flex min-w-0 flex-col items-start leading-tight">
-                      <span className="truncate text-sm sm:text-[15px]">
-                        {section.label}
-                      </span>
-                      <span className="sr-only text-[11px] font-normal text-muted-foreground/80 sm:not-sr-only sm:text-xs sm:leading-snug">
-                        {section.description}
-                      </span>
-                    </span>
-                    {isActive
-                      ? (
-                        <motion.span
-                          aria-hidden
-                          layoutId="nav-active-indicator"
-                          className="absolute inset-0 -z-[1] rounded-full bg-primary/10"
-                          transition={{
-                            type: "spring",
-                            stiffness: 260,
-                            damping: 24,
-                          }}
+                    <span className="contents">
+                      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-primary sm:h-7 sm:w-7">
+                        <Icon
+                          className="h-3.5 w-3.5 sm:h-4 sm:w-4"
+                          strokeWidth={2.1}
                         />
-                      )
-                      : null}
+                      </span>
+                      <span className="flex min-w-0 flex-col items-start leading-tight">
+                        <span className="truncate text-sm sm:text-[15px]">
+                          {section.label}
+                        </span>
+                        <span className="sr-only text-[11px] font-normal text-muted-foreground/80 sm:not-sr-only sm:text-xs sm:leading-snug">
+                          {section.description}
+                        </span>
+                      </span>
+                      {isActive
+                        ? (
+                          <motion.span
+                            aria-hidden
+                            layoutId="nav-active-indicator"
+                            className="absolute inset-0 -z-[1] rounded-full bg-primary/10"
+                            transition={{
+                              type: "spring",
+                              stiffness: 260,
+                              damping: 24,
+                            }}
+                          />
+                        )
+                        : null}
+                    </span>
                   </Link>
                 </motion.div>
               );

--- a/apps/web/components/magic-portfolio/MobileFooterNav.module.scss
+++ b/apps/web/components/magic-portfolio/MobileFooterNav.module.scss
@@ -40,6 +40,10 @@
     transition: color 0.2s ease, background 0.2s ease;
   }
 
+  .navItemInner {
+    display: contents;
+  }
+
   .navItemActive {
     color: hsl(var(--primary));
     background: hsl(var(--primary) / 0.08);

--- a/apps/web/components/magic-portfolio/MobileFooterNav.tsx
+++ b/apps/web/components/magic-portfolio/MobileFooterNav.tsx
@@ -33,7 +33,11 @@ export function MobileFooterNav() {
     }
   }, [pathname]);
 
-  const navItems = resolvePrimaryNavItems(pathname, hash, (item) => item.includeInFooter);
+  const navItems = resolvePrimaryNavItems(
+    pathname,
+    hash,
+    (item) => item.includeInFooter,
+  );
 
   if (!navItems.length) {
     return null;
@@ -50,10 +54,12 @@ export function MobileFooterNav() {
               [styles.navItemActive]: item.selected,
             })}
           >
-            <span className={styles.emoji} aria-hidden>
-              {item.emoji}
+            <span className={styles.navItemInner}>
+              <span className={styles.emoji} aria-hidden>
+                {item.emoji}
+              </span>
+              <span className={styles.label}>{item.mobileLabel}</span>
             </span>
-            <span className={styles.label}>{item.mobileLabel}</span>
           </Link>
         ))}
       </div>

--- a/apps/web/components/navigation/DesktopNav.tsx
+++ b/apps/web/components/navigation/DesktopNav.tsx
@@ -82,29 +82,31 @@ export const DesktopNav: React.FC = () => {
                   : "text-foreground hover:bg-accent hover:text-accent-foreground",
               )}
             >
-              <span
-                className={cn(
-                  "text-[11px] font-semibold uppercase tracking-wide",
-                  active
-                    ? "text-primary-foreground/80"
-                    : "text-muted-foreground",
-                )}
-              >
-                {item.step}
-              </span>
-              <div className="flex items-center gap-2 font-medium">
-                <Icon className="h-4 w-4" />
-                <span>{item.label}</span>
-              </div>
-              <span
-                className={cn(
-                  "text-xs leading-snug",
-                  active
-                    ? "text-primary-foreground/80"
-                    : "text-muted-foreground",
-                )}
-              >
-                {item.description}
+              <span className="contents">
+                <span
+                  className={cn(
+                    "text-[11px] font-semibold uppercase tracking-wide",
+                    active
+                      ? "text-primary-foreground/80"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {item.step}
+                </span>
+                <div className="flex items-center gap-2 font-medium">
+                  <Icon className="h-4 w-4" />
+                  <span>{item.label}</span>
+                </div>
+                <span
+                  className={cn(
+                    "text-xs leading-snug",
+                    active
+                      ? "text-primary-foreground/80"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {item.description}
+                </span>
               </span>
             </Link>
           </motion.div>

--- a/apps/web/components/navigation/MobileBottomNav.tsx
+++ b/apps/web/components/navigation/MobileBottomNav.tsx
@@ -103,19 +103,21 @@ export const MobileBottomNav: React.FC = () => {
                         : "text-muted-foreground hover:text-primary",
                     )}
                   >
-                    <span
-                      className={cn(
-                        "text-[10px] font-semibold uppercase tracking-wide",
-                        linkActive ? "text-primary" : "text-muted-foreground",
-                      )}
-                    >
-                      {item.step}
+                    <span className="contents">
+                      <span
+                        className={cn(
+                          "text-[10px] font-semibold uppercase tracking-wide",
+                          linkActive ? "text-primary" : "text-muted-foreground",
+                        )}
+                      >
+                        {item.step}
+                      </span>
+                      <Icon className="h-5 w-5" />
+                      <span className="text-xs font-medium leading-tight">
+                        {item.label}
+                      </span>
+                      <span className="sr-only">{item.description}</span>
                     </span>
-                    <Icon className="h-5 w-5" />
-                    <span className="text-xs font-medium leading-tight">
-                      {item.label}
-                    </span>
-                    <span className="sr-only">{item.description}</span>
                   </Link>
                 </motion.div>
               );

--- a/apps/web/components/navigation/SiteHeader.tsx
+++ b/apps/web/components/navigation/SiteHeader.tsx
@@ -38,9 +38,11 @@ export function SiteHeader() {
           aria-label="Dynamic Capital home"
           className="flex items-center gap-3"
         >
-          <BrandLogo size="md" variant="brand" showText={false} animated />
-          <span className="hidden text-sm font-semibold uppercase tracking-[0.32em] text-muted-foreground sm:inline">
-            Dynamic Capital
+          <span className="contents">
+            <BrandLogo size="md" variant="brand" showText={false} animated />
+            <span className="hidden text-sm font-semibold uppercase tracking-[0.32em] text-muted-foreground sm:inline">
+              Dynamic Capital
+            </span>
           </span>
         </Link>
 
@@ -84,8 +86,10 @@ export function SiteHeader() {
               aria-label="Open support"
             >
               <Link href="/support" aria-label="Support center">
-                <LifeBuoy className="h-5 w-5" />
-                <span className="sr-only">Support</span>
+                <span className="contents">
+                  <LifeBuoy className="h-5 w-5" />
+                  <span className="sr-only">Support</span>
+                </span>
               </Link>
             </Button>
             <MobileMenu />


### PR DESCRIPTION
## Summary
- wrap navigation links across header, desktop, and mobile menus in a single child container to satisfy Next.js Link requirements
- update mobile footer navigation styles to support the new wrapper without altering layout
- adjust support page CTA links to wrap text and icons in a single child element

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6ab56791c8322869829e2816b38b3