### PR TITLE
Add dynamic middleware orchestration algorithm

### DIFF
--- a/dynamic_algo/__init__.py
+++ b/dynamic_algo/__init__.py
@@ -8,6 +8,11 @@ from .trading_core import (
     DynamicTradingAlgo,
 )
 from .market_flow import DynamicMarketFlow, MarketFlowSnapshot, MarketFlowTrade
+from .middleware import (
+    DynamicMiddlewareAlgo,
+    MiddlewareContext,
+    MiddlewareExecutionError,
+)
 from .dynamic_pool import (
     DynamicPoolAlgo,
     InvestorAllocation,
@@ -25,6 +30,9 @@ __all__ = [
     "DynamicMarketFlow",
     "MarketFlowSnapshot",
     "MarketFlowTrade",
+    "DynamicMiddlewareAlgo",
+    "MiddlewareContext",
+    "MiddlewareExecutionError",
     "DynamicPoolAlgo",
     "InvestorAllocation",
     "PoolDeposit",

--- a/dynamic_algo/middleware.py
+++ b/dynamic_algo/middleware.py
@@ -1,0 +1,195 @@
+"""Dynamic middleware orchestration helpers for request pipelines.
+
+This module offers a lightweight middleware execution engine inspired by the
+patterns used in FastAPI/Express.  It is intentionally framework agnostic so
+it can be embedded in research notebooks, Supabase edge functions, or other
+Python services that need structured request pre-processing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+__all__ = [
+    "MiddlewareContext",
+    "MiddlewareExecutionError",
+    "MiddlewareHandler",
+    "DynamicMiddlewareAlgo",
+]
+
+MiddlewareNext = Callable[[], Any]
+MiddlewareHandler = Callable[["MiddlewareContext", MiddlewareNext], Any]
+
+
+@dataclass(slots=True)
+class MiddlewareContext:
+    """Context object shared across middleware handlers."""
+
+    payload: Any
+    state: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    response: Any = None
+    halted: bool = False
+    logs: List[str] = field(default_factory=list)
+    error: Exception | None = None
+
+    def log(self, message: str) -> None:
+        """Append ``message`` to the execution log."""
+
+        self.logs.append(str(message))
+
+    def set_state(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key`` in the shared state."""
+
+        self.state[key] = value
+
+    def get_state(self, key: str, default: Any = None) -> Any:
+        """Return the value stored under ``key`` in the shared state."""
+
+        return self.state.get(key, default)
+
+    def halt(self, response: Any) -> Any:
+        """Stop pipeline execution and set the final ``response``."""
+
+        self.halted = True
+        self.response = response
+        return response
+
+
+class MiddlewareExecutionError(RuntimeError):
+    """Raised when a middleware handler fails during execution."""
+
+    def __init__(self, name: str, original: Exception) -> None:
+        message = f"Middleware '{name}' failed: {original}"
+        super().__init__(message)
+        self.name = name
+        self.original = original
+
+
+@dataclass(order=True)
+class _MiddlewareEntry:
+    priority: int
+    order: int
+    name: str
+    handler: MiddlewareHandler = field(compare=False)
+
+
+class DynamicMiddlewareAlgo:
+    """Composable middleware pipeline with priority-aware execution."""
+
+    def __init__(self, handlers: Optional[Iterable[MiddlewareHandler]] = None) -> None:
+        self._entries: List[_MiddlewareEntry] = []
+        self._registry: Dict[str, _MiddlewareEntry] = {}
+        self._order_counter = 0
+
+        if handlers:
+            for handler in handlers:
+                self.register(handler)
+
+    # ---------------------------------------------------------------- register
+    def register(
+        self,
+        handler: MiddlewareHandler,
+        *,
+        name: Optional[str] = None,
+        priority: int = 0,
+        replace: bool = False,
+    ) -> None:
+        """Register ``handler`` with optional ``priority`` and ``name``."""
+
+        if not callable(handler):  # pragma: no cover - defensive guardrail
+            raise TypeError("handler must be callable")
+
+        resolved_name = name or getattr(handler, "__name__", None) or "handler"
+
+        if resolved_name in self._registry and not replace:
+            raise ValueError(f"Middleware '{resolved_name}' already registered")
+
+        if replace and resolved_name in self._registry:
+            self.unregister(resolved_name)
+
+        entry = _MiddlewareEntry(
+            priority=-int(priority),  # negative for ascending order sorting
+            order=self._order_counter,
+            name=resolved_name,
+            handler=handler,
+        )
+        self._order_counter += 1
+
+        self._entries.append(entry)
+        self._registry[resolved_name] = entry
+        self._entries.sort()
+
+    def unregister(self, name: str) -> bool:
+        """Remove the middleware registered under ``name``."""
+
+        entry = self._registry.pop(name, None)
+        if entry is None:
+            return False
+
+        self._entries.remove(entry)
+        return True
+
+    # --------------------------------------------------------------- introspect
+    def handlers(self) -> List[str]:
+        """Return the registered middleware names in execution order."""
+
+        return [entry.name for entry in self._entries]
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._entries)
+
+    # ----------------------------------------------------------------- execution
+    def execute(
+        self,
+        payload: Any,
+        *,
+        state: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+        raise_errors: bool = False,
+    ) -> MiddlewareContext:
+        """Run the middleware pipeline for ``payload`` and return the context."""
+
+        context = MiddlewareContext(
+            payload=payload,
+            state=dict(state or {}),
+            metadata=dict(metadata or {}),
+        )
+
+        try:
+            result = self._run(context, 0)
+        except MiddlewareExecutionError as exc:
+            if raise_errors:
+                raise
+            context.error = exc.original
+            context.state.setdefault("errors", []).append(
+                {"name": exc.name, "error": str(exc.original)}
+            )
+            context.log(f"{exc.name} failed: {exc.original}")
+            context.halted = True
+            if context.response is None:
+                context.response = context.payload
+            return context
+
+        if context.response is None:
+            context.response = result
+
+        return context
+
+    def _run(self, context: MiddlewareContext, index: int) -> Any:
+        if context.halted:
+            return context.response
+
+        if index >= len(self._entries):
+            return context.response if context.response is not None else context.payload
+
+        entry = self._entries[index]
+
+        def next_handler() -> Any:
+            return self._run(context, index + 1)
+
+        try:
+            return entry.handler(context, next_handler)
+        except Exception as exc:  # pragma: no cover - error path covered via execute
+            raise MiddlewareExecutionError(entry.name, exc) from exc

--- a/tests/test_dynamic_middleware_algo.py
+++ b/tests/test_dynamic_middleware_algo.py
@@ -1,0 +1,83 @@
+"""Tests for the dynamic middleware orchestration helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from dynamic_algo.middleware import (
+    DynamicMiddlewareAlgo,
+    MiddlewareContext,
+    MiddlewareExecutionError,
+)
+
+
+def test_pipeline_runs_in_priority_order() -> None:
+    algo = DynamicMiddlewareAlgo()
+    execution_order: List[str] = []
+
+    def low(ctx: MiddlewareContext, nxt) -> Any:
+        execution_order.append("low")
+        ctx.log("low")
+        ctx.state.setdefault("sequence", []).append("low")
+        return ctx.halt({"sequence": ctx.state["sequence"]})
+
+    def high(ctx: MiddlewareContext, nxt) -> Any:
+        execution_order.append("high")
+        ctx.log("high")
+        ctx.state.setdefault("sequence", []).append("high")
+        result = nxt()
+        execution_order.append("high:end")
+        return result
+
+    algo.register(low, name="low", priority=0)
+    algo.register(high, name="high", priority=10)
+
+    context = algo.execute({"payload": True}, state={"sequence": []})
+
+    assert execution_order == ["high", "low", "high:end"]
+    assert context.response == {"sequence": ["high", "low"]}
+    assert context.logs == ["high", "low"]
+    assert context.halted is True
+
+
+def test_register_replace_and_unregister() -> None:
+    algo = DynamicMiddlewareAlgo()
+
+    def handler(ctx: MiddlewareContext, nxt) -> Any:
+        return nxt()
+
+    algo.register(handler, name="auth")
+
+    with pytest.raises(ValueError):
+        algo.register(handler, name="auth")
+
+    algo.register(handler, name="auth", replace=True)
+    assert algo.handlers() == ["auth"]
+
+    assert algo.unregister("auth") is True
+    assert algo.handlers() == []
+    assert algo.unregister("auth") is False
+
+
+def test_execute_captures_handler_errors() -> None:
+    algo = DynamicMiddlewareAlgo()
+
+    def boom(ctx: MiddlewareContext, nxt) -> Any:
+        raise RuntimeError("database offline")
+
+    algo.register(boom, name="fail")
+
+    context = algo.execute({"payload": False})
+
+    assert isinstance(context.error, RuntimeError)
+    assert context.logs[-1] == "fail failed: database offline"
+    assert context.state["errors"] == [{"name": "fail", "error": "database offline"}]
+
+    with pytest.raises(MiddlewareExecutionError):
+        algo.execute({"payload": False}, raise_errors=True)


### PR DESCRIPTION
## Summary
- add a dynamic middleware engine that supports priority-ordered handlers, shared context, and graceful halting
- export the middleware helpers from the dynamic_algo package for external consumption
- cover the middleware pipeline with targeted unit tests verifying execution order, replacement, and error handling

## Testing
- npm run format
- pytest tests/test_dynamic_middleware_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a4f0db708322ae0cfa82fafaee37