### PR TITLE
Adjust DynamicFusionAlgo human bias overrides

### DIFF
--- a/dynamic_ai/core.py
+++ b/dynamic_ai/core.py
@@ -3,11 +3,40 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import isclose
 from typing import Any, Dict, Iterable, List, Optional
 
 
 VALID_SIGNALS = {"BUY", "SELL", "HOLD", "NEUTRAL"}
+
+ACTION_THRESHOLD = 0.2
+ACTION_TOLERANCE = 1e-6
+
+_ACTION_TO_SCORE = {"BUY": 1.0, "SELL": -1.0}
+
+
+def score_to_action(
+    score: float,
+    *,
+    neutral_action: str = "NEUTRAL",
+    threshold: float = ACTION_THRESHOLD,
+    tolerance: float = ACTION_TOLERANCE,
+) -> str:
+    """Return the discrete action corresponding to a blended ``score``.
+
+    The helper mirrors the tolerances used by the real-time Dynamic Algos so
+    that boundary scores (for example 0.1999999) resolve in the same
+    direction.  A small symmetric ``tolerance`` keeps floating point error from
+    flipping BUY/SELL intents when human overrides blend with automation.
+    """
+
+    upper_threshold = threshold - tolerance
+    lower_threshold = -threshold + tolerance
+
+    if score >= upper_threshold:
+        return "BUY"
+    if score <= lower_threshold:
+        return "SELL"
+    return neutral_action
 
 
 @dataclass
@@ -235,16 +264,8 @@ class DynamicFusionAlgo:
 
     @staticmethod
     def _action_to_score(action: str) -> float:
-        if action == "BUY":
-            return 1.0
-        if action == "SELL":
-            return -1.0
-        return 0.0
+        return _ACTION_TO_SCORE.get(action, 0.0)
 
     @staticmethod
     def _score_to_action(score: float) -> str:
-        if score > 0.2 or isclose(score, 0.2, rel_tol=0.0, abs_tol=1e-6):
-            return "BUY"
-        if score < -0.2 or isclose(score, -0.2, rel_tol=0.0, abs_tol=1e-6):
-            return "SELL"
-        return "NEUTRAL"
+        return score_to_action(score)

--- a/dynamic_ai/fusion.py
+++ b/dynamic_ai/fusion.py
@@ -6,6 +6,8 @@ import math
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Mapping, Protocol, Sequence
 
+from .core import ACTION_THRESHOLD, ACTION_TOLERANCE, score_to_action
+
 
 SignalAction = str
 
@@ -215,8 +217,9 @@ class FusionEngine:
 
     @staticmethod
     def _score_to_action(score: float) -> SignalAction:
-        if score > 0.2:
-            return "BUY"
-        if score < -0.2:
-            return "SELL"
-        return "NEUTRAL"
+        return score_to_action(
+            score,
+            neutral_action="NEUTRAL",
+            threshold=ACTION_THRESHOLD,
+            tolerance=ACTION_TOLERANCE,
+        )

--- a/tests/dynamic_ai/test_dynamic_fusion_algo.py
+++ b/tests/dynamic_ai/test_dynamic_fusion_algo.py
@@ -71,6 +71,21 @@ def test_human_bias_override_when_divergent(algo: DynamicFusionAlgo) -> None:
     assert "adjusted action" in signal.reasoning
 
 
+def test_human_bias_boundary_scores_promote_action(algo: DynamicFusionAlgo) -> None:
+    payload = {
+        "signal": "NEUTRAL",
+        "confidence": 0.55,
+        "volatility": 1.0,
+        "human_bias": "BUY",
+        # Weight yields blended score fractionally under the nominal threshold.
+        "human_weight": 0.1999995,
+    }
+
+    signal = algo.generate_signal(payload)
+
+    assert signal.action == "BUY"
+
+
 def test_news_none_is_treated_as_empty_iterable(algo: DynamicFusionAlgo) -> None:
     payload = {
         "signal": "SELL",


### PR DESCRIPTION
## Summary
- ensure DynamicFusionAlgo honours strong human overrides by tolerating blended scores that land on action boundaries
- use a float tolerance when mapping blended scores back to BUY/SELL actions so near-threshold values resolve deterministically

## Testing
- pytest tests/dynamic_ai/test_dynamic_fusion_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b62e85e483228d2441f2b7467441