### PR TITLE
docs: add duplicate receipt safeguard runbook

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -1,11 +1,24 @@
 # Go Live Checklist
 
-- [ ] Webhook set & verified.
-- [ ] Bank happy path (should approve).
-- [ ] Bank near-miss (manual_review with reason).
+- [ ] Webhook set & verified. See the
+  [Go-Live Validation Playbook](./go-live-validation-playbook.md#1-telegram-webhook-health)
+  for the scripted check and health probe steps.
+- [ ] Bank happy path (should approve). Follow the
+  [bank approval runbook](./go-live-validation-playbook.md#2-bank-approvals--happy-path)
+  to capture evidence that `current_vip.is_vip = true`.
+- [ ] Bank near-miss (manual_review with reason). Mirror the
+  [near-miss checklist](./go-live-validation-playbook.md#3-bank-approvals--near-miss)
+  so manual reviews are recorded with a reason.
 - [x] Duplicate image (blocked).
-- [ ] (If crypto enabled) TXID awaiting confirmations → approve later.
-- [ ] Admin commands respond.
+- [ ] Duplicate receipt submissions are rejected. Follow the
+  [safeguard walkthrough](./go-live-validation-playbook.md#4-duplicate-receipt-safeguard)
+  to capture the duplicate error response.
+- [ ] (If crypto enabled) TXID awaiting confirmations → approve later. Use the
+  [crypto validation steps](./go-live-validation-playbook.md#5-crypto-txid-confirmations-if-enabled)
+  when rails are active.
+- [ ] Admin commands respond. Run the
+  [admin smoke test](./go-live-validation-playbook.md#6-admin-command-smoke-test)
+  from an authorized Telegram account.
 
 ## Local webhook smoke test
 

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -89,22 +89,28 @@ in your PR/issue notes so reviewers can see the evidence.
 
 Run the `go-live` automation key
 (`npm run checklists -- --checklist go-live --include-optional`) and mirror the
-manual validations below before exposing updates to traders or admins. Refer to
-the detailed [Go Live Checklist](./GO_LIVE_CHECKLIST.md) for curl commands and
-troubleshooting steps.
+manual validations below before exposing updates to traders or admins. Use the
+[Go-Live Validation Playbook](./go-live-validation-playbook.md) for step-by-step
+runbooks, curl commands, and evidence templates.
 
 1. [ ] Confirm the Telegram webhook is set and returning `200` responses for
-       health pings.
+       health pings (see
+       [playbook §1](./go-live-validation-playbook.md#1-telegram-webhook-health)).
 2. [ ] Walk through the bank happy path to ensure approvals mark
-       `current_vip.is_vip` correctly.
+       `current_vip.is_vip` correctly (see
+       [playbook §2](./go-live-validation-playbook.md#2-bank-approvals--happy-path)).
 3. [ ] Trigger a bank near-miss so `manual_review` captures the reason and the
-       workflow pauses safely.
+       workflow pauses safely (see
+       [playbook §3](./go-live-validation-playbook.md#3-bank-approvals--near-miss)).
 4. [ ] Verify duplicate image uploads are blocked to prevent bypassing
-       compliance checks.
+       compliance checks (see
+       [playbook §4](./go-live-validation-playbook.md#4-duplicate-receipt-safeguard)).
 5. [ ] (If crypto rails are enabled) Submit a transaction with a pending TXID
-       and ensure the approval occurs after confirmations land.
-6. [ ] Exercise admin commands (`/plans`, `/sync`, etc.) to confirm operations
-       tooling responds.
+       and ensure the approval occurs after confirmations land (see
+       [playbook §5](./go-live-validation-playbook.md#5-crypto-txid-confirmations-if-enabled)).
+6. [ ] Exercise admin commands (`/ping`, `/version`, `/admin`, etc.) to confirm
+       operations tooling responds (see
+       [playbook §6](./go-live-validation-playbook.md#6-admin-command-smoke-test)).
 7. [ ] Capture evidence (screenshots, curl output) and attach it to the
        release/PR summary for audit trails.
 

--- a/docs/go-live-validation-playbook.md
+++ b/docs/go-live-validation-playbook.md
@@ -1,0 +1,172 @@
+# Go-Live Validation Playbook
+
+Use this guide to walk through the outstanding launch blockers that remain on the
+[Dynamic Capital checklist](./dynamic-capital-checklist.md). Each section is
+structured as a mini-runbook so operators can collect evidence, unblock missing
+prerequisites, and record results alongside their PR or release notes.
+
+## Prerequisites
+
+1. **Supabase project access** – You need a project ref with the Dynamic Capital
+   schema deployed and the following secrets set:
+   - `SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `SUPABASE_ANON_KEY`
+   - `TELEGRAM_BOT_TOKEN`
+   - `TELEGRAM_WEBHOOK_SECRET`
+   - `ADMIN_API_SECRET` (for privileged admin commands)
+2. **Telegram bot ownership** – Ensure you can DM the production bot as both a
+   normal user and an admin (the admin account must appear in `bot_admins`).
+3. **CLI tooling** – Install Deno (for scripts) and the Supabase CLI. Export any
+   secrets in your shell before running the commands below.
+4. **Mini app content** – Verify `MINI_APP_URL` _or_ `MINI_APP_SHORT_NAME` is set
+   so `/start` can present the launch button during manual checks.
+
+> [!TIP]
+> When network access is unavailable, capture API responses in JSON fixtures and
+> point scripts at them with helper variables such as
+> `TELEGRAM_WEBHOOK_INFO_PATH`.
+
+## 1. Telegram webhook health
+
+1. Export `TELEGRAM_BOT_TOKEN` and run the webhook checker:
+   ```bash
+   deno run -A scripts/check-webhook.ts
+   ```
+   Expected output: the deployed Functions URL, `pending_update_count`, and the
+   absence of `last_error_message`.
+2. If direct Telegram access is blocked, capture the result of
+   `https://api.telegram.org/bot<token>/getWebhookInfo` to a file and re-run the
+   checker with:
+   ```bash
+   TELEGRAM_WEBHOOK_INFO_PATH=fixtures/telegram-webhook-info.json \
+     deno run -A scripts/check-webhook.ts
+   ```
+3. Hit the lightweight health probe to confirm Supabase is serving the
+   `telegram-webhook` function:
+   ```bash
+   curl -s https://<PROJECT_REF>.functions.supabase.co/telegram-webhook/version
+   ```
+   Expect `200 OK` with the function name and timestamp.
+
+Record the webhook URL and any Telegram errors in the release notes.
+
+## 2. Bank approvals – happy path
+
+Goal: submitting a clean receipt should mark the user as VIP.
+
+1. Create or reuse a test user inside Telegram and make sure they can launch the
+   mini app (Telegram menu → Dynamic Capital).
+2. From the mini app or via API, create a checkout session:
+   ```bash
+   curl -s "https://<PROJECT>.functions.supabase.co/checkout-init" \
+     -H "Content-Type: application/json" \
+     -d '{"plan_id":"<PLAN_UUID>","method":"bank_transfer","initData":"<INIT_DATA>"}'
+   ```
+   Capture the returned `payment_id`.
+3. Request an upload URL and push a sample receipt (PNG/JPEG). The helper script
+   in `docs/PHASE_03_CHECKOUT.md` shows the expected payload. Upload the file to
+   the presigned URL returned in the previous step.
+4. Submit the receipt for review:
+   ```bash
+   curl -s "https://<PROJECT>.functions.supabase.co/receipt-submit" \
+     -H "Content-Type: application/json" \
+     -d '{"payment_id":"<PAYMENT_ID>","file_path":"<SIGNED_PATH>","initData":"<INIT_DATA>"}'
+   ```
+5. Run the auto-review job (if not scheduled) to approve clean receipts:
+   ```bash
+   curl -s "https://<PROJECT>.functions.supabase.co/payments-auto-review" \
+     -H "X-Admin-Secret: $ADMIN_API_SECRET" -d '{}'
+   ```
+6. Inspect `current_vip` for the Telegram ID:
+   ```sql
+   select is_vip, subscription_expires_at
+   from current_vip
+   where telegram_id = '<TELEGRAM_ID>';
+   ```
+
+Attach the SQL output proving `is_vip = true` for audit logs.
+
+## 3. Bank approvals – near miss
+
+Goal: an out-of-band receipt lands in `manual_review` with a clear reason.
+
+1. Repeat the checkout flow above but submit a mismatched amount. A simple
+   method is to edit the `expected_amount` in Supabase (or upload a receipt with
+   a different total) before invoking `payments-auto-review`.
+2. After the review job runs, confirm the payment intent moved to
+   `manual_review`:
+   ```sql
+   select payment_status, manual_review_reason
+   from user_subscriptions
+   where telegram_user_id = '<TELEGRAM_ID>';
+   ```
+3. Document the reason (for example `amount_mismatch`) and confirm the VIP view
+   still reports `is_vip = false`.
+
+## 4. Duplicate receipt safeguard
+
+Goal: a second upload for the same payment ID is rejected.
+
+1. Reuse the happy-path payment intent from §2 (or create a new one) and submit
+   the first receipt using the `/receipt-submit` endpoint. Capture the returned
+   payload or the log output confirming the receipt was accepted.
+2. Attempt a second submission for the same `payment_id` with a different file
+   path:
+   ```bash
+   curl -s "https://<PROJECT>.functions.supabase.co/receipt-submit" \
+     -H "Content-Type: application/json" \
+     -d '{"payment_id":"<PAYMENT_ID>","file_path":"<DUPLICATE_PATH>","initData":"<INIT_DATA>"}'
+   ```
+3. Expect an error response (HTTP `409` with `duplicate_receipt` in the body).
+   If the API returns a success payload, inspect the function logs and Supabase
+   storage bucket to confirm only the original upload exists, then file a bug.
+
+Record the rejection response so auditors can see the safeguard working.
+
+## 5. Crypto TXID confirmations (if enabled)
+
+Goal: pending crypto deposits stay blocked until confirmations arrive.
+
+1. Create a crypto payment intent:
+   ```bash
+   curl -s "https://<PROJECT>.functions.supabase.co/intent" \
+     -H "Content-Type: application/json" \
+     -d '{"initData":"<INIT_DATA>","type":"crypto"}'
+   ```
+   Note the returned `pay_code` or deposit address.
+2. Submit a placeholder TXID:
+   ```bash
+   curl -s "https://<PROJECT>.functions.supabase.co/crypto-txid" \
+     -H "Content-Type: application/json" \
+     -d '{"txid":"<PENDING_TXID>","initData":"<INIT_DATA>"}'
+   ```
+3. Verify the payment remains `pending` in Supabase until the blockchain
+   confirms the TXID (or you mark it approved manually for testing). Record the
+   transition to `approved` with timestamps once confirmations arrive.
+
+## 6. Admin command smoke test
+
+Goal: privileged commands respond for operations staff.
+
+1. From an admin Telegram account, send the following commands to the bot and
+   verify the responses:
+   - `/ping` – returns `{ "pong": true }`.
+   - `/version` – includes the deployed bot version string.
+   - `/env` – lists required environment settings (redacted where necessary).
+   - `/reviewlist` – enumerates pending manual reviews.
+   - `/admin` – returns the dashboard deep link with a signed token.
+2. Optional but recommended:
+   - `/webhookinfo` to mirror the scripted webhook check.
+   - `/vipsync <telegram_id>` to trigger a single-user VIP recomputation.
+   - `/flags` to confirm the feature flag manager loads.
+3. Capture screenshots or chat exports demonstrating successful responses.
+
+Checking off this section ensures the Telegram runtime is wired for operations
+handover.
+
+---
+
+After completing each section, update
+[`docs/GO_LIVE_CHECKLIST.md`](./GO_LIVE_CHECKLIST.md) and link evidence in the
+release or PR description so auditors can trace every validation step.


### PR DESCRIPTION
## Summary
- add a duplicate receipt safeguard checklist to the go-live playbook so operators can validate the block manually
- update the go-live and Dynamic Capital checklists to link to the new runbook and keep numbering in sync

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d73abfcb548322a3f65e100417e3e6