### PR TITLE
Fix Next prerender error on About calendar CTA

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -137,7 +137,14 @@ export default function About() {
                   name="calendar"
                   onBackground="brand-weak"
                 />
-                <Row paddingX="8">Schedule a call</Row>
+                <Text
+                  as="span"
+                  paddingX="8"
+                  variant="body-default-s"
+                  onBackground="neutral-strong"
+                >
+                  Schedule a call
+                </Text>
                 <IconButton
                   href={about.calendar.link}
                   data-border="rounded"


### PR DESCRIPTION
## Summary
- replace the calendar CTA text wrapper with a Text component so the About page no longer triggers React.Children.only during prerender

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d738f930148322b16aa9543ac902e2