### PR TITLE
Align build timezone with desk configuration

### DIFF
--- a/apps/web/resources/content.tsx
+++ b/apps/web/resources/content.tsx
@@ -3,6 +3,7 @@ import {
   Blog,
   Gallery,
   Home,
+  IANATimeZone,
   Newsletter,
   Person,
   Social,
@@ -10,8 +11,22 @@ import {
 } from "@/resources/types";
 import { Line, Row, Text } from "@/components/dynamic-ui-system";
 
+import deskTimeZone from "../../../shared/time/desk-time-zone.json";
 import { supabaseAsset } from "./assets";
 import { ogDefaults } from "./og-defaults";
+
+const fallbackDeskTimeZone: IANATimeZone = "Indian/Maldives";
+const rawDeskTimeZone =
+  typeof deskTimeZone?.iana === "string" && deskTimeZone.iana.length > 0
+    ? deskTimeZone.iana
+    : undefined;
+const DESK_TIME_ZONE =
+  (rawDeskTimeZone ?? fallbackDeskTimeZone) as IANATimeZone;
+
+const DESK_TIME_ZONE_LABEL =
+  typeof deskTimeZone?.label === "string" && deskTimeZone.label.length > 0
+    ? deskTimeZone.label
+    : "Malé, Maldives";
 
 const person: Person = {
   firstName: "Abdul Mumin",
@@ -20,8 +35,8 @@ const person: Person = {
   role: "Founder",
   avatar: supabaseAsset("images/avatar.jpg"),
   email: "dynamiccaptialapp@gmail.com",
-  location: "Indian/Maldives",
-  locationLabel: "Malé, Maldives",
+  location: DESK_TIME_ZONE,
+  locationLabel: DESK_TIME_ZONE_LABEL,
 };
 
 const newsletter: Newsletter = {

--- a/scripts/build-landing.mjs
+++ b/scripts/build-landing.mjs
@@ -4,7 +4,7 @@ import { access, cp, mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createSanitizedNpmEnv } from "./utils/npm-env.mjs";
-import { syncMaldivesClock } from "./utils/time-sync.mjs";
+import { syncDeskClock } from "./utils/time-sync.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..");
@@ -14,7 +14,7 @@ const backupDir = join(repoRoot, "_static.backup");
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
 
-const timeSyncOutcome = syncMaldivesClock({ logger: console });
+const timeSyncOutcome = syncDeskClock({ logger: console });
 if (!timeSyncOutcome.ok) {
   console.warn(
     "⚠️  Proceeding with landing snapshot build despite timezone synchronization issues.",

--- a/scripts/run-next-build.mjs
+++ b/scripts/run-next-build.mjs
@@ -9,12 +9,12 @@ import {
   applyBrandingEnvDefaults,
   PRODUCTION_ORIGIN,
 } from "./utils/branding-env.mjs";
-import { syncMaldivesClock } from "./utils/time-sync.mjs";
+import { syncDeskClock } from "./utils/time-sync.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const timeSyncOutcome = syncMaldivesClock({ logger: console });
+const timeSyncOutcome = syncDeskClock({ logger: console });
 if (!timeSyncOutcome.ok) {
   console.warn(
     "⚠️  Proceeding with Next.js build despite timezone synchronization issues.",

--- a/scripts/sync-maldives-time.mjs
+++ b/scripts/sync-maldives-time.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-import { syncMaldivesClock } from "./utils/time-sync.mjs";
+import { syncDeskClock } from "./utils/time-sync.mjs";
 
 const strict = process.argv.includes("--strict");
-const result = syncMaldivesClock({ logger: console });
+const result = syncDeskClock({ logger: console });
 
 if (!result.ok) {
   console.warn(
-    "⚠️  Required Maldives time synchronization steps were not successful.",
+    "⚠️  Required desk time synchronization steps were not successful.",
   );
   if (result.requiredFailures.length > 0) {
     for (const message of result.requiredFailures) {

--- a/shared/time/desk-time-zone.json
+++ b/shared/time/desk-time-zone.json
@@ -1,0 +1,6 @@
+{
+  "iana": "Indian/Maldives",
+  "label": "Malé, Maldives",
+  "abbreviation": "MVT",
+  "offset": "+05:00"
+}


### PR DESCRIPTION
## Summary
- add a shared desk time zone descriptor that can be reused outside the web app
- update the time synchronization utility to derive commands and messaging from the desk time zone config
- point build scripts and profile content at the shared desk time zone so Next.js builds follow the desk clock

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6ab80eb2483228e79462a19824f4a