### PR TITLE
Align Pine candlestick triggers with web config

### DIFF
--- a/algorithms/pine-script/README.md
+++ b/algorithms/pine-script/README.md
@@ -29,3 +29,20 @@ automation and EA teams.
 1. Finalize the TradingView strategy/indicator logic.
 2. Document webhook alert JSON payloads so the Vercel function can parse them.
 3. Commit exported backtests or validation notes inside `tests/` for QA.
+
+## Candlestick trigger alignment
+
+- The web configuration lists candlestick triggers under
+  `apps/web/config/strategies/core.json` (e.g. `"engulfing"`, `"pin"`). Keep the
+  names identical to the boolean toggles in
+  `strategies/dynamic_capital_regime_playbook.pine` so UI selections map
+  directly to the Pine logic.
+- `"Engulfing"` requires the current body to engulf the previous candle body
+  and close in the direction of the trend (bullish closes above the prior open,
+  bearish closes below).
+- `"Pin"` enforces a wick-to-body ratio (default 2:1) and a close near the wick
+  extreme so analysts can spot rejection candles without manual tuning.
+- Manual validation: when changing trigger definitions, (1) adjust the Pine
+  script inputs, (2) refresh the UI config list, and (3) replay a labelled
+  TradingView session to confirm that the highlighted candles match the chosen
+  triggers.

--- a/algorithms/pine-script/strategies/dynamic_capital_regime_playbook.pine
+++ b/algorithms/pine-script/strategies/dynamic_capital_regime_playbook.pine
@@ -45,6 +45,16 @@ minFvgSizePctAtr = input.float(0.25, "Min FVG Size x ATR", minval=0.05, maxval=1
 obBodyRatioMin   = input.float(0.6, "OB Body Ratio Min", minval=0.1, maxval=1.0, step=0.05, group=grpFvg)
 obMaxWickRatio   = input.float(0.8, "OB Max Wick Ratio", minval=0.1, maxval=2.0, step=0.05, group=grpFvg)
 
+// Candlestick confirmation
+var string grpCandles = "Candlestick Confirmation"
+requireCandleTrigger      = input.bool(true, "Require Candle Trigger", group=grpCandles)
+enableEngulfingTrigger    = input.bool(true, "\"Engulfing\" Pattern", group=grpCandles)
+engulfingBodyMultiplier   = input.float(1.0, "\"Engulfing\" Min Body x Prev", minval=0.5, maxval=3.0, step=0.05, group=grpCandles)
+enablePinTrigger          = input.bool(true, "\"Pin\" Pattern", group=grpCandles)
+pinMinWickToBodyRatio     = input.float(2.0, "\"Pin\" Wick:Body Min", minval=1.0, maxval=6.0, step=0.1, group=grpCandles)
+pinMaxOppWickToBodyRatio  = input.float(0.4, "\"Pin\" Opp Wick:Body Max", minval=0.0, maxval=2.0, step=0.05, group=grpCandles)
+pinCloseWithinRangePct    = input.float(0.35, "\"Pin\" Close Within Range %", minval=0.05, maxval=0.6, step=0.05, group=grpCandles)
+
 // Timing filters
 var string grpTiming = "Timing"
 sessionTimezone = input.timezone("Asia/Maldives", "Session Timezone", group=grpTiming)
@@ -328,8 +338,30 @@ if not na(lastImpulseHigh) and not na(lastImpulseLow)
     fibShortLower := fibSetOption == "38/50/61" ? lastImpulseLow + (lastImpulseHigh - lastImpulseLow) * 0.382 : lastImpulseLow + (lastImpulseHigh - lastImpulseLow) * 0.75
 
 // === Candlestick Confirmation ===
-strongRejectionLong = close > open and (low <= nzfloat(priorSwingLow, low))
-strongRejectionShort = close < open and (high >= nzfloat(priorSwingHigh, high))
+// Keep the pattern names (`engulfing`, `pin`) aligned with apps/web/config/strategies/core.json
+// so UI configuration for `candle_triggers` matches the logic evaluated here.
+currentBody = math.abs(close - open)
+previousBody = math.abs(close[1] - open[1])
+currentRange = high - low
+
+bullishEngulfingBodyOk = previousBody == 0.0 ? currentBody > 0.0 : currentBody >= previousBody * engulfingBodyMultiplier
+bearishEngulfingBodyOk = previousBody == 0.0 ? currentBody > 0.0 : currentBody >= previousBody * engulfingBodyMultiplier
+
+engulfingLong = close > open and close[1] < open[1] and open <= close[1] and close >= open[1] and bullishEngulfingBodyOk
+engulfingShort = close < open and close[1] > open[1] and open >= close[1] and close <= open[1] and bearishEngulfingBodyOk
+
+lowerWickRatio = currentBody == 0.0 ? 0.0 : calcLowerWickRatio(open, close, low)
+upperWickRatio = currentBody == 0.0 ? 0.0 : calcUpperWickRatio(open, close, high)
+
+pinLong = close >= open and currentBody > 0.0 and currentRange > 0.0 and lowerWickRatio >= pinMinWickToBodyRatio and upperWickRatio <= pinMaxOppWickToBodyRatio and (high - close) <= currentRange * pinCloseWithinRangePct
+pinShort = close <= open and currentBody > 0.0 and currentRange > 0.0 and upperWickRatio >= pinMinWickToBodyRatio and lowerWickRatio <= pinMaxOppWickToBodyRatio and (close - low) <= currentRange * pinCloseWithinRangePct
+
+anyCandleTriggersConfigured = enableEngulfingTrigger or enablePinTrigger
+longPatternMatch = (enableEngulfingTrigger and engulfingLong) or (enablePinTrigger and pinLong)
+shortPatternMatch = (enableEngulfingTrigger and engulfingShort) or (enablePinTrigger and pinShort)
+
+candleTriggerLong = not requireCandleTrigger or not anyCandleTriggersConfigured ? true : longPatternMatch
+candleTriggerShort = not requireCandleTrigger or not anyCandleTriggersConfigured ? true : shortPatternMatch
 
 // === DXY Filter ===
 dxyClose = request.security(dxyTicker, timeframe.period, close, lookahead=barmerge.lookahead_off)
@@ -377,14 +409,14 @@ rangeConfirmShort = (not rangeRequireFvgOrOb or confirmShort)
 reversalConfirmLong = (not reversalRequireFvgOrOb or confirmLong)
 reversalConfirmShort = (not reversalRequireFvgOrOb or confirmShort)
 
-trendLongSetup = enableTrendPlay and allowLongs and sessionFilter and isTrendRegime and pullbackLongZone and confirmLong and strongRejectionLong and trendSweepLongOk and trendBosReadyLong
-trendShortSetup = enableTrendPlay and allowShorts and sessionFilter and isTrendRegime and pullbackShortZone and confirmShort and strongRejectionShort and trendSweepShortOk and trendBosReadyShort
+trendLongSetup = enableTrendPlay and allowLongs and sessionFilter and isTrendRegime and pullbackLongZone and confirmLong and candleTriggerLong and trendSweepLongOk and trendBosReadyLong
+trendShortSetup = enableTrendPlay and allowShorts and sessionFilter and isTrendRegime and pullbackShortZone and confirmShort and candleTriggerShort and trendSweepShortOk and trendBosReadyShort
 
-rangeLongSetup = enableRangePlay and allowLongs and sessionFilter and isRangeRegime and rangeLongReentry and rangeSweepLongOk and rangeConfirmLong and strongRejectionLong
-rangeShortSetup = enableRangePlay and allowShorts and sessionFilter and isRangeRegime and rangeShortReentry and rangeSweepShortOk and rangeConfirmShort and strongRejectionShort
+rangeLongSetup = enableRangePlay and allowLongs and sessionFilter and isRangeRegime and rangeLongReentry and rangeSweepLongOk and rangeConfirmLong and candleTriggerLong
+rangeShortSetup = enableRangePlay and allowShorts and sessionFilter and isRangeRegime and rangeShortReentry and rangeSweepShortOk and rangeConfirmShort and candleTriggerShort
 
-reversalLongSetup = enableReversalPlay and sessionFilter and isReversalRegime and pullbackLongZone and reversalSweepLongOk and reversalConfirmLong and strongRejectionLong and reversalReadyLong
-reversalShortSetup = enableReversalPlay and sessionFilter and isReversalRegime and pullbackShortZone and reversalSweepShortOk and reversalConfirmShort and strongRejectionShort and reversalReadyShort
+reversalLongSetup = enableReversalPlay and sessionFilter and isReversalRegime and pullbackLongZone and reversalSweepLongOk and reversalConfirmLong and candleTriggerLong and reversalReadyLong
+reversalShortSetup = enableReversalPlay and sessionFilter and isReversalRegime and pullbackShortZone and reversalSweepShortOk and reversalConfirmShort and candleTriggerShort and reversalReadyShort
 
 if requireDxyAlignment
     trendLongSetup := trendLongSetup and dxyBearish


### PR DESCRIPTION
## Summary
- add configurable candlestick trigger inputs for the regime playbook strategy
- replace placeholder rejection checks with explicit engulfing/pin evaluations that mirror the web candle_triggers list
- document how to keep Pine trigger logic and UI configuration in sync

## Testing
- Not run (Pine Script changes require TradingView validation)


------
https://chatgpt.com/codex/tasks/task_e_68d6b63e737c83228688b4dbd08a78d5