### PR TITLE
feat: add MT5 heartbeat and reverse command bridge

### DIFF
--- a/apps/web/types/supabase.ts
+++ b/apps/web/types/supabase.ts
@@ -1639,6 +1639,156 @@ export type Database = {
         };
         Relationships: [];
       };
+      mt5_account_heartbeats: {
+        Row: {
+          id: string;
+          account_login: string;
+          status: string;
+          balance: number | null;
+          equity: number | null;
+          free_margin: number | null;
+          raw_payload: Json;
+          received_at: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          account_login: string;
+          status?: string;
+          balance?: number | null;
+          equity?: number | null;
+          free_margin?: number | null;
+          raw_payload: Json;
+          received_at?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          account_login?: string;
+          status?: string;
+          balance?: number | null;
+          equity?: number | null;
+          free_margin?: number | null;
+          raw_payload?: Json;
+          received_at?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      mt5_commands: {
+        Row: {
+          id: string;
+          external_id: string | null;
+          account_login: string | null;
+          command_type: string;
+          symbol: string;
+          side: string | null;
+          volume: number | null;
+          price: number | null;
+          stop_loss: number | null;
+          take_profit: number | null;
+          trailing_stop: number | null;
+          ticket: string | null;
+          comment: string | null;
+          status: string;
+          status_message: string | null;
+          payload: Json;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          external_id?: string | null;
+          account_login?: string | null;
+          command_type: string;
+          symbol: string;
+          side?: string | null;
+          volume?: number | null;
+          price?: number | null;
+          stop_loss?: number | null;
+          take_profit?: number | null;
+          trailing_stop?: number | null;
+          ticket?: string | null;
+          comment?: string | null;
+          status?: string;
+          status_message?: string | null;
+          payload: Json;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          external_id?: string | null;
+          account_login?: string | null;
+          command_type?: string;
+          symbol?: string;
+          side?: string | null;
+          volume?: number | null;
+          price?: number | null;
+          stop_loss?: number | null;
+          take_profit?: number | null;
+          trailing_stop?: number | null;
+          ticket?: string | null;
+          comment?: string | null;
+          status?: string;
+          status_message?: string | null;
+          payload?: Json;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      mt5_risk_adjustments: {
+        Row: {
+          id: string;
+          ticket: string;
+          account_login: string | null;
+          symbol: string | null;
+          desired_stop_loss: number | null;
+          desired_take_profit: number | null;
+          trailing_stop_distance: number | null;
+          status: string;
+          status_message: string | null;
+          notes: string | null;
+          payload: Json;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          ticket: string;
+          account_login?: string | null;
+          symbol?: string | null;
+          desired_stop_loss?: number | null;
+          desired_take_profit?: number | null;
+          trailing_stop_distance?: number | null;
+          status?: string;
+          status_message?: string | null;
+          notes?: string | null;
+          payload: Json;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          ticket?: string;
+          account_login?: string | null;
+          symbol?: string | null;
+          desired_stop_loss?: number | null;
+          desired_take_profit?: number | null;
+          trailing_stop_distance?: number | null;
+          status?: string;
+          status_message?: string | null;
+          notes?: string | null;
+          payload?: Json;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       mt5_trade_logs: {
         Row: {
           id: string;
@@ -1653,6 +1803,7 @@ export type Database = {
           raw_payload: Json;
           received_at: string;
           updated_at: string;
+          source: string;
         };
         Insert: {
           id?: string;
@@ -1667,6 +1818,7 @@ export type Database = {
           raw_payload?: Json;
           received_at?: string;
           updated_at?: string;
+          source?: string;
         };
         Update: {
           id?: string;
@@ -1681,6 +1833,7 @@ export type Database = {
           raw_payload?: Json;
           received_at?: string;
           updated_at?: string;
+          source?: string;
         };
         Relationships: [];
       };

--- a/docs/mt5-supabase-bridge.md
+++ b/docs/mt5-supabase-bridge.md
@@ -1,8 +1,9 @@
 # MT5 Supabase Bridge
 
-This integration pairs a native MetaTrader 5 expert advisor with a Supabase Edge
-Function so trade activity from MT5 terminals can be mirrored into the
-`mt5_trade_logs` table for downstream automation and telemetry.
+This integration pairs a native MetaTrader 5 expert advisor with a suite of
+Supabase Edge Functions so trade activity, account heartbeats, risk adjustments,
+and Dynamic AI command directives can flow bi-directionally between MT5 and the
+Dynamic Capital platform.
 
 ## MT5 Expert Advisor
 
@@ -13,24 +14,45 @@ Update the `InpSupabaseUrl` input with your project reference and adjust the
 (default: 15 seconds).
 
 Each payload includes the symbol, side, lot size, average price, floating PnL,
-account login, and the MT5 ticket identifier/open time. The expert advisor skips
-any request when the heartbeat interval has not elapsed to avoid hammering the
-webhook with identical data.
+account login, ticket identifier/open time, and a `source` tag (default: `mt5`).
+The expert advisor skips any request when the heartbeat interval has not elapsed
+to avoid hammering the webhook with identical data.
+
+Alongside per-position updates, the advisor emits an account-level heartbeat
+payload every `InpHeartbeatSeconds` so dashboards can detect if the terminal is
+online even when no trades are open. Two additional inputs enable the reverse
+bridge:
+
+- `InpCommandsUrl` / `InpCommandsSecret` (or `InpTerminalKey`) poll
+  `/mt5-commands` to receive `open`/`close`/`modify` directives from Dynamic AI
+  agents.
+- `InpRiskUrl` / `InpRiskSecret` (or `InpTerminalKey`) poll `/mt5-risk` for
+  trailing-stop and SL/TP adjustments produced by the risk policy.
+
+Both pollers acknowledge execution status back to Supabase so automation can
+track the lifecycle (`queued → sent → filled/applied/failed`).
 
 > **Important:** In MetaTrader 5 go to **Tools → Options → Expert Advisors** and
-> add your Supabase function URL to the _Allow WebRequests for listed URL_
+> add your Supabase function URLs to the _Allow WebRequests for listed URL_
 > section.
 
-## Supabase Edge Function
+## Supabase Edge Functions
 
-Deploy the [`supabase/functions/mt5`](../supabase/functions/mt5/index.ts)
-handler to receive MT5 payloads. The function normalises the trade payload,
-ensures required fields are present (symbol, side, ticket), and upserts the
-record into `public.mt5_trade_logs` using the ticket ID as a natural key.
+### Trade ingestion (`/mt5`)
+
+Deploy [`supabase/functions/mt5`](../supabase/functions/mt5/index.ts) to
+normalise MT5 payloads, ensure required fields are present (symbol, side,
+ticket), and upsert records into `public.mt5_trade_logs`. The same handler also
+recognises account heartbeat payloads and persists them to
+`public.mt5_account_heartbeats`.
+
 Required environment variables:
 
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_TRADES_CHAT_ID`
+- (Optional) `TELEGRAM_TRADES_TEMPLATE`
 
 `mt5_trade_logs` captures a heartbeat of each position with the following
 fields:
@@ -44,8 +66,56 @@ fields:
 - `account_login`
 - `opened_at`
 - `raw_payload`
+- `source`
 - Timestamps (`received_at`, `updated_at`)
 
-The handler responds with a JSON payload describing the normalised record so
-follow-up automation can react immediately (for example, dispatching Telegram
-alerts or reconciling with TradingView signals).
+`mt5_account_heartbeats` stores account snapshots (`account_login`, `status`,
+`balance`, `equity`, `free_margin`, `raw_payload`) keyed by timestamp so the web
+app can display terminal health.
+
+After persisting a trade the function pushes a Telegram notification so
+operators receive real-time alerts. Messages can be customised via the template
+environment variable mentioned above (placeholders: `symbol`, `side`, `volume`,
+`open_price`, `profit`, `account`, `ticket`, `source`).
+
+### Command queue (`/mt5-commands`)
+
+[`supabase/functions/mt5-commands`](../supabase/functions/mt5-commands/index.ts)
+provides a write API for automation (Dynamic AI, sentiment agents, etc.) to
+enqueue MT5 instructions and a read/ack API for the expert advisor.
+
+- `POST /mt5-commands` (authenticated with `MT5_COMMANDS_WEBHOOK_SECRET`)
+  validates incoming JSON, stores it in `public.mt5_commands`, and returns the
+  generated IDs.
+- `GET /mt5-commands?account=...` (authenticated with `MT5_TERMINAL_KEY`)
+  returns queued commands for the terminal, marking them as `sent`.
+- `PATCH /mt5-commands` updates the command status (`filled`, `failed`, etc.)
+  based on EA acknowledgements.
+
+### Risk adjustment feed (`/mt5-risk`)
+
+[`supabase/functions/mt5-risk`](../supabase/functions/mt5-risk/index.ts) exposes
+Dynamic AI's risk guardrails to MT5. Scheduled jobs (see
+[`dynamic_ai/risk_sync.py`](../dynamic_ai/risk_sync.py)) post desired SL/TP and
+trailing-stop levels to the endpoint, which persists them in
+`public.mt5_risk_adjustments`. Terminals poll the same endpoint for pending
+actions and respond with `PATCH` updates when adjustments have been applied.
+
+Environment variables:
+
+- `MT5_RISK_WEBHOOK_SECRET`
+- `MT5_COMMANDS_WEBHOOK_SECRET`
+- `MT5_TERMINAL_KEY`
+
+### Risk policy automation
+
+[`dynamic_ai/risk_sync.py`](../dynamic_ai/risk_sync.py) converts `RiskContext`
+plus live MT5 snapshots into adjustment payloads and posts them to `/mt5-risk`.
+Tests in [`tests/test_mt5_risk_sync.py`](../tests/test_mt5_risk_sync.py) cover
+payload generation and webhook behaviour.
+
+### Telegram notifications
+
+Every successful trade upsert triggers a Telegram message so operators receive
+real-time alerts. Configure the bot token, chat ID, and optional template via
+environment variables noted above.

--- a/dynamic_ai/risk_sync.py
+++ b/dynamic_ai/risk_sync.py
@@ -1,0 +1,117 @@
+"""Utilities for synchronising Dynamic AI risk guidance with MT5."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
+
+from .risk import RiskContext, assign_sl_tp
+
+
+@dataclass
+class PositionSnapshot:
+    """Minimal MT5 position representation used for risk adjustments."""
+
+    ticket: str
+    symbol: str
+    side: str
+    entry_price: float
+    volatility: float
+    treasury_health: float = 1.0
+
+
+def build_mt5_risk_adjustments(
+    positions: Sequence[PositionSnapshot],
+    context: RiskContext,
+    *,
+    trailing_stop_multiplier: float = 0.75,
+) -> List[MutableMapping[str, object]]:
+    """Generate desired SL/TP/trailing-stop adjustments for open MT5 positions."""
+
+    adjustments: List[MutableMapping[str, object]] = []
+    for position in positions:
+        side = position.side.upper()
+        sl, tp = assign_sl_tp(
+            entry=position.entry_price,
+            signal=side,
+            volatility=position.volatility,
+            treasury_health=position.treasury_health,
+        )
+        if sl is None and tp is None:
+            continue
+
+        trailing_stop = round(position.volatility * trailing_stop_multiplier, 2)
+        adjustments.append(
+            {
+                "ticket": str(position.ticket),
+                "symbol": position.symbol,
+                "desired_stop_loss": sl,
+                "desired_take_profit": tp,
+                "trailing_stop_distance": trailing_stop,
+                "notes": "Auto-adjusted by Dynamic AI risk engine",
+            }
+        )
+
+    return adjustments
+
+
+def _request(url: str, payload: Mapping[str, object], *, secret: str) -> None:
+    data = json.dumps(payload).encode("utf-8")
+    headers = {
+        "content-type": "application/json",
+        "authorization": f"Bearer {secret}",
+    }
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    backoff = 0.5
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=10) as response:
+                if response.status >= 400:
+                    body = response.read().decode("utf-8", "ignore")
+                    raise RuntimeError(f"HTTP {response.status}: {body}")
+                return
+        except (urllib.error.URLError, RuntimeError) as exc:  # pragma: no cover
+            if attempt == 2:
+                raise
+            time.sleep(backoff)
+            backoff *= 2
+
+
+def sync_mt5_risk_adjustments(
+    positions: Iterable[PositionSnapshot],
+    context: RiskContext,
+    *,
+    endpoint: str | None = None,
+    secret: str | None = None,
+) -> List[MutableMapping[str, object]]:
+    """Build adjustments and push them to the MT5 risk edge function."""
+
+    endpoint = endpoint or os.environ.get("MT5_RISK_WEBHOOK_URL")
+    if not endpoint:
+        raise RuntimeError("MT5_RISK_WEBHOOK_URL is not configured")
+    secret = secret or os.environ.get("MT5_RISK_WEBHOOK_SECRET")
+    if not secret:
+        raise RuntimeError("MT5_RISK_WEBHOOK_SECRET is not configured")
+
+    snapshot_positions = [
+        pos if isinstance(pos, PositionSnapshot) else PositionSnapshot(**pos)  # type: ignore[arg-type]
+        for pos in positions
+    ]
+
+    adjustments = build_mt5_risk_adjustments(snapshot_positions, context)
+    if adjustments:
+        _request(endpoint, {"adjustments": adjustments}, secret=secret)
+    return adjustments
+
+
+__all__ = [
+    "PositionSnapshot",
+    "build_mt5_risk_adjustments",
+    "sync_mt5_risk_adjustments",
+]

--- a/integrations/mt5/SupabaseBridge.mq5
+++ b/integrations/mt5/SupabaseBridge.mq5
@@ -1,7 +1,13 @@
 #property strict
-#include <stdlib.mqh>
+#include <Trade/Trade.mqh>
 
 input string InpSupabaseUrl = "https://<PROJECT_REF>.functions.supabase.co/mt5";
+input string InpSupabaseKey = "";
+input string InpCommandsUrl = "https://<PROJECT_REF>.functions.supabase.co/mt5-commands";
+input string InpCommandsSecret = "";
+input string InpRiskUrl = "https://<PROJECT_REF>.functions.supabase.co/mt5-risk";
+input string InpRiskSecret = "";
+input string InpTerminalKey = "";
 input int InpHeartbeatSeconds = 15;
 
 struct TradeHeartbeat {
@@ -9,7 +15,39 @@ struct TradeHeartbeat {
    datetime lastSent;
 };
 
+struct Mt5Command {
+   string id;
+   string action;
+   string symbol;
+   string side;
+   double volume;
+   double price;
+   double stopLoss;
+   double takeProfit;
+   double trailingStop;
+   string ticket;
+   string comment;
+};
+
+struct RiskAdjustment {
+   string id;
+   string ticket;
+   string symbol;
+   double stopLoss;
+   double takeProfit;
+   double trailingStop;
+   string notes;
+};
+
+struct AckPayload {
+   string id;
+   string status;
+   string message;
+};
+
 TradeHeartbeat heartbeats[];
+datetime lastAccountHeartbeat = 0;
+CTrade trade;
 
 int FindHeartbeatIndex(long ticket) {
    for(int i = 0; i < ArraySize(heartbeats); i++) {
@@ -17,6 +55,22 @@ int FindHeartbeatIndex(long ticket) {
          return i;
    }
    return -1;
+}
+
+string Trim(const string text) {
+   string tmp = text;
+   StringTrimLeft(tmp);
+   StringTrimRight(tmp);
+   return tmp;
+}
+
+string EscapeJson(const string value) {
+   string result = value;
+   StringReplace(result, "\\", "\\\\");
+   StringReplace(result, "\"", "\\\"");
+   StringReplace(result, "\n", "\\n");
+   StringReplace(result, "\r", "\\r");
+   return result;
 }
 
 bool ShouldSend(long ticket, datetime now) {
@@ -37,6 +91,425 @@ bool ShouldSend(long ticket, datetime now) {
    return true;
 }
 
+string BuildHeaders(bool includeJson, const string apiKey, const string bearer) {
+   string headers = "";
+   if(includeJson)
+      headers += "Content-Type: application/json\r\n";
+   if(StringLen(apiKey) > 0)
+      headers += "x-api-key: " + apiKey + "\r\n";
+   if(StringLen(bearer) > 0)
+      headers += "Authorization: Bearer " + bearer + "\r\n";
+   return headers;
+}
+
+bool HttpRequest(const string method, const string url, const string body, const string headers, string &response) {
+   ResetLastError();
+   char result[];
+   int status = WebRequest(method, url, headers, 10000, body, result, NULL);
+   if(status == -1) {
+      Print("❌ WebRequest failed: ", GetLastError(), " url=", url);
+      return false;
+   }
+   response = CharArrayToString(result);
+   if(status >= 200 && status < 300) {
+      return true;
+   }
+   Print("⚠️ HTTP status ", status, " body=", response);
+   return false;
+}
+
+bool SendTradePayload(const string payload) {
+   string response = "";
+   string headers = BuildHeaders(true, InpSupabaseKey, "");
+   bool ok = HttpRequest("POST", InpSupabaseUrl, payload, headers, response);
+   if(!ok)
+      Print("❌ Failed to sync trade: ", response);
+   return ok;
+}
+
+bool SendAccountHeartbeat(const string accountLogin) {
+   if(StringLen(InpSupabaseUrl) == 0)
+      return false;
+
+   double balance = AccountInfoDouble(ACCOUNT_BALANCE);
+   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   double marginFree = AccountInfoDouble(ACCOUNT_MARGIN_FREE);
+
+   string payload = "{" \
+      +"\"status\":\"alive\"," \
+      +"\"account\":\""+accountLogin+"\"," \
+      +"\"balance\":"+DoubleToString(balance,2)+"," \
+      +"\"equity\":"+DoubleToString(equity,2)+"," \
+      +"\"free_margin\":"+DoubleToString(marginFree,2) \
+      +"}";
+
+   string response = "";
+   string headers = BuildHeaders(true, InpSupabaseKey, "");
+   bool ok = HttpRequest("POST", InpSupabaseUrl, payload, headers, response);
+   if(!ok)
+      Print("❌ Failed to send account heartbeat: ", response);
+   else
+      lastAccountHeartbeat = TimeCurrent();
+   return ok;
+}
+
+bool JsonExtractValue(const string json, const string key, string &value) {
+   string pattern = "\"" + key + "\"";
+   int pos = StringFind(json, pattern);
+   if(pos == -1)
+      return false;
+   pos = StringFind(json, ":", pos);
+   if(pos == -1)
+      return false;
+   pos++;
+   int len = StringLen(json);
+   while(pos < len) {
+      int ch = StringGetCharacter(json, pos);
+      if(ch != ' ' && ch != '\n' && ch != '\r' && ch != '\t')
+         break;
+      pos++;
+   }
+   if(pos >= len)
+      return false;
+   int ch = StringGetCharacter(json, pos);
+   if(ch == '"') {
+      pos++;
+      int start = pos;
+      bool escape = false;
+      for(; pos < len; pos++) {
+         ch = StringGetCharacter(json, pos);
+         if(ch == '\\') {
+            escape = !escape;
+            continue;
+         }
+         if(ch == '"' && !escape) {
+            value = StringSubstr(json, start, pos - start);
+            StringReplace(value, "\\\"", "\"");
+            StringReplace(value, "\\\\", "\\");
+            return true;
+         }
+         escape = false;
+      }
+      return false;
+   }
+   int start = pos;
+   while(pos < len) {
+      ch = StringGetCharacter(json, pos);
+      if(ch == ',' || ch == '}' || ch == ']')
+         break;
+      pos++;
+   }
+   value = Trim(StringSubstr(json, start, pos - start));
+   return true;
+}
+
+bool JsonNextObject(const string json, int &index, string &object) {
+   int len = StringLen(json);
+   int start = -1;
+   int depth = 0;
+   bool inString = false;
+   for(int i = index; i < len; i++) {
+      int ch = StringGetCharacter(json, i);
+      if(ch == '"') {
+         int prev = (i > 0) ? StringGetCharacter(json, i - 1) : 0;
+         if(prev != '\\')
+            inString = !inString;
+      }
+      if(inString)
+         continue;
+      if(ch == '{') {
+         if(depth == 0)
+            start = i;
+         depth++;
+      } else if(ch == '}') {
+         depth--;
+         if(depth == 0 && start != -1) {
+            object = StringSubstr(json, start, i - start + 1);
+            index = i + 1;
+            return true;
+         }
+      }
+   }
+   return false;
+}
+
+double ParseDouble(const string value, double fallback = 0.0) {
+   string trimmed = Trim(value);
+   if(StringLen(trimmed) == 0 || trimmed == "null")
+      return fallback;
+   return StringToDouble(trimmed);
+}
+
+bool ParseCommand(const string object, Mt5Command &command) {
+   string val;
+   if(!JsonExtractValue(object, "id", val))
+      return false;
+   command.id = val;
+   if(!JsonExtractValue(object, "action", val))
+      return false;
+   command.action = StringToLower(val);
+   if(!JsonExtractValue(object, "symbol", val))
+      return false;
+   command.symbol = val;
+   if(JsonExtractValue(object, "side", val))
+      command.side = StringToLower(val);
+   else
+      command.side = "";
+   if(JsonExtractValue(object, "volume", val))
+      command.volume = ParseDouble(val, 0.0);
+   else
+      command.volume = 0.0;
+   if(JsonExtractValue(object, "price", val))
+      command.price = ParseDouble(val, 0.0);
+   else
+      command.price = 0.0;
+   if(JsonExtractValue(object, "stop_loss", val))
+      command.stopLoss = ParseDouble(val, 0.0);
+   else
+      command.stopLoss = 0.0;
+   if(JsonExtractValue(object, "take_profit", val))
+      command.takeProfit = ParseDouble(val, 0.0);
+   else
+      command.takeProfit = 0.0;
+   if(JsonExtractValue(object, "trailing_stop", val))
+      command.trailingStop = ParseDouble(val, 0.0);
+   else
+      command.trailingStop = 0.0;
+   if(JsonExtractValue(object, "ticket", val))
+      command.ticket = val;
+   else
+      command.ticket = "";
+   if(JsonExtractValue(object, "comment", val))
+      command.comment = val;
+   else
+      command.comment = "";
+   return true;
+}
+
+bool ParseAdjustment(const string object, RiskAdjustment &adj) {
+   string val;
+   if(!JsonExtractValue(object, "id", val))
+      return false;
+   adj.id = val;
+   if(JsonExtractValue(object, "ticket", val))
+      adj.ticket = val;
+   else
+      adj.ticket = "";
+   if(JsonExtractValue(object, "symbol", val))
+      adj.symbol = val;
+   else
+      adj.symbol = "";
+   if(JsonExtractValue(object, "desired_stop_loss", val))
+      adj.stopLoss = ParseDouble(val, 0.0);
+   else
+      adj.stopLoss = 0.0;
+   if(JsonExtractValue(object, "desired_take_profit", val))
+      adj.takeProfit = ParseDouble(val, 0.0);
+   else
+      adj.takeProfit = 0.0;
+   if(JsonExtractValue(object, "trailing_stop_distance", val))
+      adj.trailingStop = ParseDouble(val, 0.0);
+   else
+      adj.trailingStop = 0.0;
+   if(JsonExtractValue(object, "notes", val))
+      adj.notes = val;
+   else
+      adj.notes = "";
+   return true;
+}
+
+bool ExecuteCommand(const Mt5Command &command, string &statusMessage) {
+   bool success = false;
+   statusMessage = "";
+   if(command.action == "open") {
+      ENUM_ORDER_TYPE orderType = (command.side == "sell") ? ORDER_TYPE_SELL : ORDER_TYPE_BUY;
+      double sl = command.stopLoss > 0 ? command.stopLoss : 0.0;
+      double tp = command.takeProfit > 0 ? command.takeProfit : 0.0;
+      double price = command.price > 0 ? command.price : 0.0;
+      bool result = (orderType == ORDER_TYPE_BUY)
+         ? trade.Buy(command.volume, command.symbol, price, sl, tp, command.comment)
+         : trade.Sell(command.volume, command.symbol, price, sl, tp, command.comment);
+      if(!result) {
+         statusMessage = "Order send failed: " + IntegerToString(_LastError);
+      }
+      success = result;
+   } else if(command.action == "close") {
+      bool result = false;
+      if(StringLen(command.ticket) > 0) {
+         ulong ticket = (ulong)StringToInteger(command.ticket);
+         if(PositionSelectByTicket(ticket)) {
+            string symbol = PositionGetString(POSITION_SYMBOL);
+            result = trade.PositionClose(symbol);
+         }
+      } else {
+         result = trade.PositionClose(command.symbol);
+      }
+      if(!result)
+         statusMessage = "Close failed: " + IntegerToString(_LastError);
+      success = result;
+   } else if(command.action == "modify") {
+      double sl = command.stopLoss;
+      double tp = command.takeProfit;
+      if(command.trailingStop > 0.0) {
+         if(PositionSelect(command.symbol)) {
+            ENUM_POSITION_TYPE type = (ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
+            double priceCurrent = PositionGetDouble(POSITION_PRICE_CURRENT);
+            if(type == POSITION_TYPE_BUY)
+               sl = priceCurrent - command.trailingStop;
+            else if(type == POSITION_TYPE_SELL)
+               sl = priceCurrent + command.trailingStop;
+         }
+      }
+      bool result = trade.PositionModify(command.symbol, sl, tp);
+      if(!result)
+         statusMessage = "Modify failed: " + IntegerToString(_LastError);
+      success = result;
+   } else {
+      statusMessage = "Unsupported action";
+   }
+   return success;
+}
+
+bool ApplyRiskAdjustment(const RiskAdjustment &adj, string &statusMessage) {
+   string symbol = adj.symbol;
+   if(StringLen(symbol) == 0 && StringLen(adj.ticket) > 0) {
+      ulong ticket = (ulong)StringToInteger(adj.ticket);
+      if(PositionSelectByTicket(ticket))
+         symbol = PositionGetString(POSITION_SYMBOL);
+   }
+   if(StringLen(symbol) == 0) {
+      statusMessage = "Position not found";
+      return false;
+   }
+   if(!PositionSelect(symbol)) {
+      statusMessage = "Position unavailable";
+      return false;
+   }
+   double sl = adj.stopLoss;
+   double tp = adj.takeProfit;
+   if(adj.trailingStop > 0.0) {
+      ENUM_POSITION_TYPE type = (ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
+      double priceCurrent = PositionGetDouble(POSITION_PRICE_CURRENT);
+      double step = SymbolInfoDouble(symbol, SYMBOL_POINT);
+      if(type == POSITION_TYPE_BUY)
+         sl = priceCurrent - adj.trailingStop;
+      else if(type == POSITION_TYPE_SELL)
+         sl = priceCurrent + adj.trailingStop;
+      sl = NormalizeDouble(sl, (int)SymbolInfoInteger(symbol, SYMBOL_DIGITS));
+      if(step > 0 && adj.trailingStop > 0)
+         sl = MathFloor(sl / step) * step;
+   }
+   bool result = trade.PositionModify(symbol, sl, tp);
+   if(!result)
+      statusMessage = "Risk modify failed: " + IntegerToString(_LastError);
+   return result;
+}
+
+void SendAcknowledgements(const string url, const AckPayload &acks[], const string secret) {
+   if(ArraySize(acks) == 0)
+      return;
+   string body = "{\"results\":[";
+   for(int i = 0; i < ArraySize(acks); i++) {
+      if(i > 0) body += ",";
+      body += "{\"id\":\"" + EscapeJson(acks[i].id) + "\",\"status\":\"" + EscapeJson(acks[i].status) + "\"";
+      if(StringLen(acks[i].message) > 0)
+         body += ",\"message\":\"" + EscapeJson(acks[i].message) + "\"";
+      body += "}";
+   }
+   body += "]}";
+   string response = "";
+   string headers = BuildHeaders(true, "", StringLen(InpTerminalKey) > 0 ? InpTerminalKey : secret);
+   HttpRequest("PATCH", url, body, headers, response);
+}
+
+void PollCommands(const string accountLogin) {
+   if(StringLen(InpCommandsUrl) == 0)
+      return;
+   string url = InpCommandsUrl + "?account=" + accountLogin;
+   string response = "";
+   string headers = BuildHeaders(false, "", StringLen(InpTerminalKey) > 0 ? InpTerminalKey : InpCommandsSecret);
+   if(!HttpRequest("GET", url, "", headers, response))
+      return;
+
+   int arrPos = StringFind(response, "\"commands\"");
+   if(arrPos == -1)
+      return;
+   arrPos = StringFind(response, "[", arrPos);
+   if(arrPos == -1)
+      return;
+   int index = arrPos;
+   string object;
+   Mt5Command commands[];
+   while(JsonNextObject(response, index, object)) {
+      Mt5Command cmd;
+      if(ParseCommand(object, cmd)) {
+         int newIndex = ArraySize(commands);
+         ArrayResize(commands, newIndex + 1);
+         commands[newIndex] = cmd;
+      }
+   }
+   if(ArraySize(commands) == 0)
+      return;
+
+   AckPayload acks[];
+   for(int i = 0; i < ArraySize(commands); i++) {
+      string message;
+      bool success = ExecuteCommand(commands[i], message);
+      AckPayload ack;
+      ack.id = commands[i].id;
+      ack.status = success ? "filled" : "failed";
+      ack.message = message;
+      int newIndex = ArraySize(acks);
+      ArrayResize(acks, newIndex + 1);
+      acks[newIndex] = ack;
+   }
+   SendAcknowledgements(InpCommandsUrl, acks, InpCommandsSecret);
+}
+
+void PollRiskAdjustments(const string accountLogin) {
+   if(StringLen(InpRiskUrl) == 0)
+      return;
+   string url = InpRiskUrl + "?account=" + accountLogin;
+   string response = "";
+   string headers = BuildHeaders(false, "", StringLen(InpTerminalKey) > 0 ? InpTerminalKey : InpRiskSecret);
+   if(!HttpRequest("GET", url, "", headers, response))
+      return;
+
+   int arrPos = StringFind(response, "\"adjustments\"");
+   if(arrPos == -1)
+      return;
+   arrPos = StringFind(response, "[", arrPos);
+   if(arrPos == -1)
+      return;
+   int index = arrPos;
+   string object;
+   RiskAdjustment adjustments[];
+   while(JsonNextObject(response, index, object)) {
+      RiskAdjustment adj;
+      if(ParseAdjustment(object, adj)) {
+         int newIndex = ArraySize(adjustments);
+         ArrayResize(adjustments, newIndex + 1);
+         adjustments[newIndex] = adj;
+      }
+   }
+   if(ArraySize(adjustments) == 0)
+      return;
+
+   AckPayload acks[];
+   for(int i = 0; i < ArraySize(adjustments); i++) {
+      string message;
+      bool success = ApplyRiskAdjustment(adjustments[i], message);
+      AckPayload ack;
+      ack.id = adjustments[i].id;
+      ack.status = success ? "applied" : "failed";
+      ack.message = message;
+      int newIndex = ArraySize(acks);
+      ArrayResize(acks, newIndex + 1);
+      acks[newIndex] = ack;
+   }
+   SendAcknowledgements(InpRiskUrl, acks, InpRiskSecret);
+}
+
 int OnInit() {
    if(StringFind(InpSupabaseUrl, "<PROJECT_REF>") >= 0) {
       Print("❌ Supabase URL is not configured. Update InpSupabaseUrl input parameter.");
@@ -46,24 +519,13 @@ int OnInit() {
       Print("❌ Heartbeat interval must be >= 1 second.");
       return INIT_PARAMETERS_INCORRECT;
    }
+   EventSetTimer(MathMax(5, InpHeartbeatSeconds));
    return INIT_SUCCEEDED;
 }
 
 void OnDeinit(const int reason) {
    ArrayResize(heartbeats, 0);
-}
-
-int HttpPost(string url, string body) {
-   ResetLastError();
-   char result[];
-   string headers = "Content-Type: application/json\r\n";
-   int res = WebRequest("POST", url, headers, 5000, body, result, NULL);
-   if(res == -1) {
-      Print("❌ WebRequest failed: ", GetLastError());
-      return -1;
-   }
-   Print("✅ Supabase Response: ", CharArrayToString(result));
-   return res;
+   EventKillTimer();
 }
 
 void OnTick() {
@@ -78,7 +540,7 @@ void OnTick() {
       if(!ShouldSend(ticket, now))
          continue;
 
-      string side = (OrderType() == OP_BUY ? "BUY" : "SELL");
+      string side = (OrderType() == ORDER_TYPE_BUY ? "BUY" : "SELL");
       string payload = "{" \
          +"\"symbol\":\""+OrderSymbol()+"\"," \
          +"\"type\":\""+side+"\"," \
@@ -87,9 +549,18 @@ void OnTick() {
          +"\"profit\":"+DoubleToString(OrderProfit(),2)+"," \
          +"\"ticket\":\""+LongToString(ticket)+"\"," \
          +"\"account\":\""+accountLogin+"\"," \
-         +"\"open_time\":"+LongToString((long)OrderOpenTime()) \
+         +"\"open_time\":"+LongToString((long)OrderOpenTime())+"," \
+         +"\"source\":\"mt5\"" \
          +"}";
 
-      HttpPost(InpSupabaseUrl, payload);
+      SendTradePayload(payload);
    }
+}
+
+void OnTimer() {
+   string accountLogin = LongToString(AccountInfoInteger(ACCOUNT_LOGIN));
+   if(TimeCurrent() - lastAccountHeartbeat >= InpHeartbeatSeconds)
+      SendAccountHeartbeat(accountLogin);
+   PollCommands(accountLogin);
+   PollRiskAdjustments(accountLogin);
 }

--- a/supabase/functions/_tests/mt5-commands.test.ts
+++ b/supabase/functions/_tests/mt5-commands.test.ts
@@ -1,0 +1,194 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { clearTestEnv, setTestEnv } from "./env-mock.ts";
+
+async function withStubbedServe<T>(loader: () => Promise<T>): Promise<T> {
+  const denoGlobal = globalThis as {
+    Deno?: { serve?: (...args: unknown[]) => unknown };
+  };
+  const originalServe = denoGlobal.Deno?.serve;
+  if (denoGlobal.Deno && originalServe) {
+    denoGlobal.Deno.serve =
+      ((optionsOrHandler: unknown, maybeHandler?: unknown) => {
+        const controller = new AbortController();
+        try {
+          if (typeof optionsOrHandler === "function") {
+            const server = (originalServe as any).call(
+              denoGlobal.Deno,
+              { signal: controller.signal },
+              optionsOrHandler,
+            );
+            controller.abort();
+            return server;
+          }
+          const opts = {
+            ...(optionsOrHandler as Record<string, unknown>),
+            signal: controller.signal,
+          };
+          const server = (originalServe as any).call(
+            denoGlobal.Deno,
+            opts,
+            maybeHandler,
+          );
+          controller.abort();
+          return server;
+        } finally {
+          // close sockets
+        }
+      }) as typeof originalServe;
+  } else if (denoGlobal.Deno) {
+    denoGlobal.Deno.serve = (() => ({ abort() {} })) as typeof originalServe;
+  }
+  try {
+    return await loader();
+  } finally {
+    if (denoGlobal.Deno) {
+      if (originalServe) {
+        denoGlobal.Deno.serve = originalServe;
+      } else {
+        delete denoGlobal.Deno.serve;
+      }
+    }
+  }
+}
+
+Deno.test("mt5-commands requires webhook auth", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    MT5_COMMANDS_WEBHOOK_SECRET: "secret",
+  });
+
+  try {
+    const { handler } = await withStubbedServe(async () =>
+      await import(`../mt5-commands/index.ts?cache=${crypto.randomUUID()}`)
+    );
+
+    const res = await handler(
+      new Request("http://localhost/functions/v1/mt5-commands", {
+        method: "POST",
+        body: JSON.stringify({ action: "open", symbol: "XAUUSD" }),
+      }),
+    );
+
+    assertEquals(res.status, 401);
+  } finally {
+    clearTestEnv();
+  }
+});
+
+Deno.test("mt5-commands enqueues and fetches commands", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    MT5_COMMANDS_WEBHOOK_SECRET: "secret",
+    MT5_TERMINAL_KEY: "terminal",
+  });
+
+  const inserted: Array<Record<string, unknown>> = [];
+  const updateCalls: Array<{ status: string }> = [];
+  const fetchedRows = [{
+    id: "cmd-1",
+    command_type: "open",
+    symbol: "XAUUSD",
+    side: "buy",
+    volume: 1.2,
+    price: 0,
+    stop_loss: 1900,
+    take_profit: 1950,
+    trailing_stop: null,
+    ticket: null,
+    account_login: "123",
+    payload: { action: "open" },
+    comment: null,
+  }];
+
+  const mockSupabase = {
+    from(table: string) {
+      if (table !== "mt5_commands") {
+        throw new Error("Unexpected table " + table);
+      }
+      return {
+        insert(records: Record<string, unknown>[]) {
+          inserted.push(...records);
+          return {
+            async select() {
+              return {
+                data: records.map((record) => ({
+                  id: record.id,
+                  external_id: record.external_id,
+                })),
+                error: null,
+              };
+            },
+          };
+        },
+        select() {
+          return {
+            eq() {
+              return this;
+            },
+            order() {
+              return this;
+            },
+            limit: async () => ({ data: fetchedRows, error: null }),
+          };
+        },
+        update(values: { status: string }) {
+          updateCalls.push(values);
+          return {
+            in: async () => ({ data: null, error: null }),
+            eq: async () => ({ data: null, error: null }),
+          };
+        },
+      };
+    },
+  };
+
+  try {
+    const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
+    globalAny.__SUPABASE_SERVICE_CLIENT__ = mockSupabase as unknown;
+
+    const { handler } = await withStubbedServe(async () =>
+      await import(`../mt5-commands/index.ts?cache=${crypto.randomUUID()}`)
+    );
+
+    const enqueue = await handler(
+      new Request("http://localhost/functions/v1/mt5-commands", {
+        method: "POST",
+        headers: { Authorization: "Bearer secret" },
+        body: JSON.stringify({
+          action: "open",
+          symbol: "XAUUSD",
+          side: "buy",
+          volume: 1.2,
+        }),
+      }),
+    );
+    assertEquals(enqueue.status, 202);
+    assertEquals(inserted.length, 1);
+
+    const getRes = await handler(
+      new Request("http://localhost/functions/v1/mt5-commands?account=123", {
+        method: "GET",
+        headers: { Authorization: "Bearer terminal" },
+      }),
+    );
+    assertEquals(getRes.status, 200);
+    const body = await getRes.json() as {
+      commands: Array<Record<string, unknown>>;
+    };
+    assertEquals(body.commands.length, 1);
+    assertEquals(updateCalls.length, 1);
+
+    const patchRes = await handler(
+      new Request("http://localhost/functions/v1/mt5-commands", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer terminal" },
+        body: JSON.stringify({ results: [{ id: "cmd-1", status: "filled" }] }),
+      }),
+    );
+    assertEquals(patchRes.status, 200);
+  } finally {
+    const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
+    delete globalAny.__SUPABASE_SERVICE_CLIENT__;
+    clearTestEnv();
+  }
+});

--- a/supabase/functions/_tests/mt5-handler.test.ts
+++ b/supabase/functions/_tests/mt5-handler.test.ts
@@ -74,17 +74,27 @@ Deno.test("mt5 handler validates required fields", async () => {
 });
 
 Deno.test("mt5 handler upserts normalized log payload", async () => {
-  setTestEnv({ SUPABASE_URL: "https://stub.supabase.co" });
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    TELEGRAM_BOT_TOKEN: "bot-token",
+    TELEGRAM_TRADES_CHAT_ID: "123",
+  });
 
   const tables: string[] = [];
   const upserts: Array<{ record: Record<string, unknown>; options: unknown }> =
     [];
+  const inserts: Array<{ table: string; record: Record<string, unknown> }> = [];
+  const fetchCalls: Array<{ url: string; body: string }> = [];
   const mockSupabase = {
     from(table: string) {
       tables.push(table);
       return {
         async upsert(record: Record<string, unknown>, options: unknown) {
           upserts.push({ record, options });
+          return { data: null, error: null };
+        },
+        async insert(record: Record<string, unknown>) {
+          inserts.push({ table, record });
           return { data: null, error: null };
         },
       };
@@ -94,6 +104,12 @@ Deno.test("mt5 handler upserts normalized log payload", async () => {
   try {
     const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
     globalAny.__SUPABASE_SERVICE_CLIENT__ = mockSupabase as unknown;
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url, body: String(init?.body ?? "") });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
 
     const { handler } = await withStubbedServe(async () =>
       await import(`../mt5/index.ts?cache=${crypto.randomUUID()}`)
@@ -136,11 +152,72 @@ Deno.test("mt5 handler upserts normalized log payload", async () => {
     assertEquals(record.profit, 12.34);
     assertEquals(record.account_login, "123456");
     assertEquals(record.opened_at, expectedOpened);
+    assertEquals(record.source, "mt5");
 
     const rawPayload = record.raw_payload as Record<string, unknown>;
     assert(rawPayload);
     assertEquals(rawPayload.symbol, "XAUUSD");
     assertEquals(rawPayload.ticket, "5555555");
+
+    assertEquals(fetchCalls.length, 1);
+    assert(
+      fetchCalls[0].url.includes(
+        "https://api.telegram.org/botbot-token/sendMessage",
+      ),
+    );
+  } finally {
+    const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
+    delete globalAny.__SUPABASE_SERVICE_CLIENT__;
+    globalThis.fetch = originalFetch;
+    clearTestEnv();
+  }
+});
+
+Deno.test("mt5 handler records heartbeat payloads", async () => {
+  setTestEnv({ SUPABASE_URL: "https://stub.supabase.co" });
+
+  const tables: string[] = [];
+  const inserts: Array<{ table: string; record: Record<string, unknown> }> = [];
+  const mockSupabase = {
+    from(table: string) {
+      tables.push(table);
+      return {
+        async insert(record: Record<string, unknown>) {
+          inserts.push({ table, record });
+          return { data: null, error: null };
+        },
+      };
+    },
+  };
+
+  try {
+    const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
+    globalAny.__SUPABASE_SERVICE_CLIENT__ = mockSupabase as unknown;
+
+    const { handler } = await withStubbedServe(async () =>
+      await import(`../mt5/index.ts?cache=${crypto.randomUUID()}`)
+    );
+
+    const res = await handler(
+      new Request("http://localhost/functions/v1/mt5", {
+        method: "POST",
+        body: JSON.stringify({
+          status: "alive",
+          account: "12345",
+          balance: 1000,
+          equity: 1010,
+        }),
+      }),
+    );
+
+    assertEquals(res.status, 200);
+    assertEquals(tables, ["mt5_account_heartbeats"]);
+    assertEquals(inserts.length, 1);
+    const heartbeat = inserts[0].record;
+    assertEquals(heartbeat.account_login, "12345");
+    assertEquals(heartbeat.status, "alive");
+    assertEquals(heartbeat.balance, 1000);
+    assertEquals(heartbeat.equity, 1010);
   } finally {
     const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
     delete globalAny.__SUPABASE_SERVICE_CLIENT__;

--- a/supabase/functions/_tests/mt5-risk.test.ts
+++ b/supabase/functions/_tests/mt5-risk.test.ts
@@ -1,0 +1,181 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { clearTestEnv, setTestEnv } from "./env-mock.ts";
+
+async function withStubbedServe<T>(loader: () => Promise<T>): Promise<T> {
+  const denoGlobal = globalThis as {
+    Deno?: { serve?: (...args: unknown[]) => unknown };
+  };
+  const originalServe = denoGlobal.Deno?.serve;
+  if (denoGlobal.Deno && originalServe) {
+    denoGlobal.Deno.serve =
+      ((optionsOrHandler: unknown, maybeHandler?: unknown) => {
+        const controller = new AbortController();
+        try {
+          if (typeof optionsOrHandler === "function") {
+            const server = (originalServe as any).call(
+              denoGlobal.Deno,
+              { signal: controller.signal },
+              optionsOrHandler,
+            );
+            controller.abort();
+            return server;
+          }
+          const opts = {
+            ...(optionsOrHandler as Record<string, unknown>),
+            signal: controller.signal,
+          };
+          const server = (originalServe as any).call(
+            denoGlobal.Deno,
+            opts,
+            maybeHandler,
+          );
+          controller.abort();
+          return server;
+        } finally {
+          // close sockets immediately after wiring handler
+        }
+      }) as typeof originalServe;
+  } else if (denoGlobal.Deno) {
+    denoGlobal.Deno.serve = (() => ({ abort() {} })) as typeof originalServe;
+  }
+  try {
+    return await loader();
+  } finally {
+    if (denoGlobal.Deno) {
+      if (originalServe) {
+        denoGlobal.Deno.serve = originalServe;
+      } else {
+        delete denoGlobal.Deno.serve;
+      }
+    }
+  }
+}
+
+Deno.test("mt5-risk rejects unauthenticated webhook", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    MT5_RISK_WEBHOOK_SECRET: "risk",
+  });
+
+  try {
+    const { handler } = await withStubbedServe(async () =>
+      await import(`../mt5-risk/index.ts?cache=${crypto.randomUUID()}`)
+    );
+
+    const res = await handler(
+      new Request("http://localhost/functions/v1/mt5-risk", {
+        method: "POST",
+        body: JSON.stringify({ ticket: "1" }),
+      }),
+    );
+    assertEquals(res.status, 401);
+  } finally {
+    clearTestEnv();
+  }
+});
+
+Deno.test("mt5-risk queues and fetches adjustments", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    MT5_RISK_WEBHOOK_SECRET: "risk",
+    MT5_TERMINAL_KEY: "terminal",
+  });
+
+  const inserted: Array<Record<string, unknown>> = [];
+  const updateCalls: Array<{ status: string }> = [];
+  const fetchedRows = [{
+    id: "adj-1",
+    ticket: "123",
+    account_login: "123",
+    symbol: "XAUUSD",
+    desired_stop_loss: 1900,
+    desired_take_profit: 1950,
+    trailing_stop_distance: null,
+    payload: { ticket: "123" },
+    notes: null,
+  }];
+
+  const mockSupabase = {
+    from(table: string) {
+      if (table !== "mt5_risk_adjustments") {
+        throw new Error("Unexpected table " + table);
+      }
+      return {
+        insert(records: Record<string, unknown>[]) {
+          inserted.push(...records);
+          return {
+            async select() {
+              return {
+                data: records.map((record) => ({ id: record.id })),
+                error: null,
+              };
+            },
+          };
+        },
+        select() {
+          return {
+            eq() {
+              return this;
+            },
+            order() {
+              return this;
+            },
+            limit: async () => ({ data: fetchedRows, error: null }),
+          };
+        },
+        update(values: { status: string }) {
+          updateCalls.push(values);
+          return {
+            in: async () => ({ data: null, error: null }),
+            eq: async () => ({ data: null, error: null }),
+          };
+        },
+      };
+    },
+  };
+
+  try {
+    const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
+    globalAny.__SUPABASE_SERVICE_CLIENT__ = mockSupabase as unknown;
+
+    const { handler } = await withStubbedServe(async () =>
+      await import(`../mt5-risk/index.ts?cache=${crypto.randomUUID()}`)
+    );
+
+    const enqueue = await handler(
+      new Request("http://localhost/functions/v1/mt5-risk", {
+        method: "POST",
+        headers: { Authorization: "Bearer risk" },
+        body: JSON.stringify({ adjustments: [{ ticket: "123" }] }),
+      }),
+    );
+    assertEquals(enqueue.status, 202);
+    assertEquals(inserted.length, 1);
+
+    const getRes = await handler(
+      new Request("http://localhost/functions/v1/mt5-risk?account=123", {
+        method: "GET",
+        headers: { Authorization: "Bearer terminal" },
+      }),
+    );
+    assertEquals(getRes.status, 200);
+    const body = await getRes.json() as {
+      adjustments: Array<Record<string, unknown>>;
+    };
+    assertEquals(body.adjustments.length, 1);
+    assertEquals(updateCalls.length, 1);
+
+    const patchRes = await handler(
+      new Request("http://localhost/functions/v1/mt5-risk", {
+        method: "PATCH",
+        headers: { Authorization: "Bearer terminal" },
+        body: JSON.stringify({ results: [{ id: "adj-1", status: "applied" }] }),
+      }),
+    );
+    assertEquals(patchRes.status, 200);
+  } finally {
+    const globalAny = globalThis as { __SUPABASE_SERVICE_CLIENT__?: unknown };
+    delete globalAny.__SUPABASE_SERVICE_CLIENT__;
+    clearTestEnv();
+  }
+});

--- a/supabase/functions/mt5-commands/index.ts
+++ b/supabase/functions/mt5-commands/index.ts
@@ -1,0 +1,353 @@
+import { createClient } from "../_shared/client.ts";
+import {
+  bad,
+  corsHeaders,
+  jsonResponse,
+  methodNotAllowed,
+  oops,
+  unauth,
+} from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+const TABLE = "mt5_commands";
+
+const webhookSecret = Deno.env.get("MT5_COMMANDS_WEBHOOK_SECRET") ?? "";
+const terminalSecret = Deno.env.get("MT5_TERMINAL_KEY") ?? "";
+
+const MAX_COMMANDS = 20;
+
+type CommandAction = "open" | "close" | "modify";
+
+interface CommandPayload {
+  id?: string;
+  external_id?: string;
+  action: CommandAction;
+  symbol: string;
+  side?: string;
+  volume?: number | string;
+  price?: number | string;
+  stop_loss?: number | string;
+  take_profit?: number | string;
+  trailing_stop?: number | string;
+  ticket?: string | number;
+  account?: string | number;
+  account_login?: string | number;
+  comment?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface CommandRecord {
+  id: string;
+  external_id: string | null;
+  action: CommandAction;
+  symbol: string;
+  side: string | null;
+  volume: number | null;
+  price: number | null;
+  stop_loss: number | null;
+  take_profit: number | null;
+  trailing_stop: number | null;
+  ticket: string | null;
+  account_login: string | null;
+  status: string;
+  comment: string | null;
+  payload: Record<string, unknown>;
+}
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+function getClient(): SupabaseClient {
+  const injected =
+    (globalThis as { __SUPABASE_SERVICE_CLIENT__?: SupabaseClient })
+      .__SUPABASE_SERVICE_CLIENT__;
+  return injected ?? createClient("service");
+}
+
+function parseNumberish(value: number | string | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function parseString(value: number | string | undefined): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value).toString();
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+  return null;
+}
+
+function normaliseAction(action: string | undefined): CommandAction | null {
+  if (!action) return null;
+  const lower = action.toLowerCase();
+  if (lower === "open" || lower === "close" || lower === "modify") {
+    return lower;
+  }
+  return null;
+}
+
+function ensureWebhookAuth(req: Request): boolean {
+  if (!webhookSecret) return false;
+  const authHeader = req.headers.get("authorization") ?? "";
+  const apiKey = req.headers.get("x-api-key") ?? "";
+  return authHeader === `Bearer ${webhookSecret}` || apiKey === webhookSecret;
+}
+
+function ensureTerminalAuth(req: Request): boolean {
+  if (!terminalSecret) return false;
+  const authHeader = req.headers.get("authorization") ?? "";
+  const apiKey = req.headers.get("x-api-key") ?? "";
+  return authHeader === `Bearer ${terminalSecret}` || apiKey === terminalSecret;
+}
+
+function normaliseCommand(payload: CommandPayload): CommandRecord | null {
+  const action = normaliseAction(payload.action);
+  if (!action) return null;
+  const symbol = payload.symbol?.trim();
+  if (!symbol) return null;
+
+  const volume = parseNumberish(payload.volume);
+  const price = parseNumberish(payload.price);
+  const stopLoss = parseNumberish(payload.stop_loss);
+  const takeProfit = parseNumberish(payload.take_profit);
+  const trailingStop = parseNumberish(payload.trailing_stop);
+  const account = parseString(payload.account ?? payload.account_login);
+  const ticket = parseString(payload.ticket);
+  const side = payload.side?.trim()?.toLowerCase() ?? null;
+
+  if (action === "open" && (!side || volume === null)) {
+    return null;
+  }
+  if (action !== "open" && !ticket) {
+    return null;
+  }
+
+  return {
+    id: crypto.randomUUID(),
+    external_id: payload.id ?? payload.external_id ?? null,
+    action,
+    symbol,
+    side,
+    volume,
+    price,
+    stop_loss: stopLoss,
+    take_profit: takeProfit,
+    trailing_stop: trailingStop,
+    ticket,
+    account_login: account,
+    status: "queued",
+    comment: payload.comment?.trim() ?? null,
+    payload: payload as Record<string, unknown>,
+  };
+}
+
+function mapRecordForTerminal(record: Record<string, unknown>) {
+  const payload = record.payload as Record<string, unknown> | null;
+  return {
+    id: record.id,
+    action: record.command_type ?? payload?.action,
+    symbol: record.symbol,
+    side: record.side,
+    volume: record.volume,
+    price: record.price,
+    stop_loss: record.stop_loss,
+    take_profit: record.take_profit,
+    trailing_stop: record.trailing_stop,
+    ticket: record.ticket,
+    account_login: record.account_login,
+    comment: record.comment,
+    payload,
+  };
+}
+
+export const handler = registerHandler(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(req, "GET,POST,PATCH,OPTIONS"),
+    });
+  }
+
+  if (req.method === "POST") {
+    if (!ensureWebhookAuth(req)) {
+      return unauth("Invalid webhook credentials", req);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch (error) {
+      console.error("[mt5-commands] invalid JSON", error);
+      return bad("Invalid JSON payload", undefined, req);
+    }
+
+    const commandsArray = Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as { commands?: unknown }).commands)
+      ? (payload as { commands: unknown[] }).commands
+      : [payload];
+
+    const records: CommandRecord[] = [];
+    for (const candidate of commandsArray) {
+      const record = normaliseCommand(candidate as CommandPayload);
+      if (!record) {
+        return bad("Invalid command payload", candidate, req);
+      }
+      records.push(record);
+    }
+
+    const client = getClient();
+    const { error, data } = await client
+      .from(TABLE)
+      .insert(
+        records.map((record) => ({
+          id: record.id,
+          external_id: record.external_id,
+          account_login: record.account_login,
+          command_type: record.action,
+          symbol: record.symbol,
+          side: record.side,
+          volume: record.volume,
+          price: record.price,
+          stop_loss: record.stop_loss,
+          take_profit: record.take_profit,
+          trailing_stop: record.trailing_stop,
+          ticket: record.ticket,
+          status: record.status,
+          status_message: null,
+          payload: record.payload,
+          comment: record.comment,
+        })),
+        { defaultToNull: true },
+      )
+      .select("id, external_id");
+
+    if (error) {
+      console.error("[mt5-commands] failed to persist commands", error);
+      return oops("Failed to persist commands", error, req);
+    }
+
+    return jsonResponse(
+      {
+        status: "queued",
+        commands: (data ?? records).map((
+          entry: Record<string, unknown>,
+          idx,
+        ) => ({
+          id: entry.id ?? records[idx].id,
+          external_id: entry.external_id ?? records[idx].external_id,
+        })),
+      },
+      { status: 202 },
+      req,
+    );
+  }
+
+  if (req.method === "GET") {
+    if (!ensureTerminalAuth(req)) {
+      return unauth("Invalid terminal credentials", req);
+    }
+
+    const url = new URL(req.url);
+    const account = url.searchParams.get("account");
+    const limitParam = url.searchParams.get("limit");
+    const limit = Math.max(
+      1,
+      Math.min(MAX_COMMANDS, limitParam ? Number(limitParam) : 10),
+    );
+
+    const client = getClient();
+    const { data, error } = await client.from(TABLE)
+      .select(
+        "id, command_type, symbol, side, volume, price, stop_loss, take_profit, trailing_stop, ticket, account_login, payload, comment",
+      )
+      .eq("status", "queued")
+      .order("created_at", { ascending: true })
+      .limit(MAX_COMMANDS);
+    if (error) {
+      console.error("[mt5-commands] failed to fetch queued commands", error);
+      return oops("Failed to fetch commands", error, req);
+    }
+
+    const filtered = (data ?? []).filter((row) => {
+      if (!account || account.trim() === "") return true;
+      return row.account_login === account || row.account_login === null;
+    });
+
+    const commands = filtered.slice(0, limit).map(mapRecordForTerminal);
+    const ids = commands.map((command) => command.id);
+    if (ids.length > 0) {
+      const { error: updateError } = await client
+        .from(TABLE)
+        .update({ status: "sent" })
+        .in("id", ids);
+      if (updateError) {
+        console.error(
+          "[mt5-commands] failed to mark commands sent",
+          updateError,
+        );
+      }
+    }
+
+    return jsonResponse({ commands }, { status: 200 }, req);
+  }
+
+  if (req.method === "PATCH") {
+    if (!ensureTerminalAuth(req)) {
+      return unauth("Invalid terminal credentials", req);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch (error) {
+      console.error("[mt5-commands] invalid JSON for ack", error);
+      return bad("Invalid JSON payload", undefined, req);
+    }
+
+    const updates = Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as { results?: unknown }).results)
+      ? (payload as { results: unknown[] }).results
+      : [payload];
+
+    const client = getClient();
+    for (const update of updates) {
+      const entry = update as {
+        id?: string;
+        status?: string;
+        message?: string;
+      };
+      if (!entry?.id || !entry.status) {
+        return bad("Command acknowledgement missing fields", entry, req);
+      }
+      const status = entry.status.toLowerCase();
+      if (!["filled", "failed", "cancelled", "ignored"].includes(status)) {
+        return bad("Unsupported status", entry, req);
+      }
+      const { error } = await client
+        .from(TABLE)
+        .update({ status, status_message: entry.message ?? null })
+        .eq("id", entry.id);
+      if (error) {
+        console.error("[mt5-commands] failed to update status", {
+          entry,
+          error,
+        });
+        return oops("Failed to update command", error, req);
+      }
+    }
+
+    return jsonResponse({ status: "ok" }, { status: 200 }, req);
+  }
+
+  return methodNotAllowed(req);
+});
+
+export default handler;

--- a/supabase/functions/mt5-risk/index.ts
+++ b/supabase/functions/mt5-risk/index.ts
@@ -1,0 +1,289 @@
+import { createClient } from "../_shared/client.ts";
+import {
+  bad,
+  corsHeaders,
+  jsonResponse,
+  methodNotAllowed,
+  oops,
+  unauth,
+} from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+const TABLE = "mt5_risk_adjustments";
+
+const riskSecret = Deno.env.get("MT5_RISK_WEBHOOK_SECRET") ?? "";
+const terminalSecret = Deno.env.get("MT5_TERMINAL_KEY") ?? "";
+
+const MAX_ADJUSTMENTS = 20;
+
+type AdjustmentStatus = "pending" | "sent" | "applied" | "failed" | "ignored";
+
+interface AdjustmentPayload {
+  id?: string;
+  ticket: string | number;
+  account?: string | number;
+  account_login?: string | number;
+  symbol?: string;
+  desired_stop_loss?: number | string | null;
+  desired_take_profit?: number | string | null;
+  trailing_stop_distance?: number | string | null;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+}
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+function getClient(): SupabaseClient {
+  const injected =
+    (globalThis as { __SUPABASE_SERVICE_CLIENT__?: SupabaseClient })
+      .__SUPABASE_SERVICE_CLIENT__;
+  return injected ?? createClient("service");
+}
+
+function parseNumberish(
+  value: number | string | null | undefined,
+): number | null {
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function parseString(value: number | string | undefined): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value).toString();
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+  return null;
+}
+
+function ensureRiskAuth(req: Request): boolean {
+  if (!riskSecret) return false;
+  const authHeader = req.headers.get("authorization") ?? "";
+  const apiKey = req.headers.get("x-api-key") ?? "";
+  return authHeader === `Bearer ${riskSecret}` || apiKey === riskSecret;
+}
+
+function ensureTerminalAuth(req: Request): boolean {
+  if (!terminalSecret) return false;
+  const authHeader = req.headers.get("authorization") ?? "";
+  const apiKey = req.headers.get("x-api-key") ?? "";
+  return authHeader === `Bearer ${terminalSecret}` || apiKey === terminalSecret;
+}
+
+function normaliseAdjustment(payload: AdjustmentPayload) {
+  const ticket = parseString(payload.ticket);
+  if (!ticket) return null;
+  const account = parseString(payload.account ?? payload.account_login);
+  const sl = parseNumberish(payload.desired_stop_loss);
+  const tp = parseNumberish(payload.desired_take_profit);
+  const trailing = parseNumberish(payload.trailing_stop_distance);
+
+  return {
+    id: crypto.randomUUID(),
+    ticket,
+    account_login: account,
+    symbol: payload.symbol?.trim() ?? null,
+    desired_stop_loss: sl,
+    desired_take_profit: tp,
+    trailing_stop_distance: trailing,
+    status: "pending" as AdjustmentStatus,
+    status_message: null,
+    notes: payload.notes?.trim() ?? null,
+    payload: payload as Record<string, unknown>,
+  };
+}
+
+export const handler = registerHandler(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(req, "GET,POST,PATCH,OPTIONS"),
+    });
+  }
+
+  if (req.method === "POST") {
+    if (!ensureRiskAuth(req)) {
+      return unauth("Invalid risk webhook credentials", req);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch (error) {
+      console.error("[mt5-risk] invalid JSON", error);
+      return bad("Invalid JSON payload", undefined, req);
+    }
+
+    const adjustments = Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as { adjustments?: unknown }).adjustments)
+      ? (payload as { adjustments: unknown[] }).adjustments
+      : [payload];
+
+    const records = [] as Array<ReturnType<typeof normaliseAdjustment>>;
+    for (const candidate of adjustments) {
+      const record = normaliseAdjustment(candidate as AdjustmentPayload);
+      if (!record) {
+        return bad("Invalid adjustment payload", candidate, req);
+      }
+      records.push(record);
+    }
+
+    const client = getClient();
+    const { error, data } = await client.from(TABLE)
+      .insert(
+        records.map((record) => ({
+          id: record.id,
+          ticket: record.ticket,
+          account_login: record.account_login,
+          symbol: record.symbol,
+          desired_stop_loss: record.desired_stop_loss,
+          desired_take_profit: record.desired_take_profit,
+          trailing_stop_distance: record.trailing_stop_distance,
+          status: record.status,
+          status_message: record.status_message,
+          notes: record.notes,
+          payload: record.payload,
+        })),
+        { defaultToNull: true },
+      )
+      .select("id");
+
+    if (error) {
+      console.error("[mt5-risk] failed to persist adjustments", error);
+      return oops("Failed to persist adjustments", error, req);
+    }
+
+    return jsonResponse(
+      {
+        status: "queued",
+        adjustments: (data ?? records).map((
+          entry: Record<string, unknown>,
+          idx,
+        ) => ({
+          id: entry.id ?? records[idx].id,
+        })),
+      },
+      { status: 202 },
+      req,
+    );
+  }
+
+  if (req.method === "GET") {
+    if (!ensureTerminalAuth(req)) {
+      return unauth("Invalid terminal credentials", req);
+    }
+
+    const url = new URL(req.url);
+    const account = url.searchParams.get("account");
+    const limitParam = url.searchParams.get("limit");
+    const limit = Math.max(
+      1,
+      Math.min(MAX_ADJUSTMENTS, limitParam ? Number(limitParam) : 10),
+    );
+
+    const client = getClient();
+    const { data, error } = await client.from(TABLE)
+      .select(
+        "id, ticket, account_login, symbol, desired_stop_loss, desired_take_profit, trailing_stop_distance, payload, notes",
+      )
+      .eq("status", "pending")
+      .order("created_at", { ascending: true })
+      .limit(MAX_ADJUSTMENTS);
+
+    if (error) {
+      console.error("[mt5-risk] failed to fetch adjustments", error);
+      return oops("Failed to fetch adjustments", error, req);
+    }
+
+    const filtered = (data ?? []).filter((row) => {
+      if (!account || account.trim() === "") return true;
+      return row.account_login === account || row.account_login === null;
+    });
+
+    const adjustments = filtered.slice(0, limit).map((row) => ({
+      id: row.id,
+      ticket: row.ticket,
+      account_login: row.account_login,
+      symbol: row.symbol,
+      desired_stop_loss: row.desired_stop_loss,
+      desired_take_profit: row.desired_take_profit,
+      trailing_stop_distance: row.trailing_stop_distance,
+      notes: row.notes,
+      payload: row.payload as Record<string, unknown> | null,
+    }));
+
+    const ids = adjustments.map((entry) => entry.id);
+    if (ids.length > 0) {
+      const { error: updateError } = await client
+        .from(TABLE)
+        .update({ status: "sent" })
+        .in("id", ids);
+      if (updateError) {
+        console.error(
+          "[mt5-risk] failed to mark adjustments sent",
+          updateError,
+        );
+      }
+    }
+
+    return jsonResponse({ adjustments }, { status: 200 }, req);
+  }
+
+  if (req.method === "PATCH") {
+    if (!ensureTerminalAuth(req)) {
+      return unauth("Invalid terminal credentials", req);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch (error) {
+      console.error("[mt5-risk] invalid JSON for ack", error);
+      return bad("Invalid JSON payload", undefined, req);
+    }
+
+    const updates = Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as { results?: unknown }).results)
+      ? (payload as { results: unknown[] }).results
+      : [payload];
+
+    const client = getClient();
+    for (const update of updates) {
+      const entry = update as {
+        id?: string;
+        status?: string;
+        message?: string;
+      };
+      if (!entry?.id || !entry.status) {
+        return bad("Adjustment acknowledgement missing fields", entry, req);
+      }
+      const status = entry.status.toLowerCase();
+      if (!["applied", "failed", "ignored"].includes(status)) {
+        return bad("Unsupported status", entry, req);
+      }
+      const { error } = await client
+        .from(TABLE)
+        .update({ status, status_message: entry.message ?? null })
+        .eq("id", entry.id);
+      if (error) {
+        console.error("[mt5-risk] failed to update status", { entry, error });
+        return oops("Failed to update adjustment", error, req);
+      }
+    }
+
+    return jsonResponse({ status: "ok" }, { status: 200 }, req);
+  }
+
+  return methodNotAllowed(req);
+});
+
+export default handler;

--- a/supabase/functions/mt5/index.ts
+++ b/supabase/functions/mt5/index.ts
@@ -9,6 +9,32 @@ import {
 import { registerHandler } from "../_shared/serve.ts";
 
 const MT5_LOG_TABLE = "mt5_trade_logs";
+const MT5_HEARTBEAT_TABLE = "mt5_account_heartbeats";
+
+const TELEGRAM_CHAT_ENV = "TELEGRAM_TRADES_CHAT_ID";
+const TELEGRAM_TEMPLATE_ENV = "TELEGRAM_TRADES_TEMPLATE";
+
+const DEFAULT_TRADE_TEMPLATE =
+  "⚡️ MT5 {{side}} {{symbol}} {{volume}} lots @ {{open_price}} (PnL {{profit}})";
+
+type HeartbeatPayload = {
+  status?: string;
+  account?: string | number;
+  account_login?: string | number;
+  balance?: number | string;
+  equity?: number | string;
+  free_margin?: number | string;
+  margin_free?: number | string;
+};
+
+type NormalizedHeartbeat = {
+  account_login: string;
+  status: string;
+  balance: number | null;
+  equity: number | null;
+  free_margin: number | null;
+  raw_payload: HeartbeatPayload;
+};
 
 interface Mt5TradePayload {
   symbol?: string;
@@ -24,6 +50,12 @@ interface Mt5TradePayload {
   account_login?: string | number;
   open_time?: number | string;
   opened_at?: number | string;
+  status?: string;
+  source?: string;
+  balance?: number | string;
+  equity?: number | string;
+  margin_free?: number | string;
+  free_margin?: number | string;
 }
 
 type NormalizedTrade = {
@@ -35,6 +67,7 @@ type NormalizedTrade = {
   profit: number | null;
   account_login: string | null;
   opened_at: string | null;
+  source: string;
   raw_payload: Mt5TradePayload;
 };
 
@@ -123,6 +156,7 @@ function sanitizeRecord(record: Partial<NormalizedTrade>): NormalizedTrade {
     profit = null,
     account_login = null,
     opened_at = null,
+    source = "mt5",
     raw_payload = {},
   } = record;
 
@@ -145,8 +179,157 @@ function sanitizeRecord(record: Partial<NormalizedTrade>): NormalizedTrade {
     profit,
     account_login,
     opened_at,
+    source,
     raw_payload,
   };
+}
+
+function sanitizeHeartbeat(
+  heartbeat: Partial<NormalizedHeartbeat>,
+): NormalizedHeartbeat {
+  const {
+    account_login,
+    status = "alive",
+    balance = null,
+    equity = null,
+    free_margin = null,
+    raw_payload = {},
+  } = heartbeat;
+
+  if (!account_login) {
+    throw new Error("account_login is required for heartbeat");
+  }
+
+  return {
+    account_login,
+    status,
+    balance,
+    equity,
+    free_margin,
+    raw_payload,
+  };
+}
+
+function parseMaybeNumber(value: number | string | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function isHeartbeatPayload(payload: Mt5TradePayload | HeartbeatPayload) {
+  if (!payload) return false;
+  const status = typeof payload.status === "string"
+    ? payload.status.trim().toLowerCase()
+    : "";
+  return status === "alive";
+}
+
+async function persistHeartbeat(
+  supabase: SupabaseServiceClient,
+  payload: HeartbeatPayload,
+  req: Request,
+): Promise<Response> {
+  const account = normalizeAccount(payload.account ?? payload.account_login);
+  if (!account) {
+    return bad("Missing account identifier", { account: payload.account }, req);
+  }
+
+  const record = sanitizeHeartbeat({
+    account_login: account,
+    status: typeof payload.status === "string"
+      ? payload.status.trim()
+      : "alive",
+    balance: parseMaybeNumber(payload.balance),
+    equity: parseMaybeNumber(payload.equity),
+    free_margin: parseMaybeNumber(payload.free_margin ?? payload.margin_free),
+    raw_payload: payload,
+  });
+
+  const { error } = await supabase.from(MT5_HEARTBEAT_TABLE).insert(record);
+  if (error) {
+    console.error("[mt5] failed to persist heartbeat", error);
+    return oops("Failed to persist heartbeat", error, req);
+  }
+
+  return jsonResponse({ status: "ok", data: record }, { status: 200 }, req);
+}
+
+function asDisplayNumber(value: number | null | undefined, digits = 2) {
+  if (typeof value !== "number" || Number.isNaN(value)) return "n/a";
+  return value.toFixed(digits);
+}
+
+function renderTelegramTemplate(
+  template: string,
+  record: NormalizedTrade,
+) {
+  const replacements: Record<string, string> = {
+    symbol: record.symbol,
+    side: record.side.toUpperCase(),
+    volume: asDisplayNumber(record.volume ?? undefined),
+    open_price: asDisplayNumber(record.open_price ?? undefined, 3),
+    profit: asDisplayNumber(record.profit ?? undefined),
+    account: record.account_login ?? "unknown",
+    ticket: record.mt5_ticket_id,
+    source: record.source,
+  };
+
+  return template.replace(
+    /\{\{(\w+)\}\}/g,
+    (_, key) => replacements[key] ?? `{{${key}}}`,
+  );
+}
+
+async function notifyTelegram(record: NormalizedTrade) {
+  const chatId = Deno.env.get(TELEGRAM_CHAT_ENV);
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  if (!chatId || !token) return;
+
+  const template = Deno.env.get(TELEGRAM_TEMPLATE_ENV) ||
+    DEFAULT_TRADE_TEMPLATE;
+  const text = renderTelegramTemplate(template, record);
+
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const body = JSON.stringify({
+    chat_id: chatId,
+    text,
+    parse_mode: "Markdown",
+  });
+
+  const attemptSend = async (attempt: number) => {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 8000);
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body,
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Telegram API responded ${res.status}`);
+        }
+        return true;
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (error) {
+      console.error("[mt5] telegram notification failed", { attempt, error });
+      return false;
+    }
+  };
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const success = await attemptSend(attempt + 1);
+    if (success) return;
+    await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+  }
 }
 
 export const handler = registerHandler(async (req) => {
@@ -167,6 +350,12 @@ export const handler = registerHandler(async (req) => {
   } catch (error) {
     console.error("[mt5] invalid JSON payload", error);
     return bad("Invalid JSON payload", undefined, req);
+  }
+
+  const supabase = getSupabaseServiceClient();
+
+  if (isHeartbeatPayload(payload)) {
+    return await persistHeartbeat(supabase, payload, req);
   }
 
   const symbol = typeof payload.symbol === "string"
@@ -199,7 +388,10 @@ export const handler = registerHandler(async (req) => {
     );
   }
 
-  const supabase = getSupabaseServiceClient();
+  const source =
+    typeof payload.source === "string" && payload.source.trim() !== ""
+      ? payload.source.trim()
+      : "mt5";
   const record = sanitizeRecord({
     mt5_ticket_id: ticket,
     symbol,
@@ -209,6 +401,7 @@ export const handler = registerHandler(async (req) => {
     profit,
     account_login: accountLogin,
     opened_at: openedAt,
+    source,
     raw_payload: payload,
   });
 
@@ -220,6 +413,8 @@ export const handler = registerHandler(async (req) => {
     console.error("[mt5] failed to persist trade", error);
     return oops("Failed to persist trade", error, req);
   }
+
+  await notifyTelegram(record);
 
   return jsonResponse(
     { status: "ok", data: record },

--- a/supabase/migrations/20251030090000_create_mt5_account_heartbeats.sql
+++ b/supabase/migrations/20251030090000_create_mt5_account_heartbeats.sql
@@ -1,0 +1,18 @@
+create table if not exists public.mt5_account_heartbeats (
+  id uuid primary key default gen_random_uuid(),
+  account_login text not null,
+  status text not null default 'alive',
+  balance numeric,
+  equity numeric,
+  free_margin numeric,
+  raw_payload jsonb not null,
+  received_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_mt5_account_heartbeats_account_time
+  on public.mt5_account_heartbeats (account_login, received_at desc);
+
+create trigger set_updated_at before update on public.mt5_account_heartbeats
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20251030090500_create_mt5_commands.sql
+++ b/supabase/migrations/20251030090500_create_mt5_commands.sql
@@ -1,0 +1,29 @@
+create table if not exists public.mt5_commands (
+  id uuid primary key default gen_random_uuid(),
+  external_id text,
+  account_login text,
+  command_type text not null,
+  symbol text not null,
+  side text,
+  volume numeric,
+  price numeric,
+  stop_loss numeric,
+  take_profit numeric,
+  trailing_stop numeric,
+  ticket text,
+  comment text,
+  status text not null default 'queued',
+  status_message text,
+  payload jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_mt5_commands_status_account
+  on public.mt5_commands (status, account_login);
+
+create index if not exists idx_mt5_commands_created_at
+  on public.mt5_commands (created_at desc);
+
+create trigger set_updated_at before update on public.mt5_commands
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20251030091000_add_source_to_mt5_trade_logs.sql
+++ b/supabase/migrations/20251030091000_add_source_to_mt5_trade_logs.sql
@@ -1,0 +1,5 @@
+alter table public.mt5_trade_logs
+  add column if not exists source text not null default 'mt5';
+
+create index if not exists idx_mt5_trade_logs_source
+  on public.mt5_trade_logs (source);

--- a/supabase/migrations/20251030091500_create_mt5_risk_adjustments.sql
+++ b/supabase/migrations/20251030091500_create_mt5_risk_adjustments.sql
@@ -1,0 +1,21 @@
+create table if not exists public.mt5_risk_adjustments (
+  id uuid primary key default gen_random_uuid(),
+  ticket text not null,
+  account_login text,
+  symbol text,
+  desired_stop_loss numeric,
+  desired_take_profit numeric,
+  trailing_stop_distance numeric,
+  status text not null default 'pending',
+  status_message text,
+  notes text,
+  payload jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_mt5_risk_adjustments_status
+  on public.mt5_risk_adjustments (status, account_login);
+
+create trigger set_updated_at before update on public.mt5_risk_adjustments
+  for each row execute function public.set_updated_at();

--- a/tests/test_mt5_risk_sync.py
+++ b/tests/test_mt5_risk_sync.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import pytest
+
+from dynamic_ai.risk import RiskContext
+from dynamic_ai.risk_sync import (
+    PositionSnapshot,
+    build_mt5_risk_adjustments,
+    sync_mt5_risk_adjustments,
+)
+
+
+def test_build_mt5_risk_adjustments_generates_levels() -> None:
+    context = RiskContext()
+    positions = [
+        PositionSnapshot(
+            ticket="100",
+            symbol="XAUUSD",
+            side="buy",
+            entry_price=1950.0,
+            volatility=2.5,
+            treasury_health=0.9,
+        )
+    ]
+
+    adjustments = build_mt5_risk_adjustments(positions, context)
+    assert len(adjustments) == 1
+    adj = adjustments[0]
+    assert adj["ticket"] == "100"
+    assert adj["symbol"] == "XAUUSD"
+    assert adj["desired_stop_loss"] is not None
+    assert adj["desired_take_profit"] is not None
+    assert adj["trailing_stop_distance"] == pytest.approx(1.88, rel=1e-2)
+
+
+def test_sync_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MT5_RISK_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("MT5_RISK_WEBHOOK_SECRET", raising=False)
+
+    with pytest.raises(RuntimeError):
+        sync_mt5_risk_adjustments([], RiskContext())
+
+    monkeypatch.setenv("MT5_RISK_WEBHOOK_URL", "https://example.com")
+    with pytest.raises(RuntimeError):
+        sync_mt5_risk_adjustments([], RiskContext())
+
+
+def test_sync_posts_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: Dict[str, Any] = {}
+
+    def fake_request(url: str, payload: Dict[str, Any], *, secret: str) -> None:
+        captured["url"] = url
+        captured["payload"] = payload
+        captured["secret"] = secret
+
+    monkeypatch.setenv("MT5_RISK_WEBHOOK_URL", "https://example.com/mt5-risk")
+    monkeypatch.setenv("MT5_RISK_WEBHOOK_SECRET", "secret")
+    monkeypatch.setitem(os.environ, "MT5_RISK_WEBHOOK_SECRET", "secret")
+
+    monkeypatch.setattr("dynamic_ai.risk_sync._request", fake_request)
+
+    adjustments = sync_mt5_risk_adjustments(
+        [
+            PositionSnapshot(
+                ticket="200",
+                symbol="EURUSD",
+                side="sell",
+                entry_price=1.1,
+                volatility=0.5,
+            )
+        ],
+        RiskContext(),
+    )
+
+    assert adjustments
+    assert captured["url"] == "https://example.com/mt5-risk"
+    assert captured["secret"] == "secret"
+    assert captured["payload"]["adjustments"][0]["ticket"] == "200"


### PR DESCRIPTION
## Summary
- add MT5 account heartbeat ingestion, Telegram trade notifications, and source tagging for trade logs
- implement MT5 command queue and risk adjustment edge functions plus EA polling/acknowledgement logic
- add Supabase migrations, typed schema updates, Dynamic AI risk sync helper, documentation, and unit tests

## Testing
- npx deno test supabase/functions/_tests/mt5-handler.test.ts supabase/functions/_tests/mt5-commands.test.ts supabase/functions/_tests/mt5-risk.test.ts *(fails: TLS certificate validation in sandbox)*
- PYTHONPATH=. pytest tests/test_mt5_risk_sync.py


------
https://chatgpt.com/codex/tasks/task_e_68d78be22fbc8322bcfceefa327aef7d