### PR TITLE
Document legal entity separation for fund and treasury ops

### DIFF
--- a/docs/dct-budget-audit.md
+++ b/docs/dct-budget-audit.md
@@ -7,6 +7,14 @@ fortifies Dynamic Capital Token (DCT) utility, liquidity, and governance.
 
 ## 1. Legal and Administrative Setup
 
+### Entity segmentation & licences
+
+| Entity | Scope | Licences & Registrations | Compliance Filing |
+| --- | --- | --- | --- |
+| Dynamic Capital Token Issuer Ltd. | Token minting, redemptions, and utility integrations for DCT. | Virtual Asset Service Provider (VASP) registration and ongoing token utility disclosures. | Store regulator notices and renewal receipts in [`docs/compliance/README.md`](./compliance/README.md) alongside the certificate inventory. |
+| Dynamic Capital Asset Management Ltd. | Managed fund operations, discretionary trading, investor onboarding, and share accounting. | Investment adviser or fund management licence plus anti-money-laundering (AML) programme approval. | File licences, audits, and investor communications under [`docs/compliance/dpf.md`](./compliance/dpf.md) with cross-references to NAV attestations. |
+| Dynamic Capital Platform Services Ltd. | Treasury management, settlements, platform infrastructure, and client billing. | Money services business (MSB) registration and payment service provider approvals for supported jurisdictions. | Log correspondence, SOC reports, and control reviews in [`docs/compliance/certificates.json`](./compliance/certificates.json) and reference the supporting markdown files. |
+
 - **Company registration (MVR 10,000–20,000)**
   - Route payments from the off-chain runway into the on-chain treasury
     operations tranche so the multisig can settle registration invoices while

--- a/docs/private-fund-pool.md
+++ b/docs/private-fund-pool.md
@@ -2,6 +2,14 @@
 
 The Private Fund Pool enables share-based USDT investment cycles for Dynamic Capital members. Investors can deposit to join the active cycle, request withdrawals that obey the 7-day notice and 16% reinvestment rule, and participate in monthly settlements where profits are split across payout, reinvestment, and performance fees.
 
+## Regulatory Structure
+
+- **Dynamic Capital Asset Management Ltd.** operates the pooled investment vehicle and is the sole counterparty for investor capital. It maintains the jurisdictional fund management or investment adviser licence required for discretionary trading and files attestations in the [compliance register](./compliance/README.md).
+- **Dynamic Capital Token Issuer Ltd.** mints, redeems, and provides utility services for DCT under a virtual asset service provider (VASP) registration. A standing distribution agreement grants the issuer read-only access to fund performance data while keeping custody, settlement, and liquidity decisions inside the licensed fund manager.
+- **Dynamic Capital Platform Services Ltd.** runs the treasury, settlement automation, and customer platform infrastructure. A technology services contract between Platform Services and Asset Management defines SLAs for data delivery, NAV calculations, and investor reporting. Token Issuer Ltd. maintains an interface agreement with Platform Services to route utility redemptions without touching client capital or managed assets.
+
+The fund manager renews the operating agreements annually, documenting any regulator correspondence or licence updates under [`docs/compliance`](./compliance/README.md) so operations teams can evidence separation of duties during audits.
+
 ## Database schema
 
 The service introduces the following tables (all in the `public` schema).


### PR DESCRIPTION
## Summary
- add regulatory structure guidance to the private fund pool runbook to clarify legal-entity responsibilities and contracts
- document token issuer, fund manager, and platform operations licences in the DCT budget audit with links to compliance records

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d7985e1d5083228f8898a0e43653f3