### PR TITLE
feat: add dynamic trade journal tool

### DIFF
--- a/apps/web/app/api/tools/trade-journal/route.ts
+++ b/apps/web/app/api/tools/trade-journal/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { generateTradeJournal } from "@/services/trade-journal/engine";
+import { tradeJournalRequestSchema } from "@/services/trade-journal/schema";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json();
+    const parsed = tradeJournalRequestSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((issue) => issue.message).join(
+        "; ",
+      );
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    const report = generateTradeJournal(parsed.data);
+    return NextResponse.json(report);
+  } catch (error) {
+    const message = error instanceof Error
+      ? error.message
+      : "Unexpected error occurred.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/app/tools/trade-journal/page.tsx
+++ b/apps/web/app/tools/trade-journal/page.tsx
@@ -1,0 +1,33 @@
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
+
+import { TradeJournalWorkspace } from "@/components/tools/TradeJournalWorkspace";
+
+export const metadata = {
+  title: "Dynamic Trade Journal – Dynamic Capital",
+  description:
+    "Compile disciplined trade reviews with automated highlights, lessons, and coach prompts from your session telemetry.",
+};
+
+export default function TradeJournalToolPage() {
+  return (
+    <Column gap="32" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={40} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Dynamic trade journal
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          Feed in your session narrative, trade log, and risk telemetry to
+          generate highlights, lessons, and next actions ready to share with the
+          desk.
+        </Text>
+      </Column>
+      <Column maxWidth={72} fillWidth>
+        <TradeJournalWorkspace />
+      </Column>
+    </Column>
+  );
+}

--- a/apps/web/components/tools/TradeJournalWorkspace.tsx
+++ b/apps/web/components/tools/TradeJournalWorkspace.tsx
@@ -1,0 +1,727 @@
+"use client";
+
+import { FormEvent, useCallback, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  TradeJournalReport,
+  TradeRecordInput,
+} from "@/services/trade-journal/types";
+import {
+  formatPercentage,
+  formatPnL,
+  normaliseList,
+} from "@/services/trade-journal/utils";
+
+interface TradeFormEntry {
+  symbol: string;
+  direction: string;
+  entryPrice: string;
+  exitPrice: string;
+  size: string;
+  pnl: string;
+  rewardRisk: string;
+  setup: string;
+  grade: string;
+  notes: string;
+  tags: string;
+  checklistMisses: string;
+}
+
+const EMPTY_TRADE: TradeFormEntry = {
+  symbol: "",
+  direction: "",
+  entryPrice: "",
+  exitPrice: "",
+  size: "",
+  pnl: "",
+  rewardRisk: "",
+  setup: "",
+  grade: "",
+  notes: "",
+  tags: "",
+  checklistMisses: "",
+};
+
+function parseList(value: string): string[] {
+  if (!value.trim()) {
+    return [];
+  }
+
+  return normaliseList(
+    value
+      .split(/\n|,/)
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0),
+  );
+}
+
+function safeParseJson(value: string): Record<string, unknown> {
+  if (!value.trim()) {
+    return {};
+  }
+  return JSON.parse(value) as Record<string, unknown>;
+}
+
+export function TradeJournalWorkspace() {
+  const [sessionDate, setSessionDate] = useState("");
+  const [sessionSummary, setSessionSummary] = useState("");
+  const [objectivesInput, setObjectivesInput] = useState("");
+  const [marketContext, setMarketContext] = useState("");
+  const [riskEventsInput, setRiskEventsInput] = useState("");
+  const [mindsetInput, setMindsetInput] = useState("");
+  const [metricsInput, setMetricsInput] = useState("{}");
+  const [environmentInput, setEnvironmentInput] = useState("{}");
+  const [trades, setTrades] = useState<TradeFormEntry[]>([EMPTY_TRADE]);
+  const [report, setReport] = useState<TradeJournalReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleTradeChange = useCallback(
+    (index: number, field: keyof TradeFormEntry, value: string) => {
+      setTrades((previous) => {
+        const next = [...previous];
+        next[index] = { ...next[index], [field]: value };
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleAddTrade = useCallback(() => {
+    setTrades((previous) => [...previous, { ...EMPTY_TRADE }]);
+  }, []);
+
+  const handleRemoveTrade = useCallback((index: number) => {
+    setTrades((previous) =>
+      previous.filter((_, tradeIndex) => tradeIndex !== index)
+    );
+  }, []);
+
+  const stats = useMemo(() => {
+    if (!report) return [];
+    const { metadata } = report;
+    return [
+      { label: "Trades logged", value: metadata.tradeCount.toString() },
+      { label: "Wins", value: metadata.winningTrades.toString() },
+      { label: "Losses", value: metadata.losingTrades.toString() },
+      { label: "Win rate", value: formatPercentage(metadata.winRate) },
+      { label: "Net PnL", value: formatPnL(metadata.totalPnl) },
+      { label: "Avg PnL", value: formatPnL(metadata.averagePnl) },
+      {
+        label: "Avg R:R",
+        value: typeof metadata.averageRewardRisk === "number"
+          ? metadata.averageRewardRisk.toFixed(2)
+          : "—",
+      },
+    ];
+  }, [report]);
+
+  const tagChips = useMemo(() => {
+    if (!report) return [];
+    return Object.entries(report.metadata.tagFrequency)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 6);
+  }, [report]);
+
+  const checklistChips = useMemo(() => {
+    if (!report) return [];
+    return Object.entries(report.metadata.checklistMissFrequency)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 6);
+  }, [report]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setError(null);
+
+      if (!sessionDate.trim()) {
+        setError("Session date is required.");
+        return;
+      }
+
+      if (!sessionSummary.trim()) {
+        setError("Add a short summary for the session.");
+        return;
+      }
+
+      const parsedTrades: TradeRecordInput[] = [];
+
+      for (const trade of trades) {
+        const shouldInclude = trade.symbol.trim() ||
+          trade.direction.trim() ||
+          trade.entryPrice.trim() ||
+          trade.exitPrice.trim() ||
+          trade.size.trim() ||
+          trade.pnl.trim();
+
+        if (!shouldInclude) {
+          continue;
+        }
+
+        const requiredFields: Array<[keyof TradeFormEntry, string]> = [
+          ["symbol", trade.symbol],
+          ["direction", trade.direction],
+          ["entryPrice", trade.entryPrice],
+          ["exitPrice", trade.exitPrice],
+          ["size", trade.size],
+          ["pnl", trade.pnl],
+        ];
+
+        for (const [field, value] of requiredFields) {
+          if (!value.trim()) {
+            setError(`Trade ${field} is required when recording a trade.`);
+            return;
+          }
+        }
+
+        const entryPrice = Number.parseFloat(trade.entryPrice);
+        const exitPrice = Number.parseFloat(trade.exitPrice);
+        const size = Number.parseFloat(trade.size);
+        const pnl = Number.parseFloat(trade.pnl);
+
+        if (
+          ![entryPrice, exitPrice, size, pnl].every((value) =>
+            Number.isFinite(value)
+          )
+        ) {
+          setError(`One of the numeric fields is invalid for ${trade.symbol}.`);
+          return;
+        }
+
+        let rewardRisk: number | undefined;
+        if (trade.rewardRisk.trim()) {
+          const parsedReward = Number.parseFloat(trade.rewardRisk);
+          if (!Number.isFinite(parsedReward)) {
+            setError(`Reward to risk must be numeric for ${trade.symbol}.`);
+            return;
+          }
+          rewardRisk = parsedReward;
+        }
+
+        const parsedTrade: TradeRecordInput = {
+          symbol: trade.symbol.trim(),
+          direction: trade.direction.trim(),
+          entryPrice,
+          exitPrice,
+          size,
+          pnl,
+          rewardRisk,
+          setup: trade.setup.trim() || undefined,
+          grade: trade.grade.trim() || undefined,
+          notes: trade.notes.trim() || undefined,
+          tags: parseList(trade.tags),
+          checklistMisses: parseList(trade.checklistMisses),
+        };
+
+        parsedTrades.push(parsedTrade);
+      }
+
+      let metrics: Record<string, unknown>;
+      let environment: Record<string, unknown>;
+
+      try {
+        metrics = safeParseJson(metricsInput);
+      } catch (parseError) {
+        setError("Metrics JSON is invalid. Ensure it is valid JSON.");
+        return;
+      }
+
+      try {
+        environment = safeParseJson(environmentInput);
+      } catch (parseError) {
+        setError("Environment JSON is invalid. Ensure it is valid JSON.");
+        return;
+      }
+
+      const payload = {
+        sessionDate: sessionDate.trim(),
+        sessionSummary: sessionSummary.trim(),
+        objectives: parseList(objectivesInput),
+        marketContext: marketContext.trim(),
+        trades: parsedTrades,
+        riskEvents: parseList(riskEventsInput),
+        mindsetNotes: parseList(mindsetInput),
+        metrics,
+        environment,
+      };
+
+      setIsSubmitting(true);
+      try {
+        const response = await fetch("/api/tools/trade-journal", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => ({}));
+          const message = typeof errorBody.error === "string"
+            ? errorBody.error
+            : `Request failed with status ${response.status}.`;
+          throw new Error(message);
+        }
+
+        const data = (await response.json()) as TradeJournalReport;
+        setReport(data);
+      } catch (submitError) {
+        const message = submitError instanceof Error
+          ? submitError.message
+          : "Unable to generate the journal.";
+        setError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [
+      environmentInput,
+      metricsInput,
+      mindsetInput,
+      objectivesInput,
+      riskEventsInput,
+      sessionDate,
+      sessionSummary,
+      trades,
+      marketContext,
+    ],
+  );
+
+  return (
+    <form className="space-y-8" onSubmit={handleSubmit}>
+      <Card className="border border-white/10 bg-gradient-to-b from-background/30 to-background/70 backdrop-blur">
+        <CardHeader>
+          <CardTitle>Session overview</CardTitle>
+          <CardDescription>
+            Set the context so the desk can evaluate execution against the plan.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="session-date">Session date</Label>
+              <Input
+                id="session-date"
+                type="date"
+                value={sessionDate}
+                onChange={(event) => setSessionDate(event.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="market-context">Market context</Label>
+              <Textarea
+                id="market-context"
+                placeholder="Liquidity, catalysts, or macro posture"
+                value={marketContext}
+                onChange={(event) => setMarketContext(event.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="session-summary">Session summary</Label>
+            <Textarea
+              id="session-summary"
+              placeholder="One paragraph capturing the overall quality of execution"
+              value={sessionSummary}
+              onChange={(event) => setSessionSummary(event.target.value)}
+              required
+              rows={3}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="objectives">Objectives</Label>
+              <Textarea
+                id="objectives"
+                placeholder="One objective per line"
+                value={objectivesInput}
+                onChange={(event) => setObjectivesInput(event.target.value)}
+                rows={4}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="risk-events">Risk events</Label>
+              <Textarea
+                id="risk-events"
+                placeholder="Drawdown breaches, platform issues, or other exceptions"
+                value={riskEventsInput}
+                onChange={(event) => setRiskEventsInput(event.target.value)}
+                rows={4}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mindset">Mindset notes</Label>
+            <Textarea
+              id="mindset"
+              placeholder="Energy, confidence, or psychological observations"
+              value={mindsetInput}
+              onChange={(event) => setMindsetInput(event.target.value)}
+              rows={3}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-white/10 bg-gradient-to-b from-background/30 to-background/70 backdrop-blur">
+        <CardHeader>
+          <CardTitle>Trade log</CardTitle>
+          <CardDescription>
+            Add each executed trade with PnL, reward to risk, and any checklist
+            drift.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {trades.map((trade, index) => (
+            <div
+              key={`trade-${index}`}
+              className="rounded-lg border border-white/10 bg-background/60 p-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                  Trade {index + 1}
+                </h3>
+                {trades.length > 1 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemoveTrade(index)}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label>Symbol</Label>
+                  <Input
+                    value={trade.symbol}
+                    onChange={(event) =>
+                      handleTradeChange(index, "symbol", event.target.value)}
+                    placeholder="ES, NQ, AAPL"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Direction</Label>
+                  <Input
+                    value={trade.direction}
+                    onChange={(event) =>
+                      handleTradeChange(index, "direction", event.target.value)}
+                    placeholder="long / short"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Reward / Risk</Label>
+                  <Input
+                    value={trade.rewardRisk}
+                    onChange={(event) =>
+                      handleTradeChange(
+                        index,
+                        "rewardRisk",
+                        event.target.value,
+                      )}
+                    placeholder="1.5"
+                  />
+                </div>
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label>Entry price</Label>
+                  <Input
+                    value={trade.entryPrice}
+                    onChange={(event) =>
+                      handleTradeChange(
+                        index,
+                        "entryPrice",
+                        event.target.value,
+                      )}
+                    placeholder="4398.50"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Exit price</Label>
+                  <Input
+                    value={trade.exitPrice}
+                    onChange={(event) =>
+                      handleTradeChange(index, "exitPrice", event.target.value)}
+                    placeholder="4405.25"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Position size</Label>
+                  <Input
+                    value={trade.size}
+                    onChange={(event) =>
+                      handleTradeChange(index, "size", event.target.value)}
+                    placeholder="2"
+                  />
+                </div>
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Realized PnL</Label>
+                  <Input
+                    value={trade.pnl}
+                    onChange={(event) =>
+                      handleTradeChange(index, "pnl", event.target.value)}
+                    placeholder="125.50"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Grade</Label>
+                  <Input
+                    value={trade.grade}
+                    onChange={(event) =>
+                      handleTradeChange(index, "grade", event.target.value)}
+                    placeholder="A / B / C"
+                  />
+                </div>
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Setup</Label>
+                  <Input
+                    value={trade.setup}
+                    onChange={(event) =>
+                      handleTradeChange(index, "setup", event.target.value)}
+                    placeholder="London continuation, liquidity sweep..."
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Checklist misses</Label>
+                  <Textarea
+                    value={trade.checklistMisses}
+                    onChange={(event) =>
+                      handleTradeChange(
+                        index,
+                        "checklistMisses",
+                        event.target.value,
+                      )}
+                    placeholder="One item per line"
+                    rows={3}
+                  />
+                </div>
+              </div>
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Tags</Label>
+                  <Textarea
+                    value={trade.tags}
+                    onChange={(event) =>
+                      handleTradeChange(index, "tags", event.target.value)}
+                    placeholder="Momentum, breakout, news fade"
+                    rows={3}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Notes</Label>
+                  <Textarea
+                    value={trade.notes}
+                    onChange={(event) =>
+                      handleTradeChange(index, "notes", event.target.value)}
+                    placeholder="Execution notes, emotions, or context"
+                    rows={3}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+          <div className="flex justify-end">
+            <Button type="button" variant="outline" onClick={handleAddTrade}>
+              Add trade
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border border-white/10 bg-gradient-to-b from-background/30 to-background/70 backdrop-blur">
+        <CardHeader>
+          <CardTitle>Desk telemetry</CardTitle>
+          <CardDescription>
+            Drop in metrics or environment data the journal should consider.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="metrics">Metrics JSON</Label>
+            <Textarea
+              id="metrics"
+              value={metricsInput}
+              onChange={(event) => setMetricsInput(event.target.value)}
+              rows={6}
+              placeholder='{"winRate": 0.52, "avgHold": "12m"}'
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="environment">Environment JSON</Label>
+            <Textarea
+              id="environment"
+              value={environmentInput}
+              onChange={(event) => setEnvironmentInput(event.target.value)}
+              rows={6}
+              placeholder='{"market": "US session", "volatility": "Elevated"}'
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="text-sm text-white/70">
+          {error
+            ? error
+            : "Fill in the session details and trade log to generate the journal."}
+        </div>
+        <Button type="submit" size="lg" disabled={isSubmitting}>
+          {isSubmitting ? "Generating..." : "Generate journal"}
+        </Button>
+      </div>
+
+      {report && (
+        <Card className="border border-white/10 bg-gradient-to-b from-background/20 to-background/60 backdrop-blur">
+          <CardHeader>
+            <CardTitle>Journal output</CardTitle>
+            <CardDescription>
+              Generated insights, action items, and prompts based on your
+              session data.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-8">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {stats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-lg border border-white/10 bg-background/60 p-4"
+                >
+                  <p className="text-xs uppercase tracking-wide text-white/60">
+                    {stat.label}
+                  </p>
+                  <p className="mt-1 text-xl font-semibold text-white">
+                    {stat.value}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            {(tagChips.length > 0 || checklistChips.length > 0) && (
+              <div className="space-y-4">
+                {tagChips.length > 0 && (
+                  <div className="space-y-2">
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                      Dominant tags
+                    </h3>
+                    <div className="flex flex-wrap gap-2">
+                      {tagChips.map(([tag, count]) => (
+                        <Badge key={tag} variant="secondary">
+                          {tag} · {count}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {checklistChips.length > 0 && (
+                  <div className="space-y-2">
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                      Checklist misses
+                    </h3>
+                    <div className="flex flex-wrap gap-2">
+                      {checklistChips.map(([item, count]) => (
+                        <Badge key={item} variant="outline">
+                          {item} · {count}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <section className="space-y-6">
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-white">
+                  Session summary
+                </h3>
+                <p className="text-sm leading-relaxed text-white/80">
+                  {report.summary}
+                </p>
+              </div>
+
+              <Separator className="bg-white/10" />
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                    Performance highlights
+                  </h4>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-white/80">
+                    {report.performanceHighlights.map((item, index) => (
+                      <li key={`highlight-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                    Lessons captured
+                  </h4>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-white/80">
+                    {report.lessons.map((item, index) => (
+                      <li key={`lesson-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                    Next actions
+                  </h4>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-white/80">
+                    {report.nextActions.map((item, index) => (
+                      <li key={`action-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                    Mindset reflections
+                  </h4>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-white/80">
+                    {report.mindsetReflections.map((item, index) => (
+                      <li key={`mindset-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <h4 className="text-sm font-semibold uppercase tracking-wide text-white/70">
+                  Coach prompts
+                </h4>
+                <ul className="list-disc space-y-2 pl-5 text-sm text-white/80">
+                  {report.coachPrompts.map((item, index) => (
+                    <li key={`prompt-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            </section>
+          </CardContent>
+        </Card>
+      )}
+    </form>
+  );
+}

--- a/apps/web/services/trade-journal/engine.ts
+++ b/apps/web/services/trade-journal/engine.ts
@@ -1,0 +1,399 @@
+import {
+  average,
+  formatPercentage,
+  formatPnL,
+  normaliseList,
+  toFrequencyMap,
+} from "./utils";
+import type {
+  AggregatedTradeInsight,
+  TradeJournalReport,
+  TradeJournalRequest,
+  TradeRecordInput,
+} from "./types";
+
+function normaliseTradeRecord(trade: TradeRecordInput): AggregatedTradeInsight {
+  return {
+    symbol: trade.symbol.trim(),
+    direction: trade.direction.trim(),
+    entryPrice: trade.entryPrice,
+    exitPrice: trade.exitPrice,
+    size: trade.size,
+    pnl: trade.pnl,
+    rewardRisk: trade.rewardRisk ?? null,
+    setup: trade.setup?.trim() ?? null,
+    grade: trade.grade?.trim() ?? null,
+    notes: trade.notes?.trim() ?? null,
+    tags: normaliseList(trade.tags ?? []),
+    checklistMisses: normaliseList(trade.checklistMisses ?? []),
+  };
+}
+
+interface TradeAnalytics {
+  trades: AggregatedTradeInsight[];
+  wins: AggregatedTradeInsight[];
+  losses: AggregatedTradeInsight[];
+  flats: AggregatedTradeInsight[];
+  totalPnl: number;
+  averagePnl: number;
+  winRate: number;
+  averageRewardRisk: number | null;
+  bestTrade: AggregatedTradeInsight | null;
+  worstTrade: AggregatedTradeInsight | null;
+  tagFrequency: Record<string, number>;
+  checklistFrequency: Record<string, number>;
+}
+
+function analyseTrades(trades: TradeRecordInput[]): TradeAnalytics {
+  const normalised = trades.map(normaliseTradeRecord);
+
+  const wins = normalised.filter((trade) => trade.pnl > 0);
+  const losses = normalised.filter((trade) => trade.pnl < 0);
+  const flats = normalised.filter((trade) => trade.pnl === 0);
+  const totalPnl = normalised.reduce((total, trade) => total + trade.pnl, 0);
+  const averagePnl = normalised.length === 0 ? 0 : totalPnl / normalised.length;
+  const winRate = normalised.length === 0
+    ? 0
+    : (wins.length / normalised.length) * 100;
+  const rewardRisks = normalised
+    .map((trade) => trade.rewardRisk)
+    .filter((value): value is number =>
+      typeof value === "number" && Number.isFinite(value)
+    );
+  const averageRewardRisk = average(rewardRisks);
+
+  const bestTrade = normalised.reduce<AggregatedTradeInsight | null>(
+    (best, trade) => {
+      if (best === null || trade.pnl > best.pnl) {
+        return trade;
+      }
+      return best;
+    },
+    null,
+  );
+
+  const worstTrade = normalised.reduce<AggregatedTradeInsight | null>(
+    (worst, trade) => {
+      if (worst === null || trade.pnl < worst.pnl) {
+        return trade;
+      }
+      return worst;
+    },
+    null,
+  );
+
+  const tagFrequency = toFrequencyMap(
+    normalised.flatMap((trade) => trade.tags),
+  );
+  const checklistFrequency = toFrequencyMap(
+    normalised.flatMap((trade) => trade.checklistMisses),
+  );
+
+  return {
+    trades: normalised,
+    wins,
+    losses,
+    flats,
+    totalPnl,
+    averagePnl,
+    winRate,
+    averageRewardRisk,
+    bestTrade,
+    worstTrade,
+    tagFrequency,
+    checklistFrequency,
+  };
+}
+
+function buildSummary(
+  request: TradeJournalRequest,
+  analytics: TradeAnalytics,
+): string {
+  const lines: string[] = [];
+  const trimmedSummary = request.sessionSummary.trim();
+  if (trimmedSummary) {
+    lines.push(trimmedSummary);
+  }
+
+  if (analytics.trades.length > 0) {
+    const tradeStatement =
+      `Logged ${analytics.trades.length} trade${
+        analytics.trades.length === 1 ? "" : "s"
+      } ` +
+      `with ${analytics.wins.length} win${
+        analytics.wins.length === 1 ? "" : "s"
+      } ` +
+      `and ${analytics.losses.length} loss${
+        analytics.losses.length === 1 ? "" : "es"
+      } ` +
+      `(${formatPercentage(analytics.winRate)} win rate) for a net PnL of ${
+        formatPnL(analytics.totalPnl)
+      }.`;
+    lines.push(tradeStatement);
+  } else {
+    lines.push(
+      "No trades were logged in this session. Use the objectives below to prime tomorrow's focus.",
+    );
+  }
+
+  if (request.riskEvents.length > 0) {
+    lines.push(
+      `Risk watch: ${request.riskEvents.join(", ")}.`,
+    );
+  }
+
+  return lines.join(" ");
+}
+
+function buildHighlights(
+  request: TradeJournalRequest,
+  analytics: TradeAnalytics,
+): string[] {
+  const highlights: string[] = [];
+
+  if (analytics.bestTrade && analytics.bestTrade.pnl > 0) {
+    const reward = analytics.bestTrade.rewardRisk;
+    const rewardText = typeof reward === "number"
+      ? ` (R:R ${reward.toFixed(2)})`
+      : "";
+    highlights.push(
+      `Best trade: ${analytics.bestTrade.symbol} ${analytics.bestTrade.direction} booked ${
+        formatPnL(analytics.bestTrade.pnl)
+      }${rewardText}.`,
+    );
+  }
+
+  if (
+    typeof analytics.averageRewardRisk === "number" &&
+    analytics.averageRewardRisk > 0
+  ) {
+    highlights.push(
+      `Reward-to-risk profile averaged ${
+        analytics.averageRewardRisk.toFixed(2)
+      } across the session.`,
+    );
+  }
+
+  if (analytics.wins.length > 0) {
+    highlights.push(
+      `Win streak: ${analytics.wins.length} winning trade${
+        analytics.wins.length === 1 ? "" : "s"
+      } supporting the playbook.`,
+    );
+  }
+
+  const standoutTags = Object.entries(analytics.tagFrequency)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 2)
+    .map(([tag]) => tag);
+  if (standoutTags.length > 0) {
+    highlights.push(
+      `Tag momentum: ${
+        standoutTags.join(" & ")
+      } remained consistent through execution.`,
+    );
+  }
+
+  if (highlights.length === 0 && request.objectives.length > 0) {
+    highlights.push(
+      `Held focus on primary objective: ${request.objectives[0]}.`,
+    );
+  }
+
+  if (highlights.length === 0) {
+    highlights.push(
+      "Capture a small win or observation next session to populate highlights.",
+    );
+  }
+
+  return highlights;
+}
+
+function buildLessons(
+  analytics: TradeAnalytics,
+  request: TradeJournalRequest,
+): string[] {
+  const lessons: string[] = [];
+
+  analytics.losses.slice(0, 3).forEach((trade) => {
+    const note = trade.notes ? ` ${trade.notes}` : "";
+    lessons.push(
+      `Loss review: ${trade.symbol} ${trade.direction} finished at ${
+        formatPnL(trade.pnl)
+      }.${note}`,
+    );
+  });
+
+  Object.entries(analytics.checklistFrequency).forEach(([item]) => {
+    lessons.push(`Checklist gap: ${item} resurfaced and needs tightening.`);
+  });
+
+  request.riskEvents.forEach((event) => {
+    lessons.push(
+      `Risk event encountered: ${event}. Document the trigger and remediation.`,
+    );
+  });
+
+  if (lessons.length === 0) {
+    lessons.push(
+      "Note the specific behaviours that created smooth execution today.",
+    );
+  }
+
+  return lessons;
+}
+
+function buildNextActions(
+  analytics: TradeAnalytics,
+  request: TradeJournalRequest,
+): string[] {
+  const actions: string[] = [];
+
+  analytics.losses.slice(0, 2).forEach((trade) => {
+    actions.push(
+      `Replay ${trade.symbol} ${trade.direction} to identify one pre-trade adjustment before reattempting it.`,
+    );
+  });
+
+  Object.entries(analytics.checklistFrequency).forEach(([item]) => {
+    actions.push(`Add a drill to rehearse checklist item: ${item}.`);
+  });
+
+  request.riskEvents.forEach((event) => {
+    actions.push(
+      `Design a mitigation plan for risk event "${event}" before the next session.`,
+    );
+  });
+
+  if (actions.length < 3 && request.objectives.length > 0) {
+    actions.push(
+      `Plan the first step toward objective "${
+        request.objectives[0]
+      }" tomorrow.`,
+    );
+  }
+
+  if (actions.length === 0) {
+    actions.push(
+      "Capture a quick win task, like tagging screenshots or updating broker notes.",
+    );
+  }
+
+  return actions.slice(0, 5);
+}
+
+function buildMindsetReflections(
+  analytics: TradeAnalytics,
+  request: TradeJournalRequest,
+): string[] {
+  const reflections = normaliseList(request.mindsetNotes);
+
+  if (analytics.winRate >= 60 && analytics.wins.length > 0) {
+    reflections.push(
+      `Confidence anchor: ${analytics.wins.length} clean execution${
+        analytics.wins.length === 1 ? "" : "s"
+      } delivered a ${
+        formatPercentage(analytics.winRate)
+      } win rate. Honour the preparation that made them possible.`,
+    );
+  }
+
+  if (
+    analytics.losses.length > analytics.wins.length &&
+    analytics.losses.length > 0
+  ) {
+    const firstLoss = analytics.losses[0];
+    reflections.push(
+      `Emotional reset: acknowledge any frustration from ${firstLoss.symbol} ${firstLoss.direction} and outline how to re-centre before the open.`,
+    );
+  }
+
+  if (reflections.length === 0) {
+    reflections.push(
+      "Log one sentence about energy levels or focus to build the habit.",
+    );
+  }
+
+  return reflections;
+}
+
+function buildCoachPrompts(
+  analytics: TradeAnalytics,
+  request: TradeJournalRequest,
+): string[] {
+  const prompts = new Set<string>();
+
+  if (analytics.worstTrade) {
+    prompts.add(
+      `What specific signal would have kept you out of ${analytics.worstTrade.symbol} ${analytics.worstTrade.direction}?`,
+    );
+  }
+
+  request.riskEvents.forEach((event) => {
+    prompts.add(`How will you de-risk "${event}" before the next session?`);
+  });
+
+  if (request.objectives.length > 0) {
+    prompts.add(
+      `Which behaviour proves progress on "${request.objectives[0]}" tomorrow?`,
+    );
+  }
+
+  if (
+    typeof analytics.averageRewardRisk === "number" &&
+    analytics.averageRewardRisk < 1
+  ) {
+    prompts.add(
+      "Where can you improve reward-to-risk without reducing selectivity?",
+    );
+  }
+
+  if (prompts.size < 3) {
+    prompts.add("What felt most controlled today and why?");
+  }
+
+  return Array.from(prompts).slice(0, 5);
+}
+
+export function generateTradeJournal(
+  request: TradeJournalRequest,
+): TradeJournalReport {
+  const analytics = analyseTrades(request.trades);
+
+  const summary = buildSummary(request, analytics);
+  const highlights = buildHighlights(request, analytics);
+  const lessons = buildLessons(analytics, request);
+  const nextActions = buildNextActions(analytics, request);
+  const mindsetReflections = buildMindsetReflections(analytics, request);
+  const coachPrompts = buildCoachPrompts(analytics, request);
+
+  return {
+    summary,
+    performanceHighlights: highlights,
+    lessons,
+    nextActions,
+    mindsetReflections,
+    coachPrompts,
+    metadata: {
+      sessionDate: request.sessionDate,
+      objectiveCount: request.objectives.length,
+      riskEventCount: request.riskEvents.length,
+      tradeCount: analytics.trades.length,
+      winningTrades: analytics.wins.length,
+      losingTrades: analytics.losses.length,
+      flatTrades: analytics.flats.length,
+      totalPnl: analytics.totalPnl,
+      averagePnl: analytics.averagePnl,
+      winRate: analytics.winRate,
+      averageRewardRisk: analytics.averageRewardRisk,
+      bestTrade: analytics.bestTrade,
+      worstTrade: analytics.worstTrade,
+      tagFrequency: analytics.tagFrequency,
+      checklistMissFrequency: analytics.checklistFrequency,
+      metrics: request.metrics,
+      environment: request.environment,
+    },
+    rawResponse: null,
+    runs: [],
+  };
+}

--- a/apps/web/services/trade-journal/schema.ts
+++ b/apps/web/services/trade-journal/schema.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+import type { TradeJournalRequest, TradeRecordInput } from "./types";
+import { tradeJournalRequestDefaults } from "./utils";
+
+const nonEmptyString = z.string().trim().min(1);
+
+export const tradeRecordSchema = z.object({
+  symbol: nonEmptyString,
+  direction: nonEmptyString,
+  entryPrice: z.number().finite(),
+  exitPrice: z.number().finite(),
+  size: z.number().finite(),
+  pnl: z.number().finite(),
+  rewardRisk: z.number().finite().optional().nullable(),
+  setup: z.string().trim().optional().nullable(),
+  grade: z.string().trim().optional().nullable(),
+  notes: z.string().trim().optional().nullable(),
+  tags: z.array(nonEmptyString).max(12).default([]),
+  checklistMisses: z.array(nonEmptyString).max(12).default([]),
+});
+
+const baseTradeJournalRequestSchema = z.object({
+  sessionDate: nonEmptyString,
+  sessionSummary: nonEmptyString,
+  objectives: z.array(nonEmptyString).max(12).default([]),
+  marketContext: z.string().trim().default(""),
+  trades: z.array(tradeRecordSchema).max(60).default([]),
+  riskEvents: z.array(nonEmptyString).max(12).default([]),
+  mindsetNotes: z.array(nonEmptyString).max(12).default([]),
+  metrics: z.record(z.unknown()).default({}),
+  environment: z.record(z.unknown()).default({}),
+});
+
+export const tradeJournalRequestSchema = baseTradeJournalRequestSchema
+  .transform((value) => {
+    const trades = (value.trades ?? []).map((trade): TradeRecordInput => {
+      const parsed = tradeRecordSchema.parse(trade);
+
+      return {
+        symbol: parsed.symbol,
+        direction: parsed.direction,
+        entryPrice: parsed.entryPrice,
+        exitPrice: parsed.exitPrice,
+        size: parsed.size,
+        pnl: parsed.pnl,
+        rewardRisk: parsed.rewardRisk ?? undefined,
+        setup: parsed.setup ?? undefined,
+        grade: parsed.grade ?? undefined,
+        notes: parsed.notes ?? undefined,
+        tags: parsed.tags ?? [],
+        checklistMisses: parsed.checklistMisses ?? [],
+      };
+    });
+
+    const request: TradeJournalRequest = {
+      ...tradeJournalRequestDefaults,
+      ...value,
+      trades,
+    };
+
+    return request;
+  });
+
+export type TradeRecordInputSchema = z.infer<typeof tradeRecordSchema>;
+export type TradeJournalRequestSchema = z.infer<
+  typeof tradeJournalRequestSchema
+>;

--- a/apps/web/services/trade-journal/types.ts
+++ b/apps/web/services/trade-journal/types.ts
@@ -1,0 +1,73 @@
+export interface TradeRecordInput {
+  symbol: string;
+  direction: string;
+  entryPrice: number;
+  exitPrice: number;
+  size: number;
+  pnl: number;
+  rewardRisk?: number | null;
+  setup?: string | null;
+  grade?: string | null;
+  notes?: string | null;
+  tags?: string[];
+  checklistMisses?: string[];
+}
+
+export interface TradeJournalRequest {
+  sessionDate: string;
+  sessionSummary: string;
+  objectives: string[];
+  marketContext: string;
+  trades: TradeRecordInput[];
+  riskEvents: string[];
+  mindsetNotes: string[];
+  metrics: Record<string, unknown>;
+  environment: Record<string, unknown>;
+}
+
+export interface AggregatedTradeInsight {
+  symbol: string;
+  direction: string;
+  entryPrice: number;
+  exitPrice: number;
+  size: number;
+  pnl: number;
+  rewardRisk?: number | null;
+  setup?: string | null;
+  grade?: string | null;
+  notes?: string | null;
+  tags: string[];
+  checklistMisses: string[];
+}
+
+export interface TradeJournalMetadata {
+  sessionDate: string;
+  objectiveCount: number;
+  riskEventCount: number;
+  tradeCount: number;
+  winningTrades: number;
+  losingTrades: number;
+  flatTrades: number;
+  totalPnl: number;
+  averagePnl: number;
+  winRate: number;
+  averageRewardRisk: number | null;
+  bestTrade: AggregatedTradeInsight | null;
+  worstTrade: AggregatedTradeInsight | null;
+  tagFrequency: Record<string, number>;
+  checklistMissFrequency: Record<string, number>;
+  metrics: Record<string, unknown>;
+  environment: Record<string, unknown>;
+}
+
+export interface TradeJournalReport {
+  summary: string;
+  performanceHighlights: string[];
+  lessons: string[];
+  nextActions: string[];
+  mindsetReflections: string[];
+  coachPrompts: string[];
+  metadata: TradeJournalMetadata;
+  rawResponse: string | null;
+  runs: unknown[];
+}

--- a/apps/web/services/trade-journal/utils.ts
+++ b/apps/web/services/trade-journal/utils.ts
@@ -1,0 +1,52 @@
+import type { TradeJournalRequest } from "./types";
+
+export const tradeJournalRequestDefaults: TradeJournalRequest = {
+  sessionDate: "",
+  sessionSummary: "",
+  objectives: [],
+  marketContext: "",
+  trades: [],
+  riskEvents: [],
+  mindsetNotes: [],
+  metrics: {},
+  environment: {},
+};
+
+export function normaliseList(values: string[]): string[] {
+  return values
+    .map((value) => value.trim())
+    .filter((value, index, collection) =>
+      value.length > 0 && collection.indexOf(value) === index
+    );
+}
+
+export function formatPnL(pnl: number): string {
+  const sign = pnl >= 0 ? "+" : "-";
+  return `${sign}${Math.abs(pnl).toFixed(2)}`;
+}
+
+export function formatPercentage(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "0%";
+  }
+  return `${value.toFixed(0)}%`;
+}
+
+export function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const sum = values.reduce((total, item) => total + item, 0);
+  return sum / values.length;
+}
+
+export function toFrequencyMap(values: string[]): Record<string, number> {
+  return values.reduce<Record<string, number>>((accumulator, value) => {
+    const key = value.trim();
+    if (key.length === 0) {
+      return accumulator;
+    }
+    accumulator[key] = (accumulator[key] ?? 0) + 1;
+    return accumulator;
+  }, {});
+}


### PR DESCRIPTION
## Summary
- add a trade journal API endpoint backed by deterministic analytics utilities
- implement trade journal service types, schema normalisation, and report generation
- build the trade journal workspace UI and expose it on a dedicated tools page

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d77a2bc658832282608673c200f416