### PR TITLE
Support Hugging Face model downloads in llama server entrypoint

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,9 @@ services:
       args:
         LLAMA_CPP_COMMIT: 72b24d96c6888c609d562779a23787304ae4609c
     environment:
+      # Provide either LLAMA_MODEL or LLAMA_HF_REPO (plus optional LLAMA_HF_*).
       LLAMA_MODEL: /models/your-model.gguf
+      # LLAMA_HF_REPO: ggml-org/gemma-3-1b-it-GGUF
       LLAMA_SERVER_PORT: 8081
     command: ["--ctx-size", "4096"]
     volumes:

--- a/docker/llama-server-entrypoint.sh
+++ b/docker/llama-server-entrypoint.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${LLAMA_MODEL:-}" == "" ]]; then
-  cat <<'MSG' >&2
-[llama.cpp] Missing LLAMA_MODEL env var.
-Provide the absolute path to a GGUF model file via LLAMA_MODEL. For example:
-
-  docker run -e LLAMA_MODEL=/models/model.gguf -v /path/to/models:/models:ro \
-    dynamic-capital/llama-server:latest
-MSG
-  exit 1
-fi
-
 HOST="${LLAMA_SERVER_HOST:-0.0.0.0}"
 PORT="${LLAMA_SERVER_PORT:-8080}"
 EXTRA_ARGS=()
@@ -21,9 +10,37 @@ if [[ "${LLAMA_SERVER_EXTRA_ARGS:-}" != "" ]]; then
   EXTRA_ARGS=(${LLAMA_SERVER_EXTRA_ARGS})
 fi
 
-CMD=(
-  "/opt/llama.cpp/bin/llama-server"
-  "--model" "${LLAMA_MODEL}"
+CMD=("/opt/llama.cpp/bin/llama-server")
+
+if [[ "${LLAMA_MODEL:-}" != "" ]]; then
+  CMD+=("--model" "${LLAMA_MODEL}")
+elif [[ "${LLAMA_HF_REPO:-}" != "" ]]; then
+  CMD+=("-hf" "${LLAMA_HF_REPO}")
+  if [[ "${LLAMA_HF_FILE:-}" != "" ]]; then
+    CMD+=("--hf-file" "${LLAMA_HF_FILE}")
+  fi
+  if [[ "${LLAMA_HF_REVISION:-}" != "" ]]; then
+    CMD+=("--hf-revision" "${LLAMA_HF_REVISION}")
+  fi
+  if [[ "${LLAMA_HF_TOKEN:-}" != "" ]]; then
+    CMD+=("--hf-token" "${LLAMA_HF_TOKEN}")
+  fi
+else
+  cat <<'MSG' >&2
+[llama.cpp] Missing model configuration.
+Set LLAMA_MODEL to an absolute GGUF path or provide a Hugging Face repository
+via LLAMA_HF_REPO (optionally LLAMA_HF_FILE/LLAMA_HF_REVISION/LLAMA_HF_TOKEN).
+
+  docker run -e LLAMA_MODEL=/models/model.gguf -v /path/to/models:/models:ro \
+    dynamic-capital/llama-server:latest
+  # or
+  docker run -e LLAMA_HF_REPO=ggml-org/gemma-3-1b-it-GGUF \
+    dynamic-capital/llama-server:latest
+MSG
+  exit 1
+fi
+
+CMD+=(
   "--host" "${HOST}"
   "--port" "${PORT}"
 )

--- a/docs/llama-cpp-runtime.md
+++ b/docs/llama-cpp-runtime.md
@@ -53,12 +53,23 @@ docker compose --profile llama up llama-server
 
 Environment knobs exposed by `docker/llama-server-entrypoint.sh`:
 
-- `LLAMA_MODEL` (required): absolute path of the mounted GGUF model file.
+- `LLAMA_MODEL`: absolute path of the mounted GGUF model file.
+- `LLAMA_HF_REPO`: optional Hugging Face model repository. When set, the entrypoint invokes `llama-server -hf <repo>` and downloads the weights on demand. Pair with:
+  - `LLAMA_HF_FILE`: specific GGUF filename within the repo (defaults to the upstream manifest).
+  - `LLAMA_HF_REVISION`: git ref/commit to pin the download.
+  - `LLAMA_HF_TOKEN`: authentication token for private models.
 - `LLAMA_SERVER_HOST` (default `0.0.0.0`): listen address for the HTTP server.
-- `LLAMA_SERVER_PORT` (default `8080`, overridden to `8081` in the compose
-  file).
+- `LLAMA_SERVER_PORT` (default `8080`, overridden to `8081` in the compose file).
 - `LLAMA_SERVER_EXTRA_ARGS`: optional additional flags (e.g.
   `"--ctx-size 4096"`).
+
+For example, to stream Gemma 3 Instruct weights without mounting a model file:
+
+```bash
+docker run \
+  -e LLAMA_HF_REPO=ggml-org/gemma-3-1b-it-GGUF \
+  dynamic-capital/llama-server:latest
+```
 
 Additional CLI flags can be appended via the Compose `command` stanza. See the
 [upstream server README](https://github.com/ggml-org/llama.cpp/tree/master/examples/server)
@@ -78,8 +89,7 @@ for the full option matrix.
 ## 5. Troubleshooting
 
 - **`git` missing** – install it before running the sync script.
-- **Model path errors** – the entrypoint refuses to start without `LLAMA_MODEL`.
-  Confirm that the host directory is mounted read-only and the file suffix is
-  `.gguf`.
+- **Model configuration errors** – the entrypoint requires either `LLAMA_MODEL` or `LLAMA_HF_REPO`.
+  Confirm that the host directory is mounted read-only when using `LLAMA_MODEL`, or that the Hugging Face repository values are correct when using `LLAMA_HF_*`.
 - **High memory usage** – tune context and batch sizes via
   `LLAMA_SERVER_EXTRA_ARGS` or Compose command overrides.


### PR DESCRIPTION
## Summary
- allow the llama-server container entrypoint to download models from Hugging Face by honoring `LLAMA_HF_*` variables
- extend the runtime guide with the new configuration options and an example for Gemma 3
- annotate the docker-compose service with guidance for choosing between local GGUF files and Hugging Face repos

## Testing
- not run (docs and shell script changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d7613ee5a883228e63f241ad686db4