### PR TITLE
Calibrate Lorentzian model integration for Dynamic AI

### DIFF
--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -12,6 +12,7 @@ from .fusion import (
     TrendMomentumLobe,
     TreasuryLobe,
 )
+from .training import calibrate_lorentzian_lobe, load_lorentzian_model
 from .risk import PositionSizing, RiskContext, RiskManager, RiskParameters
 
 __all__ = [
@@ -27,6 +28,8 @@ __all__ = [
     "SignalLobe",
     "TrendMomentumLobe",
     "TreasuryLobe",
+    "calibrate_lorentzian_lobe",
+    "load_lorentzian_model",
     "PositionSizing",
     "RiskContext",
     "RiskManager",

--- a/dynamic_ai/training.py
+++ b/dynamic_ai/training.py
@@ -1,0 +1,49 @@
+"""Training utilities aligning Dynamic AI lobes with learned parameters."""
+
+from __future__ import annotations
+
+import math
+import pickle
+from pathlib import Path
+from typing import Any, Mapping
+
+from .fusion import LorentzianDistanceLobe
+from ml.lorentzian_train import LorentzianModel
+
+
+def _coerce_model(model: LorentzianModel | Mapping[str, Any]) -> LorentzianModel:
+    if isinstance(model, LorentzianModel):
+        return model
+    if isinstance(model, Mapping):
+        return LorentzianModel.from_dict(model)
+    raise TypeError("Unsupported model payload; expected LorentzianModel or mapping")
+
+
+def load_lorentzian_model(path: str | Path) -> LorentzianModel:
+    """Load a serialized Lorentzian model from ``path``."""
+
+    payload = pickle.loads(Path(path).read_bytes())
+    if isinstance(payload, LorentzianModel):
+        return payload
+    if isinstance(payload, Mapping):
+        return LorentzianModel.from_dict(payload)
+    raise TypeError("Serialized Lorentzian model has unexpected structure")
+
+
+def calibrate_lorentzian_lobe(
+    model: LorentzianModel | Mapping[str, Any], *,
+    minimum_sensitivity: float = 1e-6,
+) -> LorentzianDistanceLobe:
+    """Create a :class:`LorentzianDistanceLobe` configured from ``model``."""
+
+    hydrated = _coerce_model(model)
+
+    sensitivity = hydrated.sensitivity
+    if not math.isfinite(sensitivity) or sensitivity <= 0:
+        sensitivity = hydrated.mean + abs(hydrated.z_thresh) * hydrated.std
+        sensitivity = max(abs(sensitivity), minimum_sensitivity)
+    else:
+        sensitivity = max(sensitivity, minimum_sensitivity)
+
+    return LorentzianDistanceLobe(sensitivity=float(sensitivity))
+

--- a/tests/test_lorentzian_training.py
+++ b/tests/test_lorentzian_training.py
@@ -1,0 +1,42 @@
+import math
+import pickle
+
+from dynamic_ai.training import calibrate_lorentzian_lobe, load_lorentzian_model
+from ml.lorentzian_train import LorentzianModel, train_lorentzian
+
+
+def _synthetic_closes(count: int = 160) -> list[float]:
+    base = 100.0
+    return [base + math.sin(idx / 5) * 2 + idx * 0.05 for idx in range(count)]
+
+
+def test_train_lorentzian_emits_sensitivity(tmp_path) -> None:
+    closes = _synthetic_closes()
+    model = train_lorentzian(closes, window=30, alpha=0.4, z_thresh=1.8)
+
+    assert isinstance(model, LorentzianModel)
+    assert model.sensitivity > 0
+
+    lobe = calibrate_lorentzian_lobe(model)
+    assert math.isclose(lobe.sensitivity, model.sensitivity, rel_tol=1e-6)
+
+    model_path = tmp_path / "lorentzian.pkl"
+    with model_path.open("wb") as handle:
+        pickle.dump(model.to_dict(), handle)
+
+    loaded = load_lorentzian_model(model_path)
+    assert isinstance(loaded, LorentzianModel)
+    assert math.isclose(loaded.sensitivity, model.sensitivity, rel_tol=1e-6)
+
+
+def test_calibration_falls_back_when_missing_sensitivity() -> None:
+    closes = _synthetic_closes()
+    model = train_lorentzian(closes, window=25, alpha=0.3, z_thresh=1.5)
+
+    payload = model.to_dict()
+    payload["sensitivity"] = 0.0
+
+    lobe = calibrate_lorentzian_lobe(payload)
+
+    expected = model.mean + abs(model.z_thresh) * model.std
+    assert lobe.sensitivity >= expected or math.isclose(lobe.sensitivity, expected, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- add a Dynamic AI training helper that loads Lorentzian models and configures the fusion lobe
- extend the Lorentzian training pipeline to compute a sensitivity parameter and support robust hydration
- normalise Lorentzian models in the Supabase edge function and refresh tests for the new training workflow

## Testing
- PYTHONPATH=. pytest tests/test_lorentzian_training.py tests/test_fusion_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d7870ebd348322a200f052ad6a5d89