### PR TITLE
Switch time sync script to JSON import attributes

### DIFF
--- a/scripts/utils/time-sync.mjs
+++ b/scripts/utils/time-sync.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 
-import deskTimeZoneConfig from "../../shared/time/desk-time-zone.json" assert {
+import deskTimeZoneConfig from "../../shared/time/desk-time-zone.json" with {
   type: "json",
 };
 


### PR DESCRIPTION
## Summary
- replace the deprecated JSON module import assertion in the desk time sync utility with the modern `with { type: "json" }` syntax
- preserves compatibility with current Node releases while removing the V8 deprecation warning during Next.js builds

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d7380aa6888322bfe04632183fed61