### PR TITLE
feat: add AI-guided dynamic market maker

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,8 @@
+"""Core trading primitives shared across runtime services."""
+
+from __future__ import annotations
+
+from .fusion import DynamicFusionAlgo
+from .market_maker import DynamicMarketMaker
+
+__all__ = ["DynamicFusionAlgo", "DynamicMarketMaker"]

--- a/core/fusion.py
+++ b/core/fusion.py
@@ -1,0 +1,7 @@
+"""Adapter exposing AI fusion helpers for market-making services."""
+
+from __future__ import annotations
+
+from dynamic_ai.core import DynamicFusionAlgo
+
+__all__ = ["DynamicFusionAlgo"]

--- a/core/market_maker.py
+++ b/core/market_maker.py
@@ -1,0 +1,159 @@
+"""Dynamic market maker orchestrated by the Dynamic AI fusion layer."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol, Tuple
+
+from .fusion import DynamicFusionAlgo
+from .supabase_client import log_signal, log_trade
+
+LOGGER = logging.getLogger(__name__)
+
+
+class VenueClient(Protocol):
+    """Interface expected from exchange adapters."""
+
+    def replace_quote(self, symbol: str, bid: float, ask: float) -> None:
+        """Submit or replace the resting quote for a trading pair."""
+
+
+@dataclass
+class MarketMakerConfig:
+    """Configuration parameters for the market maker."""
+
+    gamma: float = 0.1
+    kappa: float = 1.0
+    horizon_seconds: int = 60
+    spread_floor: float = 0.001
+    inventory_soft_limit: float = 1000
+    inventory_hard_limit: float = 2000
+
+
+class DynamicMarketMaker:
+    """Avellaneda–Stoikov style market maker with AI-guided parameters."""
+
+    def __init__(self, venue_client: VenueClient, symbol: str = "DCT/USDT") -> None:
+        self.symbol = symbol
+        self.client = venue_client
+        self.fusion = DynamicFusionAlgo()
+        self.inventory: float = 0.0
+        self.pnl: float = 0.0
+        self.config = MarketMakerConfig()
+
+    def update_params_from_dai(self, market_data: Dict[str, Any], treasury: Dict[str, Any]) -> None:
+        """Ask the Dynamic AI layer for refreshed quoting parameters."""
+
+        params = self.fusion.mm_parameters(
+            market_data=market_data,
+            treasury=treasury,
+            inventory=self.inventory,
+        )
+
+        gamma = float(params.get("gamma", self.config.gamma))
+        kappa = float(params.get("kappa", self.config.kappa))
+        horizon = int(params.get("T", self.config.horizon_seconds))
+        spread_floor = float(params.get("spread_floor", self.config.spread_floor))
+
+        self.config.gamma = max(gamma, 1e-6)
+        self.config.kappa = max(kappa, 1e-6)
+        self.config.horizon_seconds = max(horizon, 1)
+        self.config.spread_floor = max(spread_floor, 0.0)
+
+    def quote(self, mid_price: float, sigma: float) -> Tuple[float, float]:
+        """Generate bid and ask quotes based on current inventory and volatility."""
+
+        gamma = self.config.gamma
+        kappa = self.config.kappa
+        horizon = self.config.horizon_seconds
+        spread_floor = self.config.spread_floor
+
+        variance_term = max(sigma, 0.0) ** 2
+        reservation_price = mid_price - (self.inventory * gamma * variance_term * horizon) / 2
+        raw_delta = (gamma * variance_term * horizon) / 2 + (1 / gamma) * math.log(1 + gamma / kappa)
+        floor_delta = spread_floor * max(mid_price, 0.0)
+        delta = max(raw_delta, floor_delta)
+
+        bid = round(reservation_price - delta, 4)
+        ask = round(reservation_price + delta, 4)
+        return bid, ask
+
+    def run_cycle(self, market_data: Dict[str, Any], treasury: Dict[str, Any]) -> Tuple[float, float]:
+        """Execute a single quoting cycle using the latest market snapshot."""
+
+        mid_price = float(market_data.get("mid_price", 1.0))
+        sigma = float(market_data.get("volatility", 0.01))
+
+        if abs(self.inventory) >= self.config.inventory_hard_limit:
+            LOGGER.warning(
+                "Inventory %.2f outside hard limit %.2f – skipping quote",
+                self.inventory,
+                self.config.inventory_hard_limit,
+            )
+            return (0.0, 0.0)
+
+        self.update_params_from_dai(market_data, treasury)
+        bid, ask = self.quote(mid_price, sigma)
+        self.client.replace_quote(self.symbol, bid, ask)
+
+        log_payload = {
+            "symbol": self.symbol,
+            "bid": bid,
+            "ask": ask,
+            "gamma": self.config.gamma,
+            "kappa": self.config.kappa,
+            "inventory": self.inventory,
+        }
+        log_signal(log_payload)
+
+        LOGGER.info(
+            "[DMM] %s | Bid=%.4f Ask=%.4f Inv=%.2f γ=%.3f",
+            self.symbol,
+            bid,
+            ask,
+            self.inventory,
+            self.config.gamma,
+        )
+        return bid, ask
+
+    def on_fill(self, side: str, qty: float, price: float) -> None:
+        """Update inventory and realised PnL in response to a fill."""
+
+        qty = float(qty)
+        price = float(price)
+        side_normalised = side.lower()
+
+        if side_normalised == "buy":
+            self.inventory += qty
+            self.pnl -= qty * price
+        elif side_normalised == "sell":
+            self.inventory -= qty
+            self.pnl += qty * price
+        else:
+            LOGGER.warning("Unknown fill side received: %s", side)
+            return
+
+        log_trade(
+            {
+                "symbol": self.symbol,
+                "side": side_normalised,
+                "qty": qty,
+                "price": price,
+                "inventory": self.inventory,
+                "pnl": self.pnl,
+            }
+        )
+
+        LOGGER.info(
+            "[FILL] %s %.4f@%.4f | Inv=%.2f | PnL=%.2f",
+            side_normalised.upper(),
+            qty,
+            price,
+            self.inventory,
+            self.pnl,
+        )
+
+
+__all__ = ["DynamicMarketMaker", "MarketMakerConfig", "VenueClient"]

--- a/core/supabase_client.py
+++ b/core/supabase_client.py
@@ -1,0 +1,65 @@
+"""Lightweight helpers for logging market maker activity into Supabase."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency at runtime
+    import requests
+except Exception:  # pragma: no cover - fall back to no-op logging
+    requests = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+def log_signal(payload: Dict[str, Any]) -> None:
+    """Persist a quoting decision for observability dashboards."""
+
+    _post("SUPABASE_MM_SIGNALS_TABLE", payload)
+
+
+def log_trade(payload: Dict[str, Any]) -> None:
+    """Persist an executed fill for PnL tracking."""
+
+    _post("SUPABASE_MM_TRADES_TABLE", payload)
+
+
+def _post(table_env: str, payload: Dict[str, Any]) -> None:
+    """Send the payload to Supabase if credentials are available."""
+
+    base_url = os.getenv("SUPABASE_URL")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    table = os.getenv(table_env)
+
+    if not table:
+        LOGGER.debug("Supabase logging skipped; environment variable %%s is unset", table_env)
+        return
+
+    if not base_url or not service_key or requests is None:
+        LOGGER.debug(
+            "Supabase logging skipped; missing configuration or requests dependency",
+        )
+        return
+
+    url = f"{base_url.rstrip('/')}/rest/v1/{table}"
+    headers = {
+        "apikey": service_key,
+        "Authorization": f"Bearer {service_key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=minimal",
+    }
+
+    payload_with_timestamp = {**payload}
+    payload_with_timestamp.setdefault("created_at", datetime.now(timezone.utc).isoformat())
+
+    try:
+        response = requests.post(url, headers=headers, json=payload_with_timestamp, timeout=10)  # type: ignore[operator]
+        response.raise_for_status()
+    except Exception as exc:  # pragma: no cover - network errors are runtime concerns
+        LOGGER.warning("Failed to log payload to Supabase table %s: %s", table, exc)
+
+
+__all__ = ["log_signal", "log_trade"]

--- a/dynamic_ai/core.py
+++ b/dynamic_ai/core.py
@@ -112,6 +112,35 @@ class DynamicFusionAlgo:
 
         return " ".join(comments)
 
+    def mm_parameters(
+        self,
+        market_data: Dict[str, Any],
+        treasury: Dict[str, Any],
+        inventory: float,
+    ) -> Dict[str, float]:
+        """Return adaptive market-making parameters based on risk context."""
+
+        sigma = self._coerce_float(market_data.get("volatility"), default=0.01)
+        treasury_balance = self._coerce_float(treasury.get("balance"), default=100_000.0)
+
+        params: Dict[str, float] = {
+            "gamma": 0.1,
+            "kappa": 1.0,
+            "T": 60.0,
+            "spread_floor": 0.001,
+        }
+
+        if treasury_balance > 500_000:
+            params["gamma"] = 0.05
+
+        if sigma > 0.05:
+            params["spread_floor"] = 0.005
+
+        if abs(inventory) > 1_000:
+            params["gamma"] = max(params["gamma"], 0.2)
+
+        return params
+
     @staticmethod
     def _coerce_float(value: Any, *, default: float) -> float:
         """Attempt to cast a value to float, falling back to a default on failure."""

--- a/tests/dynamic_ai/test_dynamic_fusion_algo.py
+++ b/tests/dynamic_ai/test_dynamic_fusion_algo.py
@@ -51,3 +51,24 @@ def test_news_none_is_treated_as_empty_iterable(algo: DynamicFusionAlgo) -> None
     signal = algo.generate_signal(payload)
 
     assert signal.confidence == pytest.approx(0.45)
+
+
+def test_mm_parameters_adjust_risk_controls(algo: DynamicFusionAlgo) -> None:
+    params = algo.mm_parameters(
+        market_data={"volatility": 0.06},
+        treasury={"balance": 750_000},
+        inventory=50,
+    )
+
+    assert params["gamma"] == pytest.approx(0.05)
+    assert params["spread_floor"] == pytest.approx(0.005)
+
+
+def test_mm_parameters_scale_with_inventory(algo: DynamicFusionAlgo) -> None:
+    params = algo.mm_parameters(
+        market_data={"volatility": 0.01},
+        treasury={"balance": 10_000},
+        inventory=2_000,
+    )
+
+    assert params["gamma"] == pytest.approx(0.2)


### PR DESCRIPTION
## Summary
- add a reusable market maker that sources parameters from the Dynamic AI fusion layer and logs activity to Supabase
- expose fusion helpers from the new core package and extend the fusion algorithm with market making parameter support
- cover the new adaptive parameter logic with unit tests

## Testing
- pytest tests/dynamic_ai/test_dynamic_fusion_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68d76e5dd6008322ab6e5b4bc8306d51