### PR TITLE
Fix BrowserRouter child layout to prevent build error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,9 +34,9 @@ function App() {
               </Routes>
             </main>
             <SiteFooter />
+            <Toaster />
+            <Sonner />
           </div>
-          <Toaster />
-          <Sonner />
         </Router>
       </AppProviders>
     </QueryClientProvider>


### PR DESCRIPTION
## Summary
- wrap the BrowserRouter contents in a single layout element so the router receives exactly one child and avoids the multi-root error

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6b75d2c348322b034a86ae79bd0e6