### PR TITLE
feat: add TradingView webhook verification script

### DIFF
--- a/scripts/verify/tradingview_webhook.sh
+++ b/scripts/verify/tradingview_webhook.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+R=".out/tradingview_webhook.txt"
+: > "$R"
+
+say "E) TradingView Webhook Verification"
+
+URL="${TRADINGVIEW_WEBHOOK_URL:-https://dynamic-capital-qazf2.ondigitalocean.app/webhook}"
+TIMEOUT="${TRADINGVIEW_WEBHOOK_TIMEOUT:-8}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  warn "curl not available, skipping TradingView webhook verification."
+  echo "url=$URL" >> "$R"
+  echo "verified=SKIPPED" >> "$R"
+  exit 0
+fi
+
+echo "url=$URL" >> "$R"
+echo "timeout=${TIMEOUT}s" >> "$R"
+
+tmp_headers=$(mktemp)
+get_status=$(curl -s -m "$TIMEOUT" -D "$tmp_headers" -o /dev/null "$URL" -w "%{http_code}" || echo 000)
+content_type=$(grep -i '^content-type:' "$tmp_headers" | tail -n 1 | cut -d' ' -f2- | tr -d '\r' | trim || true)
+rm -f "$tmp_headers"
+
+echo "get_status=$get_status" >> "$R"
+if [ -n "$content_type" ]; then
+  echo "get_content_type=$content_type" >> "$R"
+fi
+
+post_body=$(mktemp)
+post_cmd=(curl -s -m "$TIMEOUT" -o "$post_body" -w "%{http_code}" -H "content-type: application/json" -d '{}')
+post_status=$("${post_cmd[@]}" "$URL" || echo 000)
+
+echo "post_status=$post_status" >> "$R"
+if [ -s "$post_body" ]; then
+  preview=$(head -c 160 "$post_body" | tr '\n' ' ' | tr -d '\r' | trim)
+  if [ -n "$preview" ]; then
+    echo "post_preview=$preview" >> "$R"
+  fi
+fi
+rm -f "$post_body"
+
+if [ -n "${TRADINGVIEW_WEBHOOK_SECRET:-}" ]; then
+  secure_body=$(mktemp)
+  secure_cmd=(curl -s -m "$TIMEOUT" -o "$secure_body" -w "%{http_code}" -H "content-type: application/json" -H "X-Tradingview-Secret: ${TRADINGVIEW_WEBHOOK_SECRET}" -d '{}')
+  secure_status=$("${secure_cmd[@]}" "$URL" || echo 000)
+  echo "auth_status=$secure_status" >> "$R"
+  if [ -s "$secure_body" ]; then
+    secure_preview=$(head -c 160 "$secure_body" | tr '\n' ' ' | tr -d '\r' | trim)
+    if [ -n "$secure_preview" ]; then
+      echo "auth_preview=$secure_preview" >> "$R"
+    fi
+  fi
+  rm -f "$secure_body"
+else
+  echo "auth_status=SKIPPED" >> "$R"
+fi
+
+if [[ "$post_status" =~ ^(401|403|500)$ ]]; then
+  echo "verified=PASS" >> "$R"
+else
+  echo "verified=FAIL" >> "$R"
+fi
+
+say "TradingView webhook verification complete."

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -12,6 +12,7 @@ bash scripts/verify/static_code_checks.sh
 bash scripts/verify/deployed_function_checks.sh
 bash scripts/verify/runtime_wiring_checks.sh
 bash scripts/verify/miniapp_safety.sh
+bash scripts/verify/tradingview_webhook.sh
 
 # Build markdown report
 OUT=".out/verify_report.md"
@@ -37,6 +38,7 @@ emit_section "A) Static Code Checks" ".out/static_checks.txt"
 emit_section "B) Deployed Function Checks" ".out/deployed_checks.txt"
 emit_section "C) Runtime Wiring Checks" ".out/runtime_checks.txt"
 emit_section "D) Mini App Safety" ".out/miniapp_safety.txt"
+emit_section "E) TradingView Webhook" ".out/tradingview_webhook.txt"
 
 echo "Report written to $OUT"
 say "Done."


### PR DESCRIPTION
## Summary
- add a verification helper that probes the deployed TradingView webhook endpoint and records status details
- integrate the TradingView check into the aggregated verification report so it is included in `verify_all`

## Testing
- bash scripts/verify/tradingview_webhook.sh
- bash scripts/verify/verify_all.sh

------
https://chatgpt.com/codex/tasks/task_e_68d7881191f88322ba4a49003f83c8c6