### PR TITLE
Add dynamic psychology aggregation algorithm

### DIFF
--- a/dynamic_algo/__init__.py
+++ b/dynamic_algo/__init__.py
@@ -21,6 +21,12 @@ from .dynamic_pool import (
     PoolWithdrawal,
 )
 from .dynamic_metadata import DynamicMetadataAlgo, MetadataAttribute
+from .dynamic_psychology import (
+    DynamicPsychologyAlgo,
+    ElementAggregate,
+    PsychologyEntry,
+    PsychologySnapshot,
+)
 
 __all__ = [
     "ORDER_ACTION_BUY",
@@ -41,4 +47,8 @@ __all__ = [
     "PoolWithdrawal",
     "DynamicMetadataAlgo",
     "MetadataAttribute",
+    "DynamicPsychologyAlgo",
+    "PsychologyEntry",
+    "PsychologySnapshot",
+    "ElementAggregate",
 ]

--- a/dynamic_algo/dynamic_psychology.py
+++ b/dynamic_algo/dynamic_psychology.py
@@ -1,0 +1,366 @@
+"""Psychology aggregation helpers for Dynamic Capital trading workflows."""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from dataclasses import dataclass, field, fields
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
+
+from algorithms.python.trading_psychology_elements import (
+    Element,
+    ElementProfile,
+    PsychologyTelemetry,
+    score_elements,
+)
+
+__all__ = [
+    "PsychologyEntry",
+    "ElementAggregate",
+    "PsychologySnapshot",
+    "DynamicPsychologyAlgo",
+]
+
+
+def _coerce_timestamp(value: datetime | str | None) -> datetime:
+    """Return a timezone-aware timestamp for *value*."""
+
+    if value is None:
+        return datetime.now(timezone.utc)
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    raise TypeError("timestamp must be datetime, ISO-8601 string, or None")
+
+
+def _coerce_telemetry(value: PsychologyTelemetry | Mapping[str, object]) -> PsychologyTelemetry:
+    if isinstance(value, PsychologyTelemetry):
+        return value
+
+    if isinstance(value, Mapping):
+        allowed = {field.name for field in fields(PsychologyTelemetry)}
+        payload: MutableMapping[str, object] = {}
+        for key, raw in value.items():
+            if key in allowed:
+                payload[key] = raw
+        return PsychologyTelemetry(**payload)
+
+    raise TypeError("telemetry must be PsychologyTelemetry or mapping")
+
+
+def _deduplicate(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return unique
+
+
+def _element_order(element: Element) -> int:
+    return list(Element).index(element)
+
+
+@dataclass(slots=True)
+class PsychologyEntry:
+    """Captured trader psychology snapshot with resolved elemental profile."""
+
+    trader_id: str
+    profile: ElementProfile
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    telemetry: PsychologyTelemetry | None = None
+    weight: float = 1.0
+    notes: str | None = None
+
+    def __post_init__(self) -> None:
+        self.trader_id = str(self.trader_id).upper()
+        self.timestamp = _coerce_timestamp(self.timestamp)
+        self.weight = max(float(self.weight), 0.0)
+
+
+@dataclass(slots=True)
+class ElementAggregate:
+    """Aggregated statistics for a specific elemental archetype."""
+
+    element: Element
+    average_score: float
+    level: str
+    reasons: tuple[str, ...]
+    recommendations: tuple[str, ...]
+
+    @property
+    def name(self) -> str:
+        return self.element.value
+
+
+@dataclass(slots=True)
+class PsychologySnapshot:
+    """Computed mental performance snapshot for a trader."""
+
+    trader_id: str
+    sample_count: int
+    elements: tuple[ElementAggregate, ...]
+    readiness_score: float
+    caution_score: float
+    recovery_score: float
+    stability_index: float
+    dominant_element: str
+    dominant_score: float
+    dominant_level: str
+    last_sample_at: datetime | None
+
+    @property
+    def readiness_percent(self) -> float:
+        return round(self.readiness_score * 10, 2)
+
+    @property
+    def caution_percent(self) -> float:
+        return round(self.caution_score * 10, 2)
+
+    @property
+    def recovery_percent(self) -> float:
+        return round(self.recovery_score * 10, 2)
+
+
+class DynamicPsychologyAlgo:
+    """Maintain rolling psychology telemetry and compute actionable metrics."""
+
+    _READINESS_ELEMENTS = frozenset({Element.EARTH, Element.LIGHT})
+    _CAUTION_ELEMENTS = frozenset({Element.FIRE, Element.WATER, Element.WIND, Element.LIGHTNING})
+    _RECOVERY_ELEMENTS = frozenset({Element.DARKNESS})
+    _LEVEL_PRIORITY: Mapping[str, int] = {
+        "critical": 6,
+        "peak": 6,
+        "elevated": 5,
+        "building": 4,
+        "stable": 3,
+        "nascent": 2,
+    }
+
+    def __init__(
+        self,
+        *,
+        window_size: int | None = 120,
+        window_duration: timedelta | None = None,
+    ) -> None:
+        self.window_size = window_size
+        self.window_duration = window_duration
+        self._entries: Dict[str, Deque[PsychologyEntry]] = {}
+
+    # -------------------------------------------------------------- record utils
+    def record(
+        self,
+        trader_id: str,
+        *,
+        telemetry: PsychologyTelemetry | Mapping[str, object] | None = None,
+        profile: ElementProfile | None = None,
+        weight: float = 1.0,
+        timestamp: datetime | str | None = None,
+        notes: str | None = None,
+    ) -> PsychologyEntry:
+        """Store a telemetry point and return the canonical entry."""
+
+        if profile is None and telemetry is None:
+            raise ValueError("record requires telemetry or profile")
+
+        resolved_telemetry = (
+            _coerce_telemetry(telemetry) if telemetry is not None else None
+        )
+        resolved_profile = profile or score_elements(resolved_telemetry)  # type: ignore[arg-type]
+
+        entry = PsychologyEntry(
+            trader_id=trader_id,
+            profile=resolved_profile,
+            telemetry=resolved_telemetry,
+            weight=weight,
+            timestamp=timestamp or datetime.now(timezone.utc),
+            notes=notes,
+        )
+
+        history = self._history_for(entry.trader_id)
+        history.append(entry)
+        self._prune(history, reference=entry.timestamp)
+        return entry
+
+    # --------------------------------------------------------------- aggregators
+    def snapshot(self, trader_id: str) -> PsychologySnapshot:
+        """Return the aggregated psychology state for *trader_id*."""
+
+        history = self._history_for(trader_id)
+        self._prune(history)
+        if not history:
+            return PsychologySnapshot(
+                trader_id=str(trader_id).upper(),
+                sample_count=0,
+                elements=(),
+                readiness_score=0.0,
+                caution_score=0.0,
+                recovery_score=0.0,
+                stability_index=0.0,
+                dominant_element="neutral",
+                dominant_score=0.0,
+                dominant_level="stable",
+                last_sample_at=None,
+            )
+
+        totals: dict[Element, float] = {element: 0.0 for element in Element}
+        level_votes: dict[Element, Counter[str]] = {element: Counter() for element in Element}
+        reason_map: dict[Element, list[str]] = {element: [] for element in Element}
+        recommendation_map: dict[Element, list[str]] = {element: [] for element in Element}
+
+        total_weight = 0.0
+        last_sample_at: datetime | None = None
+        for entry in history:
+            weight = entry.weight if entry.weight > 0 else 1.0
+            total_weight += weight
+            profile = entry.profile
+            for signal in profile.signals:
+                totals[signal.element] += signal.score * weight
+                if signal.level:
+                    level_votes[signal.element][signal.level] += weight
+                if signal.reasons:
+                    reason_map[signal.element].extend(signal.reasons)
+                if signal.recommendations:
+                    recommendation_map[signal.element].extend(signal.recommendations)
+
+            if last_sample_at is None or entry.timestamp > last_sample_at:
+                last_sample_at = entry.timestamp
+
+        if total_weight <= 0 and history:
+            total_weight = float(len(history))
+
+        aggregates: list[ElementAggregate] = []
+        for element in Element:
+            average = totals[element] / total_weight if total_weight > 0 else 0.0
+            level = self._select_level(level_votes[element], element)
+            aggregates.append(
+                ElementAggregate(
+                    element=element,
+                    average_score=round(average, 4),
+                    level=level,
+                    reasons=tuple(_deduplicate(reason_map[element])),
+                    recommendations=tuple(_deduplicate(recommendation_map[element])),
+                )
+            )
+
+        aggregates.sort(
+            key=lambda agg: (agg.average_score, _element_order(agg.element)),
+            reverse=True,
+        )
+
+        readiness = self._average_for(aggregates, self._READINESS_ELEMENTS)
+        caution = self._average_for(aggregates, self._CAUTION_ELEMENTS)
+        recovery = self._average_for(aggregates, self._RECOVERY_ELEMENTS)
+        stability = readiness - caution
+
+        dominant = aggregates[0]
+        return PsychologySnapshot(
+            trader_id=history[0].trader_id,
+            sample_count=len(history),
+            elements=tuple(aggregates),
+            readiness_score=round(readiness, 4),
+            caution_score=round(caution, 4),
+            recovery_score=round(recovery, 4),
+            stability_index=round(stability, 4),
+            dominant_element=dominant.name,
+            dominant_score=dominant.average_score,
+            dominant_level=dominant.level,
+            last_sample_at=last_sample_at,
+        )
+
+    def snapshot_all(self) -> Dict[str, PsychologySnapshot]:
+        return {trader: self.snapshot(trader) for trader in self._entries}
+
+    def psychology_state(self, trader_id: str) -> MutableMapping[str, object]:
+        snapshot = self.snapshot(trader_id)
+        state: MutableMapping[str, object] = {
+            "trader_id": snapshot.trader_id,
+            "sample_count": snapshot.sample_count,
+            "dominant_element": snapshot.dominant_element,
+            "dominant_score": snapshot.dominant_score,
+            "dominant_level": snapshot.dominant_level,
+            "readiness_score": snapshot.readiness_score,
+            "caution_score": snapshot.caution_score,
+            "recovery_score": snapshot.recovery_score,
+            "stability_index": snapshot.stability_index,
+            "readiness_percent": snapshot.readiness_percent,
+            "caution_percent": snapshot.caution_percent,
+            "recovery_percent": snapshot.recovery_percent,
+            "last_sample_at": snapshot.last_sample_at.isoformat()
+            if snapshot.last_sample_at
+            else None,
+            "elements": [
+                {
+                    "element": aggregate.name,
+                    "score": aggregate.average_score,
+                    "level": aggregate.level,
+                    "reasons": list(aggregate.reasons),
+                    "recommendations": list(aggregate.recommendations),
+                }
+                for aggregate in snapshot.elements
+            ],
+        }
+        return state
+
+    # ------------------------------------------------------------- maintenance
+    def clear(self, trader_id: str | None = None) -> None:
+        if trader_id is None:
+            self._entries.clear()
+        else:
+            self._entries.pop(str(trader_id).upper(), None)
+
+    def traders(self) -> Iterable[str]:
+        return tuple(self._entries.keys())
+
+    def entries(self, trader_id: str) -> Iterator[PsychologyEntry]:
+        return iter(self._history_for(trader_id))
+
+    # -------------------------------------------------------------- internals
+    def _history_for(self, trader_id: str) -> Deque[PsychologyEntry]:
+        key = str(trader_id).upper()
+        if key not in self._entries:
+            self._entries[key] = deque()
+        return self._entries[key]
+
+    def _prune(
+        self,
+        history: Deque[PsychologyEntry],
+        *,
+        reference: datetime | None = None,
+    ) -> None:
+        if self.window_size is not None:
+            while len(history) > self.window_size:
+                history.popleft()
+
+        if self.window_duration is not None and history:
+            base_time = reference or history[-1].timestamp
+            cutoff = base_time - self.window_duration
+            while history and history[0].timestamp < cutoff:
+                history.popleft()
+
+    def _select_level(self, votes: Counter[str], element: Element) -> str:
+        if not votes:
+            return "nascent" if element in self._READINESS_ELEMENTS else "stable"
+        return max(
+            votes.items(),
+            key=lambda item: (item[1], self._LEVEL_PRIORITY.get(item[0], 0)),
+        )[0]
+
+    def _average_for(
+        self, aggregates: Iterable[ElementAggregate], elements: Iterable[Element]
+    ) -> float:
+        scores = [agg.average_score for agg in aggregates if agg.element in elements]
+        if not scores:
+            return 0.0
+        return sum(scores) / len(scores)
+

--- a/tests/test_dynamic_psychology_algo.py
+++ b/tests/test_dynamic_psychology_algo.py
@@ -1,0 +1,147 @@
+"""Tests for the Dynamic Capital psychology aggregation helper."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+from typing import Mapping
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from algorithms.python.trading_psychology_elements import (
+    Element,
+    ElementProfile,
+    ElementSignal,
+    PsychologyTelemetry,
+)
+from dynamic_algo.dynamic_psychology import DynamicPsychologyAlgo
+
+
+def _dt(offset_minutes: int = 0) -> datetime:
+    return datetime(2025, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=offset_minutes)
+
+
+def _profile_from_scores(scores: Mapping[Element, tuple[float, str]]):
+    signals: list[ElementSignal] = []
+    for element in Element:
+        score, level = scores.get(element, (0.0, "stable"))
+        signals.append(
+            ElementSignal(
+                element=element,
+                score=score,
+                level=level,
+                reasons=(
+                    ["Process discipline is anchoring execution."]
+                    if element == Element.EARTH and score > 0
+                    else []
+                ),
+                recommendations=(
+                    ["Keep reinforcing daily routines to bank consistency."]
+                    if element == Element.EARTH and score > 0
+                    else []
+                ),
+            )
+        )
+    return ElementProfile(signals=signals)
+
+
+def test_snapshot_aggregates_psychology_signals() -> None:
+    algo = DynamicPsychologyAlgo()
+
+    high_readiness = PsychologyTelemetry(
+        discipline_index=0.8,
+        journaling_rate=0.8,
+        focus_index=0.7,
+        account_balance_delta_pct=2.0,
+        trades_planned=2,
+        trades_executed=2,
+        conviction_index=0.7,
+        fatigue_index=0.2,
+        consecutive_wins=3,
+        emotional_volatility=0.2,
+    )
+    stressed_state = PsychologyTelemetry(
+        trades_planned=1,
+        trades_executed=4,
+        drawdown_pct=8.0,
+        account_balance_delta_pct=-4.0,
+        stress_index=0.8,
+        emotional_volatility=0.7,
+        consecutive_losses=4,
+        focus_index=0.3,
+        fatigue_index=0.8,
+        discipline_index=0.2,
+        market_volatility=0.8,
+        news_shock=True,
+    )
+
+    algo.record("alice", telemetry=high_readiness, timestamp=_dt())
+    algo.record("alice", telemetry=stressed_state, timestamp=_dt(5), weight=2.0)
+
+    snapshot = algo.snapshot("ALICE")
+
+    assert snapshot.trader_id == "ALICE"
+    assert snapshot.sample_count == 2
+    assert snapshot.dominant_element == "fire"
+    assert snapshot.dominant_score == pytest.approx(5.4, rel=1e-3)
+    assert snapshot.dominant_level == "critical"
+    assert snapshot.last_sample_at == _dt(5)
+    assert snapshot.readiness_score < snapshot.caution_score
+    assert snapshot.recovery_score > snapshot.readiness_score
+    assert snapshot.stability_index < 0
+
+    state = algo.psychology_state("alice")
+    assert state["trader_id"] == "ALICE"
+    assert state["sample_count"] == 2
+    assert state["dominant_element"] == "fire"
+    assert state["last_sample_at"] == _dt(5).isoformat()
+    assert state["readiness_score"] == pytest.approx(snapshot.readiness_score)
+    assert state["caution_score"] == pytest.approx(snapshot.caution_score)
+    assert state["elements"][0]["element"] == "fire"
+
+
+def test_window_size_limits_history() -> None:
+    algo = DynamicPsychologyAlgo(window_size=2)
+    base = {
+        "discipline_index": 0.6,
+        "focus_index": 0.6,
+        "trades_planned": 1,
+        "trades_executed": 1,
+    }
+
+    algo.record("bob", telemetry=PsychologyTelemetry(**base), timestamp=_dt())
+    algo.record("bob", telemetry=PsychologyTelemetry(**base), timestamp=_dt(1))
+    algo.record("bob", telemetry=PsychologyTelemetry(**base), timestamp=_dt(2))
+
+    snapshot = algo.snapshot("bob")
+
+    assert snapshot.sample_count == 2
+    assert len(tuple(algo.entries("bob"))) == 2
+
+
+def test_record_accepts_profile_payload() -> None:
+    algo = DynamicPsychologyAlgo()
+    scores = {
+        Element.EARTH: (6.0, "building"),
+        Element.FIRE: (2.0, "stable"),
+        Element.LIGHT: (3.0, "nascent"),
+    }
+    profile = _profile_from_scores(scores)
+
+    entry = algo.record("carol", profile=profile, weight=2.0, timestamp=_dt(), notes="manual")
+
+    assert entry.trader_id == "CAROL"
+    assert entry.weight == pytest.approx(2.0)
+    assert entry.telemetry is None
+
+    snapshot = algo.snapshot("carol")
+    assert snapshot.sample_count == 1
+    assert snapshot.dominant_element == "earth"
+    assert snapshot.readiness_score > snapshot.caution_score
+
+    algo.clear("carol")
+    assert algo.snapshot("carol").sample_count == 0


### PR DESCRIPTION
## Summary
- add a rolling psychology aggregation engine that normalises telemetry into actionable readiness, caution, and recovery metrics
- expose psychology utilities through the dynamic_algo package interface
- cover the new algorithm with targeted unit tests for aggregation, window pruning, and manual profile ingestion

## Testing
- python -m pytest tests/test_dynamic_psychology_algo.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d7abd71e208322858d7e40e6155bfc