### PR TITLE
Add daily routine allocator and Supabase table

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -246,6 +246,7 @@ from .dynamic_question_answer_algo import (
     DQAQuestion,
     DynamicQuestionAnswerAlgo,
 )
+from .daily_routine_allocator import DailyRoutineAllocator, RoutinePrompt
 from .trading_psychology_elements import (
     Element,
     ElementProfile,
@@ -394,12 +395,14 @@ __all__ = _trade_exports + [
     "DynamicAISummary",
     "DynamicAISyncReport",
     "DynamicAISynchroniser",
+    "DailyRoutineAllocator",
     "DynamicMarketOutlookEngine",
     "MarketOutlookReport",
     "MarketOutlookTelemetry",
     "OutlookSignal",
     "ProjectFAQGenerator",
     "ProjectFAQPackage",
+    "RoutinePrompt",
     "Route",
     "DynamicRouteKeeperAlgorithm",
     "RouteKeeperSyncResult",
@@ -483,6 +486,7 @@ globals().update(
         "AwesomeAlgoSyncRequest": AwesomeAlgoSyncRequest,
         "AwesomeLLMInsights": AwesomeLLMInsights,
         "AdaptiveLabelingConfig": AdaptiveLabelingConfig,
+        "DailyRoutineAllocator": DailyRoutineAllocator,
         "DynamicAdaptiveLabelingAlgorithm": DynamicAdaptiveLabelingAlgorithm,
         "LiveLabelSyncService": LiveLabelSyncService,
         "OnlineAdaptiveLabeler": OnlineAdaptiveLabeler,
@@ -568,6 +572,7 @@ globals().update(
         "FAQSource": FAQSource,
         "ProjectFAQGenerator": ProjectFAQGenerator,
         "ProjectFAQPackage": ProjectFAQPackage,
+        "RoutinePrompt": RoutinePrompt,
         "Route": Route,
         "DynamicRouteKeeperAlgorithm": DynamicRouteKeeperAlgorithm,
         "RouteKeeperSyncResult": RouteKeeperSyncResult,

--- a/algorithms/python/daily_routine_allocator.py
+++ b/algorithms/python/daily_routine_allocator.py
@@ -1,0 +1,227 @@
+"""Allocator that converts daily blueprint rows into Supabase routine prompts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from .supabase_sync import SupabaseTableWriter
+
+__all__ = [
+    "RoutinePrompt",
+    "DailyRoutineAllocator",
+]
+
+
+CATEGORY_KEYWORDS: Mapping[str, tuple[str, ...]] = {
+    "Prayer": (
+        "fajr",
+        "dhuhr",
+        "asr",
+        "maghrib",
+        "isha",
+        "prayer",
+        "salah",
+    ),
+    "Meal": (
+        "breakfast",
+        "lunch",
+        "dinner",
+        "meal",
+        "suhoor",
+        "suhur",
+        "iftar",
+    ),
+    "Trading": (
+        "trade",
+        "trading",
+        "market",
+        "london",
+        "ny",
+        "check",
+        "desk",
+    ),
+    "Journaling": (
+        "journal",
+        "journaling",
+        "log",
+        "chart review",
+        "review",
+        "mentorship",
+        "debrief",
+    ),
+    "Sleep": (
+        "sleep",
+        "lights out",
+        "bed",
+        "rest",
+        "wind down",
+    ),
+    "Training": (
+        "training",
+        "strength",
+        "zone-2",
+        "zone 2",
+        "run",
+        "conditioning",
+        "mobility",
+        "gym",
+    ),
+}
+
+EMOJI_BY_CATEGORY: Mapping[str, str] = {
+    "prayer": "🌅",
+    "meal": "🍳",
+    "trading": "📊",
+    "journaling": "📖",
+    "sleep": "😴",
+    "training": "🏋️",
+}
+
+DEFAULT_QUOTES: tuple[str, ...] = (
+    "Begin with remembrance, and the day will be blessed.",
+    "Plan the trade, trade the plan.",
+    "Discipline today compounds into tomorrow's edge.",
+)
+
+DEFAULT_TIP = "Show up with presence; honour the process."  # Fallback when notes are missing.
+DEFAULT_QUOTE = "Stay intentional and aligned with your mission."
+
+
+@dataclass(slots=True)
+class RoutinePrompt:
+    """Serialisable representation of a routine prompt row."""
+
+    time_slot: str
+    category: str
+    title: str
+    tip: str
+    quote: str
+    notification: str
+
+    def to_record(self) -> dict[str, str]:
+        return {
+            "time_slot": self.time_slot,
+            "category": self.category,
+            "title": self.title,
+            "tip": self.tip,
+            "quote": self.quote,
+            "notification": self.notification,
+        }
+
+
+class DailyRoutineAllocator:
+    """Builds :class:`RoutinePrompt` rows and syncs them into Supabase."""
+
+    def __init__(
+        self,
+        *,
+        writer: SupabaseTableWriter,
+        quotes: Sequence[str] | None = None,
+        fallback_quote: str = DEFAULT_QUOTE,
+    ) -> None:
+        self.writer = writer
+        prepared_quotes = [quote.strip() for quote in (quotes or DEFAULT_QUOTES) if quote and quote.strip()]
+        self._quotes: tuple[str, ...] = tuple(prepared_quotes) if prepared_quotes else (fallback_quote,)
+        self._fallback_quote = fallback_quote
+        self._quote_index = 0
+
+    def generate_prompts(self, blueprint_rows: Sequence[Mapping[str, Any]]) -> list[RoutinePrompt]:
+        """Convert blueprint rows into routine prompts."""
+
+        prompts: list[RoutinePrompt] = []
+        for row in blueprint_rows:
+            prompt = self._build_prompt(row)
+            prompts.append(prompt)
+        return prompts
+
+    def sync(self, blueprint_rows: Sequence[Mapping[str, Any]]) -> int:
+        """Generate prompts for the provided rows and persist them via Supabase."""
+
+        prompts = self.generate_prompts(blueprint_rows)
+        payload = [prompt.to_record() for prompt in prompts]
+        return self.writer.upsert(payload)
+
+    def _build_prompt(self, row: Mapping[str, Any]) -> RoutinePrompt:
+        time_slot = self._coerce_required(row, ("time_slot", "slot", "time"))
+        title = self._coerce_required(row, ("title", "block", "name"))
+        tip = self._coerce_first(row, ("tip", "notes", "checklist", "instructions", "todo")) or DEFAULT_TIP
+        category = self._resolve_category(row, title, tip)
+        quote = self._next_quote()
+        notification = self._format_notification(category, title, tip)
+        return RoutinePrompt(
+            time_slot=time_slot,
+            category=category,
+            title=title,
+            tip=tip,
+            quote=quote,
+            notification=notification,
+        )
+
+    def _resolve_category(self, row: Mapping[str, Any], title: str, tip: str) -> str:
+        explicit = row.get("category")
+        if explicit:
+            text = str(explicit).strip()
+            if text:
+                return text
+        haystack = " ".join(
+            part
+            for part in (
+                title,
+                tip,
+                str(row.get("notes", "")),
+                str(row.get("description", "")),
+                str(row.get("category_hint", "")),
+            )
+            if part
+        ).lower()
+        for category, keywords in CATEGORY_KEYWORDS.items():
+            for keyword in keywords:
+                pattern = rf"\b{re.escape(keyword.lower())}\b"
+                if re.search(pattern, haystack):
+                    return category
+        return "General"
+
+    def _format_notification(self, category: str, title: str, tip: str) -> str:
+        emoji = EMOJI_BY_CATEGORY.get(category.lower(), "🔔")
+        snippet = self._shorten_tip(tip)
+        if snippet:
+            return f"{emoji} {title} → {snippet}"
+        return f"{emoji} {title}"
+
+    def _shorten_tip(self, tip: str) -> str:
+        sentences = [segment.strip() for segment in re.split(r"[.;]\s*", tip) if segment.strip()]
+        if not sentences:
+            return ""
+        snippet = sentences[0]
+        if len(snippet) > 80:
+            snippet = snippet[:77].rstrip(",;:. ") + "…"
+        return snippet
+
+    def _coerce_required(self, row: Mapping[str, Any], keys: Iterable[str]) -> str:
+        for key in keys:
+            value = row.get(key)
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        raise ValueError(f"Missing required field; expected one of {', '.join(keys)}")
+
+    def _coerce_first(self, row: Mapping[str, Any], keys: Iterable[str]) -> str | None:
+        for key in keys:
+            value = row.get(key)
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        return None
+
+    def _next_quote(self) -> str:
+        if not self._quotes:
+            return self._fallback_quote
+        quote = self._quotes[self._quote_index]
+        self._quote_index = (self._quote_index + 1) % len(self._quotes)
+        return quote

--- a/algorithms/python/jobs/daily_routine_allocator_job.py
+++ b/algorithms/python/jobs/daily_routine_allocator_job.py
@@ -1,0 +1,67 @@
+"""Entrypoint helpers for synchronising Dynamic AI routine prompts."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Mapping, Sequence
+
+from ..daily_routine_allocator import DailyRoutineAllocator
+from ..supabase_sync import SupabaseTableWriter
+
+LOGGER = logging.getLogger(__name__)
+
+
+def sync_daily_routine_prompts(
+    blueprint_rows: Sequence[Mapping[str, object]],
+    *,
+    quotes: Sequence[str] | None = None,
+    base_url: str | None = None,
+    service_role_key: str | None = None,
+) -> int:
+    """Allocate prompts from blueprint rows and upsert them via Supabase."""
+
+    writer = SupabaseTableWriter(
+        table="routine_prompts",
+        conflict_column="time_slot",
+        base_url=base_url,
+        service_role_key=service_role_key,
+    )
+    allocator = DailyRoutineAllocator(writer=writer, quotes=quotes)
+    return allocator.sync(blueprint_rows)
+
+
+def main() -> None:
+    """Manual CLI entrypoint that reads blueprint rows from JSON via STDIN."""
+
+    import json
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+
+    try:
+        raw_payload = sys.stdin.read()
+        if not raw_payload.strip():
+            LOGGER.error("No blueprint payload supplied on stdin")
+            sys.exit(1)
+        blueprint_rows = json.loads(raw_payload)
+        if not isinstance(blueprint_rows, list):
+            LOGGER.error("Blueprint payload must be a JSON list of rows")
+            sys.exit(1)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        LOGGER.error("Failed to parse blueprint JSON: %s", exc)
+        sys.exit(1)
+
+    base_url = os.getenv("SUPABASE_URL")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+    count = sync_daily_routine_prompts(
+        blueprint_rows,  # type: ignore[arg-type]
+        base_url=base_url,
+        service_role_key=service_key,
+    )
+    LOGGER.info("Upserted %s routine prompts", count)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/algorithms/python/tests/test_daily_routine_allocator.py
+++ b/algorithms/python/tests/test_daily_routine_allocator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence, cast
+
+from algorithms.python.daily_routine_allocator import DailyRoutineAllocator
+from algorithms.python.supabase_sync import SupabaseTableWriter
+
+
+class _CollectingWriter:
+    """Lightweight stub that records upserts for assertions."""
+
+    def __init__(self) -> None:
+        self.rows: list[Mapping[str, Any]] = []
+
+    def upsert(self, rows: Sequence[Mapping[str, Any]]) -> int:
+        self.rows.extend(rows)
+        return len(rows)
+
+
+def _allocator(quotes: Sequence[str] | None = None) -> DailyRoutineAllocator:
+    writer = cast(SupabaseTableWriter, _CollectingWriter())
+    return DailyRoutineAllocator(writer=writer, quotes=quotes)
+
+
+def test_allocator_infers_category_and_formats_notification() -> None:
+    allocator = _allocator(["Quote"])
+    prompts = allocator.generate_prompts(
+        [
+            {
+                "time_slot": "04:30",
+                "title": "Fajr | Masjid + Qur'an",
+                "notes": "Hydrate 300ml; stretch 2 min before recitation.",
+            }
+        ]
+    )
+    prompt = prompts[0]
+    assert prompt.category == "Prayer"
+    assert prompt.tip == "Hydrate 300ml; stretch 2 min before recitation."
+    assert prompt.notification.startswith("🌅 Fajr | Masjid + Qur'an")
+    assert "hydrate" in prompt.notification.lower()
+
+
+def test_allocator_rotates_quotes_and_falls_back_when_empty() -> None:
+    allocator = _allocator(["Quote A", "Quote B"])
+    prompts = allocator.generate_prompts(
+        [
+            {"time_slot": "06:00", "title": "London Prep", "notes": "Bias W/D/H4 → H1."},
+            {"time_slot": "08:00", "title": "Breakfast", "notes": "Protein 40g."},
+        ]
+    )
+    assert prompts[0].quote == "Quote A"
+    assert prompts[1].quote == "Quote B"
+
+    fallback_allocator = _allocator([])
+    fallback_prompt = fallback_allocator.generate_prompts(
+        [{"time_slot": "21:30", "title": "Sleep Reset"}]
+    )[0]
+    assert fallback_prompt.quote  # falls back to default text
+
+
+def test_sync_uses_writer_upsert() -> None:
+    collector = _CollectingWriter()
+    writer = cast(SupabaseTableWriter, collector)
+    allocator = DailyRoutineAllocator(writer=writer, quotes=["Quote"])
+
+    count = allocator.sync([
+        {
+            "time_slot": "20:30",
+            "title": "Journaling / Mentorship Prep",
+            "notes": "3-min journal; 25-min learning.",
+        }
+    ])
+
+    assert count == 1
+    assert collector.rows[0]["time_slot"] == "20:30"
+    assert collector.rows[0]["category"] == "Journaling"

--- a/supabase/migrations/20251102090000_add_routine_prompts_table.sql
+++ b/supabase/migrations/20251102090000_add_routine_prompts_table.sql
@@ -1,0 +1,32 @@
+-- Create routine_prompts table for Dynamic AI routine allocator
+CREATE TABLE IF NOT EXISTS public.routine_prompts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  time_slot text NOT NULL,
+  category text,
+  title text,
+  tip text,
+  quote text,
+  notification text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Ensure consistent lookups by time slot
+CREATE UNIQUE INDEX IF NOT EXISTS routine_prompts_time_slot_idx
+  ON public.routine_prompts (time_slot);
+
+-- Enforce row level security with minimal surface area
+ALTER TABLE public.routine_prompts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.routine_prompts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY routine_prompts_service_all
+  ON public.routine_prompts
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY routine_prompts_authenticated_read
+  ON public.routine_prompts
+  FOR SELECT
+  TO authenticated
+  USING (true);

--- a/supabase/resource-plan.ts
+++ b/supabase/resource-plan.ts
@@ -107,6 +107,94 @@ export const resourcePlan: ResourcePlan = {
         "CREATE TRIGGER infrastructure_jobs_set_updated_at\nBEFORE UPDATE ON public.infrastructure_jobs\nFOR EACH ROW EXECUTE FUNCTION public.set_infrastructure_job_updated_at();",
       ],
     },
+    {
+      schema: "public",
+      name: "routine_prompts",
+      comment:
+        "Dynamic AI generated routine prompts that power notifications and daily cards.",
+      columns: [
+        {
+          name: "id",
+          type: "uuid",
+          nullable: false,
+          default: "gen_random_uuid()",
+          comment: "Unique identifier for the routine prompt entry.",
+        },
+        {
+          name: "time_slot",
+          type: "text",
+          nullable: false,
+          comment: "Time label associated with the scheduled routine block.",
+        },
+        {
+          name: "category",
+          type: "text",
+          comment:
+            "High-level category assigned by Dynamic AI (Prayer, Trading, etc.).",
+        },
+        {
+          name: "title",
+          type: "text",
+          comment:
+            "Display title for the scheduled block derived from the blueprint.",
+        },
+        {
+          name: "tip",
+          type: "text",
+          comment: "Practical checklist-style advice for the block.",
+        },
+        {
+          name: "quote",
+          type: "text",
+          comment: "Motivational or faith-based quote paired with the routine.",
+        },
+        {
+          name: "notification",
+          type: "text",
+          comment: "Short push notification copy combining title and tip cues.",
+        },
+        {
+          name: "created_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the routine prompt was generated.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "routine_prompts_time_slot_idx",
+          expression: "(time_slot)",
+          unique: true,
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "routine_prompts_service_all",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment:
+            "Allow the service role to manage Dynamic AI routine prompts.",
+        },
+        {
+          name: "routine_prompts_authenticated_read",
+          command: "SELECT",
+          roles: ["authenticated"],
+          using: "true",
+          comment:
+            "Permit authenticated users to read the published routine prompts.",
+        },
+      ],
+    },
   ],
   storage: {
     enableRowLevelSecurity: true,


### PR DESCRIPTION
## Summary
- create a Supabase migration and resource plan entry for the new `routine_prompts` table with indexes and RLS policies
- implement a `DailyRoutineAllocator` that derives categories, quotes, and notifications before syncing prompts
- add a job helper and unit tests exercising the allocator’s behaviour and Supabase writer integration

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `pytest algorithms/python/tests/test_daily_routine_allocator.py`


------
https://chatgpt.com/codex/tasks/task_e_68d795172dd483229e508297fdfbc0f5