### PR TITLE
Integrate llama.cpp vendor tooling

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,25 @@ services:
       - certbot-var:/var/lib/letsencrypt
     entrypoint: /bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/lib/letsencrypt; sleep 12h & wait $${!}; done;'
 
+  llama-server:
+    build:
+      context: ..
+      dockerfile: docker/llama.cpp.Dockerfile
+      args:
+        LLAMA_CPP_COMMIT: 72b24d96c6888c609d562779a23787304ae4609c
+    environment:
+      LLAMA_MODEL: /models/your-model.gguf
+      LLAMA_SERVER_PORT: 8081
+    command: ["--ctx-size", "4096"]
+    volumes:
+      - type: bind
+        source: ./models
+        target: /models
+        read_only: true
+    ports:
+      - "8081:8081"
+    profiles: ["llama"]
+
 volumes:
   certbot-etc:
   certbot-var:

--- a/docker/llama-server-entrypoint.sh
+++ b/docker/llama-server-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${LLAMA_MODEL:-}" == "" ]]; then
+  cat <<'MSG' >&2
+[llama.cpp] Missing LLAMA_MODEL env var.
+Provide the absolute path to a GGUF model file via LLAMA_MODEL. For example:
+
+  docker run -e LLAMA_MODEL=/models/model.gguf -v /path/to/models:/models:ro \
+    dynamic-capital/llama-server:latest
+MSG
+  exit 1
+fi
+
+HOST="${LLAMA_SERVER_HOST:-0.0.0.0}"
+PORT="${LLAMA_SERVER_PORT:-8080}"
+EXTRA_ARGS=()
+
+if [[ "${LLAMA_SERVER_EXTRA_ARGS:-}" != "" ]]; then
+  # shellcheck disable=SC2206
+  EXTRA_ARGS=(${LLAMA_SERVER_EXTRA_ARGS})
+fi
+
+CMD=(
+  "/opt/llama.cpp/bin/llama-server"
+  "--model" "${LLAMA_MODEL}"
+  "--host" "${HOST}"
+  "--port" "${PORT}"
+)
+
+if ((${#EXTRA_ARGS[@]})); then
+  CMD+=("${EXTRA_ARGS[@]}")
+fi
+
+if (($#)); then
+  CMD+=("$@")
+fi
+
+exec "${CMD[@]}"

--- a/docker/llama.cpp.Dockerfile
+++ b/docker/llama.cpp.Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.6
+ARG BASE_IMAGE=ubuntu:22.04
+ARG LLAMA_CPP_COMMIT=72b24d96c6888c609d562779a23787304ae4609c
+
+FROM ${BASE_IMAGE} AS builder
+ARG LLAMA_CPP_COMMIT
+ARG LLAMA_CPP_REPO=https://github.com/ggml-org/llama.cpp.git
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone --filter=blob:none ${LLAMA_CPP_REPO} llama.cpp \
+  && cd llama.cpp \
+  && git checkout ${LLAMA_CPP_COMMIT} \
+  && cmake -S . -B build \
+    -DLLAMA_BUILD_SERVER=ON \
+    -DLLAMA_BUILD_TESTS=OFF \
+    -DLLAMA_BUILD_EXAMPLES=OFF \
+    -DLLAMA_NATIVE=ON \
+  && cmake --build build --config Release -j "$(nproc)"
+
+FROM ${BASE_IMAGE} AS runtime
+ARG LLAMA_CPP_COMMIT
+ENV LLAMA_CPP_COMMIT=${LLAMA_CPP_COMMIT}
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libstdc++6 \
+    libatomic1 \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/llama.cpp
+COPY --from=builder /opt/llama.cpp/build/bin/ ./bin/
+COPY --from=builder /opt/llama.cpp/examples/server/ ./examples/server/
+COPY docker/llama-server-entrypoint.sh /opt/entrypoint.sh
+RUN chmod +x /opt/entrypoint.sh
+
+EXPOSE 8080
+ENV LLAMA_SERVER_HOST=0.0.0.0 \
+    LLAMA_SERVER_PORT=8080 \
+    LLAMA_SERVER_EXTRA_ARGS=""
+ENTRYPOINT ["/opt/entrypoint.sh"]
+CMD []

--- a/docs/language-quant-integration-guide.md
+++ b/docs/language-quant-integration-guide.md
@@ -24,6 +24,8 @@ decisions, or briefing new contributors on the technology landscape.
 - Deploy LLaMA-family models in edge-constrained or air-gapped environments.
 - Pair with quant notebooks to enable on-demand strategy explanations without
   cloud latency.
+- Follow the [llama.cpp Runtime Integration](./llama-cpp-runtime.md) guide to
+  sync vendor sources and build the optimized Docker image.
 
 ### LLaMA-Factory
 

--- a/docs/llama-cpp-runtime.md
+++ b/docs/llama-cpp-runtime.md
@@ -1,0 +1,85 @@
+# llama.cpp Runtime Integration
+
+This guide explains how Dynamic Capital vendors and deploys
+[ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp) for local inference
+workloads. It complements the high-level plan in
+[`language-quant-integration-guide.md`](./language-quant-integration-guide.md)
+with actionable steps for operators and CI pipelines.
+
+## 1. Sync the Vendor Snapshot
+
+1. Ensure `git` and `deno` are installed locally.
+2. Run the helper script to hydrate `third_party/llama.cpp/vendor`:
+
+   ```bash
+   deno run -A scripts/sync-llama-cpp.ts --force
+   ```
+
+   - The script pins commit `72b24d96c6888c609d562779a23787304ae4609c`.
+   - Non-essential directories (bindings, CI configs, large example suites) are
+     pruned by default. Pass `--no-prune` to keep the full upstream tree.
+   - `third_party/llama.cpp/version.json` records the synced commit metadata for
+     audit and reproducibility.
+
+## 2. Build the Container Image
+
+The repository ships with `docker/llama.cpp.Dockerfile`, optimized for CPU-only
+inference and a minimal runtime surface. To produce an image locally:
+
+```bash
+docker build \
+  --file docker/llama.cpp.Dockerfile \
+  --tag dynamic-capital/llama-server:dev \
+  ..
+```
+
+Key build arguments:
+
+- `LLAMA_CPP_COMMIT` (default: `72b24d96c6888c609d562779a23787304ae4609c`) keeps
+  the container aligned with the vendor metadata.
+- `BASE_IMAGE` lets you swap the Ubuntu base for a CUDA-enabled image if GPU
+  acceleration is required downstream.
+
+## 3. Run the Server via Docker Compose
+
+An optional `llama-server` service is available behind the `llama` profile in
+`docker/docker-compose.yml`. To launch it alongside the main stack:
+
+```bash
+mkdir -p models
+# Copy or link your GGUF checkpoint into ./models first.
+docker compose --profile llama up llama-server
+```
+
+Environment knobs exposed by `docker/llama-server-entrypoint.sh`:
+
+- `LLAMA_MODEL` (required): absolute path of the mounted GGUF model file.
+- `LLAMA_SERVER_HOST` (default `0.0.0.0`): listen address for the HTTP server.
+- `LLAMA_SERVER_PORT` (default `8080`, overridden to `8081` in the compose
+  file).
+- `LLAMA_SERVER_EXTRA_ARGS`: optional additional flags (e.g.
+  `"--ctx-size 4096"`).
+
+Additional CLI flags can be appended via the Compose `command` stanza. See the
+[upstream server README](https://github.com/ggml-org/llama.cpp/tree/master/examples/server)
+for the full option matrix.
+
+## 4. Operational Tips
+
+- Always verify model licensing before distributing checkpoints alongside the
+  container image.
+- Update `third_party/llama.cpp/version.json` in Git whenever the pinned commit
+  changes so downstream automation can detect upgrades.
+- For GPU deployments, inherit from this Dockerfile and enable cuBLAS
+  (`-DLLAMA_CUBLAS=ON`).
+- Keep `LLAMA_SERVER_EXTRA_ARGS` minimal in production; prefer explicit Compose
+  overrides committed to infrastructure-as-code.
+
+## 5. Troubleshooting
+
+- **`git` missing** – install it before running the sync script.
+- **Model path errors** – the entrypoint refuses to start without `LLAMA_MODEL`.
+  Confirm that the host directory is mounted read-only and the file suffix is
+  `.gguf`.
+- **High memory usage** – tune context and batch sizes via
+  `LLAMA_SERVER_EXTRA_ARGS` or Compose command overrides.

--- a/scripts/sync-llama-cpp.ts
+++ b/scripts/sync-llama-cpp.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env -S deno run -A
+import { ensureDir } from "https://deno.land/std@0.224.0/fs/ensure_dir.ts";
+import { exists } from "https://deno.land/std@0.224.0/fs/exists.ts";
+import { join, resolve } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { fromFileUrl } from "https://deno.land/std@0.224.0/path/from_file_url.ts";
+
+const REPOSITORY = "https://github.com/ggml-org/llama.cpp.git";
+const COMMIT = "72b24d96c6888c609d562779a23787304ae4609c";
+const PRUNE_PATHS = [
+  ".ci",
+  ".devops",
+  ".github",
+  "android",
+  "bindings",
+  "docs",
+  "examples/assets",
+  "examples/beat",
+  "examples/bench",
+  "examples/benchmark",
+  "examples/benchm",
+  "examples/chat",
+  "examples/convert-llama-ggml-to-gguf",
+  "examples/gguf-split",
+  "examples/lora",
+  "examples/metal",
+  "examples/quantize",
+  "examples/simple",
+  "examples/speculative",
+  "examples/supervised",
+  "examples/train-text-from-scratch",
+  "examples/unicode",
+  "examples/vdot",
+  "examples/whisper",
+  "examples/whisper-wip",
+  "models",
+  "python",
+  "scripts",
+  "tests",
+];
+const KEEP_EXAMPLES = new Set(["server"]);
+
+const args = new Set(Deno.args);
+const force = args.has("--force") || args.has("-f");
+const noPrune = args.has("--no-prune");
+
+if (args.has("--help")) {
+  printHelp();
+  Deno.exit(0);
+}
+
+const repoRoot = resolve(fromFileUrl(new URL("../", import.meta.url)));
+const baseDir = join(repoRoot, "third_party", "llama.cpp");
+const vendorDir = join(baseDir, "vendor");
+
+await ensureDir(baseDir);
+
+if (await exists(vendorDir)) {
+  if (!force) {
+    console.error(
+      `vendor directory already exists at ${vendorDir}. Rerun with --force to replace it.`,
+    );
+    Deno.exit(1);
+  }
+  console.log(`Removing existing vendor directory at ${vendorDir}`);
+  await Deno.remove(vendorDir, { recursive: true });
+}
+
+await assertGitAvailable();
+
+const tmpDir = await Deno.makeTempDir({ prefix: "llama.cpp-sync-" });
+console.log(`Cloning ${REPOSITORY} into ${tmpDir}`);
+await runCommand("git", [
+  "clone",
+  "--filter=blob:none",
+  "--no-checkout",
+  REPOSITORY,
+  tmpDir,
+]);
+
+await runCommand("git", [
+  "fetch",
+  "--depth=1",
+  "origin",
+  COMMIT,
+], tmpDir);
+await runCommand("git", ["checkout", COMMIT], tmpDir);
+
+const commitDate = (await runCapture("git", [
+  "show",
+  "-s",
+  "--format=%cI",
+  COMMIT,
+], tmpDir)).trim();
+
+if (!noPrune) {
+  console.log("Pruning unused directories");
+  for (const path of PRUNE_PATHS) {
+    const target = join(tmpDir, path);
+    if (await exists(target)) {
+      await Deno.remove(target, { recursive: true });
+    }
+  }
+
+  const examplesDir = join(tmpDir, "examples");
+  if (await exists(examplesDir)) {
+    for await (const entry of Deno.readDir(examplesDir)) {
+      if (entry.isDirectory && !KEEP_EXAMPLES.has(entry.name)) {
+        await Deno.remove(join(examplesDir, entry.name), { recursive: true });
+      }
+    }
+  }
+}
+
+await Deno.remove(join(tmpDir, ".git"), { recursive: true });
+await ensureDir(baseDir);
+await Deno.rename(tmpDir, vendorDir);
+
+await writeMetadata(baseDir, {
+  repository: REPOSITORY,
+  commit: COMMIT,
+  commitDate,
+  pruneDisabled: noPrune,
+});
+
+console.log("llama.cpp synced successfully.");
+
+function printHelp() {
+  console.log(`Sync llama.cpp into third_party/llama.cpp/vendor
+
+Usage:
+  deno run -A scripts/sync-llama-cpp.ts [options]
+
+Options:
+  --force, -f     Replace any existing vendor directory
+  --no-prune      Keep the full upstream tree without pruning
+  --help          Show this message
+`);
+}
+
+async function assertGitAvailable() {
+  try {
+    await runCommand("git", ["--version"]);
+  } catch (_error) {
+    console.error(
+      "git is required to sync llama.cpp but was not found in PATH.",
+    );
+    Deno.exit(1);
+  }
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  cwd?: string,
+) {
+  const process = new Deno.Command(command, {
+    args,
+    cwd,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const { code } = await process.output();
+  if (code !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+  }
+}
+
+async function runCapture(
+  command: string,
+  args: string[],
+  cwd?: string,
+): Promise<string> {
+  const process = new Deno.Command(command, {
+    args,
+    cwd,
+    stdout: "piped",
+    stderr: "inherit",
+  });
+  const { code, stdout } = await process.output();
+  if (code !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+  }
+  return new TextDecoder().decode(stdout);
+}
+
+async function writeMetadata(
+  base: string,
+  metadata: {
+    repository: string;
+    commit: string;
+    commitDate: string;
+    pruneDisabled: boolean;
+  },
+) {
+  const metadataPath = join(base, "version.json");
+  const content = JSON.stringify(
+    {
+      ...metadata,
+      notes: "Managed via scripts/sync-llama-cpp.ts",
+    },
+    null,
+    2,
+  ) + "\n";
+  await Deno.writeTextFile(metadataPath, content);
+}

--- a/third_party/llama.cpp/.gitignore
+++ b/third_party/llama.cpp/.gitignore
@@ -1,0 +1,5 @@
+# Ignore the fetched sources; only metadata stays under version control.
+*
+!.gitignore
+!README.md
+!version.json

--- a/third_party/llama.cpp/README.md
+++ b/third_party/llama.cpp/README.md
@@ -1,0 +1,38 @@
+# llama.cpp Vendor Snapshot
+
+Dynamic Capital vendors a curated snapshot of [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)
+to power on-premise language tooling. The full sources are not committed to this
+repository; instead we materialize them on demand using the helper script below.
+
+## How to Sync
+
+```bash
+# Fetch the pinned commit and populate third_party/llama.cpp/vendor
+deno run -A scripts/sync-llama-cpp.ts --force
+```
+
+The script pins the checkout to commit `72b24d96c6888c609d562779a23787304ae4609c`
+and prunes auxiliary assets (bindings, docs, CI configs) so the runtime footprint
+stays lean. The resolved metadata lives in `version.json` for downstream
+automation.
+
+## Local Layout
+
+After running the sync command you will have the following structure:
+
+```
+third_party/llama.cpp/
+├── README.md
+├── version.json
+└── vendor/
+    ├── CMakeLists.txt
+    ├── common/
+    ├── ggml/
+    ├── include/
+    ├── src/
+    ├── examples/server/
+    └── ...
+```
+
+The `vendor` directory is intentionally ignored by Git so local builds can
+customize or clean the checkout without polluting commits.

--- a/third_party/llama.cpp/version.json
+++ b/third_party/llama.cpp/version.json
@@ -1,0 +1,7 @@
+{
+  "repository": "https://github.com/ggml-org/llama.cpp.git",
+  "commit": "72b24d96c6888c609d562779a23787304ae4609c",
+  "commitDate": "2025-09-26T21:28:29Z",
+  "pruneDisabled": false,
+  "notes": "Managed via scripts/sync-llama-cpp.ts"
+}


### PR DESCRIPTION
## Summary
- replace the git submodule with a metadata-backed vendor directory and a Deno sync script that hydrates the pinned llama.cpp commit on demand
- add a dedicated llama.cpp Dockerfile, entrypoint, and optional docker-compose profile so the server can be built and run inside the existing infrastructure stack
- document the llama.cpp integration workflow for operators, covering vendor sync, container builds, and runtime configuration knobs

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d758641ee08322a5260e531ac51b61