### PR TITLE
feat: cache investor overview metrics

### DIFF
--- a/apps/web/app/investor/page.tsx
+++ b/apps/web/app/investor/page.tsx
@@ -2,8 +2,8 @@ import { redirect } from "next/navigation";
 
 import { Column, Heading, Text } from "@/components/dynamic-ui-system";
 import { InvestorMetricsPanel } from "@/components/investor/InvestorMetricsPanel";
+import { getCachedInvestorOverview } from "@/lib/investor-overview-cache";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { fetchInvestorOverview } from "@/lib/investor-metrics";
 
 export const metadata = {
   title: "Investor Dashboard – Dynamic Capital",
@@ -22,7 +22,7 @@ export default async function InvestorPage() {
   }
 
   try {
-    const overview = await fetchInvestorOverview(supabase, user.id);
+    const overview = await getCachedInvestorOverview(user.id);
 
     return (
       <Column

--- a/apps/web/components/investor/InvestorMetricsPanel.tsx
+++ b/apps/web/components/investor/InvestorMetricsPanel.tsx
@@ -59,15 +59,24 @@ export function InvestorMetricsPanel(
     [],
   );
 
-  const formatDateTime = useCallback((value: string | null) => {
-    if (!value) return "—";
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return "—";
-    return new Intl.DateTimeFormat("en-US", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(date);
-  }, []);
+  const dateTimeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-US", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
+    [],
+  );
+
+  const formatDateTime = useCallback(
+    (value: string | null) => {
+      if (!value) return "—";
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return "—";
+      return dateTimeFormatter.format(date);
+    },
+    [dateTimeFormatter],
+  );
 
   const profitLossValue = overview.equity.profitLossUsd;
   const profitLossClass = profitLossValue >= 0

--- a/apps/web/lib/investor-overview-cache.ts
+++ b/apps/web/lib/investor-overview-cache.ts
@@ -1,0 +1,16 @@
+import { unstable_cache } from "next/cache";
+
+import { fetchInvestorOverview } from "@/lib/investor-metrics";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+
+export const getCachedInvestorOverview = unstable_cache(
+  async (profileId: string) => {
+    const supabase = await createServerSupabaseClient();
+    return fetchInvestorOverview(supabase, profileId);
+  },
+  ["investor-overview"],
+  {
+    revalidate: 60,
+    tags: ["investor-overview"],
+  },
+);


### PR DESCRIPTION
## Summary
- add a server-side cached loader for investor overview metrics using Next.js `unstable_cache`
- reuse memoized date formatting in the investor metrics panel to avoid repeated `Intl` constructions

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6b2ea05988322835754e9997aae84