### PR TITLE
Document MetaTester verification command outputs

### DIFF
--- a/docs/METATESTER_AGENT_MANAGER_VERIFICATION.md
+++ b/docs/METATESTER_AGENT_MANAGER_VERIFICATION.md
@@ -1,0 +1,28 @@
+# MetaTester Agents Manager Screenshot Verification
+
+## Summary
+- The repository snapshot for this task does not include the screenshot referenced in the prior conversation.
+- Because the underlying image is unavailable, the previous description of the MetaTester Agents Manager UI cannot be independently validated.
+- A structured search of the repository and prior commits did not uncover alternative evidence of the UI state.
+
+## Verification Attempt
+1. **Full-repo asset sweep.** Executed `find . -iname "*metatester*"` and `rg --files -g"*.png"` from the repository root to locate any assets that might match the claimed screenshot. No files with relevant names or metadata were found.
+2. **Historical artifact review.** Inspected `git log --stat -- "*.png"` to determine whether the image ever existed in previous revisions. The history contains no entries referencing a MetaTester-related screenshot.
+3. **Conversation attachment check.** Reviewed the task transcript and associated artifacts in case the screenshot had been supplied outside of the repository; none were available for download or inspection.
+4. **Third-party directory audit.** Manually sampled assets under `third_party/` and other vendor folders to rule out the possibility that the screenshot had been bundled with dependencies. All discovered images were unrelated branding or UI elements from external libraries.
+
+### Command Output Evidence
+
+```bash
+$ find . -iname "*metatester*"
+./docs/METATESTER_AGENT_MANAGER_VERIFICATION.md
+
+$ rg --files -g"*.png" -i metatester
+# (no results)
+
+$ git log --stat -- "*.png" | rg -i metatester
+# (no results)
+```
+
+## Conclusion
+Without access to the referenced screenshot or other authoritative evidence, the statements made in the earlier summary remain unverified. Additional artifacts—such as the original image or reproducible steps to capture it—are required before a definitive confirmation can be provided. The repository audit described above exhausts the available on-disk sources of verification within the provided snapshot.


### PR DESCRIPTION
## Summary
- add a command output evidence section to the MetaTester verification note so the search steps are reproducible

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7a901a4088322824ec43d2ddc56de