### PR TITLE
Fix pytest package discovery for algorithms tests

### DIFF
--- a/algorithms/python/tests/conftest.py
+++ b/algorithms/python/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for Dynamic Capital Python algorithms."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is importable so ``import algorithms`` resolves to this repository.
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure pytest adds the repository root to sys.path so `import algorithms` resolves during collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d75a508d508322bb08747709934088