### PR TITLE
feat: add modular fusion lobes and risk guardrails

### DIFF
--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -1,5 +1,31 @@
 """Dynamic AI package exposing fusion signal generation utilities."""
 
 from .core import AISignal, DynamicFusionAlgo
+from .fusion import (
+    FusionEngine,
+    LobeSignal,
+    LorentzianDistanceLobe,
+    RegimeContext,
+    SentimentLobe,
+    SignalLobe,
+    TrendMomentumLobe,
+    TreasuryLobe,
+)
+from .risk import PositionSizing, RiskContext, RiskManager, RiskParameters
 
-__all__ = ["AISignal", "DynamicFusionAlgo"]
+__all__ = [
+    "AISignal",
+    "DynamicFusionAlgo",
+    "FusionEngine",
+    "LobeSignal",
+    "LorentzianDistanceLobe",
+    "RegimeContext",
+    "SentimentLobe",
+    "SignalLobe",
+    "TrendMomentumLobe",
+    "TreasuryLobe",
+    "PositionSizing",
+    "RiskContext",
+    "RiskManager",
+    "RiskParameters",
+]

--- a/dynamic_ai/fusion.py
+++ b/dynamic_ai/fusion.py
@@ -1,0 +1,222 @@
+"""Multi-lobe fusion logic for Dynamic AI signal orchestration."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, Protocol, Sequence
+
+
+SignalAction = str
+
+
+@dataclass
+class RegimeContext:
+    """Macro context describing the current market regime."""
+
+    volatility: float = 0.0
+    sentiment: float = 0.0
+    session: str = "global"
+    risk_off: bool = False
+
+
+@dataclass
+class LobeSignal:
+    """Normalised signal emitted by a lobe in the range [-1, 1]."""
+
+    lobe: str
+    score: float
+    confidence: float
+    rationale: str = ""
+    context: Dict[str, Any] = field(default_factory=dict)
+
+    def bounded_score(self) -> float:
+        """Clamp the score to the supported range."""
+
+        return max(-1.0, min(1.0, self.score))
+
+    def bounded_confidence(self) -> float:
+        """Clamp the confidence into [0, 1]."""
+
+        return max(0.0, min(1.0, self.confidence))
+
+
+class SignalLobe(Protocol):
+    """Protocol implemented by all signal lobes."""
+
+    name: str
+
+    def evaluate(self, data: Mapping[str, Any]) -> LobeSignal:
+        """Return the lobe's signal for the supplied data snapshot."""
+
+
+@dataclass
+class LorentzianDistanceLobe:
+    """Measures deviation from a reference path using Lorentzian distance."""
+
+    name: str = "lorentzian"
+    sensitivity: float = 1.0
+
+    def evaluate(self, data: Mapping[str, Any]) -> LobeSignal:
+        price = float(data.get("price", 0.0))
+        reference = float(data.get("reference_price", price))
+        dispersion = float(data.get("dispersion", 0.0))
+
+        # Lorentzian distance emphasises large deviations while remaining smooth.
+        diff = price - reference
+        lorentzian = math.log1p((diff**2) / (1 + dispersion))
+        score = -1.0 if lorentzian > self.sensitivity else 1.0 - lorentzian / (self.sensitivity + 1e-6)
+        score = max(-1.0, min(1.0, score))
+
+        rationale = (
+            f"Price deviation of {diff:.4f} versus reference with Lorentzian metric {lorentzian:.4f}."
+        )
+        confidence = max(0.1, 1.0 - min(1.0, lorentzian / (self.sensitivity + 1e-6)))
+
+        return LobeSignal(lobe=self.name, score=score, confidence=confidence, rationale=rationale)
+
+
+@dataclass
+class TrendMomentumLobe:
+    """Combines trend direction and momentum strength into a signal."""
+
+    name: str = "trend_momentum"
+    momentum_threshold: float = 0.4
+
+    def evaluate(self, data: Mapping[str, Any]) -> LobeSignal:
+        trend = str(data.get("trend", "neutral")).lower()
+        momentum = float(data.get("momentum", 0.0))
+
+        if trend in {"bullish", "uptrend"}:
+            base = 1.0
+        elif trend in {"bearish", "downtrend"}:
+            base = -1.0
+        else:
+            base = 0.0
+
+        intensity = min(1.0, abs(momentum) / max(self.momentum_threshold, 1e-6))
+        score = base * intensity if base != 0 else momentum
+        score = max(-1.0, min(1.0, score))
+
+        rationale = f"Trend {trend} with momentum {momentum:.2f} yields score {score:.2f}."
+        confidence = max(0.2, min(1.0, abs(momentum)))
+
+        return LobeSignal(lobe=self.name, score=score, confidence=confidence, rationale=rationale)
+
+
+@dataclass
+class SentimentLobe:
+    """Aggregates sentiment feeds into a directional stance."""
+
+    name: str = "sentiment"
+    positive_keywords: Sequence[str] = ("growth", "upgrade", "bullish")
+    negative_keywords: Sequence[str] = ("downgrade", "bearish", "risk")
+
+    def evaluate(self, data: Mapping[str, Any]) -> LobeSignal:
+        feeds: Iterable[Mapping[str, Any]] = data.get("sentiment_feeds", [])  # type: ignore[assignment]
+
+        positive_hits = 0
+        negative_hits = 0
+        aggregate_score = 0.0
+
+        for feed in feeds or []:
+            score = float(feed.get("score", 0.0))
+            aggregate_score += score
+            text = str(feed.get("summary", "")).lower()
+            if any(keyword in text for keyword in self.positive_keywords):
+                positive_hits += 1
+            if any(keyword in text for keyword in self.negative_keywords):
+                negative_hits += 1
+
+        count = max(len(list(feeds or [])), 1)
+        avg_score = aggregate_score / count
+        keyword_bias = positive_hits - negative_hits
+        score = max(-1.0, min(1.0, avg_score + 0.2 * keyword_bias))
+
+        confidence = max(0.2, min(1.0, abs(score)))
+        rationale = (
+            f"Sentiment average {avg_score:.2f} with keyword bias {keyword_bias} implies score {score:.2f}."
+        )
+
+        return LobeSignal(lobe=self.name, score=score, confidence=confidence, rationale=rationale)
+
+
+@dataclass
+class TreasuryLobe:
+    """Evaluates treasury health to determine risk appetite."""
+
+    name: str = "treasury"
+    buffer_ratio: float = 0.2
+
+    def evaluate(self, data: Mapping[str, Any]) -> LobeSignal:
+        treasury = data.get("treasury", {})
+        balance = float(treasury.get("balance", 0.0))
+        liabilities = float(treasury.get("liabilities", 1.0))
+        utilisation = float(treasury.get("utilisation", 0.0))
+
+        health_ratio = balance / max(liabilities, 1e-6)
+        score = 1.0 if health_ratio > (1 + self.buffer_ratio) else -1.0 + health_ratio
+        score = max(-1.0, min(1.0, score - utilisation))
+
+        rationale = (
+            f"Treasury health ratio {health_ratio:.2f} with utilisation {utilisation:.2f} yields {score:.2f}."
+        )
+        confidence = max(0.3, min(1.0, 1 - min(1.0, utilisation)))
+
+        return LobeSignal(lobe=self.name, score=score, confidence=confidence, rationale=rationale)
+
+
+class FusionEngine:
+    """Combine multiple lobes into a single discrete trading action."""
+
+    def __init__(self, lobes: Sequence[SignalLobe]) -> None:
+        self._lobes = list(lobes)
+
+    def combine(self, data: Mapping[str, Any], regime: RegimeContext | None = None) -> Dict[str, Any]:
+        """Fuse the lobe signals into a final recommendation."""
+
+        regime = regime or RegimeContext()
+        signals = [lobe.evaluate(data) for lobe in self._lobes]
+
+        weights = [self._regime_weight(signal, regime) for signal in signals]
+        weighted_scores = [signal.bounded_score() * weights[i] for i, signal in enumerate(signals)]
+        weighted_confidence = [signal.bounded_confidence() * weights[i] for i, signal in enumerate(signals)]
+
+        score_total = sum(weighted_scores)
+        weight_total = sum(weights) or 1.0
+        confidence_total = sum(weighted_confidence) / weight_total
+
+        normalised_score = score_total / weight_total
+        action = self._score_to_action(normalised_score)
+        action_confidence = max(0.0, min(1.0, 0.5 + 0.5 * abs(normalised_score)))
+        action_confidence = max(action_confidence, confidence_total)
+
+        return {
+            "action": action,
+            "score": round(normalised_score, 4),
+            "confidence": round(action_confidence, 4),
+            "lobes": [signal.__dict__ for signal in signals],
+            "weights": weights,
+        }
+
+    def _regime_weight(self, signal: LobeSignal, regime: RegimeContext) -> float:
+        base_weight = 1.0
+
+        if signal.lobe == "lorentzian" and regime.volatility > 1.0:
+            base_weight *= 1.4
+        if signal.lobe == "sentiment" and regime.sentiment < -0.5:
+            base_weight *= 0.7
+        if signal.lobe == "treasury" and (regime.risk_off or regime.volatility > 1.2):
+            base_weight *= 1.5
+        if signal.lobe == "trend_momentum" and regime.session in {"asia", "london"}:
+            base_weight *= 1.1
+
+        return base_weight * signal.bounded_confidence()
+
+    @staticmethod
+    def _score_to_action(score: float) -> SignalAction:
+        if score > 0.2:
+            return "BUY"
+        if score < -0.2:
+            return "SELL"
+        return "NEUTRAL"

--- a/dynamic_ai/risk.py
+++ b/dynamic_ai/risk.py
@@ -1,0 +1,83 @@
+"""Risk management utilities for Dynamic AI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class RiskParameters:
+    """Configuration controlling the risk guardrails."""
+
+    max_daily_drawdown: float = 0.08
+    treasury_utilisation_cap: float = 0.6
+    circuit_breaker_drawdown: float = 0.12
+
+
+@dataclass
+class RiskContext:
+    """Current risk state derived from telemetry."""
+
+    daily_drawdown: float = 0.0
+    treasury_utilisation: float = 0.0
+    treasury_health: float = 1.0
+    volatility: float = 0.0
+
+
+@dataclass
+class PositionSizing:
+    """Output of the sizing heuristic."""
+
+    notional: float
+    leverage: float
+    notes: str
+
+
+class RiskManager:
+    """Apply guardrails to signals and produce sizing guidance."""
+
+    def __init__(self, params: RiskParameters | None = None) -> None:
+        self.params = params or RiskParameters()
+
+    def enforce(self, signal: Dict[str, Any], context: RiskContext) -> Dict[str, Any]:
+        """Adjust the fused signal if guardrails are violated."""
+
+        adjusted = dict(signal)
+        notes: list[str] = []
+
+        if context.daily_drawdown <= -abs(self.params.circuit_breaker_drawdown):
+            adjusted["action"] = "NEUTRAL"
+            adjusted["confidence"] = min(adjusted.get("confidence", 0.0), 0.2)
+            adjusted["circuit_breaker"] = True
+            notes.append("Circuit breaker triggered due to drawdown.")
+            return self._finalise(adjusted, notes)
+
+        if context.daily_drawdown <= -abs(self.params.max_daily_drawdown):
+            adjusted["confidence"] = min(adjusted.get("confidence", 0.0), 0.4)
+            notes.append("Confidence clipped by daily drawdown guardrail.")
+
+        if context.treasury_utilisation >= self.params.treasury_utilisation_cap:
+            adjusted["action"] = "NEUTRAL"
+            notes.append("Treasury utilisation above cap; pausing new risk.")
+
+        adjusted["risk_notes"] = notes
+        return adjusted
+
+    def sizing(self, context: RiskContext, *, confidence: float, volatility: float) -> PositionSizing:
+        """Derive position sizing based on confidence and volatility."""
+
+        base_notional = max(0.0, confidence - 0.2) * context.treasury_health
+        volatility_penalty = max(0.2, min(1.0, 1.0 - volatility))
+        treasury_modifier = max(0.1, min(1.0, 1.0 - context.treasury_utilisation))
+
+        notional = base_notional * volatility_penalty * treasury_modifier
+        leverage = min(3.0, 1.0 + confidence * 2 * volatility_penalty)
+
+        notes = "Sizing adjusted for volatility and treasury health."
+        return PositionSizing(notional=round(notional, 4), leverage=round(leverage, 2), notes=notes)
+
+    @staticmethod
+    def _finalise(signal: Dict[str, Any], notes: list[str]) -> Dict[str, Any]:
+        signal["risk_notes"] = notes
+        return signal

--- a/tests/test_fusion_engine.py
+++ b/tests/test_fusion_engine.py
@@ -1,0 +1,65 @@
+"""Unit tests for the multi-lobe FusionEngine."""
+
+from dynamic_ai.fusion import (
+    FusionEngine,
+    LorentzianDistanceLobe,
+    RegimeContext,
+    SentimentLobe,
+    TrendMomentumLobe,
+    TreasuryLobe,
+)
+
+
+def build_engine() -> FusionEngine:
+    return FusionEngine(
+        [
+            LorentzianDistanceLobe(sensitivity=0.5),
+            TrendMomentumLobe(momentum_threshold=0.5),
+            SentimentLobe(),
+            TreasuryLobe(buffer_ratio=0.1),
+        ]
+    )
+
+
+def test_fusion_engine_buy_bias() -> None:
+    engine = build_engine()
+    data = {
+        "price": 105,
+        "reference_price": 100,
+        "dispersion": 0.1,
+        "trend": "bullish",
+        "momentum": 0.8,
+        "sentiment_feeds": [
+            {"score": 0.6, "summary": "Analysts issue bullish upgrade"},
+            {"score": 0.4, "summary": "Growth outlook improving"},
+        ],
+        "treasury": {"balance": 500000, "liabilities": 200000, "utilisation": 0.3},
+    }
+    regime = RegimeContext(volatility=0.8, sentiment=0.4, session="asia")
+
+    fused = engine.combine(data, regime)
+
+    assert fused["action"] == "BUY"
+    assert 0.2 < fused["score"] <= 1
+    assert 0.5 < fused["confidence"] <= 1
+
+
+def test_fusion_engine_guarded_by_treasury() -> None:
+    engine = build_engine()
+    data = {
+        "price": 99,
+        "reference_price": 100,
+        "dispersion": 0.05,
+        "trend": "bullish",
+        "momentum": 0.2,
+        "sentiment_feeds": [
+            {"score": 0.2, "summary": "Bullish"},
+        ],
+        "treasury": {"balance": 100000, "liabilities": 200000, "utilisation": 0.95},
+    }
+    regime = RegimeContext(volatility=1.3, sentiment=0.1, session="new_york", risk_off=True)
+
+    fused = engine.combine(data, regime)
+
+    assert fused["action"] in {"NEUTRAL", "SELL"}
+    assert fused["confidence"] <= 0.7

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,27 @@
+"""Tests for the risk management guardrails."""
+
+from dynamic_ai.risk import PositionSizing, RiskContext, RiskManager, RiskParameters
+
+
+def test_risk_manager_enforces_circuit_breaker() -> None:
+    manager = RiskManager(RiskParameters(max_daily_drawdown=0.05, circuit_breaker_drawdown=0.1))
+    context = RiskContext(daily_drawdown=-0.12, treasury_utilisation=0.2, treasury_health=1.0)
+
+    signal = {"action": "BUY", "confidence": 0.8}
+    adjusted = manager.enforce(signal, context)
+
+    assert adjusted["action"] == "NEUTRAL"
+    assert adjusted["confidence"] <= 0.2
+    assert adjusted.get("circuit_breaker") is True
+    assert "Circuit breaker" in " ".join(adjusted.get("risk_notes", []))
+
+
+def test_position_sizing_reflects_confidence_and_volatility() -> None:
+    manager = RiskManager()
+    context = RiskContext(treasury_health=1.2, treasury_utilisation=0.3, volatility=0.6)
+
+    sizing = manager.sizing(context, confidence=0.7, volatility=0.6)
+
+    assert isinstance(sizing, PositionSizing)
+    assert sizing.notional > 0
+    assert 1.0 <= sizing.leverage <= 3.0


### PR DESCRIPTION
## Summary
- add modular fusion engine with lorentzian, trend, sentiment, and treasury lobes
- expose risk manager utilities with guardrails and sizing heuristics for downstream use
- cover fusion and risk paths with unit tests to validate signal combination and constraints

## Testing
- npm run lint
- npm run typecheck
- PYTHONPATH=. pytest tests/test_fusion_engine.py tests/test_risk_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d771b83a608322a0e3d8e9f887f65b