### PR TITLE
docs: expand Dynamic AI roadmap and adopt DTA naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ import { FiActivity, FiHome, FiUser } from "react-icons/fi";
 - **Multi-LLM Studio tool** (`apps/web/app/tools/multi-llm`) for comparing
   OpenAI, Anthropic, and Groq chat completions side by side with configurable
   temperature and token limits directly inside the main Next.js app.
-- Step through the [Dynamic AI & Trading Algo Enhancement Roadmap](docs/multi-llm-algo-enhancement-roadmap.md)
+- Step through the [Dynamic AI & Dynamic Trading Algo Enhancement Roadmap](docs/multi-llm-algo-enhancement-roadmap.md)
   to align provider orchestration with the trading automation stack.
 
 ## Dynamic Theme System

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -25,25 +25,25 @@ Follow the numbered order below when coordinating large efforts. Each entry
 links back to the detailed checklist and, where available, the automation helper
 key.
 
-| Priority | Checklist                                                                                  | Primary focus                                                                   | Typical use                                                                           | Automation key        |
-| -------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------- |
-| 1        | [`Dynamic Capital Checklist`](./dynamic-capital-checklist.md)                              | Aggregated repo status and cross-checks                                         | Kick off large initiatives or review overall progress                                 | `dynamic-capital`     |
-| 2        | [`Setup Follow-Ups`](./dynamic-capital-checklist.md#setup-follow-ups)                      | Supabase CLI workflow and CI parity tasks                                       | Complete onboarding and align local runs with CI                                      | `setup-followups`     |
-| 3        | [`Coding Efficiency Checklist`](./coding-efficiency-checklist.md)                          | Day-to-day development hygiene                                                  | Scope and deliver individual features or maintenance updates                          | `coding-efficiency`   |
-| 4        | [`Dynamic UI Development Checklist`](./dynamic-ui-development-checklist.md)                | Frontend/back-end surfaces using Dynamic UI                                     | Build or refactor any Dynamic UI-powered surface (landing, dashboard, mini app shell) | `dynamic-ui`          |
-| 5        | [`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md)                      | Environment variables and outbound link audits                                  | Confirm production configuration before toggling features                             | `variables-and-links` |
-| 6        | [`Go Live Checklist`](./GO_LIVE_CHECKLIST.md)                                              | Manual production readiness smoke tests                                         | Validate Telegram webhook flows before launch                                         | `go-live`             |
-| 7        | [`Launch Checklist`](./LAUNCH_CHECKLIST.md)                                                | Secrets and keeper setup                                                        | Harden Supabase edge functions ahead of launch                                        | —                     |
-| 8        | [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)                          | Well-architected review for hosted frontends                                    | Audit Vercel deployments for operational readiness                                    | —                     |
-| 9        | [`Automated Trading System Build Checklist`](./automated-trading-checklist.md)             | TradingView → Vercel → Supabase → MetaTrader 5 pipeline                         | Stand up or extend the automated trading stack                                        | —                     |
-| 10       | [`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md)      | Cross-team onboarding for the TradingView webhook to MT5 flow                   | Coordinate roadmap execution across teams                                             | —                     |
-| 11       | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)          | Merging Dynamic Codex into this monorepo                                        | Completed — dashboard now lives at `/telegram` in the Next.js app                  | —                     |
-| 12       | [`Grok-1 Integration Checklist`](./grok-1-integration-checklist.md)                        | Operationalizing Grok-1 across research, automation, and delivery pipelines     | Plan and track Grok-assisted workflows before exposing them to members                  | —                     |
-| 13       | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)              | Align Git branches with deployable services and domains                         | Rework branching strategy to support independent deployments                  | —                     |
-| 14       | [`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md) | Bringing Investing.com pattern data into Supabase, queue, and Mini App surfaces | Plan and track the signal ingestion + alert rollout                  | —                     |
-| 15       | [`Trading Algo Improvement Checklist`](./trading-algo-improvement-checklist.md)            | Tune Smart Money Concepts configuration & QA loops                              | Iterate on BOS/liquidity heuristics across config, analyzers, and delivery            | —                     |
-| 16       | [`ISO 9241 Environment Alignment Checklist`](./iso9241_environment_checklist.md)          | ISO 9241-110-aligned review of environments, branches, builds, and configuration | Audit deployment hygiene against usability principles               | —                     |
-| 17       | [`CoinGecko Listing Readiness Checklist`](./coingecko-listing-checklist.md)                | Token listing evidence, market data, and compliance artifacts                     | Prepare the application package for a CoinGecko listing                                | —                     |
+| Priority | Checklist                                                                                             | Primary focus                                                                    | Typical use                                                                           | Automation key        |
+| -------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------- |
+| 1        | [`Dynamic Capital Checklist`](./dynamic-capital-checklist.md)                                         | Aggregated repo status and cross-checks                                          | Kick off large initiatives or review overall progress                                 | `dynamic-capital`     |
+| 2        | [`Setup Follow-Ups`](./dynamic-capital-checklist.md#setup-follow-ups)                                 | Supabase CLI workflow and CI parity tasks                                        | Complete onboarding and align local runs with CI                                      | `setup-followups`     |
+| 3        | [`Coding Efficiency Checklist`](./coding-efficiency-checklist.md)                                     | Day-to-day development hygiene                                                   | Scope and deliver individual features or maintenance updates                          | `coding-efficiency`   |
+| 4        | [`Dynamic UI Development Checklist`](./dynamic-ui-development-checklist.md)                           | Frontend/back-end surfaces using Dynamic UI                                      | Build or refactor any Dynamic UI-powered surface (landing, dashboard, mini app shell) | `dynamic-ui`          |
+| 5        | [`Variables and Links Checklist`](./VARIABLES_AND_LINKS_CHECKLIST.md)                                 | Environment variables and outbound link audits                                   | Confirm production configuration before toggling features                             | `variables-and-links` |
+| 6        | [`Go Live Checklist`](./GO_LIVE_CHECKLIST.md)                                                         | Manual production readiness smoke tests                                          | Validate Telegram webhook flows before launch                                         | `go-live`             |
+| 7        | [`Launch Checklist`](./LAUNCH_CHECKLIST.md)                                                           | Secrets and keeper setup                                                         | Harden Supabase edge functions ahead of launch                                        | —                     |
+| 8        | [`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)                                     | Well-architected review for hosted frontends                                     | Audit Vercel deployments for operational readiness                                    | —                     |
+| 9        | [`Automated Trading System Build Checklist`](./automated-trading-checklist.md)                        | TradingView → Vercel → Supabase → MetaTrader 5 pipeline                          | Stand up or extend the automated trading stack                                        | —                     |
+| 10       | [`TradingView → MT5 Onboarding Checklist`](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md)                 | Cross-team onboarding for the TradingView webhook to MT5 flow                    | Coordinate roadmap execution across teams                                             | —                     |
+| 11       | [`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)                     | Merging Dynamic Codex into this monorepo                                         | Completed — dashboard now lives at `/telegram` in the Next.js app                     | —                     |
+| 12       | [`Grok-1 Integration Checklist`](./grok-1-integration-checklist.md)                                   | Operationalizing Grok-1 across research, automation, and delivery pipelines      | Plan and track Grok-assisted workflows before exposing them to members                | —                     |
+| 13       | [`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)                         | Align Git branches with deployable services and domains                          | Rework branching strategy to support independent deployments                          | —                     |
+| 14       | [`Investing.com Candlestick Signal Integration`](./investing-com-candlestick-checklist.md)            | Bringing Investing.com pattern data into Supabase, queue, and Mini App surfaces  | Plan and track the signal ingestion + alert rollout                                   | —                     |
+| 15       | [`Dynamic Trading Algo (DTA) Improvement Checklist`](./dynamic-trading-algo-improvement-checklist.md) | Tune Smart Money Concepts configuration & QA loops                               | Iterate on BOS/liquidity heuristics across config, analyzers, and delivery            | —                     |
+| 16       | [`ISO 9241 Environment Alignment Checklist`](./iso9241_environment_checklist.md)                      | ISO 9241-110-aligned review of environments, branches, builds, and configuration | Audit deployment hygiene against usability principles                                 | —                     |
+| 17       | [`CoinGecko Listing Readiness Checklist`](./coingecko-listing-checklist.md)                           | Token listing evidence, market data, and compliance artifacts                    | Prepare the application package for a CoinGecko listing                               | —                     |
 
 ## Project delivery (priorities 1–3)
 
@@ -93,9 +93,9 @@ key.
 - **[`Dynamic Codex Integration Checklist`](./dynamic_codex_integration_checklist.md)**
   – archived after Dynamic Codex was merged into the main `/telegram` route;
   keep for historical context.
-- **[`Grok-1 Integration Checklist`](./grok-1-integration-checklist.md)**
-  – coordinates research, automation, and delivery changes required to safely
-  roll Grok-assisted workflows across the stack.
+- **[`Grok-1 Integration Checklist`](./grok-1-integration-checklist.md)** –
+  coordinates research, automation, and delivery changes required to safely roll
+  Grok-assisted workflows across the stack.
 - **[`Git Branch Organization Checklist`](./git-branch-organization-checklist.md)**
   – guides the restructuring of branches so each deployable service can map to
   its own domain and load-balanced release flow.
@@ -106,7 +106,8 @@ key.
   – keeps environment, branching, build, and configuration workflows aligned
   with ISO 9241-110 usability guidance.
 - **[`CoinGecko Listing Readiness Checklist`](./coingecko-listing-checklist.md)**
-  – compiles the evidence, documentation, and market data reviewers request during the CoinGecko token listing process.
+  – compiles the evidence, documentation, and market data reviewers request
+  during the CoinGecko token listing process.
 
 ## Keep documentation in sync
 

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -160,7 +160,7 @@ detailed checklists into project docs for visibility.
 3. **[Dynamic Codex Integration Checklist](./dynamic_codex_integration_checklist.md)**
    – Archived context after merging Dynamic Codex into the `/telegram` Next.js
    route; keep for historical reference.
-4. **[Trading Algo Improvement Checklist](./trading-algo-improvement-checklist.md)**
+4. **[Dynamic Trading Algo (DTA) Improvement Checklist](./dynamic-trading-algo-improvement-checklist.md)**
    – Guides Smart Money Concepts tuning across configuration, analyzers, and
    delivery workflows so BOS/liquidity updates land consistently.
 

--- a/docs/dynamic-trading-algo-improvement-checklist.md
+++ b/docs/dynamic-trading-algo-improvement-checklist.md
@@ -1,11 +1,11 @@
-# Trading Algo Improvement Checklist
+# Dynamic Trading Algo (DTA) Improvement Checklist
 
 Use this checklist to tighten the Smart Money Concepts (SMC) workflow that
-supports the trading automation stack. Each section ladders into the repository
-touchpoints called out in `algorithms/`, Supabase Edge Functions, and the
-Telegram delivery surfaces so changes propagate end-to-end. Treat the list as a
-living review ritual for each improvement sprint so that new ideas translate
-into measurable trading performance.
+supports the Dynamic Trading Algo (DTA). Each section ladders into the
+repository touchpoints called out in `algorithms/`, Supabase Edge Functions, and
+the Telegram delivery surfaces so changes propagate end-to-end. Treat the list
+as a living review ritual for each improvement sprint so that new ideas
+translate into measurable trading performance.
 
 ## 1. Foundation & Data Hygiene
 

--- a/docs/market-structure-study-notes.md
+++ b/docs/market-structure-study-notes.md
@@ -111,7 +111,7 @@
   Annotate how structure evolved, why trades succeeded or failed, and how the
   guidelines here would have adjusted the plan.
 
-## Trading Algo Improvement Checklist
+## Dynamic Trading Algo (DTA) Improvement Checklist
 
 - [x] **Root Task: Data & Structure Integrity**
   - [ ] **Validate market structure inputs**: Confirm swing classification,

--- a/docs/multi-llm-algo-enhancement-roadmap.md
+++ b/docs/multi-llm-algo-enhancement-roadmap.md
@@ -1,4 +1,4 @@
-# Dynamic AI & Trading Algo Enhancement Roadmap
+# Dynamic AI & Dynamic Trading Algo (DTA) Enhancement Roadmap
 
 This roadmap breaks the multi-LLM studio, trading automation stack, and
 analytics surfaces into staged workstreams. Follow each step in order—the
@@ -9,9 +9,9 @@ actions progressively reduce risk while layering in new capabilities.
 1. **Catalogue assets** – Map `apps/web/app/tools/multi-llm`,
    `algorithms/python`, `algorithms/pine-script`, Supabase functions, and queue
    workers that already consume model output. Flag undocumented consumers.
-2. **Instrument usage** – Add request/response logging with latency, token,
-   and error metrics per provider into Supabase analytics tables. Mirror the
-   logging inside the trading algo pipelines (`RealtimeExecutor`,
+2. **Instrument usage** – Add request/response logging with latency, token, and
+   error metrics per provider into Supabase analytics tables. Mirror the logging
+   inside the Dynamic Trading Algo (DTA) pipelines (`RealtimeExecutor`,
    `TradeLogic.on_bar`).
 3. **Capture outcomes** – Tie each trade decision to the originating provider
    mix, prompt template, and algorithm parameters so post-trade analysis can
@@ -29,18 +29,32 @@ actions progressively reduce risk while layering in new capabilities.
 
 ## 3. Orchestration Architecture
 
-1. **Design routing policy** – Start with a rules engine: route research
-   queries to reasoning-optimized models, execution guardrails to deterministic
-   ones, and fallback logic for degraded providers.
+1. **Design routing policy** – Start with a rules engine: route research queries
+   to reasoning-optimized models, execution guardrails to deterministic ones,
+   and fallback logic for degraded providers.
 2. **Introduce ensemble scoring** – Implement a reranker that compares
    multi-provider outputs, scores them via heuristics (signal alignment,
-   confidence tags), and selects the best response for downstream trading
-   logic.
-3. **Enable human-in-the-loop overrides** – Surface conflicting or low-confidence
-   outputs to analysts via the studio UI with quick-approve/reject flows that
-   feed back into the scoring weights.
+   confidence tags), and selects the best response for downstream trading logic.
+3. **Enable human-in-the-loop overrides** – Surface conflicting or
+   low-confidence outputs to analysts via the studio UI with
+   quick-approve/reject flows that feed back into the scoring weights.
 
-## 4. Trading Algo Integration
+## 4. Dynamic AI Evolution
+
+1. **Reinforce evaluation data** – Capture transcripts, prompts, and outcomes
+   from production sessions to build red-teaming corpora and golden datasets.
+   Use them to routinely calibrate reasoning depth, tool invocation accuracy,
+   and structured output fidelity across providers.
+2. **Evolve the agent graph** – Introduce specialized Dynamic AI personas for
+   research, risk, and execution review. Define explicit inputs/outputs and
+   mediation protocols so the orchestrator can route complex requests through
+   multi-agent chains without losing context.
+3. **Automate self-audits** – Schedule nightly replay jobs that compare provider
+   rationales against historical market truth. Escalate regressions to analysts
+   and capture remediation actions as configuration proposals for upcoming
+   sprints.
+
+## 5. Dynamic Trading Algo (DTA) Integration
 
 1. **Align glossary checkpoints** – Ensure prompt outputs respect SMC
    terminology so they plug directly into `MarketSnapshot` and analyzer
@@ -52,17 +66,17 @@ actions progressively reduce risk while layering in new capabilities.
    ensemble (e.g., require two providers to agree or have a combined confidence
    score above a target) before the EA or Supabase worker executes.
 
-## 5. Experimentation & Feedback Loops
+## 6. Experimentation & Feedback Loops
 
-1. **Replay harness** – Build notebooks or scripts that replay historical
-   market sessions through the multi-LLM stack to score precision/recall on
-   liquidity sweeps and mitigation blocks.
+1. **Replay harness** – Build notebooks or scripts that replay historical market
+   sessions through the multi-LLM stack to score precision/recall on liquidity
+   sweeps and mitigation blocks.
 2. **A/B pipeline** – Randomly assign signal batches to baseline vs. enhanced
    pipelines; capture performance diffs (win rate, R-multiples, drawdown).
-3. **Closed-loop learning** – Feed tagged outcomes (profitable, flat, loss)
-   into prompt/weight tuning jobs so future runs prioritize successful patterns.
+3. **Closed-loop learning** – Feed tagged outcomes (profitable, flat, loss) into
+   prompt/weight tuning jobs so future runs prioritize successful patterns.
 
-## 6. Compliance, Risk & Security
+## 7. Compliance, Risk & Security
 
 1. **Vendor assessment** – Document provider data handling policies; align with
    SOC/GDPR controls already tracked in the repo and extend to Maldivian
@@ -74,7 +88,7 @@ actions progressively reduce risk while layering in new capabilities.
    provider outages, quality regressions, or hallucinated signals. Include
    rollback instructions for algorithm parameter changes tied to the ensemble.
 
-## 7. Delivery & Communication
+## 8. Delivery & Communication
 
 1. **UI evolution** – Extend Multi-LLM Studio with comparison charts, provider
    status badges, and replay exports so stakeholders understand routing choices.
@@ -84,15 +98,16 @@ actions progressively reduce risk while layering in new capabilities.
 3. **Training modules** – Add onboarding material that teaches analysts how to
    interpret ensemble confidence, override flows, and log feedback.
 
-## 8. Milestone Timeline
+## 9. Milestone Timeline
 
-| Phase | Duration | Key Deliverables |
-|-------|----------|------------------|
-| Foundations | Weeks 1-2 | Telemetry pipelines, provider matrix, prompt library |
-| Orchestration | Weeks 3-4 | Routing engine, ensemble scoring prototype |
-| Integration | Weeks 5-6 | Shadow trading runs, guardrail automation |
-| Scale-Up | Weeks 7-8 | A/B reporting, incident runbooks, studio enhancements |
-| Continuous | Ongoing | Quarterly audits, prompt/weight refresh cadence |
+| Phase                | Duration   | Key Deliverables                                      |
+| -------------------- | ---------- | ----------------------------------------------------- |
+| Foundations          | Weeks 1-2  | Telemetry pipelines, provider matrix, prompt library  |
+| Orchestration        | Weeks 3-4  | Routing engine, ensemble scoring prototype            |
+| Dynamic AI Evolution | Weeks 5-6  | Golden datasets, persona graph, replay harness        |
+| DTA Integration      | Weeks 7-8  | Shadow trading runs, guardrail automation             |
+| Scale-Up             | Weeks 9-10 | A/B reporting, incident runbooks, studio enhancements |
+| Continuous           | Ongoing    | Quarterly audits, prompt/weight refresh cadence       |
 
 Treat each phase as reviewable iteration; do not advance without metrics and
 risk sign-off from trading, compliance, and platform engineering leads.
@@ -102,5 +117,6 @@ risk sign-off from trading, compliance, and platform engineering leads.
 Use the `algorithms/python/trading_algo_enhancement.py` module to materialise
 this roadmap as an executable orchestration plan. The helper exposes default
 tasks, dependency-aware recommendations, and an `OrchestrationPlan` builder so
-engineering, trading, and compliance teams can track telemetry, orchestration,
-integration, experimentation, and governance milestones programmatically.
+engineering, trading, and compliance teams can track telemetry, Dynamic AI
+evolution, DTA integration, experimentation, and governance milestones
+programmatically.


### PR DESCRIPTION
## Summary
- rename the trading algo documentation to Dynamic Trading Algo (DTA) and update checklist references
- expand the Dynamic AI & DTA enhancement roadmap with a dedicated evolution phase and refreshed timeline
- rename the trading algo improvement checklist file to match the new DTA terminology

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d74681606483228c1ba6f3fcbb81ba