### PR TITLE
Guard Telegram webhook notifications and add treasury regression tests

### DIFF
--- a/integrations/tradingview.py
+++ b/integrations/tradingview.py
@@ -143,7 +143,7 @@ def _format_telegram_message(
     trade_result,
     treasury_event,
 ) -> Optional[str]:
-    if trade_result.retcode == 0:
+    if not getattr(trade_result, "ok", False):
         return None
 
     lines = [

--- a/tests/dynamic_token/test_treasury_algo.py
+++ b/tests/dynamic_token/test_treasury_algo.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from dynamic_token.treasury import (
+    SUCCESS_RETCODE,
+    DynamicTreasuryAlgo,
+    TreasuryEvent,
+)
+
+
+@pytest.fixture()
+def treasury() -> DynamicTreasuryAlgo:
+    return DynamicTreasuryAlgo(starting_balance=1_000.0)
+
+
+def test_update_from_trade_happy_path(
+    capsys: pytest.CaptureFixture[str],
+    treasury: DynamicTreasuryAlgo,
+) -> None:
+    trade_result = SimpleNamespace(retcode=SUCCESS_RETCODE, profit=200.0)
+
+    event = treasury.update_from_trade(trade_result)
+
+    assert event == TreasuryEvent(
+        burned=40.0,
+        rewards_distributed=60.0,
+        profit_retained=100.0,
+    )
+    assert treasury.treasury_balance == pytest.approx(1_100.0)
+
+    captured = capsys.readouterr()
+    assert "🔥 Burning DCT worth 40.0 from treasury" in captured.out
+    assert "💰 Distributing 60.0 DCT as rewards to stakers" in captured.out
+
+
+@pytest.mark.parametrize(
+    "trade_result",
+    [
+        None,
+        SimpleNamespace(retcode=0, profit=200.0),
+        SimpleNamespace(retcode=SUCCESS_RETCODE, profit=0.0),
+        SimpleNamespace(retcode=SUCCESS_RETCODE, profit=-10.0),
+    ],
+)
+def test_update_from_trade_failure_cases(
+    trade_result,
+    treasury: DynamicTreasuryAlgo,
+) -> None:
+    starting_balance = treasury.treasury_balance
+
+    event = treasury.update_from_trade(trade_result)
+
+    assert event is None
+    assert treasury.treasury_balance == pytest.approx(starting_balance)


### PR DESCRIPTION
## Summary
- prevent Telegram notifications when a trade execution fails by checking the execution success flag
- update the TradingView webhook tests to use the real success retcode and cover the failed-trade path
- add DynamicTreasuryAlgo unit tests for positive-profit handling and for failure scenarios

## Testing
- pytest tests/integrations/test_tradingview_webhook.py tests/dynamic_token/test_treasury_algo.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d79fd8c7808322ac89f396bae07d02