### PR TITLE
Add metadata manifest for DCT jetton

### DIFF
--- a/dynamic-capital-ton/contracts/jetton/README.md
+++ b/dynamic-capital-ton/contracts/jetton/README.md
@@ -30,3 +30,10 @@ Refer to `config.yaml` for the default deployment parameters. The pool
 allocator (`../pool_allocator.tact`) expects the timelocked router and treasury
 addresses exposed by the master contract, so deploy it alongside the jetton and
 reuse the same multisig administrator when configuring the vault.
+
+## Metadata
+
+The off-chain jetton metadata lives in `metadata.json`. It surfaces the token
+name, symbol, decimals (9), and canonical project URL so wallets and explorers
+can render DCT consistently. Publish the file to IPFS or your preferred static
+host and point the master contract's metadata URI to the hosted JSON artifact.

--- a/dynamic-capital-ton/contracts/jetton/metadata.json
+++ b/dynamic-capital-ton/contracts/jetton/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "Dynamic Capital Token",
+  "symbol": "DCT",
+  "description": "Dynamic Capital Token (DCT) powers the Dynamic Capital trading desk ecosystem with governance-aligned liquidity, automated buyback-and-burn flows, and staking multipliers coordinated through the Dynamic Capital Mini App.",
+  "decimals": 9,
+  "external_url": "https://dynamic.capital",
+  "version": "1.0",
+  "standard": "ton.jetton.v1"
+}


### PR DESCRIPTION
## Summary
- add an off-chain metadata.json manifest for the Dynamic Capital Token jetton
- document the metadata file and hosting guidance in the jetton README

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d6af9fbabc8322b62e7ecbbfbe78f5