### PR TITLE
feat: add dynamic market review tool page

### DIFF
--- a/apps/web/app/tools/dynamic-market-review/head.tsx
+++ b/apps/web/app/tools/dynamic-market-review/head.tsx
@@ -1,0 +1,16 @@
+export default function Head() {
+  const title = "Dynamic Market Review – Dynamic Capital";
+  const description =
+    "Monitor currency strength, volatility, and cross-asset heatmaps with the desk's live Dynamic Market Review dashboard.";
+
+  return (
+    <>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </>
+  );
+}

--- a/apps/web/app/tools/dynamic-market-review/page.tsx
+++ b/apps/web/app/tools/dynamic-market-review/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
+
+import DynamicMarketReview from "@/components/tools/DynamicMarketReview";
+
+export default function DynamicMarketReviewPage() {
+  return (
+    <Column gap="40" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={36} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Dynamic market review
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          Get a consolidated view of FX momentum, volatility outliers, and
+          cross-asset leadership to inform the next trading session in minutes.
+        </Text>
+      </Column>
+      <DynamicMarketReview />
+    </Column>
+  );
+}

--- a/apps/web/components/navigation/SiteFooter.tsx
+++ b/apps/web/components/navigation/SiteFooter.tsx
@@ -10,6 +10,7 @@ import { schema, social } from "@/resources";
 import NAV_ITEMS from "./nav-items";
 
 const QUICK_LINKS = [
+  { label: "Dynamic market review", href: "/tools/dynamic-market-review" },
   { label: "Multi-LLM studio", href: "/tools/multi-llm" },
   { label: "Provider matrix", href: "/#provider-matrix" },
   { label: "Routing policies", href: "/#orchestration" },

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -1,4 +1,4 @@
-import { LayoutDashboard, type LucideIcon } from "lucide-react";
+import { LayoutDashboard, LineChart, type LucideIcon } from "lucide-react";
 
 import {
   HOME_NAV_SECTION_MAP,
@@ -54,25 +54,42 @@ const deskNavItems = DESK_NAV_SECTION_ORDER.map((sectionId, index) =>
   createNavItemFromSection(sectionId, index + 1)
 ).filter((item): item is NavItem => Boolean(item));
 
-const onboardingNavItem = createNavItemFromSection(
-  "advantages",
-  deskNavItems.length + 2,
-);
+const firstExtraStep = deskNavItems.length + 1;
 
-export const NAV_ITEMS: NavItem[] = [
-  ...deskNavItems,
+const extraNavItems: NavItem[] = [
   {
     id: "studio",
-    step: `Step ${deskNavItems.length + 1}`,
+    step: `Step ${firstExtraStep}`,
     label: "LLM studio",
     description: "Run side-by-side provider benchmarks.",
     icon: LayoutDashboard,
     path: "/tools/multi-llm",
-    ariaLabel: `Step ${
-      deskNavItems.length + 1
-    }: LLM studio. Run side-by-side provider benchmarks.`,
+    ariaLabel:
+      `Step ${firstExtraStep}: LLM studio. Run side-by-side provider benchmarks.`,
     showOnMobile: true,
   },
+  {
+    id: "market-review",
+    step: `Step ${firstExtraStep + 1}`,
+    label: "Market review",
+    description: "Track FX strength, volatility, and cross-asset watchlists.",
+    icon: LineChart,
+    path: "/tools/dynamic-market-review",
+    ariaLabel: `Step ${
+      firstExtraStep + 1
+    }: Market review. Track FX strength, volatility, and cross-asset watchlists.`,
+    showOnMobile: true,
+  },
+];
+
+const onboardingNavItem = createNavItemFromSection(
+  "advantages",
+  deskNavItems.length + extraNavItems.length + 1,
+);
+
+export const NAV_ITEMS: NavItem[] = [
+  ...deskNavItems,
+  ...extraNavItems,
   ...(onboardingNavItem ? [onboardingNavItem] : []),
 ];
 

--- a/apps/web/components/tools/DynamicMarketReview.tsx
+++ b/apps/web/components/tools/DynamicMarketReview.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Column, Row } from "@/components/dynamic-ui-system";
+
+import FxMarketSnapshotSection from "@/components/magic-portfolio/home/FxMarketSnapshotSection";
+import MarketWatchlist from "@/components/magic-portfolio/home/MarketWatchlist";
+import { CommodityStrengthSection } from "@/components/magic-portfolio/home/CommodityStrengthSection";
+import { CryptoStrengthSection } from "@/components/magic-portfolio/home/CryptoStrengthSection";
+import { CurrencyStrengthSection } from "@/components/magic-portfolio/home/CurrencyStrengthSection";
+import { IndexStrengthSection } from "@/components/magic-portfolio/home/IndexStrengthSection";
+
+export function DynamicMarketReview() {
+  return (
+    <Column gap="32" fillWidth maxWidth={96}>
+      <FxMarketSnapshotSection />
+      <MarketWatchlist />
+      <Row gap="24" wrap fillWidth>
+        <Column flex={1} minWidth={32}>
+          <CurrencyStrengthSection />
+        </Column>
+        <Column flex={1} minWidth={32}>
+          <CommodityStrengthSection />
+        </Column>
+      </Row>
+      <Row gap="24" wrap fillWidth>
+        <Column flex={1} minWidth={32}>
+          <IndexStrengthSection />
+        </Column>
+        <Column flex={1} minWidth={32}>
+          <CryptoStrengthSection />
+        </Column>
+      </Row>
+    </Column>
+  );
+}
+
+export default DynamicMarketReview;

--- a/apps/web/resources/content.tsx
+++ b/apps/web/resources/content.tsx
@@ -108,15 +108,15 @@ const home: Home = {
           onBackground="brand-strong"
           className="ml-4 font-semibold tracking-tight"
         >
-          Launch update: Multi-LLM Studio 2.0
+          Launch update: Dynamic market review
         </Text>
         <Line background="brand-alpha-strong" vert height="20" />
         <Text marginRight="4" onBackground="brand-medium">
-          Route prompts across OpenAI, Anthropic, and Groq instantly
+          Cross-asset intelligence with live FX, commodity, and index signals
         </Text>
       </Row>
     ),
-    href: "/tools/multi-llm",
+    href: "/tools/dynamic-market-review",
   },
   subline: (
     <>


### PR DESCRIPTION
## Summary
- add a dedicated Dynamic Market Review route that wraps the existing market intelligence widgets
- expose the page through the navigation rail, footer quick links, and home highlight CTA

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d77a44e2b4832290fbfcf1b18d68c9