### PR TITLE
Add frontend and backend keeper orchestration algorithms

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -208,6 +208,16 @@ from .team_operations import (
     build_team_operations_playbooks,
     build_team_operations_sync_algorithm,
 )
+from .backend_keeper import (
+    BackendKeeperSyncResult,
+    BackendService,
+    DynamicBackendKeeperAlgorithm,
+)
+from .frontend_keeper import (
+    DynamicFrontendKeeperAlgorithm,
+    FrontendKeeperSyncResult,
+    FrontendSurface,
+)
 from .route_keeper import DynamicRouteKeeperAlgorithm, Route, RouteKeeperSyncResult
 from .supabase_edge_functions import (
     EdgeFunctionRunbook,
@@ -416,6 +426,12 @@ __all__ = _trade_exports + [
     "Route",
     "DynamicRouteKeeperAlgorithm",
     "RouteKeeperSyncResult",
+    "BackendKeeperSyncResult",
+    "BackendService",
+    "DynamicBackendKeeperAlgorithm",
+    "DynamicFrontendKeeperAlgorithm",
+    "FrontendKeeperSyncResult",
+    "FrontendSurface",
     "StepExecution",
     "StepHandler",
     "StepResult",
@@ -586,6 +602,12 @@ globals().update(
         "Route": Route,
         "DynamicRouteKeeperAlgorithm": DynamicRouteKeeperAlgorithm,
         "RouteKeeperSyncResult": RouteKeeperSyncResult,
+        "BackendKeeperSyncResult": BackendKeeperSyncResult,
+        "BackendService": BackendService,
+        "DynamicBackendKeeperAlgorithm": DynamicBackendKeeperAlgorithm,
+        "DynamicFrontendKeeperAlgorithm": DynamicFrontendKeeperAlgorithm,
+        "FrontendKeeperSyncResult": FrontendKeeperSyncResult,
+        "FrontendSurface": FrontendSurface,
         "EdgeFunctionRunbook": EdgeFunctionRunbook,
         "EdgeFunctionSpec": EdgeFunctionSpec,
         "DynamicSupabaseEdgeFunctionAlgorithm": DynamicSupabaseEdgeFunctionAlgorithm,

--- a/algorithms/python/backend_keeper.py
+++ b/algorithms/python/backend_keeper.py
@@ -1,0 +1,384 @@
+"""Backend keeper orchestration for Dynamic Capital services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from .multi_llm import LLMConfig, LLMRun
+
+__all__ = [
+    "BackendService",
+    "DynamicBackendKeeperAlgorithm",
+    "BackendKeeperSyncResult",
+]
+
+
+def _normalise_tuple(values: Iterable[Any]) -> Tuple[str, ...]:
+    """Return a tuple of unique, stripped string values preserving order."""
+
+    seen: set[str] = set()
+    items: list[str] = []
+    for value in values or ():
+        text = str(value).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        items.append(text)
+    return tuple(items)
+
+
+@dataclass(slots=True, frozen=True)
+class BackendService:
+    """Represents a backend service overseen by the keeper."""
+
+    name: str
+    owner: str
+    status: str = "operational"
+    runtime: str = ""
+    tier: str = ""
+    priority: int = 0
+    endpoints: Tuple[str, ...] = ()
+    tags: Tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        name = self.name.strip()
+        owner = self.owner.strip()
+        if not name:
+            raise ValueError("backend service name is required")
+        if not owner:
+            raise ValueError("backend service owner is required")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "owner", owner)
+        object.__setattr__(self, "status", (self.status or "operational").strip() or "operational")
+        object.__setattr__(self, "runtime", self.runtime.strip())
+        object.__setattr__(self, "tier", self.tier.strip())
+        object.__setattr__(self, "endpoints", _normalise_tuple(self.endpoints))
+        object.__setattr__(self, "tags", _normalise_tuple(self.tags))
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+
+@dataclass(slots=True)
+class BackendKeeperSyncResult:
+    """Structured output produced by :class:`DynamicBackendKeeperAlgorithm`."""
+
+    timestamp: datetime
+    theme: Optional[str]
+    services: Sequence[MutableMapping[str, Any]]
+    dependencies: Sequence[MutableMapping[str, Any]]
+    incidents: Sequence[MutableMapping[str, Any]]
+    deployments: Sequence[MutableMapping[str, Any]]
+    risks: Sequence[MutableMapping[str, Any]]
+    llm_runs: Tuple[LLMRun, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        """Return a concise description of the synchronisation."""
+
+        parts: list[str] = [f"{len(self.services)} services"]
+        if self.dependencies:
+            parts.append(f"{len(self.dependencies)} dependency links")
+        if self.incidents:
+            parts.append(f"{len(self.incidents)} incidents")
+        if self.risks:
+            parts.append(f"{len(self.risks)} risks")
+        if self.theme:
+            parts.append(f"theme '{self.theme}'")
+        return ", ".join(parts)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the sync payload."""
+
+        payload: Dict[str, Any] = {
+            "timestamp": self.timestamp.isoformat(),
+            "theme": self.theme,
+            "services": [dict(service) for service in self.services],
+            "dependencies": [dict(dep) for dep in self.dependencies],
+            "incidents": [dict(incident) for incident in self.incidents],
+            "deployments": [dict(deployment) for deployment in self.deployments],
+            "risks": [dict(risk) for risk in self.risks],
+            "summary": self.summary(),
+        }
+        if self.llm_runs:
+            payload["llm_runs"] = [run.to_dict(include_prompt=False) for run in self.llm_runs]
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class DynamicBackendKeeperAlgorithm:
+    """Coordinates backend services, incidents, and LLM readiness reviews."""
+
+    def __init__(self) -> None:
+        self._services: list[BackendService] = []
+        self._dependencies: Dict[str, set[str]] = {}
+        self._deployments: Dict[str, Mapping[str, Any]] = {}
+
+    def register_service(self, service: BackendService) -> None:
+        """Register a persistent backend service managed by the keeper."""
+
+        self._services.append(service)
+
+    def register_dependency(self, service: str, dependencies: Iterable[str]) -> None:
+        """Register upstream dependencies for a backend service."""
+
+        service_name = service.strip()
+        if not service_name:
+            raise ValueError("service identifier is required for dependency registration")
+        targets = {target.strip() for target in dependencies or () if target and str(target).strip()}
+        if not targets:
+            return
+        links = self._dependencies.setdefault(service_name, set())
+        links.update(targets)
+
+    def register_deployment(self, service: str, details: Mapping[str, Any]) -> None:
+        """Register the current deployment metadata for a service."""
+
+        service_name = service.strip()
+        if not service_name:
+            raise ValueError("service identifier is required for deployment registration")
+        self._deployments[service_name] = dict(details or {})
+
+    def sync(
+        self,
+        *,
+        as_of: Optional[datetime] = None,
+        services: Optional[Iterable[BackendService]] = None,
+        dependencies: Optional[Mapping[str, Iterable[str]]] = None,
+        incidents: Optional[Iterable[Mapping[str, Any]]] = None,
+        deployments: Optional[Mapping[str, Mapping[str, Any]]] = None,
+        status_overrides: Optional[Mapping[str, str]] = None,
+        llm_configs: Optional[Sequence[LLMConfig]] = None,
+        theme: Optional[str] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> BackendKeeperSyncResult:
+        """Synchronise backend services and share resilience guidance."""
+
+        timestamp = (as_of or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+        service_map: Dict[str, BackendService] = {}
+        for service in (*self._services, *(services or [])):
+            service_map[service.name] = service
+        if not service_map:
+            raise ValueError("At least one backend service must be provided for synchronisation")
+
+        dependency_map: Dict[str, set[str]] = {
+            name: set(targets) for name, targets in self._dependencies.items()
+        }
+        for name, targets in (dependencies or {}).items():
+            key = name.strip()
+            if not key:
+                continue
+            dependency_map.setdefault(key, set()).update(
+                target.strip() for target in targets or () if target and str(target).strip()
+            )
+
+        deployment_map: Dict[str, Mapping[str, Any]] = {
+            name: dict(details) for name, details in self._deployments.items()
+        }
+        for name, details in (deployments or {}).items():
+            service_name = name.strip()
+            if not service_name:
+                continue
+            deployment_map[service_name] = dict(details or {})
+
+        status_map: Dict[str, str] = {}
+        for name, status in (status_overrides or {}).items():
+            service_name = name.strip()
+            status_value = status.strip()
+            if service_name and status_value:
+                status_map[service_name] = status_value
+
+        services_payload: list[MutableMapping[str, Any]] = []
+        all_runtimes: set[str] = set()
+        for service in sorted(
+            service_map.values(), key=lambda value: (-value.priority, value.name.lower())
+        ):
+            status = status_map.get(service.name, service.status)
+            payload: MutableMapping[str, Any] = {
+                "name": service.name,
+                "owner": service.owner,
+                "status": status,
+                "priority": service.priority,
+            }
+            if service.runtime:
+                payload["runtime"] = service.runtime
+                all_runtimes.add(service.runtime)
+            if service.tier:
+                payload["tier"] = service.tier
+            if service.endpoints:
+                payload["endpoints"] = list(service.endpoints)
+            if service.tags:
+                payload["tags"] = list(service.tags)
+            if service.metadata:
+                payload["metadata"] = dict(service.metadata)
+            if service.name in deployment_map:
+                payload["deployment"] = dict(deployment_map[service.name])
+            services_payload.append(payload)
+
+        dependencies_payload: list[MutableMapping[str, Any]] = []
+        missing_dependencies: list[Tuple[str, str]] = []
+        for service_name, targets in sorted(dependency_map.items()):
+            if not targets:
+                continue
+            valid_targets = sorted(target for target in targets if target in service_map)
+            missing = sorted(target for target in targets if target not in service_map)
+            dependencies_payload.append(
+                {"service": service_name, "depends_on": valid_targets, "missing": missing}
+            )
+            for dependency in missing:
+                missing_dependencies.append((service_name, dependency))
+
+        incidents_payload: list[MutableMapping[str, Any]] = [
+            {"title": incident.get("title", ""), "severity": incident.get("severity", "info"), **dict(incident)}
+            for incident in incidents or []
+        ]
+
+        deployments_payload: list[MutableMapping[str, Any]] = [
+            {"service": name, **dict(details)} for name, details in sorted(deployment_map.items())
+        ]
+
+        status_alerts = [
+            (payload["name"], payload["status"])
+            for payload in services_payload
+            if payload["status"].lower() in {"degraded", "outage", "offline"}
+        ]
+        incident_alerts = [
+            incident
+            for incident in incidents_payload
+            if str(incident.get("severity", "")).lower() in {"high", "critical"}
+        ]
+
+        risks_payload: list[MutableMapping[str, Any]] = []
+        for service_name, dependency in missing_dependencies:
+            risks_payload.append(
+                {
+                    "service": service_name,
+                    "issue": "missing_dependency",
+                    "details": f"Depends on '{dependency}' which is not registered",
+                }
+            )
+        for service_name, status in status_alerts:
+            risks_payload.append(
+                {
+                    "service": service_name,
+                    "issue": "status_alert",
+                    "details": f"Service reported status '{status}'",
+                }
+            )
+        for incident in incident_alerts:
+            risks_payload.append(
+                {
+                    "service": incident.get("service", "unknown"),
+                    "issue": "critical_incident",
+                    "details": incident.get("title") or "Critical incident reported",
+                }
+            )
+
+        metadata: Dict[str, Any] = dict(context or {})
+        prompt = self._build_prompt(
+            timestamp=timestamp,
+            theme=theme,
+            services=services_payload,
+            dependencies=dependencies_payload,
+            incidents=incidents_payload,
+            deployments=deployments_payload,
+            risks=risks_payload,
+            runtimes=sorted(all_runtimes),
+        )
+        metadata["prompt"] = prompt
+        if incidents_payload:
+            metadata["incidents"] = [dict(incident) for incident in incidents_payload]
+        if risks_payload:
+            metadata["risks"] = [dict(risk) for risk in risks_payload]
+
+        llm_runs: list[LLMRun] = []
+        if llm_configs:
+            for config in llm_configs:
+                llm_runs.append(config.run(prompt))
+
+        result = BackendKeeperSyncResult(
+            timestamp=timestamp,
+            theme=theme,
+            services=services_payload,
+            dependencies=dependencies_payload,
+            incidents=incidents_payload,
+            deployments=deployments_payload,
+            risks=risks_payload,
+            llm_runs=tuple(llm_runs),
+            metadata=metadata,
+        )
+        return result
+
+    def _build_prompt(
+        self,
+        *,
+        timestamp: datetime,
+        theme: Optional[str],
+        services: Sequence[Mapping[str, Any]],
+        dependencies: Sequence[Mapping[str, Any]],
+        incidents: Sequence[Mapping[str, Any]],
+        deployments: Sequence[Mapping[str, Any]],
+        risks: Sequence[Mapping[str, Any]],
+        runtimes: Sequence[str],
+    ) -> str:
+        """Construct a narrative prompt describing backend readiness."""
+
+        lines = [
+            "You are the Dynamic Capital backend keeper responsible for runtime resilience.",
+            f"Timestamp: {timestamp.isoformat()}",
+        ]
+        if theme:
+            lines.append(f"Theme: {theme}")
+        if runtimes:
+            lines.append(f"Runtimes observed: {', '.join(runtimes)}")
+        lines.append("Registered services:")
+        for service in services:
+            entry = (
+                f"- {service['name']} (owner={service['owner']}) — status={service['status']} priority={service['priority']}"
+            )
+            if service.get("runtime"):
+                entry += f" runtime={service['runtime']}"
+            if service.get("tier"):
+                entry += f" tier={service['tier']}"
+            if deployment := service.get("deployment"):
+                version = deployment.get("version") or deployment.get("tag")
+                if version:
+                    entry += f" deployed={version}"
+            lines.append(entry)
+        if dependencies:
+            lines.append("Dependency overview:")
+            for dependency in dependencies:
+                parts: list[str] = []
+                if dependency["depends_on"]:
+                    parts.append("depends on " + ", ".join(dependency["depends_on"]))
+                if dependency["missing"]:
+                    parts.append("missing " + ", ".join(dependency["missing"]))
+                descriptor = "; ".join(parts) if parts else "no dependencies"
+                lines.append(f"- {dependency['service']}: {descriptor}")
+        if incidents:
+            lines.append("Incidents:")
+            for incident in incidents:
+                lines.append(
+                    f"- {incident.get('service', 'unknown')}: {incident.get('title', 'Unnamed incident')} (severity={incident.get('severity', 'info')})"
+                )
+        if deployments:
+            lines.append("Deployments:")
+            for deployment in deployments:
+                lines.append(
+                    f"- {deployment['service']}: {', '.join(f'{k}={v}' for k, v in deployment.items() if k != 'service')}"
+                )
+        if risks:
+            lines.append("Risks detected:")
+            for risk in risks:
+                lines.append(
+                    f"- {risk['service']}: {risk['issue']} — {risk['details']}"
+                )
+        else:
+            lines.append("Risks detected: none")
+        lines.append(
+            "Provide backend alignment guidance, mitigation steps, and operational follow-ups for the engineering team."
+        )
+        return "\n".join(lines)

--- a/algorithms/python/frontend_keeper.py
+++ b/algorithms/python/frontend_keeper.py
@@ -1,0 +1,382 @@
+"""Frontend keeper orchestration for Dynamic Capital surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from .multi_llm import LLMConfig, LLMRun
+
+__all__ = [
+    "FrontendSurface",
+    "DynamicFrontendKeeperAlgorithm",
+    "FrontendKeeperSyncResult",
+]
+
+
+def _normalise_tuple(values: Iterable[Any]) -> Tuple[str, ...]:
+    """Return a tuple of unique, stripped string values preserving order."""
+
+    seen: set[str] = set()
+    items: list[str] = []
+    for value in values or ():
+        text = str(value).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        items.append(text)
+    return tuple(items)
+
+
+@dataclass(slots=True, frozen=True)
+class FrontendSurface:
+    """Represents a frontend surface managed by the keeper."""
+
+    name: str
+    route: str
+    description: str = ""
+    owner: str = ""
+    status: str = "planned"
+    priority: int = 0
+    components: Tuple[str, ...] = ()
+    tags: Tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        name = self.name.strip()
+        route = self.route.strip()
+        if not name:
+            raise ValueError("frontend surface name is required")
+        if not route:
+            raise ValueError("frontend surface route is required")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "route", route)
+        object.__setattr__(self, "description", self.description.strip())
+        object.__setattr__(self, "owner", self.owner.strip())
+        object.__setattr__(self, "status", (self.status or "planned").strip() or "planned")
+        object.__setattr__(self, "components", _normalise_tuple(self.components))
+        object.__setattr__(self, "tags", _normalise_tuple(self.tags))
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+
+@dataclass(slots=True)
+class FrontendKeeperSyncResult:
+    """Structured output produced by :class:`DynamicFrontendKeeperAlgorithm`."""
+
+    timestamp: datetime
+    theme: Optional[str]
+    surfaces: Sequence[MutableMapping[str, Any]]
+    dependencies: Sequence[MutableMapping[str, Any]]
+    experiments: Sequence[MutableMapping[str, Any]]
+    risks: Sequence[MutableMapping[str, Any]]
+    llm_runs: Tuple[LLMRun, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        """Return a concise description of the synchronisation."""
+
+        parts: list[str] = [f"{len(self.surfaces)} surfaces"]
+        if self.dependencies:
+            parts.append(f"{len(self.dependencies)} dependency links")
+        if self.experiments:
+            parts.append(f"{len(self.experiments)} experiments")
+        if self.risks:
+            parts.append(f"{len(self.risks)} risks")
+        if self.theme:
+            parts.append(f"theme '{self.theme}'")
+        return ", ".join(parts)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the sync payload."""
+
+        payload: Dict[str, Any] = {
+            "timestamp": self.timestamp.isoformat(),
+            "theme": self.theme,
+            "surfaces": [dict(surface) for surface in self.surfaces],
+            "dependencies": [dict(dep) for dep in self.dependencies],
+            "experiments": [dict(experiment) for experiment in self.experiments],
+            "risks": [dict(risk) for risk in self.risks],
+            "summary": self.summary(),
+        }
+        if self.llm_runs:
+            payload["llm_runs"] = [run.to_dict(include_prompt=False) for run in self.llm_runs]
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class DynamicFrontendKeeperAlgorithm:
+    """Coordinates frontend surfaces, dependencies, and LLM health checks."""
+
+    def __init__(self) -> None:
+        self._surfaces: list[FrontendSurface] = []
+        self._dependencies: Dict[str, set[str]] = {}
+        self._experiments: Dict[str, set[str]] = {}
+
+    def register_surface(self, surface: FrontendSurface) -> None:
+        """Register a persistent surface managed by the keeper."""
+
+        self._surfaces.append(surface)
+
+    def register_dependency(self, surface: str, dependencies: Iterable[str]) -> None:
+        """Register dependency relationships for a surface."""
+
+        surface_name = surface.strip()
+        if not surface_name:
+            raise ValueError("surface identifier is required for dependency registration")
+        targets = {target.strip() for target in dependencies or () if target and str(target).strip()}
+        if not targets:
+            return
+        links = self._dependencies.setdefault(surface_name, set())
+        links.update(targets)
+
+    def register_experiment(self, name: str, surfaces: Iterable[str]) -> None:
+        """Register a feature experiment associated with one or more surfaces."""
+
+        experiment = name.strip()
+        if not experiment:
+            raise ValueError("experiment name is required for registration")
+        assignments = {surface.strip() for surface in surfaces or () if surface and str(surface).strip()}
+        if not assignments:
+            return
+        current = self._experiments.setdefault(experiment, set())
+        current.update(assignments)
+
+    def sync(
+        self,
+        *,
+        as_of: Optional[datetime] = None,
+        surfaces: Optional[Iterable[FrontendSurface]] = None,
+        dependencies: Optional[Mapping[str, Iterable[str]]] = None,
+        experiments: Optional[Mapping[str, Iterable[str]]] = None,
+        status_overrides: Optional[Mapping[str, str]] = None,
+        llm_configs: Optional[Sequence[LLMConfig]] = None,
+        theme: Optional[str] = None,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> FrontendKeeperSyncResult:
+        """Synchronise frontend assets and expose alignment guidance."""
+
+        timestamp = (as_of or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+        surface_map: Dict[str, FrontendSurface] = {}
+        for surface in (*self._surfaces, *(surfaces or [])):
+            surface_map[surface.name] = surface
+        if not surface_map:
+            raise ValueError("At least one frontend surface must be provided for synchronisation")
+
+        dependency_map: Dict[str, set[str]] = {
+            name: set(targets) for name, targets in self._dependencies.items()
+        }
+        for name, targets in (dependencies or {}).items():
+            key = name.strip()
+            if not key:
+                continue
+            dependency_map.setdefault(key, set()).update(
+                target.strip() for target in targets or () if target and str(target).strip()
+            )
+
+        experiment_map: Dict[str, set[str]] = {
+            name: set(surfaces) for name, surfaces in self._experiments.items()
+        }
+        for name, assigned_surfaces in (experiments or {}).items():
+            experiment = name.strip()
+            if not experiment:
+                continue
+            experiment_map.setdefault(experiment, set()).update(
+                surface.strip()
+                for surface in assigned_surfaces or ()
+                if surface and str(surface).strip()
+            )
+
+        experiment_assignments: Dict[str, set[str]] = {}
+        for experiment, assigned_surfaces in experiment_map.items():
+            for surface_name in assigned_surfaces:
+                if not surface_name:
+                    continue
+                experiment_assignments.setdefault(surface_name, set()).add(experiment)
+
+        status_map: Dict[str, str] = {}
+        for name, status in (status_overrides or {}).items():
+            surface_name = name.strip()
+            status_value = status.strip()
+            if surface_name and status_value:
+                status_map[surface_name] = status_value
+
+        surfaces_payload: list[MutableMapping[str, Any]] = []
+        all_components: set[str] = set()
+        for surface in sorted(
+            surface_map.values(), key=lambda value: (-value.priority, value.name.lower())
+        ):
+            status = status_map.get(surface.name, surface.status)
+            payload: MutableMapping[str, Any] = {
+                "name": surface.name,
+                "route": surface.route,
+                "status": status,
+                "priority": surface.priority,
+            }
+            if surface.description:
+                payload["description"] = surface.description
+            if surface.owner:
+                payload["owner"] = surface.owner
+            if surface.components:
+                components = list(surface.components)
+                payload["components"] = components
+                all_components.update(components)
+            if surface.tags:
+                payload["tags"] = list(surface.tags)
+            if surface.metadata:
+                payload["metadata"] = dict(surface.metadata)
+            assignments = sorted(experiment_assignments.get(surface.name, set()))
+            if assignments:
+                payload["experiments"] = assignments
+            surfaces_payload.append(payload)
+
+        dependencies_payload: list[MutableMapping[str, Any]] = []
+        missing_dependencies: list[Tuple[str, str]] = []
+        for surface_name, targets in sorted(dependency_map.items()):
+            if not targets:
+                continue
+            valid_targets = sorted(target for target in targets if target in surface_map)
+            missing = sorted(target for target in targets if target not in surface_map)
+            dependencies_payload.append(
+                {"surface": surface_name, "depends_on": valid_targets, "missing": missing}
+            )
+            for dependency in missing:
+                missing_dependencies.append((surface_name, dependency))
+
+        experiments_payload: list[MutableMapping[str, Any]] = [
+            {"name": name, "surfaces": sorted(surfaces)}
+            for name, surfaces in sorted(experiment_map.items())
+            if surfaces
+        ]
+
+        status_alerts = [
+            (payload["name"], payload["status"])
+            for payload in surfaces_payload
+            if payload["status"].lower() in {"offline", "degraded"}
+        ]
+        priority_alerts = [
+            payload["name"]
+            for payload in surfaces_payload
+            if payload["priority"] >= 7 and payload["status"].lower() not in {"live", "active"}
+        ]
+
+        risks_payload: list[MutableMapping[str, Any]] = []
+        for surface_name, dependency in missing_dependencies:
+            risks_payload.append(
+                {
+                    "surface": surface_name,
+                    "issue": "missing_dependency",
+                    "details": f"Depends on '{dependency}' which is not registered",
+                }
+            )
+        for surface_name, status in status_alerts:
+            risks_payload.append(
+                {
+                    "surface": surface_name,
+                    "issue": "status_alert",
+                    "details": f"Surface reported status '{status}'",
+                }
+            )
+        for surface_name in priority_alerts:
+            risks_payload.append(
+                {
+                    "surface": surface_name,
+                    "issue": "priority_without_activation",
+                    "details": "High priority surface is not active",
+                }
+            )
+
+        metadata: Dict[str, Any] = dict(context or {})
+        prompt = self._build_prompt(
+            timestamp=timestamp,
+            theme=theme,
+            surfaces=surfaces_payload,
+            dependencies=dependencies_payload,
+            experiments=experiments_payload,
+            risks=risks_payload,
+            components=sorted(all_components),
+        )
+        metadata["prompt"] = prompt
+        if risks_payload:
+            metadata["risks"] = [dict(risk) for risk in risks_payload]
+
+        llm_runs: list[LLMRun] = []
+        if llm_configs:
+            for config in llm_configs:
+                llm_runs.append(config.run(prompt))
+
+        result = FrontendKeeperSyncResult(
+            timestamp=timestamp,
+            theme=theme,
+            surfaces=surfaces_payload,
+            dependencies=dependencies_payload,
+            experiments=experiments_payload,
+            risks=risks_payload,
+            llm_runs=tuple(llm_runs),
+            metadata=metadata,
+        )
+        return result
+
+    def _build_prompt(
+        self,
+        *,
+        timestamp: datetime,
+        theme: Optional[str],
+        surfaces: Sequence[Mapping[str, Any]],
+        dependencies: Sequence[Mapping[str, Any]],
+        experiments: Sequence[Mapping[str, Any]],
+        risks: Sequence[Mapping[str, Any]],
+        components: Sequence[str],
+    ) -> str:
+        """Construct a narrative prompt describing the sync state."""
+
+        lines = [
+            "You are the Dynamic Capital frontend keeper orchestrating UI health.",
+            f"Timestamp: {timestamp.isoformat()}",
+        ]
+        if theme:
+            lines.append(f"Theme: {theme}")
+        if components:
+            lines.append(f"Components observed: {', '.join(components)}")
+        lines.append("Registered surfaces:")
+        for surface in surfaces:
+            entry = f"- {surface['name']} ({surface['route']}) — status={surface['status']} priority={surface['priority']}"
+            if surface.get("experiments"):
+                entry += f" experiments={', '.join(surface['experiments'])}"
+            if surface.get("owner"):
+                entry += f" owner={surface['owner']}"
+            lines.append(entry)
+        if dependencies:
+            lines.append("Dependency overview:")
+            for dependency in dependencies:
+                parts: list[str] = []
+                if dependency["depends_on"]:
+                    parts.append(
+                        "depends on " + ", ".join(dependency["depends_on"])
+                    )
+                if dependency["missing"]:
+                    parts.append(
+                        "missing " + ", ".join(dependency["missing"])
+                    )
+                descriptor = "; ".join(parts) if parts else "no dependencies"
+                lines.append(f"- {dependency['surface']}: {descriptor}")
+        if experiments:
+            lines.append("Active experiments:")
+            for experiment in experiments:
+                lines.append(
+                    f"- {experiment['name']}: {', '.join(experiment['surfaces'])}"
+                )
+        if risks:
+            lines.append("Risks detected:")
+            for risk in risks:
+                lines.append(
+                    f"- {risk['surface']}: {risk['issue']} — {risk['details']}"
+                )
+        else:
+            lines.append("Risks detected: none")
+        lines.append(
+            "Provide frontend alignment guidance, risk mitigations, and next steps for design-system cohesion."
+        )
+        return "\n".join(lines)

--- a/algorithms/python/tests/test_backend_keeper.py
+++ b/algorithms/python/tests/test_backend_keeper.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.backend_keeper import (  # noqa: E402
+    BackendService,
+    DynamicBackendKeeperAlgorithm,
+)
+from algorithms.python.multi_llm import LLMConfig  # noqa: E402
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str, *, temperature: float, max_tokens: int, nucleus_p: float) -> str:
+        self.prompts.append(prompt)
+        return json.dumps(
+            {
+                "summary": "Backend keeper synced",
+                "actions": ["Escalate auth-gateway rollout"],
+            }
+        )
+
+
+def test_backend_keeper_sync_tracks_services_and_incidents() -> None:
+    keeper = DynamicBackendKeeperAlgorithm()
+    core_api = BackendService(
+        name="core-api",
+        owner="CoreApps",
+        status="operational",
+        runtime="Node.js",
+        tier="critical",
+        priority=10,
+        endpoints=("/v1/core",),
+        tags=("core", "graphql"),
+    )
+    keeper.register_service(core_api)
+    keeper.register_dependency("core-api", ("auth-gateway", "metrics-service"))
+    keeper.register_deployment("core-api", {"version": "2024.05.01", "env": "production"})
+
+    risk_engine = BackendService(
+        name="risk-engine",
+        owner="QuantOps",
+        status="operational",
+        runtime="Python",
+        priority=8,
+        endpoints=("/jobs/risk",),
+    )
+    data_pipeline = BackendService(
+        name="data-pipeline",
+        owner="DataOps",
+        status="operational",
+        runtime="Go",
+        priority=7,
+        endpoints=("/streams/market",),
+    )
+
+    dummy_client = DummyClient()
+    config = LLMConfig(
+        name="backend-keeper-gpt",
+        client=dummy_client,
+        temperature=0.25,
+        nucleus_p=0.85,
+        max_tokens=256,
+    )
+
+    as_of = datetime(2024, 5, 1, 12, 45, tzinfo=timezone.utc)
+    result = keeper.sync(
+        as_of=as_of,
+        services=(risk_engine, data_pipeline),
+        dependencies={"risk-engine": ("core-api", "auth-db")},
+        incidents=(
+            {"service": "auth-gateway", "title": "Auth gateway latency spike", "severity": "critical"},
+        ),
+        deployments={"risk-engine": {"version": "2024.05.01-beta", "env": "staging"}},
+        status_overrides={"risk-engine": "degraded"},
+        llm_configs=(config,),
+        theme="Backend resilience",
+        context={"notes": ["Monitor auth dependencies"]},
+    )
+
+    assert result.timestamp == as_of
+    assert result.theme == "Backend resilience"
+    assert len(result.services) == 3
+
+    risk_payload = next(service for service in result.services if service["name"] == "risk-engine")
+    assert risk_payload["status"] == "degraded"
+    assert risk_payload["deployment"]["version"] == "2024.05.01-beta"
+
+    core_payload = next(service for service in result.services if service["name"] == "core-api")
+    assert core_payload["deployment"]["version"] == "2024.05.01"
+
+    dependency_entry = next(dep for dep in result.dependencies if dep["service"] == "risk-engine")
+    assert "auth-db" in dependency_entry["missing"]
+
+    assert any(risk["issue"] == "missing_dependency" for risk in result.risks)
+    assert any(risk["issue"] == "status_alert" and risk["service"] == "risk-engine" for risk in result.risks)
+    assert any(risk["issue"] == "critical_incident" for risk in result.risks)
+
+    assert result.llm_runs and result.llm_runs[0].name == "backend-keeper-gpt"
+    assert dummy_client.prompts and dummy_client.prompts[0] == result.metadata["prompt"]
+    assert "Backend resilience" in result.metadata["prompt"]
+    assert "auth-gateway" in result.metadata["prompt"]
+
+    payload = result.to_dict()
+    assert payload["timestamp"] == as_of.isoformat()
+    assert payload["summary"].startswith("3 services")
+    assert payload["metadata"]["prompt"] == result.metadata["prompt"]
+
+
+def test_backend_keeper_requires_services() -> None:
+    keeper = DynamicBackendKeeperAlgorithm()
+    with pytest.raises(ValueError):
+        keeper.sync()

--- a/algorithms/python/tests/test_frontend_keeper.py
+++ b/algorithms/python/tests/test_frontend_keeper.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from algorithms.python.frontend_keeper import (  # noqa: E402
+    DynamicFrontendKeeperAlgorithm,
+    FrontendSurface,
+)
+from algorithms.python.multi_llm import LLMConfig  # noqa: E402
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str, *, temperature: float, max_tokens: int, nucleus_p: float) -> str:
+        self.prompts.append(prompt)
+        return json.dumps(
+            {
+                "summary": "Frontend keeper aligned",
+                "actions": ["Ship updated design tokens"],
+            }
+        )
+
+
+def test_frontend_keeper_sync_tracks_surfaces_and_experiments() -> None:
+    keeper = DynamicFrontendKeeperAlgorithm()
+    design_system = FrontendSurface(
+        name="design-system",
+        route="/design-system",
+        description="Core token and component library",
+        owner="DesignOps",
+        status="live",
+        priority=10,
+        components=("theme-provider", "ui-kit"),
+        tags=("core", "shared"),
+    )
+    keeper.register_surface(design_system)
+    keeper.register_dependency("portfolio-dashboard", ("design-system",))
+    keeper.register_experiment("alpha-ui", ("design-system",))
+
+    insights_feed = FrontendSurface(
+        name="insights-feed",
+        route="/insights",
+        description="Market insights stream",
+        owner="Growth",
+        status="offline",
+        priority=6,
+        components=("stream-view",),
+    )
+    portfolio_dashboard = FrontendSurface(
+        name="portfolio-dashboard",
+        route="/portfolio",
+        description="Trader facing performance surface",
+        owner="CoreApps",
+        status="beta",
+        priority=9,
+        components=("portfolio-grid", "pnl-widget"),
+        tags=("portfolio", "pwa"),
+    )
+
+    dummy_client = DummyClient()
+    config = LLMConfig(
+        name="frontend-keeper-gpt",
+        client=dummy_client,
+        temperature=0.2,
+        nucleus_p=0.9,
+        max_tokens=256,
+    )
+
+    as_of = datetime(2024, 5, 1, 12, 45, tzinfo=timezone.utc)
+    result = keeper.sync(
+        as_of=as_of,
+        surfaces=(insights_feed, portfolio_dashboard),
+        dependencies={
+            "portfolio-dashboard": ("design-system", "auth-gateway"),
+            "insights-feed": ("design-system",),
+        },
+        experiments={"new-cta": ("portfolio-dashboard",)},
+        status_overrides={"portfolio-dashboard": "active"},
+        llm_configs=(config,),
+        theme="Frontend alignment",
+        context={"notes": ["Ensure auth-gateway parity"]},
+    )
+
+    assert result.timestamp == as_of
+    assert result.theme == "Frontend alignment"
+    assert len(result.surfaces) == 3
+
+    portfolio_payload = next(surface for surface in result.surfaces if surface["name"] == "portfolio-dashboard")
+    assert portfolio_payload["status"] == "active"
+    assert "portfolio" in portfolio_payload["tags"]
+    assert sorted(portfolio_payload["experiments"]) == ["new-cta"]
+
+    insights_payload = next(surface for surface in result.surfaces if surface["name"] == "insights-feed")
+    assert insights_payload["status"] == "offline"
+
+    dependency_entry = next(dep for dep in result.dependencies if dep["surface"] == "portfolio-dashboard")
+    assert "auth-gateway" in dependency_entry["missing"]
+
+    assert any(risk["issue"] == "missing_dependency" for risk in result.risks)
+    assert any(risk["surface"] == "insights-feed" and risk["issue"] == "status_alert" for risk in result.risks)
+
+    assert result.llm_runs and result.llm_runs[0].name == "frontend-keeper-gpt"
+    assert dummy_client.prompts and dummy_client.prompts[0] == result.metadata["prompt"]
+    assert "Frontend alignment" in result.metadata["prompt"]
+    assert "auth-gateway" in result.metadata["prompt"]
+
+    payload = result.to_dict()
+    assert payload["timestamp"] == as_of.isoformat()
+    assert payload["summary"].startswith("3 surfaces")
+    assert payload["metadata"]["prompt"] == result.metadata["prompt"]
+
+
+def test_frontend_keeper_requires_surfaces() -> None:
+    keeper = DynamicFrontendKeeperAlgorithm()
+    with pytest.raises(ValueError):
+        keeper.sync()


### PR DESCRIPTION
## Summary
- add dedicated frontend and backend keeper orchestrators for tracking surfaces, services, dependencies, and risks
- expose the new orchestrators through the python algorithms package
- cover the new keepers with focused pytest suites validating risk detection and LLM prompt generation

## Testing
- pytest algorithms/python/tests/test_frontend_keeper.py algorithms/python/tests/test_backend_keeper.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b0b54e108322a4debe93c45bd8c4