### PR TITLE
fix: declare zod dependency for landing workspace

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,8 +1,11 @@
 {
-"name": "landing",
-"private": true,
-"scripts": {
-"build": "node ../../scripts/build-landing.mjs",
-"start": "npx serve ../../_static -l ${PORT:-8080}"
-}
+  "name": "landing",
+  "private": true,
+  "scripts": {
+    "build": "node ../../scripts/build-landing.mjs",
+    "start": "npx serve ../../_static -l ${PORT:-8080}"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,11 @@
         "node": "^20"
       }
     },
-    "apps/landing": {},
+    "apps/landing": {
+      "dependencies": {
+        "zod": "^3.23.8"
+      }
+    },
     "apps/web": {
       "dependencies": {
         "@auth/supabase-adapter": "^1.10.0",
@@ -51,11 +55,14 @@
         "@mdx-js/loader": "^3.0.1",
         "@next/mdx": "^15.5.4",
         "@once-ui-system/core": "^1.4.31",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "0.57.1",
         "@opentelemetry/exporter-prometheus": "^0.57.1",
         "@opentelemetry/instrumentation": "0.57.1",
         "@opentelemetry/instrumentation-fetch": "^0.57.1",
         "@opentelemetry/instrumentation-http": "^0.57.1",
         "@opentelemetry/resources": "^1.27.0",
+        "@opentelemetry/sdk-logs": "^0.57.1",
         "@opentelemetry/sdk-metrics": "^1.27.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@radix-ui/react-accordion": "^1.2.0",


### PR DESCRIPTION
## Summary
- add the missing zod runtime dependency to the landing workspace manifest
- update the lockfile so the new workspace dependency is tracked

## Testing
- npm run build --workspace landing

------
https://chatgpt.com/codex/tasks/task_e_68d76a89b508832287abb90134b524c2