### PR TITLE
Add risk-aware dynamic leverage guidance

### DIFF
--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -11,7 +11,7 @@ from .fusion import (
     TrendMomentumLobe,
     TreasuryLobe,
 )
-from .risk import PositionSizing, RiskContext, RiskManager, RiskParameters
+from .risk import LeverageGuidance, PositionSizing, RiskContext, RiskManager, RiskParameters
 
 __all__ = [
     "AISignal",
@@ -24,6 +24,7 @@ __all__ = [
     "SignalLobe",
     "TrendMomentumLobe",
     "TreasuryLobe",
+    "LeverageGuidance",
     "PositionSizing",
     "RiskContext",
     "RiskManager",

--- a/dynamic_ai/risk.py
+++ b/dynamic_ai/risk.py
@@ -13,6 +13,7 @@ class RiskParameters:
     max_daily_drawdown: float = 0.08
     treasury_utilisation_cap: float = 0.6
     circuit_breaker_drawdown: float = 0.12
+    max_leverage: float = 3.0
 
 
 @dataclass
@@ -31,6 +32,15 @@ class PositionSizing:
 
     notional: float
     leverage: float
+    notes: str
+
+
+@dataclass
+class LeverageGuidance:
+    """Recommended leverage band together with explanatory notes."""
+
+    leverage: float
+    band: str
     notes: str
 
 
@@ -72,10 +82,93 @@ class RiskManager:
         treasury_modifier = max(0.1, min(1.0, 1.0 - context.treasury_utilisation))
 
         notional = base_notional * volatility_penalty * treasury_modifier
-        leverage = min(3.0, 1.0 + confidence * 2 * volatility_penalty)
+        leverage = min(self.params.max_leverage, 1.0 + confidence * 2 * volatility_penalty)
 
         notes = "Sizing adjusted for volatility and treasury health."
         return PositionSizing(notional=round(notional, 4), leverage=round(leverage, 2), notes=notes)
+
+    def dynamic_leverage(
+        self,
+        context: RiskContext,
+        *,
+        confidence: float,
+        regime_bias: float = 0.0,
+    ) -> LeverageGuidance:
+        """Suggest a leverage level that reacts to risk telemetry.
+
+        The heuristic starts from a confidence-led baseline and then applies
+        penalties or boosts for treasury utilisation, drawdowns, volatility and
+        optional regime bias (e.g. macro overlay in the range [-1, 1]).
+        """
+
+        notes: list[str] = []
+
+        # Baseline scales with confidence while favouring conservative gearing.
+        baseline = 1.0 + max(0.0, confidence - 0.3) * 1.6
+        notes.append(f"Baseline leverage derived from confidence ({confidence:.2f}).")
+
+        leverage = baseline
+
+        if context.daily_drawdown < 0:
+            # Penalty grows as drawdown approaches the circuit breaker.
+            circuit = max(self.params.circuit_breaker_drawdown, 1e-6)
+            stress_ratio = min(1.0, abs(context.daily_drawdown) / circuit)
+            drawdown_penalty = 0.8 * stress_ratio
+            leverage -= drawdown_penalty
+            notes.append(
+                f"Drawdown pressure reduced leverage by {drawdown_penalty:.2f} "
+                f"(drawdown {context.daily_drawdown:.2%})."
+            )
+
+        if context.treasury_utilisation > 0:
+            utilisation_penalty = min(0.7, context.treasury_utilisation * 0.9)
+            leverage -= utilisation_penalty
+            notes.append(
+                f"Treasury utilisation penalty applied ({context.treasury_utilisation:.2f})."
+            )
+
+        if context.treasury_health < 1.0:
+            health_penalty = min(0.6, (1.0 - context.treasury_health) * 1.2)
+            leverage -= health_penalty
+            notes.append(f"Treasury health below par reduced leverage by {health_penalty:.2f}.")
+        elif context.treasury_health > 1.2:
+            health_boost = min(0.4, (context.treasury_health - 1.2) * 0.8)
+            leverage += health_boost
+            notes.append(f"Robust treasury health added a boost of {health_boost:.2f}.")
+
+        volatility = context.volatility
+        if volatility > 0:
+            if volatility >= 0.7:
+                vol_penalty = min(0.9, (volatility - 0.7) * 1.2 + 0.2)
+                leverage -= vol_penalty
+                notes.append(
+                    f"Elevated volatility penalty applied reducing leverage by {vol_penalty:.2f}."
+                )
+            elif volatility <= 0.3:
+                vol_boost = min(0.3, (0.3 - volatility) * 0.6)
+                leverage += vol_boost
+                notes.append(f"Low volatility environment boosted leverage by {vol_boost:.2f}.")
+
+        if regime_bias:
+            leverage += max(-0.5, min(0.5, regime_bias * 0.5))
+            notes.append(f"Regime bias adjustment of {regime_bias:.2f} applied.")
+
+        leverage = max(0.5, min(self.params.max_leverage, leverage))
+
+        if leverage <= 1.1:
+            band = "capital_preservation"
+        elif leverage <= 1.6:
+            band = "balanced"
+        elif leverage <= 2.3:
+            band = "growth"
+        else:
+            band = "aggressive"
+
+        if leverage == self.params.max_leverage:
+            notes.append("Leverage capped by risk parameters.")
+
+        guidance_notes = " ".join(notes)
+        return LeverageGuidance(leverage=round(leverage, 2), band=band, notes=guidance_notes)
 
     @staticmethod
     def _finalise(signal: Dict[str, Any], notes: list[str]) -> Dict[str, Any]:

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,6 +1,12 @@
 """Tests for the risk management guardrails."""
 
-from dynamic_ai.risk import PositionSizing, RiskContext, RiskManager, RiskParameters
+from dynamic_ai.risk import (
+    LeverageGuidance,
+    PositionSizing,
+    RiskContext,
+    RiskManager,
+    RiskParameters,
+)
 
 
 def test_risk_manager_enforces_circuit_breaker() -> None:
@@ -25,3 +31,37 @@ def test_position_sizing_reflects_confidence_and_volatility() -> None:
     assert isinstance(sizing, PositionSizing)
     assert sizing.notional > 0
     assert 1.0 <= sizing.leverage <= 3.0
+
+
+def test_dynamic_leverage_reacts_to_drawdown_and_utilisation() -> None:
+    manager = RiskManager(RiskParameters(max_leverage=2.5, circuit_breaker_drawdown=0.15))
+    context = RiskContext(
+        daily_drawdown=-0.12,
+        treasury_utilisation=0.5,
+        treasury_health=0.9,
+        volatility=0.8,
+    )
+
+    guidance = manager.dynamic_leverage(context, confidence=0.8)
+
+    assert isinstance(guidance, LeverageGuidance)
+    assert guidance.leverage < 1.3
+    assert "drawdown" in guidance.notes.lower()
+    assert guidance.band == "capital_preservation"
+
+
+def test_dynamic_leverage_acknowledges_positive_regime_bias() -> None:
+    manager = RiskManager(RiskParameters(max_leverage=3.0))
+    context = RiskContext(
+        daily_drawdown=0.0,
+        treasury_utilisation=0.1,
+        treasury_health=1.3,
+        volatility=0.2,
+    )
+
+    guidance = manager.dynamic_leverage(context, confidence=0.85, regime_bias=0.8)
+
+    assert guidance.leverage <= manager.params.max_leverage
+    assert guidance.leverage > 1.6
+    assert guidance.band in {"growth", "aggressive"}
+    assert "regime bias" in guidance.notes.lower()


### PR DESCRIPTION
## Summary
- add a `LeverageGuidance` dataclass and dynamic leverage heuristic to the risk manager
- expose the new guidance type through the `dynamic_ai` package interface
- extend the risk manager tests to cover leverage guidance scenarios

## Testing
- PYTHONPATH=. pytest tests/test_risk_manager.py


------
https://chatgpt.com/codex/tasks/task_e_68d77b045a7c8322b4c644cf4a3aebb4