### PR TITLE
Fix landing navigation rail ARIA semantics

### DIFF
--- a/apps/web/components/landing/HomeNavigationRail.tsx
+++ b/apps/web/components/landing/HomeNavigationRail.tsx
@@ -237,8 +237,6 @@ export function HomeNavigationRail({ className }: { className?: string }) {
               "md:flex-wrap md:justify-center md:overflow-visible md:pb-0",
               "lg:justify-start",
             )}
-            role="tablist"
-            aria-orientation="horizontal"
           >
             {HOME_NAV_SECTIONS.map((section, index) => {
               const Icon = section.icon;
@@ -267,8 +265,6 @@ export function HomeNavigationRail({ className }: { className?: string }) {
                         : "border-border/70 bg-background/60 text-muted-foreground hover:border-primary/40 hover:text-primary",
                     )}
                     aria-current={isActive ? "page" : undefined}
-                    role="tab"
-                    aria-selected={isActive}
                   >
                     <span className="contents">
                       <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-primary sm:h-7 sm:w-7">


### PR DESCRIPTION
## Summary
- remove tab-specific ARIA roles from the landing navigation rail so it uses standard link semantics
- keep the active section announcement via `aria-current` on the anchor elements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b1e403d083229d450d888d3cb3c7