### PR TITLE
feat: source desk cards and onboarding steps from Supabase

### DIFF
--- a/apps/web/hooks/useDeskOnboardingSteps.ts
+++ b/apps/web/hooks/useDeskOnboardingSteps.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  DEFAULT_DESK_ONBOARDING_STEPS,
+  type DeskOnboardingStepResult,
+  fetchDeskOnboardingSteps,
+} from "@/services/deskOnboardingSteps";
+
+export function useDeskOnboardingSteps() {
+  const query = useQuery<DeskOnboardingStepResult, Error>({
+    queryKey: ["desk-onboarding-steps"],
+    queryFn: () => fetchDeskOnboardingSteps(),
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: 1,
+  });
+
+  const data = query.data;
+
+  const steps = query.isLoading
+    ? []
+    : data?.steps ?? DEFAULT_DESK_ONBOARDING_STEPS;
+
+  const isFallback = query.isLoading
+    ? false
+    : query.isError || data?.isFallback === true;
+
+  return {
+    steps,
+    isFallback,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/apps/web/hooks/useDeskPreviewCards.ts
+++ b/apps/web/hooks/useDeskPreviewCards.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  DEFAULT_DESK_PREVIEW_CARDS,
+  type DeskPreviewCardResult,
+  fetchDeskPreviewCards,
+} from "@/services/deskPreviewCards";
+
+export function useDeskPreviewCards() {
+  const query = useQuery<DeskPreviewCardResult, Error>({
+    queryKey: ["desk-preview-cards"],
+    queryFn: () => fetchDeskPreviewCards(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+    retry: 1,
+  });
+
+  const data = query.data;
+
+  const cards = query.isLoading
+    ? []
+    : data?.cards ?? DEFAULT_DESK_PREVIEW_CARDS;
+
+  const isFallback = query.isLoading
+    ? false
+    : query.isError || data?.isFallback === true;
+
+  return {
+    cards,
+    isFallback,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}

--- a/apps/web/services/deskOnboardingSteps.ts
+++ b/apps/web/services/deskOnboardingSteps.ts
@@ -1,0 +1,273 @@
+import { callEdgeFunction } from "@/config/supabase";
+
+const CONTENT_KEY = "desk_onboarding_steps" as const;
+
+interface ContentBatchEntry {
+  content_key?: string | null;
+  content_value?: unknown;
+}
+
+interface ContentBatchResponse {
+  contents?: ContentBatchEntry[] | null;
+}
+
+export interface DeskOnboardingStep {
+  id: string;
+  label: string;
+  icon: string;
+  summary: string;
+  highlights: string[];
+  actionLabel: string;
+  actionHref: string;
+}
+
+export interface DeskOnboardingStepResult {
+  steps: DeskOnboardingStep[];
+  isFallback: boolean;
+}
+
+const TELEGRAM_LINK = "https://t.me/DynamicCapital_Support";
+
+export const DEFAULT_DESK_ONBOARDING_STEPS: DeskOnboardingStep[] = [
+  {
+    id: "orientation",
+    label: "Orientation sprint",
+    icon: "sparkles",
+    summary:
+      "Five bite-sized prompts help you define a goal, funding level, and time commitment in under ten minutes.",
+    highlights: [
+      "Tour the workspace and translate jargon into plain language",
+      "Pin your first checklist so you always know the next move",
+      "Bookmark the dashboard that tracks progress in real time",
+    ],
+    actionLabel: "Open guided workspace",
+    actionHref: "/",
+  },
+  {
+    id: "practice",
+    label: "Practice in the simulator",
+    icon: "calendar",
+    summary:
+      "Lock in a weekly drill using the desk calendar and rehearse the strategy on live markets without risking capital.",
+    highlights: [
+      "Follow a mentor-led warm-up before every session",
+      "Journal practice trades with one-click templates",
+      "Collect instant feedback to celebrate small wins early",
+    ],
+    actionLabel: "Schedule a drill",
+    actionHref: "/plans",
+  },
+  {
+    id: "feedback",
+    label: "Get mentor feedback",
+    icon: "repeat",
+    summary:
+      "Share your trading plan for a desk-side review and get a personal redirect toward VIP coaching or group labs.",
+    highlights: [
+      "Upload your plan for a recorded walkthrough",
+      "Collect community playbooks matched to your goals",
+      "Decide whether to scale solo or join a live lab",
+    ],
+    actionLabel: "Message the mentors",
+    actionHref: TELEGRAM_LINK,
+  },
+];
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((entry): entry is string => isNonEmptyString(entry))
+    .map((entry) => entry.trim());
+}
+
+function safeParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function extractStepsPayload(
+  response: ContentBatchResponse | null | undefined,
+): unknown {
+  if (!response || !Array.isArray(response.contents)) {
+    return null;
+  }
+
+  const entry = response.contents.find((item) =>
+    item?.content_key === CONTENT_KEY
+  );
+  if (!entry) {
+    return null;
+  }
+
+  const rawValue = entry.content_value;
+  if (typeof rawValue === "string") {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return safeParseJson(trimmed);
+  }
+
+  return rawValue ?? null;
+}
+
+function asStepsArray(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && typeof payload === "object" && "steps" in payload) {
+    const candidate = (payload as { steps?: unknown }).steps;
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+  }
+
+  return [];
+}
+
+function normalizeStep(
+  raw: unknown,
+  fallback: DeskOnboardingStep,
+): DeskOnboardingStep {
+  if (!raw || typeof raw !== "object") {
+    return { ...fallback };
+  }
+
+  const record = raw as Record<string, unknown>;
+
+  const idSource =
+    (isNonEmptyString(record.id)
+      ? record.id
+      : isNonEmptyString(record.slug)
+      ? record.slug
+      : null) ?? fallback.id;
+
+  const label =
+    (isNonEmptyString(record.label)
+      ? record.label
+      : isNonEmptyString(record.title)
+      ? record.title
+      : null) ?? fallback.label;
+
+  const icon =
+    (isNonEmptyString(record.icon)
+      ? record.icon
+      : isNonEmptyString(record.iconName)
+      ? record.iconName
+      : null) ?? fallback.icon;
+
+  const summary =
+    (isNonEmptyString(record.summary)
+      ? record.summary
+      : isNonEmptyString(record.description)
+      ? record.description
+      : null) ?? fallback.summary;
+
+  const highlights = (() => {
+    const candidate = "highlights" in record
+      ? asStringArray(record.highlights)
+      : "bullets" in record
+      ? asStringArray(record.bullets)
+      : [];
+
+    if (candidate.length > 0) {
+      return candidate;
+    }
+
+    return [...fallback.highlights];
+  })();
+
+  const action = (() => {
+    if (record.action && typeof record.action === "object") {
+      return record.action as Record<string, unknown>;
+    }
+
+    if (record.cta && typeof record.cta === "object") {
+      return record.cta as Record<string, unknown>;
+    }
+
+    return {} as Record<string, unknown>;
+  })();
+
+  const actionLabel =
+    (isNonEmptyString(record.actionLabel)
+      ? record.actionLabel
+      : isNonEmptyString(record.action_label)
+      ? record.action_label
+      : isNonEmptyString(action.label)
+      ? action.label
+      : isNonEmptyString(action.title)
+      ? action.title
+      : null) ?? fallback.actionLabel;
+
+  const actionHref =
+    (isNonEmptyString(record.actionHref)
+      ? record.actionHref
+      : isNonEmptyString(record.action_href)
+      ? record.action_href
+      : isNonEmptyString(action.href)
+      ? action.href
+      : isNonEmptyString(action.url)
+      ? action.url
+      : null) ?? fallback.actionHref;
+
+  return {
+    id: idSource,
+    label,
+    icon,
+    summary,
+    highlights,
+    actionLabel,
+    actionHref,
+  };
+}
+
+function normalizeSteps(payload: unknown): DeskOnboardingStep[] {
+  const rawSteps = asStepsArray(payload);
+  if (rawSteps.length === 0) {
+    return [];
+  }
+
+  return rawSteps.map((step, index) => {
+    const fallback = DEFAULT_DESK_ONBOARDING_STEPS[
+      index % DEFAULT_DESK_ONBOARDING_STEPS.length
+    ];
+    return normalizeStep(step, fallback);
+  });
+}
+
+export async function fetchDeskOnboardingSteps(
+  options: { callEdge?: typeof callEdgeFunction } = {},
+): Promise<DeskOnboardingStepResult> {
+  const { callEdge = callEdgeFunction } = options;
+
+  const { data, error } = await callEdge<ContentBatchResponse>(
+    "CONTENT_BATCH",
+    {
+      method: "POST",
+      body: { keys: [CONTENT_KEY] },
+    },
+  );
+
+  if (error) {
+    throw new Error(error.message || "Unable to load desk onboarding steps");
+  }
+
+  const steps = normalizeSteps(extractStepsPayload(data ?? null));
+  if (steps.length === 0) {
+    return { steps: DEFAULT_DESK_ONBOARDING_STEPS, isFallback: true };
+  }
+
+  return { steps, isFallback: false };
+}

--- a/apps/web/services/deskPreviewCards.ts
+++ b/apps/web/services/deskPreviewCards.ts
@@ -1,0 +1,209 @@
+import { callEdgeFunction } from "@/config/supabase";
+
+const CONTENT_KEY = "desk_preview_cards" as const;
+
+interface ContentBatchEntry {
+  content_key?: string | null;
+  content_value?: unknown;
+}
+
+interface ContentBatchResponse {
+  contents?: ContentBatchEntry[] | null;
+}
+
+export interface DeskPreviewCard {
+  title: string;
+  subtitle: string;
+  metricLabel: string;
+  metricValue: string;
+  description: string;
+  gradient: string;
+}
+
+export interface DeskPreviewCardResult {
+  cards: DeskPreviewCard[];
+  isFallback: boolean;
+}
+
+export const DEFAULT_DESK_PREVIEW_CARDS: DeskPreviewCard[] = [
+  {
+    title: "Desk Signal Feed",
+    subtitle: "Next catalyst in 1h 42m",
+    metricLabel: "Playbook edge",
+    metricValue: "+1.9%",
+    description: "EUR/USD breakout · Risk 0.4% · Targets stacked",
+    gradient:
+      "linear-gradient(135deg, hsl(var(--dc-brand) / 0.95) 0%, hsl(var(--dc-secondary) / 0.85) 48%, hsl(var(--dc-brand-dark) / 0.85) 100%)",
+  },
+  {
+    title: "Mentor Office Hours",
+    subtitle: "Today · 18:30 GMT",
+    metricLabel: "Seats left",
+    metricValue: "5",
+    description: "Submit your plan for live teardown and adjustments",
+    gradient:
+      "linear-gradient(135deg, hsl(var(--dc-secondary) / 0.9) 0%, hsl(var(--dc-accent) / 0.78) 60%, hsl(var(--dc-brand-dark) / 0.82) 100%)",
+  },
+  {
+    title: "Risk Automation",
+    subtitle: "Dynamic guardrails armed",
+    metricLabel: "Max draw",
+    metricValue: "0.6%",
+    description: "Auto-pauses trigger if the threshold is breached",
+    gradient:
+      "linear-gradient(135deg, hsl(var(--dc-accent) / 0.88) 0%, hsl(var(--dc-secondary) / 0.8) 55%, hsl(var(--dc-brand-dark) / 0.85) 100%)",
+  },
+];
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function safeParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function extractCardsPayload(
+  response: ContentBatchResponse | null | undefined,
+): unknown {
+  if (!response || !Array.isArray(response.contents)) {
+    return null;
+  }
+
+  const entry = response.contents.find((item) =>
+    item?.content_key === CONTENT_KEY
+  );
+  if (!entry) {
+    return null;
+  }
+
+  const rawValue = entry.content_value;
+  if (typeof rawValue === "string") {
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return null;
+    }
+    return safeParseJson(trimmed);
+  }
+
+  return rawValue ?? null;
+}
+
+function asCardArray(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && typeof payload === "object" && "cards" in payload) {
+    const candidate = (payload as { cards?: unknown }).cards;
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+  }
+
+  return [];
+}
+
+function normalizeCard(
+  raw: unknown,
+  fallback: DeskPreviewCard,
+): DeskPreviewCard {
+  if (!raw || typeof raw !== "object") {
+    return { ...fallback };
+  }
+
+  const record = raw as Record<string, unknown>;
+
+  const title =
+    (isNonEmptyString(record.title)
+      ? record.title
+      : isNonEmptyString(record.name)
+      ? record.name
+      : null) ?? fallback.title;
+
+  const subtitle =
+    (isNonEmptyString(record.subtitle)
+      ? record.subtitle
+      : isNonEmptyString(record.subheading)
+      ? record.subheading
+      : null) ?? fallback.subtitle;
+
+  const metricLabel =
+    (isNonEmptyString(record.metricLabel)
+      ? record.metricLabel
+      : isNonEmptyString(record.metric_label)
+      ? record.metric_label
+      : null) ?? fallback.metricLabel;
+
+  const metricValue =
+    (isNonEmptyString(record.metricValue)
+      ? record.metricValue
+      : isNonEmptyString(record.metric_value)
+      ? record.metric_value
+      : null) ?? fallback.metricValue;
+
+  const description =
+    (isNonEmptyString(record.description)
+      ? record.description
+      : isNonEmptyString(record.body)
+      ? record.body
+      : null) ?? fallback.description;
+
+  const gradient =
+    (isNonEmptyString(record.gradient)
+      ? record.gradient
+      : isNonEmptyString(record.background)
+      ? record.background
+      : null) ?? fallback.gradient;
+
+  return {
+    title,
+    subtitle,
+    metricLabel,
+    metricValue,
+    description,
+    gradient,
+  };
+}
+
+function normalizeCards(payload: unknown): DeskPreviewCard[] {
+  const rawCards = asCardArray(payload);
+  if (rawCards.length === 0) {
+    return [];
+  }
+
+  return rawCards.map((card, index) => {
+    const fallback =
+      DEFAULT_DESK_PREVIEW_CARDS[index % DEFAULT_DESK_PREVIEW_CARDS.length];
+    return normalizeCard(card, fallback);
+  });
+}
+
+export async function fetchDeskPreviewCards(
+  options: { callEdge?: typeof callEdgeFunction } = {},
+): Promise<DeskPreviewCardResult> {
+  const { callEdge = callEdgeFunction } = options;
+
+  const { data, error } = await callEdge<ContentBatchResponse>(
+    "CONTENT_BATCH",
+    {
+      method: "POST",
+      body: { keys: [CONTENT_KEY] },
+    },
+  );
+
+  if (error) {
+    throw new Error(error.message || "Unable to load desk preview cards");
+  }
+
+  const cards = normalizeCards(extractCardsPayload(data ?? null));
+  if (cards.length === 0) {
+    return { cards: DEFAULT_DESK_PREVIEW_CARDS, isFallback: true };
+  }
+
+  return { cards, isFallback: false };
+}

--- a/tests/desk-onboarding-steps.test.ts
+++ b/tests/desk-onboarding-steps.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import {
+  deepStrictEqual as assertDeepStrictEqual,
+  equal as assertEqual,
+  rejects as assertRejects,
+} from 'node:assert/strict';
+
+import {
+  DEFAULT_DESK_ONBOARDING_STEPS,
+  fetchDeskOnboardingSteps,
+} from '../apps/web/services/deskOnboardingSteps.ts';
+
+test('fetchDeskOnboardingSteps normalises Supabase payloads', async () => {
+  const result = await fetchDeskOnboardingSteps({
+    callEdge: async () => ({
+      data: {
+        contents: [
+          {
+            content_key: 'desk_onboarding_steps',
+            content_value: JSON.stringify([
+              {
+                id: 'calibrate',
+                title: 'Calibrate my plan',
+                iconName: 'sparkles',
+                description: 'Answer quick prompts to tailor alerts.',
+                bullets: [
+                  'Pick your risk ceiling',
+                  'Select favourite markets',
+                ],
+                action: { label: 'Start intake', href: '/intake' },
+              },
+              {
+                slug: 'drill',
+                label: 'Drill with mentors',
+                icon: 'calendar',
+                summary: 'Join the next rehearsal window.',
+                highlights: ['Book a live lab'],
+                cta: { title: 'See lab schedule', url: '/labs' },
+              },
+            ]),
+          },
+        ],
+      },
+    }),
+  });
+
+  assertEqual(result.isFallback, false);
+  assertEqual(result.steps.length, 2);
+  assertDeepStrictEqual(result.steps[0], {
+    id: 'calibrate',
+    label: 'Calibrate my plan',
+    icon: 'sparkles',
+    summary: 'Answer quick prompts to tailor alerts.',
+    highlights: ['Pick your risk ceiling', 'Select favourite markets'],
+    actionLabel: 'Start intake',
+    actionHref: '/intake',
+  });
+  assertDeepStrictEqual(result.steps[1], {
+    id: 'drill',
+    label: 'Drill with mentors',
+    icon: 'calendar',
+    summary: 'Join the next rehearsal window.',
+    highlights: ['Book a live lab'],
+    actionLabel: 'See lab schedule',
+    actionHref: '/labs',
+  });
+});
+
+test('fetchDeskOnboardingSteps falls back to defaults when payload is missing', async () => {
+  const result = await fetchDeskOnboardingSteps({
+    callEdge: async () => ({
+      data: { contents: [] },
+    }),
+  });
+
+  assertEqual(result.isFallback, true);
+  assertDeepStrictEqual(result.steps, DEFAULT_DESK_ONBOARDING_STEPS);
+});
+
+test('fetchDeskOnboardingSteps propagates Supabase errors', async () => {
+  await assertRejects(
+    () =>
+      fetchDeskOnboardingSteps({
+        callEdge: async () => ({
+          error: { status: 503, message: 'temporarily unavailable' },
+        }),
+      }),
+    /temporarily unavailable/,
+  );
+});

--- a/tests/desk-preview-cards.test.ts
+++ b/tests/desk-preview-cards.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import {
+  deepStrictEqual as assertDeepStrictEqual,
+  equal as assertEqual,
+  rejects as assertRejects,
+} from 'node:assert/strict';
+
+import {
+  DEFAULT_DESK_PREVIEW_CARDS,
+  fetchDeskPreviewCards,
+} from '../apps/web/services/deskPreviewCards.ts';
+
+const mockGradient = 'linear-gradient(135deg, #000, #111)';
+
+test('fetchDeskPreviewCards normalises Supabase payloads', async () => {
+  const result = await fetchDeskPreviewCards({
+    callEdge: async () => ({
+      data: {
+        contents: [
+          {
+            content_key: 'desk_preview_cards',
+            content_value: JSON.stringify([
+              {
+                title: 'Live Signal Matrix',
+                subtitle: 'New catalyst queued',
+                metric_label: 'Playbook edge',
+                metric_value: '+4.2%',
+                description: 'AUD/JPY momentum · 2 alerts firing',
+                background: mockGradient,
+              },
+              {
+                name: 'Mentor Availability',
+                subheading: 'Next lab in 45m',
+                metricLabel: 'Seats left',
+                metricValue: '2',
+                body: 'Reserve your slot before the room fills',
+                gradient: mockGradient,
+              },
+            ]),
+          },
+        ],
+      },
+    }),
+  });
+
+  assertEqual(result.isFallback, false);
+  assertEqual(result.cards.length, 2);
+  assertDeepStrictEqual(result.cards[0], {
+    title: 'Live Signal Matrix',
+    subtitle: 'New catalyst queued',
+    metricLabel: 'Playbook edge',
+    metricValue: '+4.2%',
+    description: 'AUD/JPY momentum · 2 alerts firing',
+    gradient: mockGradient,
+  });
+  assertDeepStrictEqual(result.cards[1], {
+    title: 'Mentor Availability',
+    subtitle: 'Next lab in 45m',
+    metricLabel: 'Seats left',
+    metricValue: '2',
+    description: 'Reserve your slot before the room fills',
+    gradient: mockGradient,
+  });
+});
+
+test('fetchDeskPreviewCards falls back to defaults when no content is returned', async () => {
+  const result = await fetchDeskPreviewCards({
+    callEdge: async () => ({
+      data: {
+        contents: [
+          {
+            content_key: 'desk_preview_cards',
+            content_value: JSON.stringify([]),
+          },
+        ],
+      },
+    }),
+  });
+
+  assertEqual(result.isFallback, true);
+  assertDeepStrictEqual(result.cards, DEFAULT_DESK_PREVIEW_CARDS);
+});
+
+test('fetchDeskPreviewCards propagates Supabase errors', async () => {
+  await assertRejects(
+    () =>
+      fetchDeskPreviewCards({
+        callEdge: async () => ({
+          error: { status: 500, message: 'edge unavailable' },
+        }),
+      }),
+    /edge unavailable/,
+  );
+});


### PR DESCRIPTION
## Summary
- add typed services and React Query hooks that load desk preview cards and onboarding steps from the content batch edge function with safe fallbacks
- refactor the hero experience and route archive notice surfaces to consume the new hooks, layering in skeleton and fallback messaging when Supabase data is unavailable
- cover the new normalization logic with unit tests for success, fallback, and error scenarios

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d7a46c34088322925c3a15b3c82593