### PR TITLE
Ensure landing app derives SITE_URL from public fallback

### DIFF
--- a/apps/landing/lib/env.ts
+++ b/apps/landing/lib/env.ts
@@ -48,9 +48,14 @@ function validatePublicEnv(): MissingMap['public'] {
 }
 
 function validateServerEnv(): MissingMap['server'] {
+  const resolvedSiteUrl = process.env.SITE_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? undefined;
   const result = serverSchema.safeParse({
-    SITE_URL: process.env.SITE_URL,
+    SITE_URL: resolvedSiteUrl,
   });
+
+  if (result.success && typeof resolvedSiteUrl === 'string' && process.env.SITE_URL === undefined) {
+    process.env.SITE_URL = resolvedSiteUrl;
+  }
 
   return result.success ? [] : extractMissing(result.error);
 }


### PR DESCRIPTION
## Summary
- allow the landing environment validator to fall back to NEXT_PUBLIC_SITE_URL when SITE_URL is unset
- populate process.env.SITE_URL from the fallback to keep downstream consumers consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d73a142c0883229402c007140e705f