### PR TITLE
Prefix algorithm classes with Dynamic branding

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -23,6 +23,12 @@ from .awesome_sync import (
     AwesomeAlgoSyncRequest,
     AwesomeLLMInsights,
 )
+from .data_labeling_algorithm import (
+    AdaptiveLabelingConfig,
+    DynamicAdaptiveLabelingAlgorithm,
+    LiveLabelSyncService,
+    OnlineAdaptiveLabeler,
+)
 from .backtest_analysis import BacktestAnalysis, BacktestSummary, analyze_backtest
 from .backtest_demo import run_mock_backtest
 from .back_to_breakeven import (
@@ -55,8 +61,8 @@ from .economic_catalysts import (
     EconomicCatalystSyncJob,
 )
 from .dex_scanner import (
+    DynamicDexScannerAlgo,
     DexPoolSnapshot,
-    DexScannerAlgo,
     DexScannerSignal,
     build_scanner_for_tokens,
 )
@@ -84,7 +90,7 @@ from .dct_market_maker import (
     DCTMarketMakerQuote,
 )
 from .dct_buyback_algo import (
-    DCTBuybackAlgorithm,
+    DynamicDCTBuybackAlgorithm,
     DCTBuybackInputs,
     DCTBuybackPlan,
     DCTBuybackTranche,
@@ -129,6 +135,14 @@ from .desk_token_hub import (
     TokenHubDevelopmentOrchestrator,
     TokenHubSyncReport,
 )
+from .desk_sync import (
+    DeskSyncReport,
+    DynamicTeamRoleSyncAlgorithm,
+    TeamRolePlaybook,
+    TeamRoleSyncResult,
+    TradingDeskSynchroniser,
+    summarise_trade_logic,
+)
 from .project_faq_generator import (
     FAQEntry,
     FAQRequest,
@@ -165,11 +179,11 @@ from .team_operations import (
     build_team_operations_playbooks,
     build_team_operations_sync_algorithm,
 )
-from .route_keeper import Route, RouteKeeperAlgorithm, RouteKeeperSyncResult
+from .route_keeper import DynamicRouteKeeperAlgorithm, Route, RouteKeeperSyncResult
 from .supabase_edge_functions import (
     EdgeFunctionRunbook,
     EdgeFunctionSpec,
-    SupabaseEdgeFunctionAlgorithm,
+    DynamicSupabaseEdgeFunctionAlgorithm,
     SupabaseEdgeFunctionPlan,
 )
 from .tonkeeper_sync import (
@@ -189,9 +203,9 @@ from .trading_psychology_elements import (
     score_elements,
 )
 from .time_keeper import (
+    DynamicTimeKeeperAlgorithm,
     KillZone,
     MVT_TIMEZONE,
-    TimeKeeperAlgorithm,
     TimeKeeperSyncResult,
     TradingSession,
 )
@@ -229,6 +243,10 @@ __all__ = _trade_exports + [
     "AwesomeAlgoSyncReport",
     "AwesomeAlgoSyncRequest",
     "AwesomeLLMInsights",
+    "AdaptiveLabelingConfig",
+    "DynamicAdaptiveLabelingAlgorithm",
+    "LiveLabelSyncService",
+    "OnlineAdaptiveLabeler",
     "AccountSnapshot",
     "BackToBreakevenCalculator",
     "BreakevenPhase",
@@ -242,12 +260,12 @@ __all__ = _trade_exports + [
     "DCTMarketMakerInputs",
     "DCTMarketMakerModel",
     "DCTMarketMakerQuote",
-    "DCTBuybackAlgorithm",
+    "DynamicDCTBuybackAlgorithm",
     "DCTBuybackInputs",
     "DCTBuybackPlan",
     "DCTBuybackTranche",
     "DexPoolSnapshot",
-    "DexScannerAlgo",
+    "DynamicDexScannerAlgo",
     "DexScannerSignal",
     "build_scanner_for_tokens",
     "EconomicCatalyst",
@@ -299,6 +317,10 @@ __all__ = _trade_exports + [
     "TokenHubDevelopmentContext",
     "TokenHubDevelopmentOrchestrator",
     "TokenHubSyncReport",
+    "EdgeFunctionRunbook",
+    "EdgeFunctionSpec",
+    "DynamicSupabaseEdgeFunctionAlgorithm",
+    "SupabaseEdgeFunctionPlan",
     "FAQEntry",
     "FAQRequest",
     "FAQSource",
@@ -312,7 +334,7 @@ __all__ = _trade_exports + [
     "ProjectFAQGenerator",
     "ProjectFAQPackage",
     "Route",
-    "RouteKeeperAlgorithm",
+    "DynamicRouteKeeperAlgorithm",
     "RouteKeeperSyncResult",
     "StepExecution",
     "StepHandler",
@@ -348,7 +370,7 @@ __all__ = _trade_exports + [
     "score_elements",
     "KillZone",
     "MVT_TIMEZONE",
-    "TimeKeeperAlgorithm",
+    "DynamicTimeKeeperAlgorithm",
     "TimeKeeperSyncResult",
     "TradingSession",
     "EnhancementTask",
@@ -382,6 +404,10 @@ globals().update(
         "AwesomeAlgoSyncReport": AwesomeAlgoSyncReport,
         "AwesomeAlgoSyncRequest": AwesomeAlgoSyncRequest,
         "AwesomeLLMInsights": AwesomeLLMInsights,
+        "AdaptiveLabelingConfig": AdaptiveLabelingConfig,
+        "DynamicAdaptiveLabelingAlgorithm": DynamicAdaptiveLabelingAlgorithm,
+        "LiveLabelSyncService": LiveLabelSyncService,
+        "OnlineAdaptiveLabeler": OnlineAdaptiveLabeler,
         "AccountSnapshot": AccountSnapshot,
         "BackToBreakevenCalculator": BackToBreakevenCalculator,
         "BreakevenPhase": BreakevenPhase,
@@ -392,11 +418,12 @@ globals().update(
         "ElliottWaveReport": ElliottWaveReport,
         "MechanicalAnalysisCalculator": MechanicalAnalysisCalculator,
         "MechanicalMetrics": MechanicalMetrics,
+        "DynamicDCTBuybackAlgorithm": DynamicDCTBuybackAlgorithm,
         "EconomicCatalyst": EconomicCatalyst,
         "EconomicCatalystGenerator": EconomicCatalystGenerator,
         "EconomicCatalystSyncJob": EconomicCatalystSyncJob,
         "DexPoolSnapshot": DexPoolSnapshot,
-        "DexScannerAlgo": DexScannerAlgo,
+        "DynamicDexScannerAlgo": DynamicDexScannerAlgo,
         "DexScannerSignal": DexScannerSignal,
         "build_scanner_for_tokens": build_scanner_for_tokens,
         "CorrelationSeries": CorrelationSeries,
@@ -456,9 +483,22 @@ globals().update(
         "FAQSource": FAQSource,
         "ProjectFAQGenerator": ProjectFAQGenerator,
         "ProjectFAQPackage": ProjectFAQPackage,
+        "Route": Route,
+        "DynamicRouteKeeperAlgorithm": DynamicRouteKeeperAlgorithm,
+        "RouteKeeperSyncResult": RouteKeeperSyncResult,
+        "EdgeFunctionRunbook": EdgeFunctionRunbook,
+        "EdgeFunctionSpec": EdgeFunctionSpec,
+        "DynamicSupabaseEdgeFunctionAlgorithm": DynamicSupabaseEdgeFunctionAlgorithm,
+        "SupabaseEdgeFunctionPlan": SupabaseEdgeFunctionPlan,
+        "DeskSyncReport": DeskSyncReport,
+        "DynamicTeamRoleSyncAlgorithm": DynamicTeamRoleSyncAlgorithm,
+        "TeamRolePlaybook": TeamRolePlaybook,
+        "TeamRoleSyncResult": TeamRoleSyncResult,
+        "TradingDeskSynchroniser": TradingDeskSynchroniser,
+        "summarise_trade_logic": summarise_trade_logic,
         "KillZone": KillZone,
         "MVT_TIMEZONE": MVT_TIMEZONE,
-        "TimeKeeperAlgorithm": TimeKeeperAlgorithm,
+        "DynamicTimeKeeperAlgorithm": DynamicTimeKeeperAlgorithm,
         "TimeKeeperSyncResult": TimeKeeperSyncResult,
         "TradingSession": TradingSession,
         "CEO_PLAYBOOK": CEO_PLAYBOOK,

--- a/algorithms/python/data_labeling_algorithm.py
+++ b/algorithms/python/data_labeling_algorithm.py
@@ -23,7 +23,7 @@ from .trade_logic import FeaturePipeline, LabeledFeature, MarketSnapshot
 
 @dataclass(slots=True)
 class AdaptiveLabelingConfig:
-    """Configuration for :class:`AdaptiveLabelingAlgorithm`.
+    """Configuration for :class:`DynamicAdaptiveLabelingAlgorithm`.
 
     Attributes
     ----------
@@ -50,7 +50,7 @@ class AdaptiveLabelingConfig:
     confidence_slope: float = 1.0
 
 
-class AdaptiveLabelingAlgorithm:
+class DynamicAdaptiveLabelingAlgorithm:
     """Produce labels with a volatility-aware neutral zone."""
 
     def __init__(self, *, pipeline: Optional[FeaturePipeline] = None) -> None:
@@ -158,14 +158,14 @@ class AdaptiveLabelingAlgorithm:
     ) -> LabeledFeature:
         move = (future_snapshot.close - snapshot.close) / snapshot.pip_size
         magnitude = abs(move)
-        threshold = AdaptiveLabelingAlgorithm._calculate_threshold(config, local_vol)
+        threshold = DynamicAdaptiveLabelingAlgorithm._calculate_threshold(config, local_vol)
 
         if magnitude <= threshold:
             label = 0
             confidence = 0.0
         else:
             label = 1 if move > 0 else -1
-            confidence = AdaptiveLabelingAlgorithm._confidence_from_move(
+            confidence = DynamicAdaptiveLabelingAlgorithm._confidence_from_move(
                 magnitude, threshold, config
             )
 
@@ -279,7 +279,7 @@ class OnlineAdaptiveLabeler:
             base = self._buffer.popleft()
             target = self._buffer[self.config.lookahead - 1].snapshot
             emitted.append(
-                AdaptiveLabelingAlgorithm._build_label(
+                DynamicAdaptiveLabelingAlgorithm._build_label(
                     base.snapshot,
                     base.features,
                     base.volatility,
@@ -427,7 +427,7 @@ def _coerce_timestamp(value: object, fallback: Optional[datetime]) -> Optional[d
 
 __all__ = [
     "AdaptiveLabelingConfig",
-    "AdaptiveLabelingAlgorithm",
+    "DynamicAdaptiveLabelingAlgorithm",
     "LiveLabelSyncService",
     "OnlineAdaptiveLabeler",
 ]

--- a/algorithms/python/dct_buyback_algo.py
+++ b/algorithms/python/dct_buyback_algo.py
@@ -10,7 +10,7 @@ __all__ = [
     "DCTBuybackInputs",
     "DCTBuybackTranche",
     "DCTBuybackPlan",
-    "DCTBuybackAlgorithm",
+    "DynamicDCTBuybackAlgorithm",
 ]
 
 
@@ -114,7 +114,7 @@ class DCTBuybackPlan:
     notes: Tuple[str, ...] = field(default_factory=tuple)
 
 
-class DCTBuybackAlgorithm:
+class DynamicDCTBuybackAlgorithm:
     """Generate structured buyback plans from treasury and market data."""
 
     def generate_plan(self, inputs: DCTBuybackInputs) -> DCTBuybackPlan:

--- a/algorithms/python/desk_sync.py
+++ b/algorithms/python/desk_sync.py
@@ -24,7 +24,7 @@ from .trade_logic import PerformanceMetrics, TradeLogic
 __all__ = [
     "TeamRolePlaybook",
     "TeamRoleSyncResult",
-    "TeamRoleSyncAlgorithm",
+    "DynamicTeamRoleSyncAlgorithm",
     "summarise_trade_logic",
     "DeskSyncReport",
     "TradingDeskSynchroniser",
@@ -55,7 +55,7 @@ class TeamRolePlaybook:
 
 @dataclass(slots=True)
 class TeamRoleSyncResult:
-    """Result of running :class:`TeamRoleSyncAlgorithm`."""
+    """Result of running :class:`DynamicTeamRoleSyncAlgorithm`."""
 
     playbooks: Dict[str, TeamRolePlaybook]
     generated_at: datetime
@@ -83,7 +83,7 @@ class TeamRoleSyncResult:
         }
 
 
-class TeamRoleSyncAlgorithm:
+class DynamicTeamRoleSyncAlgorithm:
     """Deterministic registry that exposes trading desk playbooks."""
 
     def __init__(self, playbooks: Iterable[TeamRolePlaybook]):
@@ -190,7 +190,7 @@ class TradingDeskSynchroniser:
     def __init__(
         self,
         *,
-        team_sync: TeamRoleSyncAlgorithm,
+        team_sync: DynamicTeamRoleSyncAlgorithm,
         protocol_planner,
         trade_logic: TradeLogic,
     ) -> None:

--- a/algorithms/python/dex_scanner.py
+++ b/algorithms/python/dex_scanner.py
@@ -38,7 +38,7 @@ class DexScannerSignal:
     notes: tuple[str, ...]
 
 
-class DexScannerAlgo:
+class DynamicDexScannerAlgo:
     """Scores TON DEX pools to help prioritise monitoring."""
 
     def __init__(
@@ -180,8 +180,8 @@ class DexScannerAlgo:
         return max(0.0, min(momentum, 1.0)), volatility_penalty
 
 
-def build_scanner_for_tokens(tokens: Sequence[str]) -> DexScannerAlgo:
+def build_scanner_for_tokens(tokens: Sequence[str]) -> DynamicDexScannerAlgo:
     """Convenience factory for constructing a TON DEX scanner."""
 
-    return DexScannerAlgo(tracked_tokens=tokens)
+    return DynamicDexScannerAlgo(tracked_tokens=tokens)
 

--- a/algorithms/python/executive_playbooks.py
+++ b/algorithms/python/executive_playbooks.py
@@ -1,7 +1,7 @@
 """Executive leadership coordination playbooks.
 
 This module captures the operating rhythm for the executive team so the
-``TeamRoleSyncAlgorithm`` can expose consistent guidance to upstream
+``DynamicTeamRoleSyncAlgorithm`` can expose consistent guidance to upstream
 orchestrators.  Each playbook is intentionally verbose: the objectives focus on
 why the role exists, the workflow documents how each leader executes, and the
 outputs/KPIs provide tangible checkpoints for governance and automation.
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .desk_sync import TeamRolePlaybook, TeamRoleSyncAlgorithm
+from .desk_sync import DynamicTeamRoleSyncAlgorithm, TeamRolePlaybook
 
 __all__ = [
     "CEO_PLAYBOOK",
@@ -113,7 +113,7 @@ def build_executive_playbooks() -> Dict[str, TeamRolePlaybook]:
     return dict(EXECUTIVE_PLAYBOOKS)
 
 
-def build_executive_sync_algorithm() -> TeamRoleSyncAlgorithm:
-    """Return a ``TeamRoleSyncAlgorithm`` configured with executive playbooks."""
+def build_executive_sync_algorithm() -> DynamicTeamRoleSyncAlgorithm:
+    """Return a ``DynamicTeamRoleSyncAlgorithm`` configured with executive playbooks."""
 
-    return TeamRoleSyncAlgorithm(EXECUTIVE_PLAYBOOKS.values())
+    return DynamicTeamRoleSyncAlgorithm(EXECUTIVE_PLAYBOOKS.values())

--- a/algorithms/python/exness_partnership_algorithm.py
+++ b/algorithms/python/exness_partnership_algorithm.py
@@ -16,7 +16,7 @@ __all__ = [
     "PartnershipTask",
     "PartnershipPhase",
     "ExnessPartnershipPlan",
-    "ExnessPartnershipAlgorithm",
+    "DynamicExnessPartnershipAlgorithm",
 ]
 
 
@@ -140,7 +140,7 @@ class ExnessPartnershipPlan:
         }
 
 
-class ExnessPartnershipAlgorithm:
+class DynamicExnessPartnershipAlgorithm:
     """Construct a deterministic plan for executing the Exness partnership."""
 
     def __init__(

--- a/algorithms/python/human_resources_playbooks.py
+++ b/algorithms/python/human_resources_playbooks.py
@@ -4,7 +4,7 @@ This module packages the operational cadence for the people organisation so
 team orchestration services can deliver consistent enablement across the desk.
 Each playbook documents why the function exists, how the work happens, and what
 value signals leaders should monitor.  The intent is to mirror the structure of
-``TeamRoleSyncAlgorithm`` integrations already available for the executive team
+``DynamicTeamRoleSyncAlgorithm`` integrations already available for the executive team
 while focusing on workforce health and compensation governance.
 """
 
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from .desk_sync import TeamRolePlaybook, TeamRoleSyncAlgorithm
+from .desk_sync import DynamicTeamRoleSyncAlgorithm, TeamRolePlaybook
 
 __all__ = [
     "PEOPLE_OPERATIONS_PLAYBOOK",
@@ -146,7 +146,7 @@ def build_human_resources_playbooks() -> Dict[str, TeamRolePlaybook]:
     return dict(HUMAN_RESOURCES_PLAYBOOKS)
 
 
-def build_human_resources_sync_algorithm() -> TeamRoleSyncAlgorithm:
-    """Return a ``TeamRoleSyncAlgorithm`` configured with HR playbooks."""
+def build_human_resources_sync_algorithm() -> DynamicTeamRoleSyncAlgorithm:
+    """Return a ``DynamicTeamRoleSyncAlgorithm`` configured with HR playbooks."""
 
-    return TeamRoleSyncAlgorithm(HUMAN_RESOURCES_PLAYBOOKS.values())
+    return DynamicTeamRoleSyncAlgorithm(HUMAN_RESOURCES_PLAYBOOKS.values())

--- a/algorithms/python/route_keeper.py
+++ b/algorithms/python/route_keeper.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Seque
 from .multi_llm import LLMConfig, LLMRun
 
 
-__all__ = ["Route", "RouteKeeperAlgorithm", "RouteKeeperSyncResult"]
+__all__ = ["Route", "DynamicRouteKeeperAlgorithm", "RouteKeeperSyncResult"]
 
 
 def _normalise_tuple(values: Iterable[Any]) -> Tuple[str, ...]:
@@ -61,7 +61,7 @@ class Route:
 
 @dataclass(slots=True)
 class RouteKeeperSyncResult:
-    """Structured output produced by :class:`RouteKeeperAlgorithm`."""
+    """Structured output produced by :class:`DynamicRouteKeeperAlgorithm`."""
 
     timestamp: datetime
     theme: Optional[str]
@@ -103,7 +103,7 @@ class RouteKeeperSyncResult:
         return payload
 
 
-class RouteKeeperAlgorithm:
+class DynamicRouteKeeperAlgorithm:
     """Coordinates route definitions and cross-algorithm synchronisation."""
 
     def __init__(self) -> None:
@@ -376,7 +376,7 @@ class RouteKeeperAlgorithm:
             for key, value in sorted(context.items()):
                 if key == "prompt" or value is None:
                     continue
-                lines.append(f"- {key}: {RouteKeeperAlgorithm._format_context_value(value)}")
+                lines.append(f"- {key}: {DynamicRouteKeeperAlgorithm._format_context_value(value)}")
         lines.append("")
         lines.append("Routes:")
         for route in routes:
@@ -426,8 +426,12 @@ class RouteKeeperAlgorithm:
     @staticmethod
     def _format_context_value(value: Any) -> str:
         if isinstance(value, Mapping):
-            pairs = ", ".join(f"{key}={RouteKeeperAlgorithm._format_context_value(val)}" for key, val in value.items())
+            pairs = ", ".join(
+                f"{key}={DynamicRouteKeeperAlgorithm._format_context_value(val)}" for key, val in value.items()
+            )
             return f"{{{pairs}}}"
         if isinstance(value, (Sequence, set)) and not isinstance(value, (str, bytes, bytearray)):
-            return ", ".join(RouteKeeperAlgorithm._format_context_value(item) for item in value)
+            return ", ".join(
+                DynamicRouteKeeperAlgorithm._format_context_value(item) for item in value
+            )
         return str(value)

--- a/algorithms/python/supabase_edge_functions.py
+++ b/algorithms/python/supabase_edge_functions.py
@@ -9,7 +9,7 @@ __all__ = [
     "EdgeFunctionSpec",
     "EdgeFunctionRunbook",
     "SupabaseEdgeFunctionPlan",
-    "SupabaseEdgeFunctionAlgorithm",
+    "DynamicSupabaseEdgeFunctionAlgorithm",
 ]
 
 
@@ -103,7 +103,7 @@ class SupabaseEdgeFunctionPlan:
         }
 
 
-class SupabaseEdgeFunctionAlgorithm:
+class DynamicSupabaseEdgeFunctionAlgorithm:
     """Build structured runbooks for deploying Supabase Edge Functions."""
 
     def __init__(self, specs: Iterable[EdgeFunctionSpec]):

--- a/algorithms/python/team_operations.py
+++ b/algorithms/python/team_operations.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
 
-from .desk_sync import TeamRolePlaybook, TeamRoleSyncAlgorithm
+from .desk_sync import DynamicTeamRoleSyncAlgorithm, TeamRolePlaybook
 from .multi_llm import LLMConfig, LLMRun, collect_strings, parse_json_response, serialise_runs
 
 __all__ = [
@@ -697,10 +697,10 @@ def build_team_operations_playbooks(*, include_optional: bool = True) -> Dict[st
     return dict(_aggregate_playbooks(include_optional=include_optional))
 
 
-def build_team_operations_sync_algorithm(*, include_optional: bool = True) -> TeamRoleSyncAlgorithm:
-    """Construct a ``TeamRoleSyncAlgorithm`` for team operations playbooks."""
+def build_team_operations_sync_algorithm(*, include_optional: bool = True) -> DynamicTeamRoleSyncAlgorithm:
+    """Construct a ``DynamicTeamRoleSyncAlgorithm`` for team operations playbooks."""
 
-    return TeamRoleSyncAlgorithm(
+    return DynamicTeamRoleSyncAlgorithm(
         build_team_operations_playbooks(include_optional=include_optional).values()
     )
 

--- a/algorithms/python/tests/test_dct_buyback_algo.py
+++ b/algorithms/python/tests/test_dct_buyback_algo.py
@@ -7,7 +7,7 @@ import math
 import pytest
 
 from algorithms.python.dct_buyback_algo import (
-    DCTBuybackAlgorithm,
+    DynamicDCTBuybackAlgorithm,
     DCTBuybackInputs,
 )
 
@@ -35,7 +35,7 @@ def _build_inputs(**overrides: float) -> DCTBuybackInputs:
 
 
 def test_profit_driven_allocation_creates_balanced_tranches() -> None:
-    algo = DCTBuybackAlgorithm()
+    algo = DynamicDCTBuybackAlgorithm()
     inputs = _build_inputs()
 
     plan = algo.generate_plan(inputs)
@@ -59,7 +59,7 @@ def test_profit_driven_allocation_creates_balanced_tranches() -> None:
 
 
 def test_discounted_market_triggers_accelerated_buybacks() -> None:
-    algo = DCTBuybackAlgorithm()
+    algo = DynamicDCTBuybackAlgorithm()
     inputs = _build_inputs(
         liquid_reserves=600_000.0,
         monthly_profit=300_000.0,
@@ -82,7 +82,7 @@ def test_discounted_market_triggers_accelerated_buybacks() -> None:
 
 
 def test_invalid_inputs_raise_errors() -> None:
-    algo = DCTBuybackAlgorithm()
+    algo = DynamicDCTBuybackAlgorithm()
     inputs = _build_inputs(circulating_supply=0.0)
 
     with pytest.raises(ValueError):

--- a/algorithms/python/tests/test_desk_sync.py
+++ b/algorithms/python/tests/test_desk_sync.py
@@ -12,8 +12,8 @@ import pytest
 
 from algorithms.python.desk_sync import (
     DeskSyncReport,
+    DynamicTeamRoleSyncAlgorithm,
     TeamRolePlaybook,
-    TeamRoleSyncAlgorithm,
     summarise_trade_logic,
     TradingDeskSynchroniser,
 )
@@ -53,7 +53,7 @@ def _build_playbooks() -> list[TeamRolePlaybook]:
 
 def test_team_role_sync_filters_and_serialises() -> None:
     playbooks = _build_playbooks()
-    sync = TeamRoleSyncAlgorithm(playbooks)
+    sync = DynamicTeamRoleSyncAlgorithm(playbooks)
 
     result = sync.synchronise(focus=("Strategist",), context={"shift": "nyc"})
 
@@ -86,7 +86,7 @@ class _StubPlanner:
 
 def test_trading_desk_synchroniser_builds_report() -> None:
     playbooks = _build_playbooks()
-    sync = TeamRoleSyncAlgorithm(playbooks)
+    sync = DynamicTeamRoleSyncAlgorithm(playbooks)
     planner = _StubPlanner()
     trade_logic = TradeLogic()
 
@@ -119,7 +119,7 @@ def test_trading_desk_synchroniser_builds_report() -> None:
 
 
 def test_team_role_sync_errors_on_unknown_focus() -> None:
-    sync = TeamRoleSyncAlgorithm(_build_playbooks())
+    sync = DynamicTeamRoleSyncAlgorithm(_build_playbooks())
     with pytest.raises(KeyError):
         sync.synchronise(focus=("Unknown",))
 

--- a/algorithms/python/tests/test_dex_scanner.py
+++ b/algorithms/python/tests/test_dex_scanner.py
@@ -1,18 +1,18 @@
-"""Tests for the DexScannerAlgo TON DEX scoring engine."""
+"""Tests for the DynamicDexScannerAlgo TON DEX scoring engine."""
 
 from __future__ import annotations
 
 import pytest
 
 from algorithms.python.dex_scanner import (
+    DynamicDexScannerAlgo,
     DexPoolSnapshot,
-    DexScannerAlgo,
     build_scanner_for_tokens,
 )
 
 
 def test_prime_pool_scores_high() -> None:
-    algo = DexScannerAlgo()
+    algo = DynamicDexScannerAlgo()
     snapshot = DexPoolSnapshot(
         dex="DeDust",
         pool_address="0:pool",
@@ -35,7 +35,7 @@ def test_prime_pool_scores_high() -> None:
 
 
 def test_low_liquidity_and_volume_flagged() -> None:
-    algo = DexScannerAlgo(min_liquidity_usd=10_000.0, min_volume_24h_usd=5_000.0, min_transactions_24h=10)
+    algo = DynamicDexScannerAlgo(min_liquidity_usd=10_000.0, min_volume_24h_usd=5_000.0, min_transactions_24h=10)
     snapshot = DexPoolSnapshot(
         dex="STON.fi",
         pool_address="0:thin",
@@ -57,7 +57,7 @@ def test_low_liquidity_and_volume_flagged() -> None:
 
 
 def test_high_volatility_penalty_applied() -> None:
-    algo = DexScannerAlgo(high_volatility_threshold_pct=10.0)
+    algo = DynamicDexScannerAlgo(high_volatility_threshold_pct=10.0)
     snapshot = DexPoolSnapshot(
         dex="DeDust",
         pool_address="0:volatile",
@@ -77,7 +77,7 @@ def test_high_volatility_penalty_applied() -> None:
 
 
 def test_untracked_pool_raises_error() -> None:
-    algo = DexScannerAlgo(tracked_tokens=("DCT",))
+    algo = DynamicDexScannerAlgo(tracked_tokens=("DCT",))
     snapshot = DexPoolSnapshot(
         dex="DeDust",
         pool_address="0:ignored",

--- a/algorithms/python/tests/test_executive_playbooks.py
+++ b/algorithms/python/tests/test_executive_playbooks.py
@@ -8,7 +8,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.executive_playbooks import build_executive_playbooks
-from algorithms.python.desk_sync import TeamRoleSyncAlgorithm
+from algorithms.python.desk_sync import DynamicTeamRoleSyncAlgorithm
 
 
 EXPECTED_ROLES = ("CEO", "CFO", "COO")
@@ -27,7 +27,7 @@ def test_builder_returns_all_executive_roles():
 
 def test_builder_integrates_with_team_role_sync_algorithm():
     playbooks = build_executive_playbooks()
-    algorithm = TeamRoleSyncAlgorithm(playbooks.values())
+    algorithm = DynamicTeamRoleSyncAlgorithm(playbooks.values())
 
     result = algorithm.synchronise()
     assert result.context["role_count"] == len(playbooks)

--- a/algorithms/python/tests/test_exness_partnership_algorithm.py
+++ b/algorithms/python/tests/test_exness_partnership_algorithm.py
@@ -10,13 +10,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.exness_partnership_algorithm import (  # noqa: E402  (import after path fix)
-    ExnessPartnershipAlgorithm,
+    DynamicExnessPartnershipAlgorithm,
     ExnessPartnershipPlan,
 )
 
 
 def build_plan(include_white_label: bool = True) -> ExnessPartnershipPlan:
-    algorithm = ExnessPartnershipAlgorithm(
+    algorithm = DynamicExnessPartnershipAlgorithm(
         ib_tracking_url="https://one.exnessonelink.com/a/s58ps2kc",
         jurisdictions=("Maldives", "Seychelles"),
         partner_brand="Dynamic Capital",
@@ -73,7 +73,7 @@ def test_plan_excludes_white_label_when_disabled() -> None:
 
 def test_missing_inputs_raise_value_error() -> None:
     with pytest.raises(ValueError):
-        ExnessPartnershipAlgorithm(ib_tracking_url="", jurisdictions=("Maldives",))
+        DynamicExnessPartnershipAlgorithm(ib_tracking_url="", jurisdictions=("Maldives",))
 
     with pytest.raises(ValueError):
-        ExnessPartnershipAlgorithm(ib_tracking_url="https://example.com", jurisdictions=())
+        DynamicExnessPartnershipAlgorithm(ib_tracking_url="https://example.com", jurisdictions=())

--- a/algorithms/python/tests/test_human_resources_playbooks.py
+++ b/algorithms/python/tests/test_human_resources_playbooks.py
@@ -8,7 +8,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.human_resources_playbooks import build_human_resources_playbooks
-from algorithms.python.desk_sync import TeamRoleSyncAlgorithm
+from algorithms.python.desk_sync import DynamicTeamRoleSyncAlgorithm
 
 
 EXPECTED_ROLES = (
@@ -33,7 +33,7 @@ def test_builder_returns_all_human_resources_roles():
 
 def test_builder_integrates_with_team_role_sync_algorithm():
     playbooks = build_human_resources_playbooks()
-    algorithm = TeamRoleSyncAlgorithm(playbooks.values())
+    algorithm = DynamicTeamRoleSyncAlgorithm(playbooks.values())
 
     result = algorithm.synchronise()
     assert result.context["role_count"] == len(playbooks)

--- a/algorithms/python/tests/test_route_keeper.py
+++ b/algorithms/python/tests/test_route_keeper.py
@@ -12,8 +12,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.route_keeper import (  # noqa: E402
+    DynamicRouteKeeperAlgorithm,
     Route,
-    RouteKeeperAlgorithm,
 )
 from algorithms.python.multi_llm import LLMConfig  # noqa: E402
 
@@ -33,7 +33,7 @@ class DummyClient:
 
 
 def test_route_keeper_sync_manages_routes_and_conflicts() -> None:
-    keeper = RouteKeeperAlgorithm()
+    keeper = DynamicRouteKeeperAlgorithm()
     fx_route = Route(
         name="fx-core",
         entrypoint="market_advisory.scan",
@@ -123,6 +123,6 @@ def test_route_keeper_sync_manages_routes_and_conflicts() -> None:
 
 
 def test_route_keeper_requires_routes() -> None:
-    keeper = RouteKeeperAlgorithm()
+    keeper = DynamicRouteKeeperAlgorithm()
     with pytest.raises(ValueError):
         keeper.sync()

--- a/algorithms/python/tests/test_supabase_edge_functions.py
+++ b/algorithms/python/tests/test_supabase_edge_functions.py
@@ -10,12 +10,12 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.supabase_edge_functions import (  # noqa: E402
+    DynamicSupabaseEdgeFunctionAlgorithm,
     EdgeFunctionSpec,
-    SupabaseEdgeFunctionAlgorithm,
 )
 
 
-def build_algorithm() -> SupabaseEdgeFunctionAlgorithm:
+def build_algorithm() -> DynamicSupabaseEdgeFunctionAlgorithm:
     specs = [
         EdgeFunctionSpec(
             name="shared-utils",
@@ -41,7 +41,7 @@ def build_algorithm() -> SupabaseEdgeFunctionAlgorithm:
             schedule="*/5 * * * *",
         ),
     ]
-    return SupabaseEdgeFunctionAlgorithm(specs)
+    return DynamicSupabaseEdgeFunctionAlgorithm(specs)
 
 
 def test_supabase_edge_function_plan_orders_dependencies() -> None:
@@ -80,7 +80,7 @@ def test_supabase_edge_function_unknown_dependency() -> None:
         owners=("platform",),
         dependencies=("missing",),
     )
-    algo = SupabaseEdgeFunctionAlgorithm([spec])
+    algo = DynamicSupabaseEdgeFunctionAlgorithm([spec])
 
     with pytest.raises(KeyError):
         algo.build_plan(environment="staging")
@@ -102,7 +102,7 @@ def test_supabase_edge_function_cycle_detection() -> None:
         dependencies=("a",),
     )
 
-    algo = SupabaseEdgeFunctionAlgorithm([a, b])
+    algo = DynamicSupabaseEdgeFunctionAlgorithm([a, b])
 
     with pytest.raises(ValueError):
         algo.build_plan(environment="dev")

--- a/algorithms/python/tests/test_time_keeper.py
+++ b/algorithms/python/tests/test_time_keeper.py
@@ -12,9 +12,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from algorithms.python.time_keeper import (  # noqa: E402
+    DynamicTimeKeeperAlgorithm,
     KillZone,
     MVT_TIMEZONE,
-    TimeKeeperAlgorithm,
     TradingSession,
 )
 from algorithms.python.multi_llm import LLMConfig  # noqa: E402
@@ -36,7 +36,7 @@ class DummyClient:
 
 
 def test_time_keeper_sync_tracks_sessions_and_llm_runs() -> None:
-    algo = TimeKeeperAlgorithm()
+    algo = DynamicTimeKeeperAlgorithm()
     london = TradingSession(
         market="London",
         open_time=time(7, 0),
@@ -107,6 +107,6 @@ def test_time_keeper_sync_tracks_sessions_and_llm_runs() -> None:
 
 
 def test_time_keeper_requires_sessions() -> None:
-    algo = TimeKeeperAlgorithm()
+    algo = DynamicTimeKeeperAlgorithm()
     with pytest.raises(ValueError):
         algo.sync()

--- a/algorithms/python/time_keeper.py
+++ b/algorithms/python/time_keeper.py
@@ -37,7 +37,7 @@ class KillZone:
 
 @dataclass(slots=True)
 class TimeKeeperSyncResult:
-    """Structured output of the :class:`TimeKeeperAlgorithm`."""
+    """Structured output of the :class:`DynamicTimeKeeperAlgorithm`."""
 
     desk_time: datetime
     desk_timezone: tzinfo
@@ -94,7 +94,7 @@ class TimeKeeperSyncResult:
         return payload
 
 
-class TimeKeeperAlgorithm:
+class DynamicTimeKeeperAlgorithm:
     """Coordinates trading time windows and multi-LLM narratives."""
 
     def __init__(self, *, desk_timezone: tzinfo = MVT_TIMEZONE) -> None:
@@ -315,5 +315,5 @@ __all__ = [
     "TradingSession",
     "KillZone",
     "TimeKeeperSyncResult",
-    "TimeKeeperAlgorithm",
+    "DynamicTimeKeeperAlgorithm",
 ]


### PR DESCRIPTION
## Summary
- rename algorithm-oriented classes and factories to start with `Dynamic`, including buyback, desk sync, route keeper, DEX scanner, time keeper, and more
- refresh package exports, helper utilities, and docstrings to reflect the new class names
- update the associated unit tests to reference the renamed classes

## Testing
- PYTHONPATH=. pytest algorithms/python/tests

------
https://chatgpt.com/codex/tasks/task_e_68d74856ca088322a8f7807a27eb63a9