### PR TITLE
Add Lorentzian strategy integration and policy engine

### DIFF
--- a/algorithms/python/tests/test_trading_workflow.py
+++ b/algorithms/python/tests/test_trading_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+import math
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sys
@@ -29,6 +30,7 @@ from algorithms.python.trade_logic import (
     TradeConfig,
     TradeLogic,
     TradeSignal,
+    _lorentzian_distance,
 )
 
 
@@ -1146,3 +1148,18 @@ def test_generate_exit_decisions_prioritises_nearest_level_when_both_hit():
     assert decisions
     assert decisions[0].context["trigger"] == "take_profit"
     assert decisions[0].exit == pytest.approx(1.205)
+def test_lorentzian_distance_supports_modes() -> None:
+    a = (1.0, 2.0, 3.0)
+    b = (0.5, 1.5, 2.0)
+
+    l1_distance = _lorentzian_distance(a, b, mode="l1")
+    expected_l1 = sum(abs(x - y) for x, y in zip(a, b))
+    assert l1_distance == pytest.approx(expected_l1)
+
+    cauchy_default = _lorentzian_distance(a, b)
+    cauchy_high_alpha = _lorentzian_distance(a, b, alpha=2.0)
+    assert cauchy_high_alpha > cauchy_default > 0
+
+    manual_cauchy = sum(math.log1p((x - y) ** 2) for x, y in zip(a, b))
+    assert cauchy_default == pytest.approx(manual_cauchy)
+

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -4,5 +4,16 @@ from __future__ import annotations
 
 from .fusion import DynamicFusionAlgo
 from .market_maker import DynamicMarketMaker
+from .strategies.lorentzian import (
+    LorentzianSignalState,
+    lorentzian_distance,
+    rolling_signal,
+)
 
-__all__ = ["DynamicFusionAlgo", "DynamicMarketMaker"]
+__all__ = [
+    "DynamicFusionAlgo",
+    "DynamicMarketMaker",
+    "LorentzianSignalState",
+    "lorentzian_distance",
+    "rolling_signal",
+]

--- a/core/strategies/lorentzian.py
+++ b/core/strategies/lorentzian.py
@@ -1,0 +1,172 @@
+"""Lorentzian distance helpers and rolling signal utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean, median, pstdev
+from typing import Iterable, List, Literal, Optional, Sequence
+
+from algorithms.python.trade_logic import _lorentzian_distance
+
+LorentzianMode = Literal["cauchy", "l1"]
+LorentzianStyle = Literal["mean_rev", "trend"]
+
+
+@dataclass(slots=True)
+class LorentzianSignalState:
+    """Container for a normalised Lorentzian distance signal."""
+
+    score: float
+    distance: float
+    signal: str
+    regime: str
+    style: LorentzianStyle
+    mode: LorentzianMode
+    alpha: float
+    window: int
+    reference: float
+    history_mean: float
+    history_std: float
+    enter_z: float
+    exit_z: float
+
+    def to_dict(self) -> dict[str, float | str]:
+        return {
+            "score": self.score,
+            "distance": self.distance,
+            "signal": self.signal,
+            "regime": self.regime,
+            "style": self.style,
+            "mode": self.mode,
+            "alpha": self.alpha,
+            "window": self.window,
+            "reference": self.reference,
+            "history_mean": self.history_mean,
+            "history_std": self.history_std,
+            "enter_z": self.enter_z,
+            "exit_z": self.exit_z,
+        }
+
+
+def lorentzian_distance(
+    x: Sequence[float],
+    y: Sequence[float],
+    *,
+    mode: LorentzianMode = "cauchy",
+    alpha: float = 1.0,
+) -> float:
+    """Proxy wrapper that exposes the shared Lorentzian helper."""
+
+    return _lorentzian_distance(x, y, mode=mode, alpha=alpha)
+
+
+def _build_history_distances(
+    prices: List[float],
+    *,
+    window: int,
+    mode: LorentzianMode,
+    alpha: float,
+) -> List[float]:
+    distances: List[float] = []
+    for end in range(window, len(prices)):
+        window_slice = prices[end - window : end]
+        if end >= 2 * window:
+            reference_slice = prices[end - 2 * window : end - window]
+        else:
+            reference_slice = prices[: end - window]
+        if not reference_slice:
+            reference_value = median(prices[:end]) if end else prices[0]
+        else:
+            reference_value = median(reference_slice)
+        reference_series = [reference_value] * window
+        distances.append(
+            lorentzian_distance(window_slice, reference_series, mode=mode, alpha=alpha)
+        )
+    return distances
+
+
+def rolling_signal(
+    prices: Iterable[float],
+    *,
+    window: int = 50,
+    alpha: float = 0.5,
+    mode: LorentzianMode = "cauchy",
+    style: LorentzianStyle = "mean_rev",
+    enter_z: float = 2.0,
+    exit_z: float = 0.5,
+) -> Optional[LorentzianSignalState]:
+    """Compute a Lorentzian z-score and derive a trading bias."""
+
+    price_list = [float(p) for p in prices]
+    if len(price_list) < window * 2:
+        return None
+
+    reference_slice = price_list[-2 * window : -window]
+    if not reference_slice:
+        return None
+
+    reference_value = median(reference_slice)
+    current_window = price_list[-window:]
+    reference_series = [reference_value] * window
+
+    distance = lorentzian_distance(current_window, reference_series, mode=mode, alpha=alpha)
+
+    history_distances = _build_history_distances(
+        price_list, window=window, mode=mode, alpha=alpha
+    )
+    if not history_distances:
+        return None
+
+    history_mean = mean(history_distances)
+    history_std = pstdev(history_distances) if len(history_distances) > 1 else 0.0
+    epsilon = 1e-9
+    score = (distance - history_mean) / (history_std + epsilon)
+
+    if style == "trend":
+        if score >= enter_z:
+            signal = "BUY"
+        elif score <= -enter_z:
+            signal = "SELL"
+        elif abs(score) <= exit_z:
+            signal = "NEUTRAL"
+        else:
+            signal = "HOLD"
+    else:  # mean reversion
+        if score >= enter_z:
+            signal = "SELL"
+        elif score <= -enter_z:
+            signal = "BUY"
+        elif abs(score) <= exit_z:
+            signal = "NEUTRAL"
+        else:
+            signal = "HOLD"
+
+    if abs(score) >= enter_z:
+        regime = "stressed"
+    elif abs(score) <= exit_z:
+        regime = "calm"
+    else:
+        regime = "transition"
+
+    return LorentzianSignalState(
+        score=score,
+        distance=distance,
+        signal=signal,
+        regime=regime,
+        style=style,
+        mode=mode,
+        alpha=alpha,
+        window=window,
+        reference=reference_value,
+        history_mean=history_mean,
+        history_std=history_std,
+        enter_z=enter_z,
+        exit_z=exit_z,
+    )
+
+
+__all__ = [
+    "LorentzianSignalState",
+    "lorentzian_distance",
+    "rolling_signal",
+]

--- a/dynamic_ai/core.py
+++ b/dynamic_ai/core.py
@@ -2,11 +2,45 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover - imported lazily at runtime to avoid cycles
+    from core.strategies.lorentzian import LorentzianSignalState
 
 
 VALID_SIGNALS = {"BUY", "SELL", "HOLD", "NEUTRAL"}
+
+
+@dataclass
+class FusionComponent:
+    """Normalised representation of an upstream trading signal."""
+
+    name: str
+    signal: str
+    confidence: float
+    score: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def direction(self) -> float:
+        signal_key = self.signal.upper()
+        if signal_key == "BUY":
+            return 1.0
+        if signal_key == "SELL":
+            return -1.0
+        return 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = {
+            "name": self.name,
+            "signal": self.signal,
+            "confidence": round(float(self.confidence), 4),
+        }
+        if self.score is not None:
+            payload["score"] = float(self.score)
+        if self.metadata:
+            payload["metadata"] = self.metadata
+        return payload
 
 
 @dataclass
@@ -17,6 +51,8 @@ class AISignal:
     confidence: float
     reasoning: str
     original_signal: Optional[str] = None
+    components: Optional[List[Dict[str, Any]]] = None
+    score: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Represent the signal as a serialisable dictionary."""
@@ -26,6 +62,8 @@ class AISignal:
             "confidence": self.confidence,
             "reasoning": self.reasoning,
             "original_signal": self.original_signal,
+            "components": self.components,
+            "score": self.score,
         }
 
 
@@ -43,16 +81,28 @@ class DynamicFusionAlgo:
         if raw_signal not in VALID_SIGNALS:
             raw_signal = "NEUTRAL"
 
-        ai_action = self._refine_action(raw_signal, market_data)
+        momentum = self._coerce_float(market_data.get("momentum"), default=0.0)
+        trend = str(market_data.get("trend", "")).lower()
+        ai_action = self._refine_action(raw_signal, momentum, trend)
         confidence = self._calculate_confidence(raw_signal, market_data)
         reasoning = self._build_reasoning(ai_action, confidence, market_data)
 
-        return AISignal(action=ai_action, confidence=confidence, reasoning=reasoning, original_signal=raw_signal)
+        component = FusionComponent(
+            name="heuristic",
+            signal=ai_action,
+            confidence=confidence,
+            metadata={"momentum": momentum, "trend": trend},
+        )
 
-    def _refine_action(self, raw_signal: str, market_data: Dict[str, Any]) -> str:
-        momentum = self._coerce_float(market_data.get("momentum"), default=0.0)
-        trend = str(market_data.get("trend", "")).lower()
+        return AISignal(
+            action=ai_action,
+            confidence=confidence,
+            reasoning=reasoning,
+            original_signal=raw_signal,
+            components=[component.to_dict()],
+        )
 
+    def _refine_action(self, raw_signal: str, momentum: float, trend: str) -> str:
         if momentum > 0.6 and raw_signal == "BUY":
             return "BUY"
         if momentum < -0.6 and raw_signal == "SELL":
@@ -111,6 +161,176 @@ class DynamicFusionAlgo:
             comments.append("Signal defaulted to neutral heuristics due to limited context.")
 
         return " ".join(comments)
+
+    def dai_lorentzian_params(
+        self, vol: float, news_bias: float, session: Optional[str]
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "window": 50,
+            "alpha": 0.5,
+            "mode": "cauchy",
+            "enter_z": 2.0,
+            "exit_z": 0.5,
+            "style": "mean_rev",
+        }
+
+        if vol > 0.03:
+            params["alpha"] = 1.0
+            params["enter_z"] = 2.5
+
+        if news_bias > 0:
+            params["style"] = "trend"
+
+        session_key = (session or "").strip()
+        if session_key in {"Asia-open", "London-open"}:
+            params["enter_z"] += 0.3
+
+        return params
+
+    def build_lorentzian_component(
+        self, prices: Sequence[float], params: Dict[str, Any]
+    ) -> Optional[FusionComponent]:
+        if not prices:
+            return None
+
+        from core.strategies.lorentzian import rolling_signal  # Local import avoids circular deps
+
+        window = int(params.get("window", 50))
+        alpha = float(params.get("alpha", 0.5))
+        mode = str(params.get("mode", "cauchy")).lower()
+        if mode not in {"cauchy", "l1"}:
+            mode = "cauchy"
+        style_param = str(params.get("style", "mean_rev")).lower()
+        style = "trend" if style_param == "trend" else "mean_rev"
+        enter_z = float(params.get("enter_z", 2.0))
+        exit_z = float(params.get("exit_z", 0.5))
+
+        state = rolling_signal(
+            prices,
+            window=window,
+            alpha=alpha,
+            mode=mode,
+            style=style,  # type: ignore[arg-type]
+            enter_z=enter_z,
+            exit_z=exit_z,
+        )
+
+        if state is None:
+            return None
+
+        signal = state.signal
+        if signal == "HOLD":
+            signal = "NEUTRAL"
+
+        confidence = min(1.0, max(0.0, abs(state.score) / 3.0))
+
+        metadata = state.to_dict()
+        metadata["style"] = style
+
+        return FusionComponent(
+            name="lorentzian",
+            signal=signal,
+            confidence=confidence,
+            score=state.score,
+            metadata=metadata,
+        )
+
+    def combine(
+        self,
+        components: Sequence[FusionComponent | Dict[str, Any]],
+        *,
+        default_signal: str = "NEUTRAL",
+    ) -> AISignal:
+        normalised = self._coerce_components(components)
+        if not normalised:
+            return AISignal(
+                action="NEUTRAL",
+                confidence=0.0,
+                reasoning="No actionable signals provided.",
+                original_signal=default_signal,
+                components=[],
+                score=None,
+            )
+
+        total_conf = sum(max(comp.confidence, 0.0) for comp in normalised)
+        weighted = sum(comp.direction() * max(comp.confidence, 0.0) for comp in normalised)
+
+        if total_conf <= 0:
+            final_action = "NEUTRAL"
+            final_confidence = 0.0
+        else:
+            ratio = weighted / total_conf
+            if ratio > 0:
+                final_action = "BUY"
+            elif ratio < 0:
+                final_action = "SELL"
+            else:
+                final_action = "NEUTRAL"
+            final_confidence = min(1.0, abs(ratio))
+
+        reasoning = self._compose_component_reasoning(
+            normalised, final_action, final_confidence
+        )
+
+        return AISignal(
+            action=final_action,
+            confidence=round(final_confidence, 2),
+            reasoning=reasoning,
+            original_signal=default_signal,
+            components=[component.to_dict() for component in normalised],
+            score=round(weighted, 4),
+        )
+
+    def _coerce_components(
+        self, components: Sequence[FusionComponent | Dict[str, Any]]
+    ) -> List[FusionComponent]:
+        normalised: List[FusionComponent] = []
+        for index, component in enumerate(components):
+            if component is None:
+                continue
+            if isinstance(component, FusionComponent):
+                normalised.append(component)
+                continue
+            if not isinstance(component, dict):
+                continue
+            name = str(component.get("name") or f"component-{index+1}")
+            signal = str(component.get("signal", "NEUTRAL")).upper()
+            confidence = float(component.get("confidence", 0.0))
+            score = component.get("score")
+            metadata = component.get("metadata") or {}
+            if signal not in VALID_SIGNALS:
+                signal = "NEUTRAL"
+            normalised.append(
+                FusionComponent(
+                    name=name,
+                    signal=signal,
+                    confidence=max(0.0, confidence),
+                    score=float(score) if score is not None else None,
+                    metadata=dict(metadata),
+                )
+            )
+        return normalised
+
+    def _compose_component_reasoning(
+        self,
+        components: Sequence[FusionComponent],
+        final_action: str,
+        final_confidence: float,
+    ) -> str:
+        fragments: List[str] = []
+        for component in components:
+            fragments.append(
+                f"{component.name}: {component.signal} ({component.confidence:.2f})"
+            )
+
+        if final_action == "NEUTRAL":
+            summary = "Fusion neutral after balancing component votes."
+        else:
+            summary = (
+                f"Combined vote favours {final_action} with {final_confidence:.2f} confidence."
+            )
+        fragments.append(summary)
+        return " ".join(fragments)
 
     def mm_parameters(
         self,

--- a/dynamic_token/__init__.py
+++ b/dynamic_token/__init__.py
@@ -1,5 +1,6 @@
 """Dynamic Capital token economy helpers."""
 
+from .policy_engine import PolicyDecision, PolicyEngine
 from .treasury import DynamicTreasuryAlgo
 
-__all__ = ["DynamicTreasuryAlgo"]
+__all__ = ["DynamicTreasuryAlgo", "PolicyDecision", "PolicyEngine"]

--- a/dynamic_token/policy_engine.py
+++ b/dynamic_token/policy_engine.py
@@ -1,0 +1,90 @@
+"""Policy engine coordinating treasury actions based on Lorentzian regimes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass(slots=True)
+class PolicyDecision:
+    """Structured decision describing treasury actions for the current regime."""
+
+    regime: str
+    buyback: float = 0.0
+    burn: float = 0.0
+    spread_target_bps: Optional[float] = None
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "regime": self.regime,
+            "buyback": round(self.buyback, 2),
+            "burn": round(self.burn, 2),
+            "spread_target_bps": self.spread_target_bps,
+        }
+        if self.notes:
+            payload["notes"] = list(self.notes)
+        return payload
+
+
+class PolicyEngine:
+    """Decide when to trigger buybacks, burns, or spread adjustments."""
+
+    def __init__(
+        self,
+        *,
+        buyback_budget: float = 10_000.0,
+        max_burn_share: float = 0.02,
+        quiet_vol_threshold: float = 0.015,
+        stress_threshold: float = 3.0,
+        calm_threshold: float = 1.0,
+        base_spread_bps: float = 12.0,
+        tight_spread_bps: float = 6.0,
+    ) -> None:
+        self.buyback_budget = float(buyback_budget)
+        self.max_burn_share = float(max_burn_share)
+        self.quiet_vol_threshold = float(quiet_vol_threshold)
+        self.stress_threshold = float(stress_threshold)
+        self.calm_threshold = float(calm_threshold)
+        self.base_spread_bps = float(base_spread_bps)
+        self.tight_spread_bps = float(tight_spread_bps)
+
+    def evaluate(
+        self,
+        *,
+        score: float,
+        volatility: float,
+        treasury_balance: float,
+        twap_deviation: float = 0.0,
+    ) -> PolicyDecision:
+        magnitude = abs(score)
+        regime = "calm"
+        if magnitude >= self.stress_threshold:
+            regime = "stressed"
+        elif magnitude > self.calm_threshold:
+            regime = "transition"
+
+        decision = PolicyDecision(regime=regime)
+
+        if regime == "stressed" and twap_deviation < 0:
+            deviation_ratio = min(1.0, abs(twap_deviation))
+            decision.buyback = round(min(self.buyback_budget, deviation_ratio * self.buyback_budget), 2)
+            decision.notes.append("TWAP deviation negative – scheduling buybacks")
+
+        if regime in {"calm", "transition"} and treasury_balance > 0:
+            burn_amount = treasury_balance * self.max_burn_share
+            decision.burn = round(burn_amount, 2)
+            if burn_amount > 0:
+                decision.notes.append("Treasury surplus earmarked for burns")
+
+        if regime == "calm" and volatility <= self.quiet_vol_threshold:
+            decision.spread_target_bps = self.tight_spread_bps
+            decision.notes.append("Quiet regime – tightening spreads")
+        else:
+            decision.spread_target_bps = self.base_spread_bps
+
+        return decision
+
+
+__all__ = ["PolicyDecision", "PolicyEngine"]

--- a/dynamic_token/treasury.py
+++ b/dynamic_token/treasury.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 
 SUCCESS_RETCODE = 10009
@@ -16,35 +16,76 @@ class TreasuryEvent:
     burned: float
     rewards_distributed: float
     profit_retained: float
+    policy_buyback: float
+    policy_burn: float
+    policy_spread_target_bps: Optional[float]
+    policy_regime: str
+    policy_notes: List[str] = field(default_factory=list)
 
 
 class DynamicTreasuryAlgo:
     """Adjust token flows based on trade outcomes."""
 
-    def __init__(self, starting_balance: float = 100_000.0) -> None:
+    def __init__(
+        self,
+        starting_balance: float = 100_000.0,
+        *,
+        policy_engine: Optional["PolicyEngine"] = None,
+    ) -> None:
         self.treasury_balance = starting_balance
+        from dynamic_token.policy_engine import PolicyEngine  # Local import avoids cycle
 
-    def update_from_trade(self, trade_result: Optional[object]) -> Optional[TreasuryEvent]:
+        self.policy_engine = policy_engine or PolicyEngine()
+
+    def update_from_trade(
+        self, trade_result: Optional[object], market_context: Optional[Dict[str, Any]] = None
+    ) -> Optional[TreasuryEvent]:
         if not trade_result or getattr(trade_result, "retcode", None) != SUCCESS_RETCODE:
-            return None
+            decision = self._evaluate_policy(market_context)
+            return TreasuryEvent(
+                burned=0.0,
+                rewards_distributed=0.0,
+                profit_retained=0.0,
+                policy_buyback=decision.buyback,
+                policy_burn=decision.burn,
+                policy_spread_target_bps=decision.spread_target_bps,
+                policy_regime=decision.regime,
+                policy_notes=list(decision.notes),
+            )
 
         profit = float(getattr(trade_result, "profit", 0.0))
-        if profit <= 0:
-            return None
+        burn_amount = 0.0
+        rewards_amount = 0.0
+        retained = 0.0
+        if profit > 0:
+            burn_amount = round(profit * 0.2, 2)
+            rewards_amount = round(profit * 0.3, 2)
+            retained = round(profit - burn_amount - rewards_amount, 2)
 
-        burn_amount = round(profit * 0.2, 2)
-        rewards_amount = round(profit * 0.3, 2)
-        retained = round(profit - burn_amount - rewards_amount, 2)
+        prospective_balance = self.treasury_balance + retained
+        decision = self._evaluate_policy(market_context, balance_override=prospective_balance)
 
-        self.treasury_balance += retained
+        self.treasury_balance = prospective_balance
 
-        self.buy_and_burn(burn_amount)
-        self.distribute_rewards(rewards_amount)
+        total_burn = burn_amount + decision.burn
+        if total_burn > 0:
+            self.buy_and_burn(total_burn)
+        if rewards_amount > 0:
+            self.distribute_rewards(rewards_amount)
+        if decision.buyback > 0:
+            self.schedule_buyback(decision.buyback)
+        if decision.spread_target_bps is not None:
+            self.adjust_market_making_spread(decision.spread_target_bps)
 
         return TreasuryEvent(
-            burned=burn_amount,
+            burned=total_burn,
             rewards_distributed=rewards_amount,
             profit_retained=retained,
+            policy_buyback=decision.buyback,
+            policy_burn=decision.burn,
+            policy_spread_target_bps=decision.spread_target_bps,
+            policy_regime=decision.regime,
+            policy_notes=list(decision.notes),
         )
 
     def buy_and_burn(self, amount: float) -> None:
@@ -52,3 +93,28 @@ class DynamicTreasuryAlgo:
 
     def distribute_rewards(self, amount: float) -> None:
         print(f"💰 Distributing {amount} DCT as rewards to stakers")
+
+    def schedule_buyback(self, amount: float) -> None:
+        print(f"🛒 Scheduling buyback programme for {amount} DCT")
+
+    def adjust_market_making_spread(self, target_bps: float) -> None:
+        print(f"⚙️ Adjusting DMM spread target to {target_bps} bps")
+
+    def _evaluate_policy(
+        self, market_context: Optional[Dict[str, Any]], *, balance_override: Optional[float] = None
+    ) -> "PolicyDecision":
+        from dynamic_token.policy_engine import PolicyDecision
+
+        context = market_context or {}
+        lorentzian = context.get("lorentzian") or {}
+        score = float(lorentzian.get("score", 0.0))
+        volatility = float(context.get("volatility", 0.0))
+        twap_deviation = float(context.get("twap_deviation", 0.0))
+
+        balance = balance_override if balance_override is not None else self.treasury_balance
+        return self.policy_engine.evaluate(
+            score=score,
+            volatility=volatility,
+            treasury_balance=balance,
+            twap_deviation=twap_deviation,
+        )

--- a/integrations/tradingview.py
+++ b/integrations/tradingview.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from hmac import compare_digest
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from flask import Flask, Response, jsonify, request
 
@@ -57,13 +58,67 @@ def webhook() -> Any:
     logger.info("TradingView alert received: %s", payload)
 
     symbol = str(payload.get("symbol", "XAUUSD"))
-    lot = float(payload.get("lot", 0.1))
+    base_lot = float(payload.get("lot", 0.1))
+    session_name = payload.get("session")
+    volatility = _coerce_float(payload.get("volatility"))
+    news_bias = _coerce_float(payload.get("news_bias"))
 
-    ai_signal = fusion.generate_signal(payload)
-    trade_result = trader.execute_trade(ai_signal, lot=lot, symbol=symbol)
-    treasury_event = treasury.update_from_trade(trade_result)
+    lorentzian_blob = _extract_lorentzian_blob(payload)
+    params = fusion.dai_lorentzian_params(volatility, news_bias, session_name)
+    params = _apply_lorentzian_overrides(params, lorentzian_blob)
 
-    supabase_logger.log_trade(_build_supabase_payload(payload, ai_signal, trade_result, treasury_event))
+    prices = _coerce_prices(lorentzian_blob.get("prices") if lorentzian_blob else None)
+    components: list[Any] = []
+    lorentzian_state: Dict[str, Any] = {}
+
+    if prices:
+        component = fusion.build_lorentzian_component(prices, params)
+        if component is not None:
+            components.append(component)
+            lorentzian_state = dict(component.metadata)
+
+    if not lorentzian_state and lorentzian_blob:
+        fallback_component = _component_from_payload(lorentzian_blob, params)
+        if fallback_component is not None:
+            components.append(fallback_component)
+            lorentzian_state = dict(fallback_component.get("metadata", {}))
+
+    components.extend(_extract_additional_components(payload))
+
+    default_signal = str(payload.get("signal", "NEUTRAL"))
+    if components:
+        ai_signal = fusion.combine(components, default_signal=default_signal)
+    else:
+        ai_signal = fusion.generate_signal(payload)
+
+    lorentzian_state.setdefault("enter_z", params.get("enter_z"))
+    lorentzian_state.setdefault("exit_z", params.get("exit_z"))
+    lorentzian_state.setdefault("style", params.get("style"))
+
+    execution_context = {
+        "volatility": volatility,
+        "news_bias": news_bias,
+        "twap_deviation": _coerce_float(
+            (lorentzian_blob or {}).get("twap_deviation"), default=0.0
+        ),
+        "session": {
+            "name": session_name,
+            "halt": bool(payload.get("halt_trading")),
+        },
+        "lorentzian": lorentzian_state if lorentzian_state else None,
+        "lorentzian_params": params,
+    }
+
+    trade_result = trader.execute_trade(
+        ai_signal, base_lot=base_lot, symbol=symbol, context=execution_context
+    )
+    treasury_event = treasury.update_from_trade(trade_result, market_context=execution_context)
+
+    supabase_logger.log_trade(
+        _build_supabase_payload(
+            payload, ai_signal, trade_result, treasury_event, execution_context
+        )
+    )
 
     message = _format_telegram_message(symbol, ai_signal.to_dict(), trade_result, treasury_event)
     if telegram_bot and message:
@@ -81,9 +136,10 @@ def webhook() -> Any:
                 "profit": trade_result.profit,
                 "ticket": trade_result.ticket,
                 "symbol": trade_result.symbol or symbol,
-                "lot": trade_result.lot or lot,
+                "lot": trade_result.lot or base_lot,
             },
             "treasury_event": _treasury_event_to_dict(treasury_event),
+            "lorentzian": lorentzian_state or None,
         }
     )
 
@@ -93,6 +149,7 @@ def _build_supabase_payload(
     ai_signal,
     trade_result,
     treasury_event,
+    market_context: Dict[str, Any],
 ) -> Dict[str, Any]:
     supabase_payload = {
         "symbol": trade_result.symbol or payload.get("symbol"),
@@ -106,12 +163,22 @@ def _build_supabase_payload(
         "ticket": trade_result.ticket,
         "status": "executed" if trade_result.ok else "skipped",
     }
+    if getattr(ai_signal, "components", None):
+        supabase_payload["components"] = ai_signal.components
+    lorentzian_state = market_context.get("lorentzian")
+    if lorentzian_state:
+        supabase_payload["lorentzian"] = lorentzian_state
     if treasury_event:
         supabase_payload.update(
             {
                 "burned": treasury_event.burned,
                 "rewards_distributed": treasury_event.rewards_distributed,
                 "profit_retained": treasury_event.profit_retained,
+                "policy_buyback": treasury_event.policy_buyback,
+                "policy_burn": treasury_event.policy_burn,
+                "policy_spread_target_bps": treasury_event.policy_spread_target_bps,
+                "policy_regime": treasury_event.policy_regime,
+                "policy_notes": treasury_event.policy_notes,
             }
         )
     return supabase_payload
@@ -135,8 +202,147 @@ def _format_telegram_message(
     if treasury_event:
         lines.append(f"🔥 Burned {treasury_event.burned} DCT")
         lines.append(f"💰 Rewards Distributed: {treasury_event.rewards_distributed} DCT")
+        if treasury_event.policy_buyback > 0:
+            lines.append(f"🛒 Buybacks: {treasury_event.policy_buyback} DCT")
+        if treasury_event.policy_spread_target_bps is not None:
+            lines.append(
+                f"⚙️ Spread Target: {treasury_event.policy_spread_target_bps} bps ({treasury_event.policy_regime})"
+            )
 
     return "\n".join(lines)
+
+
+def _extract_lorentzian_blob(payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    blob = payload.get("lorentzian")
+    if isinstance(blob, str):
+        try:
+            blob = json.loads(blob)
+        except json.JSONDecodeError:
+            blob = None
+    if isinstance(blob, dict):
+        return blob
+
+    message = payload.get("message")
+    if isinstance(message, str):
+        try:
+            parsed = json.loads(message)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, dict) and parsed.get("strategy") == "DynamicLorentzian":
+            return parsed
+    return None
+
+
+def _apply_lorentzian_overrides(
+    params: Dict[str, Any], blob: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    if not blob:
+        return params
+
+    overrides = dict(params)
+    mapping = {
+        "win": "window",
+        "window": "window",
+        "alpha": "alpha",
+        "mode": "mode",
+        "style": "style",
+        "enter_z": "enter_z",
+        "exit_z": "exit_z",
+    }
+    for source, target in mapping.items():
+        if source not in blob:
+            continue
+        value = blob[source]
+        if target in {"alpha", "enter_z", "exit_z", "window"}:
+            numeric = _coerce_float(value, default=params.get(target, 0.0))
+            overrides[target] = int(numeric) if target == "window" else numeric
+        else:
+            overrides[target] = value
+    return overrides
+
+
+def _coerce_prices(raw: Any) -> Optional[Sequence[float]]:
+    if raw is None:
+        return None
+    data = raw
+    if isinstance(raw, str):
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(data, Sequence):
+        return None
+    try:
+        return [float(value) for value in data]
+    except (TypeError, ValueError):
+        return None
+
+
+def _component_from_payload(
+    blob: Dict[str, Any], params: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    signal = str(blob.get("signal", "NEUTRAL")).upper()
+    score = _coerce_float(blob.get("score"))
+    if signal not in {"BUY", "SELL", "HOLD", "NEUTRAL"}:
+        signal = "NEUTRAL"
+    confidence = min(1.0, abs(score) / 3.0)
+    metadata = {
+        **{k: v for k, v in blob.items() if k not in {"signal", "score"}},
+        "score": score,
+        "enter_z": params.get("enter_z"),
+        "exit_z": params.get("exit_z"),
+        "mode": params.get("mode"),
+        "style": params.get("style"),
+    }
+    return {
+        "name": "lorentzian",
+        "signal": signal,
+        "confidence": confidence,
+        "score": score,
+        "metadata": metadata,
+    }
+
+
+def _extract_additional_components(payload: Dict[str, Any]) -> Sequence[Dict[str, Any]]:
+    components: list[Dict[str, Any]] = []
+    raw_components = payload.get("components")
+    if isinstance(raw_components, Sequence):
+        for item in raw_components:
+            if isinstance(item, dict):
+                components.append(item)
+
+    ma_signal = payload.get("ma_signal")
+    if ma_signal:
+        components.append(
+            {
+                "name": "trend_ma",
+                "signal": ma_signal,
+                "confidence": _coerce_float(payload.get("ma_confidence"), default=0.4),
+            }
+        )
+
+    sentiment_signal = payload.get("sentiment_signal")
+    if sentiment_signal:
+        components.append(
+            {
+                "name": "sentiment",
+                "signal": sentiment_signal,
+                "confidence": _coerce_float(
+                    payload.get("sentiment_confidence"), default=0.3
+                ),
+            }
+        )
+
+    return components
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _treasury_event_to_dict(event) -> Optional[Dict[str, Any]]:
@@ -146,6 +352,11 @@ def _treasury_event_to_dict(event) -> Optional[Dict[str, Any]]:
         "burned": event.burned,
         "rewards_distributed": event.rewards_distributed,
         "profit_retained": event.profit_retained,
+        "policy_buyback": event.policy_buyback,
+        "policy_burn": event.policy_burn,
+        "policy_spread_target_bps": event.policy_spread_target_bps,
+        "policy_regime": event.policy_regime,
+        "policy_notes": event.policy_notes,
     }
 
 

--- a/tests/core/test_lorentzian_strategy.py
+++ b/tests/core/test_lorentzian_strategy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.strategies.lorentzian import LorentzianSignalState, lorentzian_distance, rolling_signal
+from algorithms.python.trade_logic import _lorentzian_distance
+
+
+def test_lorentzian_distance_wrapper_matches_core() -> None:
+    a = [1.0, 2.0, 3.0]
+    b = [0.0, 1.0, 1.5]
+    assert lorentzian_distance(a, b) == _lorentzian_distance(a, b)
+    assert lorentzian_distance(a, b, mode="l1") == _lorentzian_distance(a, b, mode="l1")
+
+
+def test_rolling_signal_generates_mean_reversion_bias() -> None:
+    prices = [100 + i * 0.5 for i in range(80)]
+    state = rolling_signal(
+        prices,
+        window=20,
+        alpha=0.5,
+        style="mean_rev",
+        enter_z=1.0,
+        exit_z=0.25,
+    )
+    assert isinstance(state, LorentzianSignalState)
+    assert state.signal in {"SELL", "HOLD"}
+    assert state.regime in {"stressed", "transition"}
+
+
+def test_rolling_signal_flips_for_trend_style() -> None:
+    prices = [200 - i * 0.3 for i in range(80)]
+    state = rolling_signal(
+        prices,
+        window=20,
+        alpha=0.5,
+        style="trend",
+        enter_z=1.0,
+        exit_z=0.25,
+    )
+    assert isinstance(state, LorentzianSignalState)
+    assert state.signal in {"SELL", "HOLD"}
+    assert state.regime in {"stressed", "transition"}
+
+
+def test_rolling_signal_requires_history() -> None:
+    assert rolling_signal([1.0] * 10, window=8) is None

--- a/tests/dynamic_token/test_policy_engine.py
+++ b/tests/dynamic_token/test_policy_engine.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dynamic_token.policy_engine import PolicyDecision, PolicyEngine
+
+
+def test_policy_engine_triggers_buyback_on_stress() -> None:
+    engine = PolicyEngine(buyback_budget=5000.0)
+    decision = engine.evaluate(score=4.0, volatility=0.04, treasury_balance=100_000.0, twap_deviation=-0.5)
+    assert isinstance(decision, PolicyDecision)
+    assert decision.regime == "stressed"
+    assert decision.buyback > 0
+    assert any("buybacks" in note.lower() for note in decision.notes)
+
+
+def test_policy_engine_burns_surplus_when_calm() -> None:
+    engine = PolicyEngine(max_burn_share=0.05)
+    decision = engine.evaluate(score=0.2, volatility=0.01, treasury_balance=200_000.0)
+    assert decision.regime == "calm"
+    assert decision.burn == 200_000.0 * 0.05
+    assert decision.spread_target_bps == engine.tight_spread_bps
+
+
+def test_policy_engine_handles_transition_regime() -> None:
+    engine = PolicyEngine()
+    decision = engine.evaluate(score=1.5, volatility=0.03, treasury_balance=50_000.0)
+    assert decision.regime == "transition"
+    assert decision.burn > 0
+    assert decision.spread_target_bps == engine.base_spread_bps


### PR DESCRIPTION
## Summary
- add configurable Lorentzian distance modes with accompanying strategy utilities and tests
- integrate Lorentzian scoring through the fusion layer, execution pipeline, webhook, and treasury policy logic
- introduce a policy engine that drives buybacks, burns, and spread adjustments with new coverage for strategy and token behavior
- fix the TradingView webhook response so its lot fallback uses the provided base lot value

## Testing
- pytest algorithms/python/tests/test_trading_workflow.py::test_lorentzian_distance_supports_modes
- pytest tests/core/test_lorentzian_strategy.py
- pytest tests/dynamic_token/test_policy_engine.py
- pytest tests/integrations/test_tradingview_webhook.py::test_webhook_processes_payload_with_valid_secret *(fails: Flask not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d770970b0883228a9592e4c7ec9b8a