### PR TITLE
Add dynamic skeleton governance and compliance layers

### DIFF
--- a/dynamic_skeleton/__init__.py
+++ b/dynamic_skeleton/__init__.py
@@ -1,0 +1,23 @@
+"""Dynamic Skeleton governance and compliance algorithms."""
+
+from .governance import (
+    AuditLogEntry,
+    DynamicGovernanceAlgo,
+    Proposal,
+    Vote,
+)
+from .compliance import (
+    ComplianceCheck,
+    ComplianceReport,
+    DynamicComplianceAlgo,
+)
+
+__all__ = [
+    "AuditLogEntry",
+    "DynamicGovernanceAlgo",
+    "Proposal",
+    "Vote",
+    "ComplianceCheck",
+    "ComplianceReport",
+    "DynamicComplianceAlgo",
+]

--- a/dynamic_skeleton/compliance.py
+++ b/dynamic_skeleton/compliance.py
@@ -1,0 +1,117 @@
+"""Compliance modeling for the Dynamic Skeleton layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Dict, List, Optional
+
+
+COMPLIANCE_STATUSES = {"pending", "pass", "warn", "fail"}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+@dataclass
+class ComplianceCheck:
+    """Definition of an AML/KYC compliance control."""
+
+    check_id: str
+    name: str
+    description: str
+    status: str = "pending"
+    last_updated: datetime = field(default_factory=_utcnow)
+    notes: List[str] = field(default_factory=list)
+
+    def update(self, status: str, note: Optional[str] = None) -> None:
+        if status not in COMPLIANCE_STATUSES:
+            raise ValueError(f"Unsupported compliance status '{status}'")
+        self.status = status
+        self.last_updated = _utcnow()
+        if note:
+            self.notes.append(note)
+
+
+@dataclass
+class ComplianceReport:
+    """Aggregate view of compliance posture."""
+
+    generated_at: datetime
+    overall_status: str
+    totals: Dict[str, int]
+    checks: List[ComplianceCheck]
+    summary: str
+
+
+class DynamicComplianceAlgo:
+    """Track compliance checks and surface aggregated status."""
+
+    def __init__(self) -> None:
+        self._checks: Dict[str, ComplianceCheck] = {}
+
+    def register_check(self, check_id: str, name: str, description: str) -> ComplianceCheck:
+        if check_id in self._checks:
+            raise ValueError(f"Compliance check '{check_id}' already registered")
+        check = ComplianceCheck(check_id=check_id, name=name, description=description)
+        self._checks[check_id] = check
+        return check
+
+    def update_check(self, check_id: str, status: str, note: Optional[str] = None) -> ComplianceCheck:
+        check = self._get_check_or_raise(check_id)
+        check.update(status, note)
+        return check
+
+    def get_check(self, check_id: str) -> ComplianceCheck:
+        return self._get_check_or_raise(check_id)
+
+    def all_checks(self) -> List[ComplianceCheck]:
+        return list(self._checks.values())
+
+    def status_totals(self) -> Dict[str, int]:
+        totals = {status: 0 for status in COMPLIANCE_STATUSES}
+        for check in self._checks.values():
+            totals[check.status] += 1
+        return totals
+
+    def status_summary(self) -> str:
+        totals = self.status_totals()
+        parts = [f"{status}:{totals[status]}" for status in sorted(totals)]
+        return ", ".join(parts)
+
+    def generate_report(self) -> ComplianceReport:
+        totals = self.status_totals()
+        overall_status = self._derive_overall_status(totals)
+        summary = self._build_summary(overall_status, totals)
+        return ComplianceReport(
+            generated_at=_utcnow(),
+            overall_status=overall_status,
+            totals=totals,
+            checks=self.all_checks(),
+            summary=summary,
+        )
+
+    def _derive_overall_status(self, totals: Dict[str, int]) -> str:
+        if totals.get("fail", 0) > 0:
+            return "fail"
+        if totals.get("warn", 0) > 0:
+            return "warn"
+        if totals.get("pass", 0) == len(self._checks) and self._checks:
+            return "pass"
+        return "pending"
+
+    def _build_summary(self, overall_status: str, totals: Dict[str, int]) -> str:
+        if not self._checks:
+            return "No compliance checks registered"
+        details = ", ".join(
+            f"{status}={count}" for status, count in sorted(totals.items()) if count
+        )
+        if not details:
+            details = "all pending"
+        return f"Overall {overall_status.upper()} ({details})"
+
+    def _get_check_or_raise(self, check_id: str) -> ComplianceCheck:
+        if check_id not in self._checks:
+            raise KeyError(f"Unknown compliance check '{check_id}'")
+        return self._checks[check_id]

--- a/dynamic_skeleton/governance.py
+++ b/dynamic_skeleton/governance.py
@@ -1,0 +1,181 @@
+"""Governance primitives for the Dynamic Skeleton layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Dict, Iterable, List, Optional
+
+
+PROPOSAL_STATUS_DRAFT = "draft"
+PROPOSAL_STATUS_VOTING = "voting"
+PROPOSAL_STATUS_EXECUTED = "executed"
+PROPOSAL_STATUS_REJECTED = "rejected"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+@dataclass
+class Vote:
+    """A weighted vote cast by a stakeholder."""
+
+    voter_id: str
+    support: bool
+    weight: float = 1.0
+    reason: Optional[str] = None
+    timestamp: datetime = field(default_factory=_utcnow)
+
+
+@dataclass
+class Proposal:
+    """Governance proposal tracked through its lifecycle."""
+
+    proposal_id: str
+    title: str
+    description: str
+    quorum: float = 0.0
+    status: str = PROPOSAL_STATUS_DRAFT
+    created_at: datetime = field(default_factory=_utcnow)
+    votes: List[Vote] = field(default_factory=list)
+    executed_at: Optional[datetime] = None
+    rejection_reason: Optional[str] = None
+
+    def record_vote(self, vote: Vote) -> None:
+        self.votes.append(vote)
+
+
+@dataclass
+class AuditLogEntry:
+    """Immutable log entry for governance actions."""
+
+    proposal_id: str
+    action: str
+    actor: str
+    timestamp: datetime = field(default_factory=_utcnow)
+    details: Optional[Dict[str, object]] = None
+
+
+class DynamicGovernanceAlgo:
+    """Manage proposals, votes, and immutable audit records."""
+
+    def __init__(self) -> None:
+        self._proposals: Dict[str, Proposal] = {}
+        self._audit_log: List[AuditLogEntry] = []
+
+    def create_proposal(
+        self,
+        proposal_id: str,
+        title: str,
+        description: str,
+        *,
+        quorum: float = 0.0,
+        actor: str = "system",
+    ) -> Proposal:
+        if proposal_id in self._proposals:
+            raise ValueError(f"Proposal '{proposal_id}' already exists")
+
+        proposal = Proposal(
+            proposal_id=proposal_id,
+            title=title,
+            description=description,
+            quorum=quorum,
+        )
+        self._proposals[proposal_id] = proposal
+        self._record_audit(proposal_id, "created", actor, {"quorum": quorum})
+        return proposal
+
+    def open_voting(self, proposal_id: str, *, actor: str) -> Proposal:
+        proposal = self._get_proposal_or_raise(proposal_id)
+        if proposal.status != PROPOSAL_STATUS_DRAFT:
+            raise ValueError("Only draft proposals can enter voting")
+
+        proposal.status = PROPOSAL_STATUS_VOTING
+        self._record_audit(proposal_id, "opened_voting", actor)
+        return proposal
+
+    def cast_vote(self, proposal_id: str, vote: Vote) -> Proposal:
+        proposal = self._get_proposal_or_raise(proposal_id)
+        if proposal.status != PROPOSAL_STATUS_VOTING:
+            raise ValueError("Voting is not open for this proposal")
+
+        proposal.record_vote(vote)
+        self._record_audit(
+            proposal_id,
+            "vote_cast",
+            vote.voter_id,
+            {
+                "support": vote.support,
+                "weight": vote.weight,
+            },
+        )
+        return proposal
+
+    def tally_votes(self, proposal_id: str) -> Dict[str, float]:
+        proposal = self._get_proposal_or_raise(proposal_id)
+        support_weight = sum(v.weight for v in proposal.votes if v.support)
+        against_weight = sum(v.weight for v in proposal.votes if not v.support)
+        total_weight = support_weight + against_weight
+        return {
+            "support_weight": support_weight,
+            "against_weight": against_weight,
+            "total_weight": total_weight,
+        }
+
+    def finalize(self, proposal_id: str, *, actor: str) -> Proposal:
+        proposal = self._get_proposal_or_raise(proposal_id)
+        if proposal.status != PROPOSAL_STATUS_VOTING:
+            raise ValueError("Only proposals in voting can be finalized")
+
+        totals = self.tally_votes(proposal_id)
+        if totals["total_weight"] < proposal.quorum:
+            proposal.status = PROPOSAL_STATUS_REJECTED
+            proposal.rejection_reason = "quorum_not_met"
+        elif totals["support_weight"] > totals["against_weight"]:
+            proposal.status = PROPOSAL_STATUS_EXECUTED
+            proposal.executed_at = _utcnow()
+        else:
+            proposal.status = PROPOSAL_STATUS_REJECTED
+            proposal.rejection_reason = "vote_failed"
+
+        self._record_audit(
+            proposal_id,
+            "finalized",
+            actor,
+            {
+                "status": proposal.status,
+                "totals": totals,
+                "rejection_reason": proposal.rejection_reason,
+            },
+        )
+        return proposal
+
+    def list_proposals(self) -> Iterable[Proposal]:
+        return self._proposals.values()
+
+    def get_audit_log(self, proposal_id: Optional[str] = None) -> List[AuditLogEntry]:
+        if proposal_id is None:
+            return list(self._audit_log)
+        self._get_proposal_or_raise(proposal_id)
+        return [entry for entry in self._audit_log if entry.proposal_id == proposal_id]
+
+    def _get_proposal_or_raise(self, proposal_id: str) -> Proposal:
+        if proposal_id not in self._proposals:
+            raise KeyError(f"Unknown proposal '{proposal_id}'")
+        return self._proposals[proposal_id]
+
+    def _record_audit(
+        self,
+        proposal_id: str,
+        action: str,
+        actor: str,
+        details: Optional[Dict[str, object]] = None,
+    ) -> None:
+        entry = AuditLogEntry(
+            proposal_id=proposal_id,
+            action=action,
+            actor=actor,
+            details=details,
+        )
+        self._audit_log.append(entry)

--- a/tests/dynamic_skeleton/test_compliance_algo.py
+++ b/tests/dynamic_skeleton/test_compliance_algo.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from dynamic_skeleton.compliance import (  # noqa: E402
+    ComplianceCheck,
+    ComplianceReport,
+    DynamicComplianceAlgo,
+)
+
+
+@pytest.fixture()
+def compliance() -> DynamicComplianceAlgo:
+    return DynamicComplianceAlgo()
+
+
+def test_compliance_register_and_update(compliance: DynamicComplianceAlgo) -> None:
+    onboarding = compliance.register_check("kyc-onboard", "KYC Onboarding", "Verify all new wallets")
+    sanctions = compliance.register_check("sanctions", "Sanctions Screening", "Screen transfers against OFAC")
+
+    assert isinstance(onboarding, ComplianceCheck)
+    assert onboarding.status == "pending"
+
+    compliance.update_check("kyc-onboard", "pass", note="All clear")
+    compliance.update_check("sanctions", "warn", note="One manual review pending")
+
+    totals = compliance.status_totals()
+    assert totals == {"pending": 0, "pass": 1, "warn": 1, "fail": 0}
+
+    summary = compliance.status_summary()
+    assert "pass:1" in summary
+    assert "warn:1" in summary
+
+    report = compliance.generate_report()
+    assert isinstance(report, ComplianceReport)
+    assert report.overall_status == "warn"
+    assert len(report.checks) == 2
+    assert any("manual review" in note for check in report.checks for note in check.notes)
+
+
+def test_compliance_overall_statuses(compliance: DynamicComplianceAlgo) -> None:
+    compliance.register_check("aml-1", "AML", "Monitor transactions")
+
+    report_pending = compliance.generate_report()
+    assert report_pending.overall_status == "pending"
+
+    compliance.update_check("aml-1", "pass")
+    report_pass = compliance.generate_report()
+    assert report_pass.overall_status == "pass"
+
+    compliance.register_check("aml-2", "AML Escalation", "Investigate alerts")
+    compliance.update_check("aml-2", "warn")
+    report_warn = compliance.generate_report()
+    assert report_warn.overall_status == "warn"
+
+    compliance.update_check("aml-2", "fail", note="Escalated to compliance officer")
+    report_fail = compliance.generate_report()
+    assert report_fail.overall_status == "fail"
+    assert "FAIL" in report_fail.summary
+
+    with pytest.raises(KeyError):
+        compliance.update_check("missing", "pass")
+
+    with pytest.raises(ValueError):
+        compliance.update_check("aml-1", "invalid")

--- a/tests/dynamic_skeleton/test_governance_algo.py
+++ b/tests/dynamic_skeleton/test_governance_algo.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from dynamic_skeleton.governance import (  # noqa: E402
+    PROPOSAL_STATUS_DRAFT,
+    PROPOSAL_STATUS_EXECUTED,
+    PROPOSAL_STATUS_REJECTED,
+    AuditLogEntry,
+    DynamicGovernanceAlgo,
+    Vote,
+)
+
+
+@pytest.fixture()
+def governance() -> DynamicGovernanceAlgo:
+    return DynamicGovernanceAlgo()
+
+
+def test_governance_happy_path(governance: DynamicGovernanceAlgo) -> None:
+    proposal = governance.create_proposal(
+        "upgrade-1",
+        "Upgrade consensus",
+        "Introduce zk-proof attestation",
+        quorum=3.0,
+        actor="alice",
+    )
+
+    assert proposal.status == PROPOSAL_STATUS_DRAFT
+
+    governance.open_voting("upgrade-1", actor="bob")
+
+    governance.cast_vote("upgrade-1", Vote(voter_id="alice", support=True, weight=2.0))
+    governance.cast_vote("upgrade-1", Vote(voter_id="carol", support=True, weight=1.5))
+    governance.cast_vote("upgrade-1", Vote(voter_id="dave", support=False, weight=0.5))
+
+    finalized = governance.finalize("upgrade-1", actor="bob")
+
+    assert finalized.status == PROPOSAL_STATUS_EXECUTED
+    assert finalized.executed_at is not None
+
+    totals = governance.tally_votes("upgrade-1")
+    assert totals == {"support_weight": pytest.approx(3.5), "against_weight": pytest.approx(0.5), "total_weight": pytest.approx(4.0)}
+
+    log_entries = governance.get_audit_log("upgrade-1")
+    actions = [entry.action for entry in log_entries]
+    assert actions == ["created", "opened_voting", "vote_cast", "vote_cast", "vote_cast", "finalized"]
+
+    # audit entries should be immutable snapshots
+    for entry in log_entries:
+        assert isinstance(entry, AuditLogEntry)
+        assert isinstance(entry.timestamp, datetime)
+
+
+def test_governance_rejected_on_quorum(governance: DynamicGovernanceAlgo) -> None:
+    governance.create_proposal(
+        "policy-1",
+        "Change fee policy",
+        "Lower transaction fees",
+        quorum=5.0,
+        actor="alice",
+    )
+
+    governance.open_voting("policy-1", actor="alice")
+    governance.cast_vote("policy-1", Vote(voter_id="eve", support=True, weight=2.0))
+
+    finalized = governance.finalize("policy-1", actor="frank")
+
+    assert finalized.status == PROPOSAL_STATUS_REJECTED
+    assert finalized.rejection_reason == "quorum_not_met"
+    assert finalized.executed_at is None
+
+    totals = governance.tally_votes("policy-1")
+    assert totals["total_weight"] == pytest.approx(2.0)
+
+    with pytest.raises(KeyError):
+        governance.get_audit_log("missing")
+
+    all_entries = governance.get_audit_log()
+    assert any(entry.proposal_id == "policy-1" for entry in all_entries)
+
+
+def test_governance_prevents_invalid_transitions(governance: DynamicGovernanceAlgo) -> None:
+    governance.create_proposal("ops-1", "Ops", "", quorum=1.0, actor="alice")
+
+    with pytest.raises(ValueError):
+        governance.finalize("ops-1", actor="alice")
+
+    governance.open_voting("ops-1", actor="bob")
+    governance.cast_vote("ops-1", Vote(voter_id="alice", support=False, weight=1.0))
+
+    finalized = governance.finalize("ops-1", actor="bob")
+
+    assert finalized.status == PROPOSAL_STATUS_REJECTED
+    assert finalized.rejection_reason == "vote_failed"
+
+    with pytest.raises(ValueError):
+        governance.open_voting("ops-1", actor="bob")


### PR DESCRIPTION
## Summary
- add a dynamic_skeleton package that exposes governance and compliance entry points
- implement lifecycle-aware governance with immutable audit logging and compliance aggregation logic
- add pytest coverage for governance transitions, quorum handling, and compliance reporting

## Testing
- pytest tests/dynamic_skeleton

------
https://chatgpt.com/codex/tasks/task_e_68d7b2549dac83228d603afafd423e19