### PR TITLE
Implement dynamic hedge model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,20 @@ now modelled end-to-end:
 Set `TRADINGVIEW_LOG_LEVEL=DEBUG` locally to inspect scraping output when
 troubleshooting.
 
+## Dynamic Hedge Model
+
+The automated hedge engine now complements the directional trading pipeline:
+
+- **Database schema** – `public.hedge_actions` records every hedge lifecycle
+  event with enums for side, reason, and status so dashboards and bots can
+  track volatility offsets alongside standard trades.
+- **Policy node** – the `dynamic-hedge` entry in `public.node_configs` runs
+  every five minutes, watching trades, correlations, and risk settings before
+  persisting new hedges and emitting MT5-ready signals.
+- **Edge function** – the `dynamic-hedge` Supabase function evaluates ATR
+  spikes, drawdown breaches, and high-impact news, logs the action, and queues
+  execution orders for the trading core.
+
 ## GitHub Integration
 
 This project features **bidirectional GitHub sync** through Dynamic Codex:

--- a/apps/web/integrations/supabase/types.ts
+++ b/apps/web/integrations/supabase/types.ts
@@ -1476,6 +1476,54 @@ export type Database = {
           },
         ];
       };
+      hedge_actions: {
+        Row: {
+          id: string;
+          symbol: string;
+          hedge_symbol: string;
+          side: Database["public"]["Enums"]["hedge_action_side_enum"];
+          qty: number;
+          reason: Database["public"]["Enums"]["hedge_action_reason_enum"];
+          status: Database["public"]["Enums"]["hedge_action_status_enum"];
+          entry_price: number | null;
+          close_price: number | null;
+          pnl: number | null;
+          metadata: Json;
+          created_at: string;
+          closed_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          symbol: string;
+          hedge_symbol: string;
+          side: Database["public"]["Enums"]["hedge_action_side_enum"];
+          qty: number;
+          reason: Database["public"]["Enums"]["hedge_action_reason_enum"];
+          status?: Database["public"]["Enums"]["hedge_action_status_enum"];
+          entry_price?: number | null;
+          close_price?: number | null;
+          pnl?: number | null;
+          metadata?: Json;
+          created_at?: string;
+          closed_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          symbol?: string;
+          hedge_symbol?: string;
+          side?: Database["public"]["Enums"]["hedge_action_side_enum"];
+          qty?: number;
+          reason?: Database["public"]["Enums"]["hedge_action_reason_enum"];
+          status?: Database["public"]["Enums"]["hedge_action_status_enum"];
+          entry_price?: number | null;
+          close_price?: number | null;
+          pnl?: number | null;
+          metadata?: Json;
+          created_at?: string;
+          closed_at?: string | null;
+        };
+        Relationships: [];
+      };
       signals: {
         Row: {
           account_id: string | null;
@@ -2225,6 +2273,9 @@ export type Database = {
       };
     };
     Enums: {
+      hedge_action_reason_enum: "ATR_SPIKE" | "NEWS" | "DD_LIMIT";
+      hedge_action_side_enum: "LONG_HEDGE" | "SHORT_HEDGE";
+      hedge_action_status_enum: "OPEN" | "CLOSED" | "CANCELLED";
       signal_dispatch_status_enum:
         | "pending"
         | "claimed"

--- a/apps/web/types/supabase.ts
+++ b/apps/web/types/supabase.ts
@@ -1476,6 +1476,54 @@ export type Database = {
           },
         ];
       };
+      hedge_actions: {
+        Row: {
+          id: string;
+          symbol: string;
+          hedge_symbol: string;
+          side: Database["public"]["Enums"]["hedge_action_side_enum"];
+          qty: number;
+          reason: Database["public"]["Enums"]["hedge_action_reason_enum"];
+          status: Database["public"]["Enums"]["hedge_action_status_enum"];
+          entry_price: number | null;
+          close_price: number | null;
+          pnl: number | null;
+          metadata: Json;
+          created_at: string;
+          closed_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          symbol: string;
+          hedge_symbol: string;
+          side: Database["public"]["Enums"]["hedge_action_side_enum"];
+          qty: number;
+          reason: Database["public"]["Enums"]["hedge_action_reason_enum"];
+          status?: Database["public"]["Enums"]["hedge_action_status_enum"];
+          entry_price?: number | null;
+          close_price?: number | null;
+          pnl?: number | null;
+          metadata?: Json;
+          created_at?: string;
+          closed_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          symbol?: string;
+          hedge_symbol?: string;
+          side?: Database["public"]["Enums"]["hedge_action_side_enum"];
+          qty?: number;
+          reason?: Database["public"]["Enums"]["hedge_action_reason_enum"];
+          status?: Database["public"]["Enums"]["hedge_action_status_enum"];
+          entry_price?: number | null;
+          close_price?: number | null;
+          pnl?: number | null;
+          metadata?: Json;
+          created_at?: string;
+          closed_at?: string | null;
+        };
+        Relationships: [];
+      };
       signals: {
         Row: {
           account_id: string | null;
@@ -2308,6 +2356,9 @@ export type Database = {
       };
     };
     Enums: {
+      hedge_action_reason_enum: "ATR_SPIKE" | "NEWS" | "DD_LIMIT";
+      hedge_action_side_enum: "LONG_HEDGE" | "SHORT_HEDGE";
+      hedge_action_status_enum: "OPEN" | "CLOSED" | "CANCELLED";
       signal_dispatch_status_enum:
         | "pending"
         | "claimed"

--- a/docs/node-configuration.md
+++ b/docs/node-configuration.md
@@ -69,6 +69,15 @@ the schema. It is enabled by default, depends on no upstream nodes, emits to the
 `{"source": "analyst_insights"}` so Fusion Brain can look up the discretionary
 ideas persisted by the analyst collector.
 
+### Dynamic Hedge Policy Node
+
+The `dynamic-hedge` policy node is registered with a five-minute interval and
+depends on `trades`, `correlations`, and `risk_settings` inputs. Its outputs are
+the new `hedge_actions` ledger and follow-up `signals` rows so the MT5 bridge
+can execute offsetting orders when volatility spikes, drawdown thresholds are
+breached, or scheduled macro events approach. Metadata captures a `confidence`
+score of `0.9` to help schedulers prioritise hedge execution.
+
 ### Step-by-Step Node Configuration Workflow
 
 1. **Model the node contract**

--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -14,6 +14,16 @@ from .fusion import (
 )
 from .training import calibrate_lorentzian_lobe, load_lorentzian_model
 from .risk import PositionSizing, RiskContext, RiskManager, RiskParameters
+from .hedge import (
+    AccountState,
+    DynamicHedgePolicy,
+    ExposurePosition,
+    HedgeDecision,
+    HedgePosition,
+    MarketState,
+    NewsEvent,
+    VolatilitySnapshot,
+)
 
 __all__ = [
     "AISignal",
@@ -34,4 +44,12 @@ __all__ = [
     "RiskContext",
     "RiskManager",
     "RiskParameters",
+    "AccountState",
+    "DynamicHedgePolicy",
+    "ExposurePosition",
+    "HedgeDecision",
+    "HedgePosition",
+    "MarketState",
+    "NewsEvent",
+    "VolatilitySnapshot",
 ]

--- a/dynamic_ai/hedge.py
+++ b/dynamic_ai/hedge.py
@@ -1,0 +1,359 @@
+"""Dynamic hedging policy utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Literal, MutableMapping, Sequence
+
+HedgeReason = Literal["ATR_SPIKE", "NEWS", "DD_LIMIT"]
+HedgeSide = Literal["LONG_HEDGE", "SHORT_HEDGE"]
+AccountMode = Literal["hedging", "netting"]
+
+
+@dataclass
+class ExposurePosition:
+    """Represents an open directional exposure in the book."""
+
+    symbol: str
+    side: Literal["LONG", "SHORT"]
+    quantity: float
+    beta: float = 1.0
+    price: float | None = None
+    pip_value: float | None = None
+
+
+@dataclass
+class VolatilitySnapshot:
+    """Volatility telemetry for a tradable instrument."""
+
+    symbol: str
+    atr: float
+    close: float
+    median_ratio: float
+    pip_value: float | None = None
+
+    @property
+    def atr_ratio(self) -> float:
+        if self.close <= 0:
+            return 0.0
+        return self.atr / self.close
+
+
+@dataclass
+class NewsEvent:
+    """Upcoming macro event with potential impact on hedging."""
+
+    symbol: str | None
+    minutes_until: float
+    severity: Literal["low", "medium", "high"] = "high"
+
+
+@dataclass
+class HedgePosition:
+    """Existing hedge recorded in the ledger."""
+
+    id: str
+    symbol: str
+    hedge_symbol: str
+    side: HedgeSide
+    qty: float
+    reason: HedgeReason
+
+
+@dataclass
+class AggregatedExposure:
+    """Internal representation combining duplicate exposures."""
+
+    symbol: str
+    net_quantity: float
+    gross_quantity: float
+    beta: float
+    price: float | None
+    pip_value: float | None
+
+
+@dataclass
+class AccountState:
+    """Summary of account level guardrails and open positions."""
+
+    mode: AccountMode = "hedging"
+    exposures: Sequence[ExposurePosition] = ()
+    hedges: Sequence[HedgePosition] = ()
+    drawdown_r: float = 0.0
+    risk_capital: float = 0.0
+    max_basket_risk: float = 1.5
+
+
+@dataclass
+class MarketState:
+    """Aggregated market context consumed by the hedge model."""
+
+    volatility: Dict[str, VolatilitySnapshot]
+    correlations: Dict[str, Dict[str, float]] | None = None
+    news: Sequence[NewsEvent] = ()
+
+
+@dataclass
+class HedgeDecision:
+    """Directive instructing the execution layer to open or close a hedge."""
+
+    action: Literal["OPEN", "CLOSE"]
+    symbol: str
+    hedge_symbol: str
+    side: HedgeSide
+    quantity: float
+    reason: HedgeReason
+    score: float
+    hedge_id: str | None = None
+    notes: str | None = None
+
+
+class DynamicHedgePolicy:
+    """Evaluate risk telemetry and produce hedge directives."""
+
+    def __init__(
+        self,
+        *,
+        volatility_spike_multiplier: float = 1.3,
+        volatility_recovery_buffer: float = 1.05,
+        news_lead_minutes: float = 60.0,
+        drawdown_r_trigger: float = 2.0,
+    ) -> None:
+        self.volatility_spike_multiplier = volatility_spike_multiplier
+        self.volatility_recovery_buffer = volatility_recovery_buffer
+        self.news_lead_minutes = news_lead_minutes
+        self.drawdown_r_trigger = drawdown_r_trigger
+
+    def evaluate(self, market: MarketState, account: AccountState) -> List[HedgeDecision]:
+        """Return hedge directives based on the supplied telemetry."""
+
+        correlations = market.correlations or {}
+        news = list(market.news or ())
+        aggregates = _aggregate_exposures(account.exposures)
+        active = list(account.hedges or ())
+
+        decisions: List[HedgeDecision] = []
+
+        for symbol, exposure in aggregates.items():
+            if abs(exposure.net_quantity) <= 1e-6:
+                continue
+            snapshot = market.volatility.get(symbol)
+            trigger = self._evaluate_triggers(symbol, snapshot, account, news)
+            if trigger is None:
+                continue
+            reason, score = trigger
+
+            if any(
+                hedge.symbol == symbol and hedge.reason == reason
+                for hedge in active
+            ):
+                continue
+
+            hedge_symbol = (
+                symbol
+                if account.mode == "hedging"
+                else self._select_inverse_symbol(symbol, correlations)
+            )
+            side: HedgeSide = "SHORT_HEDGE" if exposure.net_quantity > 0 else "LONG_HEDGE"
+            quantity = self._compute_quantity(reason, score, exposure, snapshot, account)
+            notes = None
+            if reason == "NEWS":
+                minutes = _closest_news_minutes(news, symbol, self.news_lead_minutes)
+                if minutes is not None:
+                    notes = f"{minutes:.0f}m to high impact news"
+
+            decisions.append(
+                HedgeDecision(
+                    action="OPEN",
+                    symbol=symbol,
+                    hedge_symbol=hedge_symbol,
+                    side=side,
+                    quantity=round(max(quantity, 0.0), 6),
+                    reason=reason,
+                    score=score,
+                    notes=notes,
+                )
+            )
+
+        for hedge in active:
+            snapshot = market.volatility.get(hedge.symbol)
+            if self._should_close(hedge, snapshot, account, news):
+                decisions.append(
+                    HedgeDecision(
+                        action="CLOSE",
+                        symbol=hedge.symbol,
+                        hedge_symbol=hedge.hedge_symbol,
+                        side=hedge.side,
+                        quantity=round(max(hedge.qty, 0.0), 6),
+                        reason=hedge.reason,
+                        score=1.0,
+                        hedge_id=hedge.id,
+                    )
+                )
+
+        return decisions
+
+    def _evaluate_triggers(
+        self,
+        symbol: str,
+        snapshot: VolatilitySnapshot | None,
+        account: AccountState,
+        news: Sequence[NewsEvent],
+    ) -> tuple[HedgeReason, float] | None:
+        if snapshot and snapshot.median_ratio > 0:
+            ratio = snapshot.atr_ratio
+            if ratio > self.volatility_spike_multiplier * snapshot.median_ratio:
+                vol_ratio = ratio / snapshot.median_ratio
+                return "ATR_SPIKE", max(vol_ratio, 1.0)
+
+        if abs(account.drawdown_r) >= self.drawdown_r_trigger:
+            return "DD_LIMIT", abs(account.drawdown_r)
+
+        relevant_scores = [
+            self._news_score(event)
+            for event in news
+            if _news_relevant(event, symbol, self.news_lead_minutes)
+        ]
+        if relevant_scores:
+            return "NEWS", max(relevant_scores)
+
+        return None
+
+    def _compute_quantity(
+        self,
+        reason: HedgeReason,
+        score: float,
+        exposure: AggregatedExposure,
+        snapshot: VolatilitySnapshot | None,
+        account: AccountState,
+    ) -> float:
+        base_exposure = abs(exposure.net_quantity)
+        if base_exposure <= 0:
+            return 0.0
+
+        if reason == "ATR_SPIKE":
+            qty = base_exposure * exposure.beta * max(1.0, score)
+        elif reason == "DD_LIMIT":
+            risk_cap = account.risk_capital or (exposure.price or 1.0) * base_exposure
+            atr_value = snapshot.atr if snapshot else 1.0
+            pip_value = snapshot.pip_value or exposure.pip_value or 1.0
+            qty = risk_cap / max(atr_value * pip_value, 1e-6)
+        else:  # NEWS
+            qty = base_exposure * max(score, 1.0)
+
+        max_multiplier = account.max_basket_risk if account.max_basket_risk > 0 else None
+        if max_multiplier is not None:
+            qty = min(qty, base_exposure * max_multiplier)
+
+        return qty
+
+    def _should_close(
+        self,
+        hedge: HedgePosition,
+        snapshot: VolatilitySnapshot | None,
+        account: AccountState,
+        news: Sequence[NewsEvent],
+    ) -> bool:
+        if hedge.reason == "ATR_SPIKE":
+            if not snapshot or snapshot.median_ratio <= 0:
+                return False
+            ratio = snapshot.atr_ratio
+            return ratio <= self.volatility_recovery_buffer * snapshot.median_ratio
+
+        if hedge.reason == "DD_LIMIT":
+            return abs(account.drawdown_r) < max(1.0, self.drawdown_r_trigger * 0.5)
+
+        # NEWS
+        return not any(
+            _news_relevant(event, hedge.symbol, self.news_lead_minutes)
+            for event in news
+        )
+
+    def _select_inverse_symbol(
+        self, symbol: str, correlations: Dict[str, Dict[str, float]]
+    ) -> str:
+        correlation_row = correlations.get(symbol) or {}
+        best_symbol = symbol
+        best_value = 1.0
+        for candidate, value in correlation_row.items():
+            if value is None:
+                continue
+            if value < best_value:
+                best_value = value
+                best_symbol = candidate
+        if best_value <= -0.6:
+            return best_symbol
+        return symbol
+
+    def _news_score(self, event: NewsEvent) -> float:
+        base = {"low": 0.6, "medium": 1.0, "high": 1.3}.get(event.severity, 1.0)
+        time_factor = max(0.5, (self.news_lead_minutes - event.minutes_until) / max(self.news_lead_minutes, 1.0))
+        return max(0.5, base * time_factor)
+
+
+def _aggregate_exposures(
+    exposures: Sequence[ExposurePosition],
+) -> Dict[str, AggregatedExposure]:
+    aggregates: Dict[str, AggregatedExposure] = {}
+    beta_weight: MutableMapping[str, float] = {}
+    beta_sum: MutableMapping[str, float] = {}
+
+    for position in exposures:
+        qty = abs(position.quantity)
+        if qty <= 0:
+            continue
+        direction = 1 if position.side.upper() == "LONG" else -1
+
+        aggregate = aggregates.get(position.symbol)
+        if aggregate is None:
+            aggregate = AggregatedExposure(
+                symbol=position.symbol,
+                net_quantity=0.0,
+                gross_quantity=0.0,
+                beta=1.0,
+                price=position.price,
+                pip_value=position.pip_value,
+            )
+            aggregates[position.symbol] = aggregate
+            beta_weight[position.symbol] = 0.0
+            beta_sum[position.symbol] = 0.0
+
+        aggregate.net_quantity += direction * qty
+        aggregate.gross_quantity += qty
+        if position.price is not None:
+            aggregate.price = position.price
+        if position.pip_value is not None:
+            aggregate.pip_value = position.pip_value
+
+        beta_weight[position.symbol] += qty
+        beta_sum[position.symbol] += qty * (position.beta if position.beta else 1.0)
+
+    for symbol, aggregate in aggregates.items():
+        weight = beta_weight.get(symbol, 0.0)
+        aggregate.beta = beta_sum.get(symbol, 0.0) / weight if weight > 0 else 1.0
+
+    return aggregates
+
+
+def _news_relevant(event: NewsEvent, symbol: str, horizon: float) -> bool:
+    if event.minutes_until < 0 or event.minutes_until > horizon:
+        return False
+    if event.symbol is None:
+        return True
+    normalized = event.symbol.upper()
+    if normalized in {symbol.upper(), "GLOBAL", "ALL"}:
+        return True
+    return False
+
+
+def _closest_news_minutes(
+    events: Iterable[NewsEvent], symbol: str, horizon: float
+) -> float | None:
+    mins: List[float] = [
+        event.minutes_until
+        for event in events
+        if _news_relevant(event, symbol, horizon)
+    ]
+    if not mins:
+        return None
+    return min(mins)

--- a/supabase/functions/dynamic-hedge/index.ts
+++ b/supabase/functions/dynamic-hedge/index.ts
@@ -1,0 +1,621 @@
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { registerHandler } from "../_shared/serve.ts";
+import { bad, jsonResponse, methodNotAllowed } from "../_shared/http.ts";
+import { createClient } from "../_shared/client.ts";
+
+const corsHeaders = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST,OPTIONS",
+  "access-control-allow-headers": "content-type",
+};
+
+type HedgeSide = "LONG_HEDGE" | "SHORT_HEDGE";
+type HedgeReason = "ATR_SPIKE" | "DD_LIMIT" | "NEWS";
+
+type ExposureInput = {
+  symbol: string;
+  direction: "LONG" | "SHORT";
+  quantity: number;
+  beta?: number;
+  price?: number;
+  pipValue?: number;
+};
+
+type VolatilitySnapshot = {
+  symbol: string;
+  atr: number;
+  price: number;
+  medianRatio: number;
+  pipValue?: number;
+};
+
+type HedgeRow = {
+  id: string;
+  symbol: string;
+  hedge_symbol: string;
+  side: HedgeSide;
+  qty: number;
+  reason: HedgeReason;
+  status: "OPEN" | "CLOSED" | "CANCELLED";
+};
+
+type HedgeDecision = {
+  action: "OPEN" | "CLOSE";
+  symbol: string;
+  hedgeSymbol: string;
+  side: HedgeSide;
+  quantity: number;
+  reason: HedgeReason;
+  score: number;
+  hedgeId?: string;
+  notes?: string;
+};
+
+type AggregatedExposure = {
+  symbol: string;
+  net: number;
+  gross: number;
+  beta: number;
+  price?: number;
+  pipValue?: number;
+};
+
+type NewsEvent = {
+  symbol?: string | null;
+  minutesUntil: number;
+  severity: "low" | "medium" | "high";
+};
+
+type HedgeConfig = {
+  volatilitySpikeMultiplier: number;
+  volatilityRecoveryBuffer: number;
+  newsLeadMinutes: number;
+  drawdownTriggerR: number;
+  maxBasketRiskMultiple: number;
+};
+
+const requestSchema = z.object({
+  mode: z.enum(["hedging", "netting"]).default("hedging"),
+  exposures: z
+    .array(
+      z.object({
+        symbol: z.string(),
+        direction: z.enum(["LONG", "SHORT"]),
+        quantity: z.number(),
+        beta: z.number().optional(),
+        price: z.number().optional(),
+        pipValue: z.number().optional(),
+      }),
+    )
+    .optional(),
+  volatility: z
+    .array(
+      z.object({
+        symbol: z.string(),
+        atr: z.number().nonnegative(),
+        price: z.number().positive(),
+        medianRatio: z.number().positive(),
+        pipValue: z.number().positive().optional(),
+      }),
+    )
+    .optional(),
+  drawdown: z
+    .object({
+      openR: z.number().optional(),
+      riskCapital: z.number().optional(),
+    })
+    .optional(),
+  correlations: z
+    .record(z.string(), z.record(z.string(), z.number()))
+    .optional(),
+  news: z
+    .array(
+      z.object({
+        symbol: z.string().optional(),
+        minutesUntil: z.number().nonnegative(),
+        severity: z.enum(["low", "medium", "high"]).default("high"),
+      }),
+    )
+    .optional(),
+  config: z
+    .object({
+      volatilitySpikeMultiplier: z.number().positive().optional(),
+      volatilityRecoveryBuffer: z.number().positive().optional(),
+      newsLeadMinutes: z.number().positive().optional(),
+      drawdownTriggerR: z.number().positive().optional(),
+      maxBasketRiskMultiple: z.number().positive().optional(),
+    })
+    .optional(),
+});
+
+export const handler = registerHandler(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return methodNotAllowed(req);
+  }
+
+  let payload: z.infer<typeof requestSchema>;
+  try {
+    payload = requestSchema.parse(await req.json());
+  } catch (error) {
+    console.error("[dynamic-hedge] invalid request body", error);
+    return bad("Invalid request body", undefined, req);
+  }
+
+  const supabase = createClient("service");
+
+  const exposures = payload.exposures ??
+    (await loadExposuresFromTrades(supabase));
+  const volatility = new Map<string, VolatilitySnapshot>(
+    (payload.volatility ?? []).map((snapshot) => [snapshot.symbol, snapshot]),
+  );
+  const correlations = payload.correlations ?? {};
+  const news = payload.news ?? [];
+  const activeHedges = await loadActiveHedges(supabase);
+
+  const config: HedgeConfig = {
+    volatilitySpikeMultiplier: payload.config?.volatilitySpikeMultiplier ?? 1.3,
+    volatilityRecoveryBuffer: payload.config?.volatilityRecoveryBuffer ?? 1.05,
+    newsLeadMinutes: payload.config?.newsLeadMinutes ?? 60,
+    drawdownTriggerR: payload.config?.drawdownTriggerR ?? 2,
+    maxBasketRiskMultiple: payload.config?.maxBasketRiskMultiple ?? 1.5,
+  };
+
+  const drawdownR = payload.drawdown?.openR ?? 0;
+  const riskCapital = payload.drawdown?.riskCapital ?? 0;
+
+  const decisions = evaluateDecisions({
+    mode: payload.mode ?? "hedging",
+    exposures,
+    volatility,
+    correlations,
+    news,
+    activeHedges,
+    config,
+    drawdownR,
+    riskCapital,
+  });
+
+  const opens = decisions.filter((decision) => decision.action === "OPEN");
+  const closes = decisions.filter((decision) => decision.action === "CLOSE");
+
+  const opened: unknown[] = [];
+  for (const decision of opens) {
+    const insertPayload = {
+      symbol: decision.symbol,
+      hedge_symbol: decision.hedgeSymbol,
+      side: decision.side,
+      qty: Number(decision.quantity.toFixed(6)),
+      reason: decision.reason,
+      entry_price: volatility.get(decision.symbol)?.price ?? null,
+      metadata: {
+        score: decision.score,
+        notes: decision.notes ?? null,
+      },
+    };
+
+    const { data, error } = await supabase
+      .from("hedge_actions")
+      .insert(insertPayload)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("[dynamic-hedge] failed to insert hedge action", error);
+      continue;
+    }
+
+    opened.push(data);
+
+    const { error: signalError } = await supabase.from("signals").insert({
+      alert_id: `hedge-${decision.symbol}-${crypto.randomUUID()}`,
+      source: "dynamic-hedge",
+      symbol: decision.hedgeSymbol,
+      direction: decision.side === "SHORT_HEDGE" ? "short" : "long",
+      order_type: "market",
+      priority: 5,
+      payload: {
+        reason: decision.reason,
+        hedge_symbol: decision.hedgeSymbol,
+        quantity: Number(decision.quantity.toFixed(6)),
+        score: decision.score,
+      },
+    });
+
+    if (signalError) {
+      console.error("[dynamic-hedge] failed to emit signal", signalError);
+    }
+  }
+
+  const closed: unknown[] = [];
+  for (const decision of closes) {
+    if (!decision.hedgeId) continue;
+    const updatePayload = {
+      status: "CLOSED",
+      closed_at: new Date().toISOString(),
+      close_price: volatility.get(decision.symbol)?.price ?? null,
+      metadata: {
+        score: decision.score,
+        notes: decision.notes ?? null,
+      },
+    };
+
+    const { data, error } = await supabase
+      .from("hedge_actions")
+      .update(updatePayload)
+      .eq("id", decision.hedgeId)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("[dynamic-hedge] failed to close hedge", error);
+      continue;
+    }
+
+    closed.push(data);
+
+    const { error: signalError } = await supabase.from("signals").insert({
+      alert_id: `hedge-close-${decision.symbol}-${crypto.randomUUID()}`,
+      source: "dynamic-hedge",
+      symbol: decision.hedgeSymbol,
+      direction: "flat",
+      order_type: "market",
+      priority: 4,
+      payload: {
+        reason: decision.reason,
+        hedge_symbol: decision.hedgeSymbol,
+        quantity: Number(decision.quantity.toFixed(6)),
+        action: "CLOSE",
+      },
+    });
+
+    if (signalError) {
+      console.error(
+        "[dynamic-hedge] failed to emit closing signal",
+        signalError,
+      );
+    }
+  }
+
+  return jsonResponse({
+    opened,
+    closed,
+    summary: {
+      requestedOpens: opens.length,
+      requestedCloses: closes.length,
+    },
+  }, { headers: corsHeaders });
+});
+
+export default handler;
+
+type EvaluationInput = {
+  mode: "hedging" | "netting";
+  exposures: ExposureInput[];
+  volatility: Map<string, VolatilitySnapshot>;
+  correlations: Record<string, Record<string, number>>;
+  news: NewsEvent[];
+  activeHedges: HedgeRow[];
+  config: HedgeConfig;
+  drawdownR: number;
+  riskCapital: number;
+};
+
+function evaluateDecisions(input: EvaluationInput): HedgeDecision[] {
+  const {
+    mode,
+    exposures,
+    volatility,
+    correlations,
+    news,
+    activeHedges,
+    config,
+    drawdownR,
+    riskCapital,
+  } = input;
+
+  const aggregates = aggregateExposures(exposures);
+  const decisions: HedgeDecision[] = [];
+
+  for (const aggregate of aggregates.values()) {
+    if (Math.abs(aggregate.net) <= 1e-6) continue;
+    const snapshot = volatility.get(aggregate.symbol);
+    const trigger = evaluateTriggers({
+      symbol: aggregate.symbol,
+      snapshot,
+      config,
+      drawdownR,
+      news,
+    });
+
+    if (!trigger) continue;
+    const { reason, score } = trigger;
+    const alreadyActive = activeHedges.some(
+      (hedge) =>
+        hedge.symbol === aggregate.symbol && hedge.reason === reason &&
+        hedge.status === "OPEN",
+    );
+    if (alreadyActive) continue;
+
+    const hedgeSymbol = mode === "hedging"
+      ? aggregate.symbol
+      : selectInverseSymbol(aggregate.symbol, correlations);
+    const side: HedgeSide = aggregate.net > 0 ? "SHORT_HEDGE" : "LONG_HEDGE";
+    const quantity = computeQuantity({
+      reason,
+      score,
+      aggregate,
+      snapshot,
+      config,
+      riskCapital,
+    });
+    const notes = reason === "NEWS"
+      ? describeNewsTiming(news, aggregate.symbol, config.newsLeadMinutes)
+      : undefined;
+
+    decisions.push({
+      action: "OPEN",
+      symbol: aggregate.symbol,
+      hedgeSymbol,
+      side,
+      quantity: Number(quantity.toFixed(6)),
+      reason,
+      score,
+      notes,
+    });
+  }
+
+  for (const hedge of activeHedges) {
+    if (hedge.status !== "OPEN") continue;
+    const snapshot = volatility.get(hedge.symbol);
+    if (shouldClose({ hedge, snapshot, config, drawdownR, news })) {
+      decisions.push({
+        action: "CLOSE",
+        symbol: hedge.symbol,
+        hedgeSymbol: hedge.hedge_symbol,
+        side: hedge.side,
+        quantity: Number(hedge.qty ?? 0),
+        reason: hedge.reason,
+        score: 1,
+        hedgeId: hedge.id,
+      });
+    }
+  }
+
+  return decisions;
+}
+
+type TriggerInput = {
+  symbol: string;
+  snapshot?: VolatilitySnapshot;
+  config: HedgeConfig;
+  drawdownR: number;
+  news: NewsEvent[];
+};
+
+type TriggerResult = { reason: HedgeReason; score: number } | null;
+
+function evaluateTriggers(input: TriggerInput): TriggerResult {
+  const { snapshot, config, drawdownR, news, symbol } = input;
+  if (snapshot && snapshot.medianRatio > 0) {
+    const ratio = snapshot.atr / snapshot.price;
+    if (ratio > config.volatilitySpikeMultiplier * snapshot.medianRatio) {
+      const volRatio = ratio / snapshot.medianRatio;
+      return { reason: "ATR_SPIKE", score: Math.max(volRatio, 1) };
+    }
+  }
+
+  if (Math.abs(drawdownR) >= config.drawdownTriggerR) {
+    return { reason: "DD_LIMIT", score: Math.abs(drawdownR) };
+  }
+
+  const newsScores = news
+    .filter((event) => newsRelevant(event, symbol, config.newsLeadMinutes))
+    .map((event) => newsScore(event, config.newsLeadMinutes));
+
+  if (newsScores.length > 0) {
+    return { reason: "NEWS", score: Math.max(...newsScores) };
+  }
+
+  return null;
+}
+
+type QuantityInput = {
+  reason: HedgeReason;
+  score: number;
+  aggregate: AggregatedExposure;
+  snapshot?: VolatilitySnapshot;
+  config: HedgeConfig;
+  riskCapital: number;
+};
+
+function computeQuantity(input: QuantityInput): number {
+  const { reason, score, aggregate, snapshot, config, riskCapital } = input;
+  const baseExposure = Math.abs(aggregate.net);
+  if (baseExposure <= 0) return 0;
+
+  let quantity: number;
+  if (reason === "ATR_SPIKE") {
+    quantity = baseExposure * aggregate.beta * Math.max(1, score);
+  } else if (reason === "DD_LIMIT") {
+    const atrValue = snapshot?.atr ?? 1;
+    const pipValue = snapshot?.pipValue ?? aggregate.pipValue ?? 1;
+    const riskBudget = riskCapital || (aggregate.price ?? 1) * baseExposure;
+    quantity = riskBudget / Math.max(atrValue * pipValue, 1e-6);
+  } else {
+    quantity = baseExposure * Math.max(score, 1);
+  }
+
+  const maxMultiple = config.maxBasketRiskMultiple;
+  if (maxMultiple > 0) {
+    quantity = Math.min(quantity, baseExposure * maxMultiple);
+  }
+
+  return quantity;
+}
+
+type CloseInput = {
+  hedge: HedgeRow;
+  snapshot?: VolatilitySnapshot;
+  config: HedgeConfig;
+  drawdownR: number;
+  news: NewsEvent[];
+};
+
+function shouldClose(input: CloseInput): boolean {
+  const { hedge, snapshot, config, drawdownR, news } = input;
+  if (hedge.reason === "ATR_SPIKE") {
+    if (!snapshot || snapshot.medianRatio <= 0) return false;
+    const ratio = snapshot.atr / snapshot.price;
+    return ratio <= config.volatilityRecoveryBuffer * snapshot.medianRatio;
+  }
+  if (hedge.reason === "DD_LIMIT") {
+    return Math.abs(drawdownR) < Math.max(1, config.drawdownTriggerR * 0.5);
+  }
+  return !news.some((event) =>
+    newsRelevant(event, hedge.symbol, config.newsLeadMinutes)
+  );
+}
+
+function aggregateExposures(
+  exposures: ExposureInput[],
+): Map<string, AggregatedExposure> {
+  const aggregates = new Map<string, AggregatedExposure>();
+  const betaWeights = new Map<string, number>();
+  const betaTotals = new Map<string, number>();
+
+  for (const exposure of exposures) {
+    const qty = Math.abs(exposure.quantity);
+    if (!Number.isFinite(qty) || qty <= 0) continue;
+    const direction = exposure.direction === "LONG" ? 1 : -1;
+    const existing = aggregates.get(exposure.symbol);
+    if (!existing) {
+      aggregates.set(exposure.symbol, {
+        symbol: exposure.symbol,
+        net: direction * qty,
+        gross: qty,
+        beta: exposure.beta ?? 1,
+        price: exposure.price,
+        pipValue: exposure.pipValue,
+      });
+      betaWeights.set(exposure.symbol, qty);
+      betaTotals.set(exposure.symbol, qty * (exposure.beta ?? 1));
+    } else {
+      existing.net += direction * qty;
+      existing.gross += qty;
+      if (exposure.price !== undefined) existing.price = exposure.price;
+      if (exposure.pipValue !== undefined) {
+        existing.pipValue = exposure.pipValue;
+      }
+      betaWeights.set(
+        exposure.symbol,
+        (betaWeights.get(exposure.symbol) ?? 0) + qty,
+      );
+      betaTotals.set(
+        exposure.symbol,
+        (betaTotals.get(exposure.symbol) ?? 0) + qty * (exposure.beta ?? 1),
+      );
+    }
+  }
+
+  for (const [symbol, aggregate] of aggregates.entries()) {
+    const weight = betaWeights.get(symbol) ?? 0;
+    aggregate.beta = weight > 0 ? (betaTotals.get(symbol) ?? 0) / weight : 1;
+  }
+
+  return aggregates;
+}
+
+function selectInverseSymbol(
+  symbol: string,
+  correlations: Record<string, Record<string, number>>,
+): string {
+  const row = correlations[symbol] ?? {};
+  let bestSymbol = symbol;
+  let bestValue = 1;
+  for (const [candidate, value] of Object.entries(row)) {
+    if (typeof value !== "number") continue;
+    if (value < bestValue) {
+      bestValue = value;
+      bestSymbol = candidate;
+    }
+  }
+  return bestValue <= -0.6 ? bestSymbol : symbol;
+}
+
+function newsRelevant(
+  event: NewsEvent,
+  symbol: string,
+  horizon: number,
+): boolean {
+  if (event.minutesUntil < 0 || event.minutesUntil > horizon) return false;
+  if (!event.symbol) return true;
+  const normalized = event.symbol.toUpperCase();
+  return normalized === symbol.toUpperCase() || normalized === "GLOBAL" ||
+    normalized === "ALL";
+}
+
+function newsScore(event: NewsEvent, horizon: number): number {
+  const base = event.severity === "high"
+    ? 1.3
+    : event.severity === "medium"
+    ? 1
+    : 0.6;
+  const timeFactor = Math.max(
+    0.5,
+    (horizon - event.minutesUntil) / Math.max(horizon, 1),
+  );
+  return Math.max(0.5, base * timeFactor);
+}
+
+function describeNewsTiming(
+  news: NewsEvent[],
+  symbol: string,
+  horizon: number,
+): string | undefined {
+  const times = news
+    .filter((event) => newsRelevant(event, symbol, horizon))
+    .map((event) => event.minutesUntil);
+  if (times.length === 0) return undefined;
+  const min = Math.min(...times);
+  return `${Math.round(min)}m to high impact news`;
+}
+
+type SupabaseLike = ReturnType<typeof createClient>;
+
+async function loadExposuresFromTrades(
+  supabase: SupabaseLike,
+): Promise<ExposureInput[]> {
+  const { data, error } = await supabase
+    .from("trades")
+    .select("symbol,direction,volume,status,closed_at");
+  if (error) {
+    console.error("[dynamic-hedge] failed to load trades", error);
+    return [];
+  }
+  return (data ?? [])
+    .filter((row: any) => !row.closed_at)
+    .map((row: any) => ({
+      symbol: String(row.symbol ?? ""),
+      direction: String(row.direction ?? "long").toUpperCase() === "SHORT"
+        ? "SHORT"
+        : "LONG",
+      quantity: Number(row.volume ?? 0) || 0,
+    }))
+    .filter((row) => row.quantity > 0);
+}
+
+async function loadActiveHedges(supabase: SupabaseLike): Promise<HedgeRow[]> {
+  const { data, error } = await supabase
+    .from("hedge_actions")
+    .select("id,symbol,hedge_symbol,side,qty,reason,status")
+    .eq("status", "OPEN");
+  if (error) {
+    console.error("[dynamic-hedge] failed to load hedges", error);
+    return [];
+  }
+  return data ?? [];
+}

--- a/supabase/migrations/20251103090000_add_hedge_actions_table.sql
+++ b/supabase/migrations/20251103090000_add_hedge_actions_table.sql
@@ -1,0 +1,56 @@
+-- Hedge actions lifecycle tracking for Dynamic Hedge Model
+
+-- Enum definitions
+DO $$ BEGIN
+  CREATE TYPE public.hedge_action_side_enum AS ENUM ('LONG_HEDGE', 'SHORT_HEDGE');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE public.hedge_action_reason_enum AS ENUM ('ATR_SPIKE', 'NEWS', 'DD_LIMIT');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE public.hedge_action_status_enum AS ENUM ('OPEN', 'CLOSED', 'CANCELLED');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.hedge_actions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  symbol text NOT NULL,
+  hedge_symbol text NOT NULL,
+  side public.hedge_action_side_enum NOT NULL,
+  qty numeric(18,6) NOT NULL,
+  reason public.hedge_action_reason_enum NOT NULL,
+  status public.hedge_action_status_enum NOT NULL DEFAULT 'OPEN',
+  entry_price numeric(18,8),
+  close_price numeric(18,8),
+  pnl numeric(18,8),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  closed_at timestamptz
+);
+
+ALTER TABLE public.hedge_actions ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS hedge_actions_status_idx
+  ON public.hedge_actions (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS hedge_actions_symbol_idx
+  ON public.hedge_actions (symbol, created_at DESC);
+
+CREATE POLICY hedge_actions_service_role_full_access
+  ON public.hedge_actions
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE POLICY hedge_actions_authenticated_select
+  ON public.hedge_actions
+  FOR SELECT
+  TO authenticated
+  USING (true);

--- a/supabase/migrations/20251103091000_seed_dynamic_hedge_node.sql
+++ b/supabase/migrations/20251103091000_seed_dynamic_hedge_node.sql
@@ -1,0 +1,33 @@
+-- Register the dynamic-hedge policy node in the orchestration graph
+
+INSERT INTO public.node_configs AS nc (
+  node_id,
+  type,
+  enabled,
+  interval_sec,
+  dependencies,
+  outputs,
+  metadata,
+  weight
+) VALUES (
+  'dynamic-hedge',
+  'policy',
+  true,
+  300,
+  '["trades","correlations","risk_settings"]'::jsonb,
+  '["hedge_actions","signals"]'::jsonb,
+  jsonb_build_object(
+    'description', 'Dynamic hedge model evaluating volatility, drawdown, and news triggers',
+    'confidence', 0.9
+  ),
+  0.9
+)
+ON CONFLICT (node_id) DO UPDATE
+SET
+  type = EXCLUDED.type,
+  enabled = EXCLUDED.enabled,
+  interval_sec = EXCLUDED.interval_sec,
+  dependencies = EXCLUDED.dependencies,
+  outputs = EXCLUDED.outputs,
+  metadata = EXCLUDED.metadata,
+  weight = EXCLUDED.weight;

--- a/tests/dynamic-hedge-function.test.ts
+++ b/tests/dynamic-hedge-function.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { freshImport } from "./utils/freshImport.ts";
+import {
+  __resetSupabaseState,
+  __testSupabaseState,
+} from "./supabase-client-stub.ts";
+
+function patchSource(src: string): string {
+  return src
+    .replace("../_shared/client.ts", "../../../tests/supabase-client-stub.ts")
+    .replace("../_shared/serve.ts", "../../../tests/serve-stub.ts");
+}
+
+test("dynamic hedge opens and closes hedges based on telemetry", async () => {
+  __resetSupabaseState();
+  const orig = new URL(
+    "../supabase/functions/dynamic-hedge/index.ts",
+    import.meta.url,
+  );
+  const patched = new URL(
+    "../supabase/functions/dynamic-hedge/index.test.ts",
+    import.meta.url,
+  );
+  let handler: (req: Request) => Promise<Response>;
+
+  try {
+    const src = await Deno.readTextFile(orig);
+    await Deno.writeTextFile(patched, patchSource(src));
+    ({ default: handler } = await freshImport(patched));
+
+    const initialRequest = new Request("http://localhost/dynamic-hedge", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "netting",
+        exposures: [
+          { symbol: "XAUUSD", direction: "LONG", quantity: 2.0, beta: 1.1 },
+        ],
+        volatility: [
+          { symbol: "XAUUSD", atr: 24, price: 1905, medianRatio: 0.01 },
+        ],
+        correlations: { XAUUSD: { DXY: -0.75 } },
+        drawdown: { openR: 2.5, riskCapital: 400 },
+        news: [
+          { symbol: "XAUUSD", minutesUntil: 45, severity: "high" },
+        ],
+      }),
+    });
+
+    const openResponse = await handler(initialRequest);
+    assert.equal(openResponse.status, 200);
+    const openBody = await openResponse.json();
+    assert.equal(openBody.summary.requestedOpens, 1);
+    assert.equal(__testSupabaseState.hedgeActions.size, 1);
+    assert.equal(__testSupabaseState.signals.size >= 1, true);
+
+    const hedgeId = Array.from(__testSupabaseState.hedgeActions.keys())[0]!;
+
+    const calmRequest = new Request("http://localhost/dynamic-hedge", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        exposures: [],
+        volatility: [
+          { symbol: "XAUUSD", atr: 12, price: 1910, medianRatio: 0.01 },
+        ],
+        drawdown: { openR: 0.4 },
+      }),
+    });
+
+    const closeResponse = await handler(calmRequest);
+    assert.equal(closeResponse.status, 200);
+    const closeBody = await closeResponse.json();
+    assert.equal(closeBody.summary.requestedCloses, 1);
+
+    const closedRecord = __testSupabaseState.hedgeActions.get(hedgeId);
+    assert.ok(closedRecord);
+    assert.equal(closedRecord?.status, "CLOSED");
+  } finally {
+    await Deno.remove(patched).catch(() => {});
+  }
+});

--- a/tests/test_dynamic_hedge.py
+++ b/tests/test_dynamic_hedge.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from dynamic_ai.hedge import (
+    AccountState,
+    DynamicHedgePolicy,
+    ExposurePosition,
+    HedgePosition,
+    MarketState,
+    NewsEvent,
+    VolatilitySnapshot,
+)
+
+
+def _vol(symbol: str, atr: float, close: float, median: float, pip: float | None = None) -> VolatilitySnapshot:
+    return VolatilitySnapshot(symbol=symbol, atr=atr, close=close, median_ratio=median, pip_value=pip)
+
+
+def test_policy_opens_inverse_hedge_for_atr_spike() -> None:
+    policy = DynamicHedgePolicy()
+    market = MarketState(
+        volatility={"XAUUSD": _vol("XAUUSD", atr=25, close=1900, median=0.01)},
+        correlations={"XAUUSD": {"DXY": -0.78}},
+    )
+    account = AccountState(
+        mode="netting",
+        exposures=[ExposurePosition(symbol="XAUUSD", side="LONG", quantity=2.5, beta=1.2)],
+        drawdown_r=0.5,
+    )
+
+    decisions = policy.evaluate(market, account)
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.action == "OPEN"
+    assert decision.side == "SHORT_HEDGE"
+    assert decision.hedge_symbol == "DXY"
+    assert decision.reason == "ATR_SPIKE"
+    assert decision.quantity > 2.5
+
+
+def test_policy_uses_atr_formula_for_drawdown_capital() -> None:
+    policy = DynamicHedgePolicy()
+    market = MarketState(volatility={"BTCUSDT": _vol("BTCUSDT", atr=200, close=64000, median=0.004, pip=10)})
+    account = AccountState(
+        mode="hedging",
+        exposures=[ExposurePosition(symbol="BTCUSDT", side="SHORT", quantity=1.8, price=64000, pip_value=10)],
+        drawdown_r=2.4,
+        risk_capital=900,
+        max_basket_risk=2.0,
+    )
+
+    decisions = policy.evaluate(market, account)
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision.reason == "DD_LIMIT"
+    expected_qty = account.risk_capital / (200 * 10)
+    assert decision.quantity == pytest.approx(expected_qty)
+
+
+def test_policy_skips_duplicate_when_active() -> None:
+    policy = DynamicHedgePolicy()
+    market = MarketState(volatility={"ETHUSDT": _vol("ETHUSDT", atr=40, close=3200, median=0.01)})
+    account = AccountState(
+        exposures=[ExposurePosition(symbol="ETHUSDT", side="LONG", quantity=3.0)],
+        hedges=[
+            HedgePosition(
+                id="hedge-1",
+                symbol="ETHUSDT",
+                hedge_symbol="ETHUSDT",
+                side="SHORT_HEDGE",
+                qty=3.2,
+                reason="ATR_SPIKE",
+            )
+        ],
+    )
+
+    decisions = policy.evaluate(market, account)
+    # Should only propose a close if applicable but no new open for same reason
+    assert not any(decision.action == "OPEN" for decision in decisions)
+
+
+def test_policy_closes_when_vol_normalises() -> None:
+    policy = DynamicHedgePolicy()
+    market = MarketState(volatility={"XAUUSD": _vol("XAUUSD", atr=18, close=1920, median=0.01)})
+    account = AccountState(
+        hedges=[
+            HedgePosition(
+                id="hedge-2",
+                symbol="XAUUSD",
+                hedge_symbol="XAUUSD",
+                side="SHORT_HEDGE",
+                qty=1.2,
+                reason="ATR_SPIKE",
+            )
+        ]
+    )
+
+    decisions = policy.evaluate(market, account)
+    assert any(decision.action == "CLOSE" and decision.hedge_id == "hedge-2" for decision in decisions)
+
+
+def test_policy_closes_news_after_event() -> None:
+    policy = DynamicHedgePolicy(news_lead_minutes=45)
+    market = MarketState(volatility={})
+    account = AccountState(
+        hedges=[
+            HedgePosition(
+                id="hedge-3",
+                symbol="BTCUSDT",
+                hedge_symbol="BTCUSDT",
+                side="LONG_HEDGE",
+                qty=0.8,
+                reason="NEWS",
+            )
+        ]
+    )
+
+    # Event already passed so hedge should close
+    news = [NewsEvent(symbol="BTCUSDT", minutes_until=90, severity="high")]
+    decisions = policy.evaluate(MarketState(volatility={}, news=news), account)
+    assert any(decision.action == "CLOSE" and decision.hedge_id == "hedge-3" for decision in decisions)


### PR DESCRIPTION
## Summary
- add Supabase migrations for hedge action lifecycle tracking and register the dynamic-hedge policy node with documentation updates
- implement the Dynamic Hedge policy module plus Supabase Edge Function wiring MT5 signals through the existing trading stack
- extend Supabase client types/stubs and add automated tests covering policy math and function orchestration

## Testing
- npm run test
- PYTHONPATH=. pytest tests/test_dynamic_hedge.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a0d1e008832295f974014807980e