### PR TITLE
Add valuation framework equations to DCT whitepaper

### DIFF
--- a/content/whitepapers/dct.json
+++ b/content/whitepapers/dct.json
@@ -145,7 +145,7 @@
         "price": 0.1,
         "priceDenom": "Treasury cost basis USD",
         "vesting": "Locked in DEX pools.",
-        "notes": "Matches the STON.fi and DeDust deployment plan to guarantee two-sided quotes."        
+        "notes": "Matches the STON.fi and DeDust deployment plan to guarantee two-sided quotes."
       },
       {
         "name": "Community Sale",
@@ -180,9 +180,76 @@
       ]
     }
   ],
+  "valuationFramework": {
+    "intro": [
+      "Dynamic Capital maintains an auditable valuation model so contributors can verify how treasury performance, supply policy, and market activity translate into tokenholder value."
+    ],
+    "equations": [
+      {
+        "title": "Token Supply & Circulation",
+        "formula": "Circulating Supply = Total Supply - Locked Tokens - Treasury Reserves",
+        "explanation": "Calculates the liquid float that is available to the market after excluding long-term locks and treasury-held balances.",
+        "notes": [
+          "Helps investors see how many tokens are actually in the market."
+        ]
+      },
+      {
+        "title": "Treasury Net Asset Value (NAV)",
+        "formula": "Treasury NAV = Total Assets (TON, USDT, Profits) - Liabilities",
+        "explanation": "Measures the treasury's net backing so stakeholders can audit collateral coverage and solvency.",
+        "notes": [
+          "Provides the basis for transparency reporting and price floor calculations."
+        ]
+      },
+      {
+        "title": "Price Floor Equation",
+        "formula": "Price Floor (per DCT) = Treasury NAV / Circulating Supply",
+        "explanation": "Estimates the intrinsic value per token by dividing verifiable treasury assets by the circulating float.",
+        "notes": [
+          "Shows the minimum intrinsic value that is backed by real assets."
+        ]
+      },
+      {
+        "title": "Burn & Deflation Equation",
+        "formula": "ΔS = -(Tx Volume × Burn Rate)",
+        "explanation": "Represents how transaction-driven burns contract supply over time through protocol-level fee mechanics.",
+        "notes": [
+          "Burn rate can be defined as 50% of a 2–5% transaction fee split."
+        ]
+      },
+      {
+        "title": "Reward Yield (Staking / Algo Performance)",
+        "formula": "Staking Yield (%) = (Distributed Rewards / Staked Tokens) × 100",
+        "explanation": "Quantifies the return that tokenholders earn for locking DCT into staking programs or algorithmic strategy vaults.",
+        "notes": [
+          "Rewards are funded from treasury inflows and algorithmic trading profits."
+        ]
+      },
+      {
+        "title": "Dynamic Pricing Link to Algo Performance",
+        "formula": "P_{t+1} = P_t × (1 + Algo ROI / Scaling Factor)",
+        "explanation": "Connects token pricing adjustments to algorithmic returns while smoothing volatility through a governance-defined scaling factor.",
+        "notes": [
+          "Positive strategy performance nudges price targets upward without overreacting to short-term noise."
+        ]
+      },
+      {
+        "title": "Buyback Function",
+        "formula": "Buyback Amount = α × Monthly Profits",
+        "explanation": "Defines the portion of treasury profits routed to secondary-market buybacks that reinforce price support.",
+        "notes": [
+          "α represents a fixed allocation percentage of profits (e.g., 30%).",
+          "Tokens acquired via buybacks can be burned or reintroduced into treasury reserves to support future programs."
+        ]
+      }
+    ],
+    "closing": [
+      "Together these equations form the mathematical backbone of the whitepaper, demonstrating how sustainability, asset backing, and value distribution are engineered for DCT holders."
+    ]
+  },
   "treasury": [
     "Profit-sharing treasury automation triggers buybacks and burns when profitability metrics exceed thresholds, reinforcing scarcity without manual intervention.",
-    "Vault fees denominated in DCT recycle value back into staking rewards, creating a closed loop between traders, contributors, and the treasury."  
+    "Vault fees denominated in DCT recycle value back into staking rewards, creating a closed loop between traders, contributors, and the treasury."
   ],
   "governance": {
     "councils": [

--- a/docs/dynamic-capital-ton-whitepaper.md
+++ b/docs/dynamic-capital-ton-whitepaper.md
@@ -141,6 +141,110 @@ stability concerns arise.
 - Treasury-controlled mint functions are time-locked and require multi-signature
   authorization to protect against supply shocks.
 
+## Token Valuation Framework
+
+Dynamic Capital maintains an auditable valuation model so contributors can
+verify how treasury performance, supply policy, and market activity translate
+into tokenholder value.
+
+### Token Supply & Circulation
+
+**Formula**
+
+```
+Circulating Supply = Total Supply - Locked Tokens - Treasury Reserves
+```
+
+Calculates the liquid float that is available to the market after excluding
+long-term locks and treasury-held balances.
+
+- Helps investors see how many tokens are actually in the market.
+
+### Treasury Net Asset Value (NAV)
+
+**Formula**
+
+```
+Treasury NAV = Total Assets (TON, USDT, Profits) - Liabilities
+```
+
+Measures the treasury's net backing so stakeholders can audit collateral
+coverage and solvency.
+
+- Provides the basis for transparency reporting and price floor calculations.
+
+### Price Floor Equation
+
+**Formula**
+
+```
+Price Floor (per DCT) = Treasury NAV / Circulating Supply
+```
+
+Estimates the intrinsic value per token by dividing verifiable treasury assets
+by the circulating float.
+
+- Shows the minimum intrinsic value that is backed by real assets.
+
+### Burn & Deflation Equation
+
+**Formula**
+
+```
+ΔS = -(Tx Volume × Burn Rate)
+```
+
+Represents how transaction-driven burns contract supply over time through
+protocol-level fee mechanics.
+
+- Burn rate can be defined as 50% of a 2–5% transaction fee split.
+
+### Reward Yield (Staking / Algo Performance)
+
+**Formula**
+
+```
+Staking Yield (%) = (Distributed Rewards / Staked Tokens) × 100
+```
+
+Quantifies the return that tokenholders earn for locking DCT into staking
+programs or algorithmic strategy vaults.
+
+- Rewards are funded from treasury inflows and algorithmic trading profits.
+
+### Dynamic Pricing Link to Algo Performance
+
+**Formula**
+
+```
+P_{t+1} = P_t × (1 + Algo ROI / Scaling Factor)
+```
+
+Connects token pricing adjustments to algorithmic returns while smoothing
+volatility through a governance-defined scaling factor.
+
+- Positive strategy performance nudges price targets upward without overreacting
+  to short-term noise.
+
+### Buyback Function
+
+**Formula**
+
+```
+Buyback Amount = α × Monthly Profits
+```
+
+Defines the portion of treasury profits routed to secondary-market buybacks that
+reinforce price support.
+
+- α represents a fixed allocation percentage of profits (e.g., 30%).
+- Tokens acquired via buybacks can be burned or reintroduced into treasury
+  reserves to support future programs.
+
+Together these equations form the mathematical backbone of the whitepaper,
+demonstrating how sustainability, asset backing, and value distribution are
+engineered for DCT holders.
+
 ### Sale Rounds
 
 Token distribution campaigns translate the long-term supply map into

--- a/scripts/whitepaper/generate.ts
+++ b/scripts/whitepaper/generate.ts
@@ -33,6 +33,13 @@ interface UtilityProgram {
   readonly bullets: readonly string[];
 }
 
+interface EquationSection {
+  readonly title: string;
+  readonly formula: string;
+  readonly explanation: string;
+  readonly notes?: readonly string[];
+}
+
 interface RoadmapPhase {
   readonly phase: string;
   readonly focus: string;
@@ -79,6 +86,11 @@ interface WhitepaperConfig {
     readonly rounds: readonly SaleRound[];
   };
   readonly utilityPrograms: readonly UtilityProgram[];
+  readonly valuationFramework?: {
+    readonly intro?: readonly string[];
+    readonly equations: readonly EquationSection[];
+    readonly closing?: readonly string[];
+  };
   readonly treasury: readonly string[];
   readonly governance: {
     readonly councils: readonly string[];
@@ -237,6 +249,30 @@ function renderUtilityPrograms(programs: readonly UtilityProgram[]): string {
     .join("\n");
 }
 
+function renderEquationSections(sections: readonly EquationSection[]): string {
+  return sections
+    .map((section) => {
+      const parts = [
+        `### ${section.title}`,
+        "",
+        "**Formula**",
+        "",
+        "```",
+        section.formula,
+        "```",
+        "",
+        section.explanation.trim(),
+      ];
+
+      if (section.notes?.length) {
+        parts.push("", renderBullets(section.notes));
+      }
+
+      return parts.join("\n");
+    })
+    .join("\n\n");
+}
+
 function renderRoadmap(phases: readonly RoadmapPhase[]): string {
   return phases
     .map((phase) =>
@@ -301,6 +337,17 @@ function buildDocument(config: WhitepaperConfig): string {
   parts.push("## Token Supply & Emissions");
   parts.push(renderDistributionTable(config.distributionTable));
   parts.push("\n" + renderBullets(config.emissionNotes));
+
+  if (config.valuationFramework) {
+    parts.push("## Token Valuation Framework");
+    if (config.valuationFramework.intro?.length) {
+      parts.push(renderParagraphs(config.valuationFramework.intro));
+    }
+    parts.push(renderEquationSections(config.valuationFramework.equations));
+    if (config.valuationFramework.closing?.length) {
+      parts.push(renderParagraphs(config.valuationFramework.closing));
+    }
+  }
 
   parts.push("### Sale Rounds");
   if (config.saleRounds.intro) {


### PR DESCRIPTION
## Summary
- extend the whitepaper generator to support rendering a valuation framework section from configuration
- define the DCT valuation equations in the JSON source and regenerate the published whitepaper with the new math content

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7a5e321cc832282c0b60dbab8f327