### PR TITLE
Add SL/TP helper and Lorentzian trade logging

### DIFF
--- a/supabase/functions/_shared/sl_tp.ts
+++ b/supabase/functions/_shared/sl_tp.ts
@@ -1,0 +1,129 @@
+export type TradeSide = "BUY" | "SELL";
+
+export interface SlTpParams {
+  entry: number;
+  side: TradeSide;
+  volatility: number;
+  rr?: number;
+  fibonacciRetracement?: number | null;
+  fibonacciExtension?: number | null;
+  treasuryHealth?: number;
+}
+
+export interface SlTpResult {
+  sl: number | null;
+  tp: number | null;
+}
+
+const MIN_TREASURY = 0;
+const MAX_TREASURY = 2;
+const LOWER_BUFFER = 0.8;
+const UPPER_BUFFER = 1.2;
+
+function roundToTwo(value: number): number {
+  return Number.isFinite(value) ? Number(value.toFixed(2)) : value;
+}
+
+function applyTreasuryScale(treasuryHealth: number | undefined): number {
+  const clamped = Math.min(
+    MAX_TREASURY,
+    Math.max(MIN_TREASURY, treasuryHealth ?? 1),
+  );
+
+  if (clamped < LOWER_BUFFER) {
+    const ratio = LOWER_BUFFER === 0 ? 0 : clamped / LOWER_BUFFER;
+    return 0.6 + 0.5 * ratio;
+  }
+
+  if (clamped > UPPER_BUFFER) {
+    return 1 + Math.min(0.5, (clamped - UPPER_BUFFER) * 0.5);
+  }
+
+  return 1;
+}
+
+function blendWithFibonacci(base: number, distance?: number | null): number {
+  if (distance === undefined || distance === null) return base;
+  return (base * 0.5) + (Math.abs(distance) * 0.5);
+}
+
+export function assignStops(params: SlTpParams): SlTpResult {
+  const rr = params.rr && params.rr > 0 ? params.rr : 2;
+  const side = params.side;
+
+  if (side !== "BUY" && side !== "SELL") {
+    return { sl: null, tp: null };
+  }
+
+  const price = params.entry;
+  const baseline = Math.max(Math.abs(price) * 0.01, params.volatility * 1.5);
+  const fibAdjusted = blendWithFibonacci(
+    baseline,
+    params.fibonacciRetracement !== undefined
+      ? price - Number(params.fibonacciRetracement)
+      : undefined,
+  );
+
+  const risk = Math.max(
+    0,
+    fibAdjusted * applyTreasuryScale(params.treasuryHealth),
+  );
+  const rewardBase = risk * rr;
+  const reward = blendWithFibonacci(
+    rewardBase,
+    params.fibonacciExtension !== undefined &&
+      params.fibonacciExtension !== null
+      ? Number(params.fibonacciExtension) - price
+      : undefined,
+  );
+
+  if (side === "BUY") {
+    return {
+      sl: roundToTwo(price - risk),
+      tp: roundToTwo(price + reward),
+    };
+  }
+
+  return {
+    sl: roundToTwo(price + risk),
+    tp: roundToTwo(price - reward),
+  };
+}
+
+export function computeVolatility(prices: number[], lookback = 10): number {
+  if (prices.length < 2) return 0;
+  const window = Math.min(lookback, prices.length - 1);
+  let sum = 0;
+  for (let i = prices.length - window; i < prices.length; i++) {
+    const prev = prices[i - 1];
+    const current = prices[i];
+    sum += Math.abs(current - prev);
+  }
+  return sum / window;
+}
+
+export function deriveFibonacciAnchors(
+  prices: number[],
+  side: TradeSide,
+): { retracement: number; extension: number } {
+  if (prices.length === 0) {
+    return { retracement: 0, extension: 0 };
+  }
+
+  const window = prices.slice(-20);
+  const high = Math.max(...window);
+  const low = Math.min(...window);
+  const range = high - low || Math.abs(prices[prices.length - 1]) * 0.02;
+
+  if (side === "BUY") {
+    return {
+      retracement: high - range * 0.786,
+      extension: low + range * 1.618,
+    };
+  }
+
+  return {
+    retracement: low + range * 0.786,
+    extension: high - range * 1.618,
+  };
+}

--- a/tests/lorentzian-eval-sl-tp.test.ts
+++ b/tests/lorentzian-eval-sl-tp.test.ts
@@ -1,0 +1,76 @@
+if (typeof Deno !== "undefined") {
+  const { assertEquals, assertGreater, assertLess } = await import(
+    "https://deno.land/std@0.224.0/assert/mod.ts"
+  );
+  const {
+    assignStops,
+    computeVolatility,
+    deriveFibonacciAnchors,
+  } = await import("../supabase/functions/_shared/sl_tp.ts");
+
+  Deno.test("assignStops mirrors python helper for BUY with fibonacci levels", () => {
+    const result = assignStops({
+      entry: 100,
+      side: "BUY",
+      volatility: 10,
+      rr: 2,
+      fibonacciRetracement: 96,
+      fibonacciExtension: 118,
+      treasuryHealth: 1,
+    });
+
+    assertEquals(result.sl, 90.5);
+    assertEquals(result.tp, 118.5);
+  });
+
+  Deno.test("assignStops widens SELL targets with strong treasury", () => {
+    const result = assignStops({
+      entry: 220,
+      side: "SELL",
+      volatility: 12,
+      rr: 1.5,
+      fibonacciRetracement: 228,
+      fibonacciExtension: 190,
+      treasuryHealth: 1.4,
+    });
+
+    assertEquals(result.sl, 234.3);
+    assertEquals(result.tp, 194.28);
+  });
+
+  Deno.test("treasury stress tightens stops", () => {
+    const baseline = assignStops({
+      entry: 150,
+      side: "BUY",
+      volatility: 8,
+    });
+    const stressed = assignStops({
+      entry: 150,
+      side: "BUY",
+      volatility: 8,
+      treasuryHealth: 0.4,
+    });
+
+    if (baseline.sl === null || stressed.sl === null) {
+      throw new Error("expected SL levels");
+    }
+
+    assertGreater(stressed.sl, baseline.sl);
+  });
+
+  Deno.test("computeVolatility averages recent deltas", () => {
+    const prices = [100, 102, 101, 105, 104, 108];
+    const vol = computeVolatility(prices, 3);
+    assertLess(vol, 5);
+    assertGreater(vol, 0);
+  });
+
+  Deno.test("deriveFibonacciAnchors returns retracement/extension pairs", () => {
+    const prices = [100, 104, 99, 110, 108, 112];
+    const buyAnchors = deriveFibonacciAnchors(prices, "BUY");
+    const sellAnchors = deriveFibonacciAnchors(prices, "SELL");
+
+    assertGreater(buyAnchors.extension, buyAnchors.retracement);
+    assertGreater(sellAnchors.retracement, sellAnchors.extension);
+  });
+}

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,6 +1,14 @@
 """Tests for the risk management guardrails."""
 
-from dynamic_ai.risk import PositionSizing, RiskContext, RiskManager, RiskParameters
+import pytest
+
+from dynamic_ai.risk import (
+    PositionSizing,
+    RiskContext,
+    RiskManager,
+    RiskParameters,
+    assign_sl_tp,
+)
 
 
 def test_risk_manager_enforces_circuit_breaker() -> None:
@@ -25,3 +33,51 @@ def test_position_sizing_reflects_confidence_and_volatility() -> None:
     assert isinstance(sizing, PositionSizing)
     assert sizing.notional > 0
     assert 1.0 <= sizing.leverage <= 3.0
+
+
+def test_assign_sl_tp_buy_blends_volatility_and_fibonacci() -> None:
+    sl, tp = assign_sl_tp(
+        entry=100,
+        signal="BUY",
+        volatility=10,
+        rr=2.0,
+        fibonacci_retrace=96,
+        fibonacci_extension=118,
+    )
+
+    assert sl == pytest.approx(90.5)
+    assert tp == pytest.approx(118.5)
+
+
+def test_assign_sl_tp_sell_treasury_expands_targets() -> None:
+    sl, tp = assign_sl_tp(
+        entry=220,
+        signal="SELL",
+        volatility=12,
+        rr=1.5,
+        fibonacci_retrace=228,
+        fibonacci_extension=190,
+        treasury_health=1.4,
+    )
+
+    assert sl == pytest.approx(234.3)
+    assert tp == pytest.approx(194.28)
+
+
+def test_assign_sl_tp_tightens_with_low_treasury() -> None:
+    baseline_sl, _ = assign_sl_tp(entry=150, signal="BUY", volatility=8)
+    tightened_sl, _ = assign_sl_tp(
+        entry=150,
+        signal="BUY",
+        volatility=8,
+        treasury_health=0.4,
+    )
+
+    assert baseline_sl is not None and tightened_sl is not None
+    assert tightened_sl > baseline_sl
+
+
+def test_assign_sl_tp_invalid_signal() -> None:
+    sl, tp = assign_sl_tp(entry=100, signal="HOLD", volatility=5)
+
+    assert sl is None and tp is None


### PR DESCRIPTION
## Summary
- add a treasury-aware `assign_sl_tp` helper in the risk toolkit that blends volatility, Fibonacci anchors, and risk:reward inputs
- expose a shared TypeScript stop/target helper and hook the Lorentzian edge function into it so each trade insert carries SL/TP metadata
- cover the new logic with Python and Deno tests to validate BUY/SELL paths, treasury tightening, and Fibonacci-driven rewards

## Testing
- PYTHONPATH=. pytest tests/test_risk_manager.py
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d779ecb4708322befd3cac2107f3e6