### PR TITLE
Add executive analytics algorithms

### DIFF
--- a/dynamic_algo/__init__.py
+++ b/dynamic_algo/__init__.py
@@ -13,6 +13,19 @@ from .middleware import (
     MiddlewareContext,
     MiddlewareExecutionError,
 )
+from .dynamic_ceo import CEOPulse, CEOInitiativeSummary, CEOSnapshot, DynamicCEOAlgo
+from .dynamic_cfo import (
+    CFOSnapshot,
+    DynamicCFOAlgo,
+    FinancialEntry,
+    FinancialPeriodSummary,
+)
+from .dynamic_coo import (
+    DynamicCOOAlgo,
+    OperationalDomainSummary,
+    OperationalSignal,
+    OperationsSnapshot,
+)
 from .dynamic_pool import (
     DynamicPoolAlgo,
     InvestorAllocation,
@@ -56,6 +69,18 @@ __all__ = [
     "DynamicMarketFlow",
     "MarketFlowSnapshot",
     "MarketFlowTrade",
+    "DynamicCEOAlgo",
+    "CEOPulse",
+    "CEOInitiativeSummary",
+    "CEOSnapshot",
+    "DynamicCFOAlgo",
+    "FinancialEntry",
+    "FinancialPeriodSummary",
+    "CFOSnapshot",
+    "DynamicCOOAlgo",
+    "OperationalSignal",
+    "OperationalDomainSummary",
+    "OperationsSnapshot",
     "DynamicMiddlewareAlgo",
     "MiddlewareContext",
     "MiddlewareExecutionError",

--- a/dynamic_algo/dynamic_ceo.py
+++ b/dynamic_algo/dynamic_ceo.py
@@ -1,0 +1,321 @@
+"""Executive alignment analytics for Dynamic Capital's leadership pods.
+
+This module models a lightweight telemetry layer for the office of the CEO.
+Teams can log weighted qualitative and quantitative pulses for strategic
+initiatives, and the algorithm produces normalised snapshots that highlight the
+most resilient focus areas, areas requiring attention, and the current
+leadership momentum trend.  The API mirrors other ``dynamic_algo`` utilities so
+services can plug executive telemetry into dashboards without requiring a
+backend database.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Iterable, Mapping, MutableMapping, Tuple
+
+__all__ = [
+    "CEOPulse",
+    "CEOInitiativeSummary",
+    "CEOSnapshot",
+    "DynamicCEOAlgo",
+]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_timestamp(value: datetime | str | None) -> datetime:
+    if value is None:
+        return _now()
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    raise TypeError("timestamp must be datetime, ISO-8601 string, or None")
+
+
+def _coerce_float(value: object, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_positive(value: object, *, default: float = 1.0) -> float:
+    coerced = _coerce_float(value, default=default)
+    if coerced <= 0:
+        raise ValueError("weight must be positive")
+    return coerced
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_initiative(value: str) -> str:
+    normalised = str(value).strip()
+    if not normalised:
+        raise ValueError("initiative is required")
+    return normalised.lower()
+
+
+def _normalise_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalised = str(value).strip()
+    return normalised or None
+
+
+def _normalise_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guardrail
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+@dataclass(slots=True)
+class CEOPulse:
+    """Weighted qualitative + quantitative signal for an initiative."""
+
+    initiative: str
+    growth_score: float
+    innovation_score: float
+    sentiment_score: float
+    risk_score: float
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_now)
+    note: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.initiative = _normalise_initiative(self.initiative)
+        self.growth_score = _clamp(_coerce_float(self.growth_score))
+        self.innovation_score = _clamp(_coerce_float(self.innovation_score))
+        self.sentiment_score = _clamp(_coerce_float(self.sentiment_score), lower=0.0, upper=1.0)
+        self.risk_score = _clamp(_coerce_float(self.risk_score), lower=0.0, upper=1.0)
+        self.weight = _coerce_positive(self.weight)
+        self.timestamp = _coerce_timestamp(self.timestamp)
+        self.note = _normalise_text(self.note)
+        self.metadata = _normalise_metadata(self.metadata)
+
+    def combined_score(self) -> float:
+        return (self.growth_score + self.innovation_score + self.sentiment_score) / 3.0 - self.risk_score
+
+
+@dataclass(slots=True)
+class CEOInitiativeSummary:
+    """Aggregated executive telemetry for a single initiative."""
+
+    initiative: str
+    sample_count: int
+    total_weight: float
+    average_growth: float
+    average_innovation: float
+    average_sentiment: float
+    average_risk: float
+    momentum: float
+    last_updated: datetime | None
+
+    @property
+    def health_score(self) -> float:
+        return _clamp(
+            (self.average_growth + self.average_innovation + self.average_sentiment) / 3.0 - self.average_risk,
+            lower=0.0,
+            upper=1.0,
+        )
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "initiative": self.initiative,
+            "sample_count": self.sample_count,
+            "total_weight": self.total_weight,
+            "average_growth": self.average_growth,
+            "average_innovation": self.average_innovation,
+            "average_sentiment": self.average_sentiment,
+            "average_risk": self.average_risk,
+            "momentum": self.momentum,
+            "health_score": self.health_score,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+        }
+
+
+@dataclass(slots=True)
+class CEOSnapshot:
+    """Holistic CEO intelligence snapshot."""
+
+    total_initiatives: int
+    total_pulses: int
+    overall_growth: float
+    overall_innovation: float
+    overall_sentiment: float
+    overall_risk: float
+    strategic_health: float
+    dominant_initiative: str | None
+    momentum: float
+    last_updated: datetime | None
+    initiatives: Tuple[CEOInitiativeSummary, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "total_initiatives": self.total_initiatives,
+            "total_pulses": self.total_pulses,
+            "overall_growth": self.overall_growth,
+            "overall_innovation": self.overall_innovation,
+            "overall_sentiment": self.overall_sentiment,
+            "overall_risk": self.overall_risk,
+            "strategic_health": self.strategic_health,
+            "dominant_initiative": self.dominant_initiative,
+            "momentum": self.momentum,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+            "initiatives": [summary.as_dict() for summary in self.initiatives],
+        }
+
+
+class DynamicCEOAlgo:
+    """Maintain rolling CEO telemetry and compute strategic insights."""
+
+    def __init__(
+        self,
+        *,
+        window_size: int | None = 160,
+        window_duration: timedelta | None = timedelta(days=60),
+    ) -> None:
+        self.window_size = window_size if window_size and window_size > 0 else None
+        self.window_duration = window_duration
+        self._pulses: Dict[str, Deque[CEOPulse]] = {}
+
+    # ---------------------------------------------------------------- recording
+    def record_pulse(self, pulse: CEOPulse | Mapping[str, object]) -> CEOPulse:
+        if not isinstance(pulse, CEOPulse):
+            pulse = CEOPulse(**pulse)
+        queue = self._pulses.setdefault(pulse.initiative, self._make_queue())
+        queue.append(pulse)
+        self._purge_old(queue)
+        return pulse
+
+    def ingest(self, pulses: Iterable[CEOPulse | Mapping[str, object]]) -> None:
+        for pulse in pulses:
+            self.record_pulse(pulse)
+
+    # ---------------------------------------------------------------- snapshots
+    def build_snapshot(self, *, now: datetime | None = None) -> CEOSnapshot:
+        now_ts = _coerce_timestamp(now) if now is not None else _now()
+        summaries: list[CEOInitiativeSummary] = []
+        total_weight = 0.0
+        total_growth = 0.0
+        total_innovation = 0.0
+        total_sentiment = 0.0
+        total_risk = 0.0
+        total_pulses = 0
+        weighted_momentum = 0.0
+        last_updated: datetime | None = None
+
+        for initiative, queue in list(self._pulses.items()):
+            self._purge_old(queue, reference=now_ts)
+            if not queue:
+                continue
+            summary = self._summarise_initiative(initiative, queue)
+            summaries.append(summary)
+            total_pulses += summary.sample_count
+            total_weight += summary.total_weight
+            total_growth += summary.average_growth * summary.total_weight
+            total_innovation += summary.average_innovation * summary.total_weight
+            total_sentiment += summary.average_sentiment * summary.total_weight
+            total_risk += summary.average_risk * summary.total_weight
+            weighted_momentum += summary.momentum * summary.total_weight
+            if summary.last_updated and (last_updated is None or summary.last_updated > last_updated):
+                last_updated = summary.last_updated
+
+        overall_growth = total_growth / total_weight if total_weight else 0.0
+        overall_innovation = total_innovation / total_weight if total_weight else 0.0
+        overall_sentiment = total_sentiment / total_weight if total_weight else 0.0
+        overall_risk = total_risk / total_weight if total_weight else 0.0
+        strategic_health = _clamp(
+            (overall_growth + overall_innovation + overall_sentiment) / 3.0 - overall_risk,
+            lower=0.0,
+            upper=1.0,
+        )
+        average_momentum = weighted_momentum / total_weight if total_weight else 0.0
+
+        dominant_initiative = None
+        if summaries:
+            dominant_initiative = max(summaries, key=lambda item: item.health_score).initiative
+
+        summaries.sort(key=lambda summary: summary.health_score, reverse=True)
+
+        return CEOSnapshot(
+            total_initiatives=len(summaries),
+            total_pulses=total_pulses,
+            overall_growth=overall_growth,
+            overall_innovation=overall_innovation,
+            overall_sentiment=overall_sentiment,
+            overall_risk=overall_risk,
+            strategic_health=strategic_health,
+            dominant_initiative=dominant_initiative,
+            momentum=average_momentum,
+            last_updated=last_updated,
+            initiatives=tuple(summaries),
+        )
+
+    # ----------------------------------------------------------------- helpers
+    def _make_queue(self) -> Deque[CEOPulse]:
+        return deque(maxlen=self.window_size)
+
+    def _purge_old(self, queue: Deque[CEOPulse], *, reference: datetime | None = None) -> None:
+        if self.window_duration is None:
+            return
+        reference_ts = reference or _now()
+        threshold = reference_ts - self.window_duration
+        while queue and queue[0].timestamp < threshold:
+            queue.popleft()
+
+    def _summarise_initiative(self, initiative: str, queue: Deque[CEOPulse]) -> CEOInitiativeSummary:
+        pulses = list(queue)
+        sample_count = len(pulses)
+        total_weight = sum(pulse.weight for pulse in pulses)
+        if total_weight <= 0:
+            total_weight = float(sample_count) or 1.0
+        weighted_growth = sum(pulse.growth_score * pulse.weight for pulse in pulses)
+        weighted_innovation = sum(pulse.innovation_score * pulse.weight for pulse in pulses)
+        weighted_sentiment = sum(pulse.sentiment_score * pulse.weight for pulse in pulses)
+        weighted_risk = sum(pulse.risk_score * pulse.weight for pulse in pulses)
+
+        average_growth = weighted_growth / total_weight if total_weight else 0.0
+        average_innovation = weighted_innovation / total_weight if total_weight else 0.0
+        average_sentiment = weighted_sentiment / total_weight if total_weight else 0.0
+        average_risk = weighted_risk / total_weight if total_weight else 0.0
+
+        combined_scores = [pulse.combined_score() for pulse in pulses]
+        if sample_count >= 3:
+            split = max(1, sample_count // 3)
+            early = combined_scores[:split]
+            recent = combined_scores[-split:]
+            momentum = (sum(recent) / len(recent)) - (sum(early) / len(early))
+        elif sample_count == 2:
+            momentum = combined_scores[-1] - combined_scores[0]
+        else:
+            momentum = 0.0
+
+        last_updated = pulses[-1].timestamp if pulses else None
+
+        return CEOInitiativeSummary(
+            initiative=initiative,
+            sample_count=sample_count,
+            total_weight=total_weight,
+            average_growth=average_growth,
+            average_innovation=average_innovation,
+            average_sentiment=average_sentiment,
+            average_risk=average_risk,
+            momentum=momentum,
+            last_updated=last_updated,
+        )

--- a/dynamic_algo/dynamic_cfo.py
+++ b/dynamic_algo/dynamic_cfo.py
@@ -1,0 +1,350 @@
+"""Financial control analytics tailored for Dynamic Capital's CFO pod."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Iterable, Mapping, MutableMapping, Tuple
+
+__all__ = [
+    "FinancialEntry",
+    "FinancialPeriodSummary",
+    "CFOSnapshot",
+    "DynamicCFOAlgo",
+]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_timestamp(value: datetime | str | None) -> datetime:
+    if value is None:
+        return _now()
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    raise TypeError("timestamp must be datetime, ISO-8601 string, or None")
+
+
+def _coerce_float(value: object, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_non_negative(value: object, *, default: float = 0.0) -> float:
+    return max(0.0, _coerce_float(value, default=default))
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_period(value: str) -> str:
+    period = str(value).strip()
+    if not period:
+        raise ValueError("period identifier is required")
+    return period.lower()
+
+
+def _normalise_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guardrail
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+@dataclass(slots=True)
+class FinancialEntry:
+    """Normalised financial telemetry captured from FP&A sources."""
+
+    period: str
+    revenue: float = 0.0
+    cogs: float = 0.0
+    operating_expenses: float = 0.0
+    cash: float = 0.0
+    receivables: float = 0.0
+    payables: float = 0.0
+    debt: float = 0.0
+    equity: float = 0.0
+    timestamp: datetime = field(default_factory=_now)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.period = _normalise_period(self.period)
+        self.revenue = _coerce_non_negative(self.revenue)
+        self.cogs = _coerce_non_negative(self.cogs)
+        self.operating_expenses = _coerce_non_negative(self.operating_expenses)
+        self.cash = _coerce_non_negative(self.cash)
+        self.receivables = _coerce_non_negative(self.receivables)
+        self.payables = _coerce_non_negative(self.payables)
+        self.debt = _coerce_non_negative(self.debt)
+        self.equity = _coerce_non_negative(self.equity)
+        self.timestamp = _coerce_timestamp(self.timestamp)
+        self.metadata = _normalise_metadata(self.metadata)
+
+    @property
+    def total_expenses(self) -> float:
+        return self.cogs + self.operating_expenses
+
+    @property
+    def gross_profit(self) -> float:
+        return max(0.0, self.revenue - self.cogs)
+
+    @property
+    def operating_income(self) -> float:
+        return self.revenue - self.total_expenses
+
+    @property
+    def burn_rate(self) -> float:
+        return max(0.0, self.total_expenses - self.revenue)
+
+
+@dataclass(slots=True)
+class FinancialPeriodSummary:
+    """Aggregated financial metrics for a reporting period."""
+
+    period: str
+    sample_count: int
+    revenue: float
+    cogs: float
+    operating_expenses: float
+    cash: float
+    receivables: float
+    payables: float
+    debt: float
+    equity: float
+    gross_profit: float
+    operating_income: float
+    burn_rate: float
+    liquidity_ratio: float | None
+    debt_to_equity: float | None
+    runway_months: float | None
+    last_updated: datetime | None
+
+    @property
+    def gross_margin(self) -> float:
+        if self.revenue <= 0:
+            return 0.0
+        return self.gross_profit / self.revenue
+
+    @property
+    def operating_margin(self) -> float:
+        if self.revenue <= 0:
+            return 0.0
+        return self.operating_income / self.revenue
+
+    @property
+    def health_score(self) -> float:
+        liquidity = _clamp((self.liquidity_ratio or 0.0) / 2.0)
+        solvency = _clamp(1.0 / (1.0 + (self.debt_to_equity or 0.0)))
+        margin = _clamp((self.operating_margin + 1.0) / 2.0)
+        burn_penalty = _clamp(self.burn_rate / max(self.revenue, 1.0))
+        return _clamp((liquidity + solvency + margin) / 3.0 - burn_penalty / 2.0)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "period": self.period,
+            "sample_count": self.sample_count,
+            "revenue": self.revenue,
+            "cogs": self.cogs,
+            "operating_expenses": self.operating_expenses,
+            "cash": self.cash,
+            "receivables": self.receivables,
+            "payables": self.payables,
+            "debt": self.debt,
+            "equity": self.equity,
+            "gross_profit": self.gross_profit,
+            "operating_income": self.operating_income,
+            "burn_rate": self.burn_rate,
+            "gross_margin": self.gross_margin,
+            "operating_margin": self.operating_margin,
+            "liquidity_ratio": self.liquidity_ratio,
+            "debt_to_equity": self.debt_to_equity,
+            "runway_months": self.runway_months,
+            "health_score": self.health_score,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+        }
+
+
+@dataclass(slots=True)
+class CFOSnapshot:
+    """Organisation-wide financial stability snapshot."""
+
+    total_periods: int
+    total_samples: int
+    total_revenue: float
+    total_expenses: float
+    overall_gross_margin: float
+    overall_operating_margin: float
+    average_burn_rate: float
+    liquidity_score: float
+    solvency_score: float
+    risk_level: str
+    last_updated: datetime | None
+    periods: Tuple[FinancialPeriodSummary, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "total_periods": self.total_periods,
+            "total_samples": self.total_samples,
+            "total_revenue": self.total_revenue,
+            "total_expenses": self.total_expenses,
+            "overall_gross_margin": self.overall_gross_margin,
+            "overall_operating_margin": self.overall_operating_margin,
+            "average_burn_rate": self.average_burn_rate,
+            "liquidity_score": self.liquidity_score,
+            "solvency_score": self.solvency_score,
+            "risk_level": self.risk_level,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+            "periods": [summary.as_dict() for summary in self.periods],
+        }
+
+
+class DynamicCFOAlgo:
+    """Maintain rolling FP&A telemetry and compute treasury insights."""
+
+    def __init__(
+        self,
+        *,
+        window_size: int | None = 24,
+        window_duration: timedelta | None = timedelta(days=540),
+    ) -> None:
+        self.window_size = window_size if window_size and window_size > 0 else None
+        self.window_duration = window_duration
+        self._entries: Dict[str, Deque[FinancialEntry]] = {}
+
+    # ---------------------------------------------------------------- recording
+    def record_entry(self, entry: FinancialEntry | Mapping[str, object]) -> FinancialEntry:
+        if not isinstance(entry, FinancialEntry):
+            entry = FinancialEntry(**entry)
+        queue = self._entries.setdefault(entry.period, self._make_queue())
+        queue.append(entry)
+        self._purge_old(queue)
+        return entry
+
+    def ingest(self, entries: Iterable[FinancialEntry | Mapping[str, object]]) -> None:
+        for entry in entries:
+            self.record_entry(entry)
+
+    # ---------------------------------------------------------------- snapshots
+    def build_snapshot(self, *, now: datetime | None = None) -> CFOSnapshot:
+        now_ts = _coerce_timestamp(now) if now is not None else _now()
+        summaries: list[FinancialPeriodSummary] = []
+        total_revenue = 0.0
+        total_expenses = 0.0
+        total_gross_profit = 0.0
+        total_operating_income = 0.0
+        total_burn = 0.0
+        total_samples = 0
+        liquidity_scores: list[float] = []
+        solvency_scores: list[float] = []
+        last_updated: datetime | None = None
+
+        for period, queue in list(self._entries.items()):
+            self._purge_old(queue, reference=now_ts)
+            if not queue:
+                continue
+            summary = self._summarise_period(period, queue)
+            summaries.append(summary)
+            total_revenue += summary.revenue
+            total_expenses += summary.cogs + summary.operating_expenses
+            total_gross_profit += summary.gross_profit
+            total_operating_income += summary.operating_income
+            total_burn += summary.burn_rate
+            total_samples += summary.sample_count
+            liquidity_scores.append(_clamp((summary.liquidity_ratio or 0.0) / 2.0))
+            solvency_scores.append(_clamp(1.0 / (1.0 + (summary.debt_to_equity or 0.0))))
+            if summary.last_updated and (last_updated is None or summary.last_updated > last_updated):
+                last_updated = summary.last_updated
+
+        overall_gross_margin = total_gross_profit / total_revenue if total_revenue else 0.0
+        overall_operating_margin = total_operating_income / total_revenue if total_revenue else 0.0
+        average_burn_rate = total_burn / len(summaries) if summaries else 0.0
+        liquidity_score = sum(liquidity_scores) / len(liquidity_scores) if liquidity_scores else 0.0
+        solvency_score = sum(solvency_scores) / len(solvency_scores) if solvency_scores else 0.0
+
+        if liquidity_score >= 0.75 and solvency_score >= 0.75 and average_burn_rate <= 0.05 * max(total_revenue, 1.0):
+            risk_level = "LOW"
+        elif liquidity_score >= 0.5 and solvency_score >= 0.5:
+            risk_level = "MEDIUM"
+        else:
+            risk_level = "HIGH"
+
+        summaries.sort(key=lambda item: item.period)
+
+        return CFOSnapshot(
+            total_periods=len(summaries),
+            total_samples=total_samples,
+            total_revenue=total_revenue,
+            total_expenses=total_expenses,
+            overall_gross_margin=overall_gross_margin,
+            overall_operating_margin=overall_operating_margin,
+            average_burn_rate=average_burn_rate,
+            liquidity_score=liquidity_score,
+            solvency_score=solvency_score,
+            risk_level=risk_level,
+            last_updated=last_updated,
+            periods=tuple(summaries),
+        )
+
+    # ----------------------------------------------------------------- helpers
+    def _make_queue(self) -> Deque[FinancialEntry]:
+        return deque(maxlen=self.window_size)
+
+    def _purge_old(self, queue: Deque[FinancialEntry], *, reference: datetime | None = None) -> None:
+        if self.window_duration is None:
+            return
+        reference_ts = reference or _now()
+        threshold = reference_ts - self.window_duration
+        while queue and queue[0].timestamp < threshold:
+            queue.popleft()
+
+    def _summarise_period(self, period: str, queue: Deque[FinancialEntry]) -> FinancialPeriodSummary:
+        entries = list(queue)
+        sample_count = len(entries)
+        total_revenue = sum(entry.revenue for entry in entries)
+        total_cogs = sum(entry.cogs for entry in entries)
+        total_operating = sum(entry.operating_expenses for entry in entries)
+        cash = sum(entry.cash for entry in entries) / sample_count if sample_count else 0.0
+        receivables = sum(entry.receivables for entry in entries) / sample_count if sample_count else 0.0
+        payables = sum(entry.payables for entry in entries) / sample_count if sample_count else 0.0
+        debt = sum(entry.debt for entry in entries) / sample_count if sample_count else 0.0
+        equity = sum(entry.equity for entry in entries) / sample_count if sample_count else 0.0
+        gross_profit = max(0.0, total_revenue - total_cogs)
+        operating_income = total_revenue - (total_cogs + total_operating)
+        burn_rate = max(0.0, (total_cogs + total_operating) - total_revenue)
+        liquidity_ratio = ((cash + receivables) / payables) if payables > 0 else None
+        debt_to_equity = (debt / equity) if equity > 0 else None
+        runway_months = (cash / burn_rate) if burn_rate > 0 else None
+        last_updated = entries[-1].timestamp if entries else None
+
+        return FinancialPeriodSummary(
+            period=period,
+            sample_count=sample_count,
+            revenue=total_revenue,
+            cogs=total_cogs,
+            operating_expenses=total_operating,
+            cash=cash,
+            receivables=receivables,
+            payables=payables,
+            debt=debt,
+            equity=equity,
+            gross_profit=gross_profit,
+            operating_income=operating_income,
+            burn_rate=burn_rate,
+            liquidity_ratio=liquidity_ratio,
+            debt_to_equity=debt_to_equity,
+            runway_months=runway_months,
+            last_updated=last_updated,
+        )

--- a/dynamic_algo/dynamic_coo.py
+++ b/dynamic_algo/dynamic_coo.py
@@ -1,0 +1,336 @@
+"""Operational excellence analytics for Dynamic Capital's COO office."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Iterable, Mapping, MutableMapping, Tuple
+
+__all__ = [
+    "OperationalSignal",
+    "OperationalDomainSummary",
+    "OperationsSnapshot",
+    "DynamicCOOAlgo",
+]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_timestamp(value: datetime | str | None) -> datetime:
+    if value is None:
+        return _now()
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    raise TypeError("timestamp must be datetime, ISO-8601 string, or None")
+
+
+def _coerce_float(value: object, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_positive(value: object, *, default: float = 1.0) -> float:
+    coerced = _coerce_float(value, default=default)
+    if coerced <= 0:
+        raise ValueError("weight must be positive")
+    return coerced
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_domain(value: str) -> str:
+    domain = str(value).strip()
+    if not domain:
+        raise ValueError("domain identifier is required")
+    return domain.lower()
+
+
+def _normalise_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalised = str(value).strip()
+    return normalised or None
+
+
+def _normalise_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guardrail
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+@dataclass(slots=True)
+class OperationalSignal:
+    """Normalised operational telemetry from squads and runbooks."""
+
+    domain: str
+    throughput_per_day: float
+    cycle_time_hours: float
+    on_time_rate: float
+    quality_score: float
+    incident_count: int
+    customer_impact: float
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_now)
+    note: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.domain = _normalise_domain(self.domain)
+        self.throughput_per_day = max(0.0, _coerce_float(self.throughput_per_day))
+        self.cycle_time_hours = max(0.0, _coerce_float(self.cycle_time_hours, default=0.0))
+        self.on_time_rate = _clamp(_coerce_float(self.on_time_rate))
+        self.quality_score = _clamp(_coerce_float(self.quality_score))
+        self.incident_count = int(max(0.0, _coerce_float(self.incident_count)))
+        self.customer_impact = _clamp(_coerce_float(self.customer_impact))
+        self.weight = _coerce_positive(self.weight)
+        self.timestamp = _coerce_timestamp(self.timestamp)
+        self.note = _normalise_text(self.note)
+        self.metadata = _normalise_metadata(self.metadata)
+
+    @property
+    def efficiency_score(self) -> float:
+        return _clamp((self.throughput_per_day / max(self.cycle_time_hours or 1.0, 1.0)) / 10.0)
+
+    @property
+    def stability_score(self) -> float:
+        incident_penalty = _clamp(self.incident_count / 10.0)
+        impact_penalty = self.customer_impact
+        return _clamp((self.on_time_rate + self.quality_score) / 2.0 - (incident_penalty + impact_penalty) / 2.0)
+
+
+@dataclass(slots=True)
+class OperationalDomainSummary:
+    """Aggregated metrics for an operational domain."""
+
+    domain: str
+    sample_count: int
+    total_weight: float
+    average_throughput: float
+    average_cycle_time: float
+    average_on_time_rate: float
+    average_quality_score: float
+    incident_rate: float
+    average_customer_impact: float
+    efficiency_index: float
+    stability_index: float
+    last_updated: datetime | None
+
+    @property
+    def health_index(self) -> float:
+        return _clamp((self.efficiency_index + self.stability_index) / 2.0)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "domain": self.domain,
+            "sample_count": self.sample_count,
+            "total_weight": self.total_weight,
+            "average_throughput": self.average_throughput,
+            "average_cycle_time": self.average_cycle_time,
+            "average_on_time_rate": self.average_on_time_rate,
+            "average_quality_score": self.average_quality_score,
+            "incident_rate": self.incident_rate,
+            "average_customer_impact": self.average_customer_impact,
+            "efficiency_index": self.efficiency_index,
+            "stability_index": self.stability_index,
+            "health_index": self.health_index,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+        }
+
+
+@dataclass(slots=True)
+class OperationsSnapshot:
+    """Executive-ready snapshot of operational performance."""
+
+    total_domains: int
+    total_samples: int
+    average_throughput: float
+    average_cycle_time: float
+    average_on_time_rate: float
+    average_quality_score: float
+    incident_rate: float
+    average_customer_impact: float
+    efficiency_index: float
+    stability_index: float
+    dominant_domain: str | None
+    last_updated: datetime | None
+    domains: Tuple[OperationalDomainSummary, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "total_domains": self.total_domains,
+            "total_samples": self.total_samples,
+            "average_throughput": self.average_throughput,
+            "average_cycle_time": self.average_cycle_time,
+            "average_on_time_rate": self.average_on_time_rate,
+            "average_quality_score": self.average_quality_score,
+            "incident_rate": self.incident_rate,
+            "average_customer_impact": self.average_customer_impact,
+            "efficiency_index": self.efficiency_index,
+            "stability_index": self.stability_index,
+            "dominant_domain": self.dominant_domain,
+            "last_updated": self.last_updated.isoformat() if self.last_updated else None,
+            "domains": [summary.as_dict() for summary in self.domains],
+        }
+
+
+class DynamicCOOAlgo:
+    """Maintain rolling operational telemetry and derive focus areas."""
+
+    def __init__(
+        self,
+        *,
+        window_size: int | None = 180,
+        window_duration: timedelta | None = timedelta(days=120),
+    ) -> None:
+        self.window_size = window_size if window_size and window_size > 0 else None
+        self.window_duration = window_duration
+        self._signals: Dict[str, Deque[OperationalSignal]] = {}
+
+    # ---------------------------------------------------------------- recording
+    def record_signal(self, signal: OperationalSignal | Mapping[str, object]) -> OperationalSignal:
+        if not isinstance(signal, OperationalSignal):
+            signal = OperationalSignal(**signal)
+        queue = self._signals.setdefault(signal.domain, self._make_queue())
+        queue.append(signal)
+        self._purge_old(queue)
+        return signal
+
+    def ingest(self, signals: Iterable[OperationalSignal | Mapping[str, object]]) -> None:
+        for signal in signals:
+            self.record_signal(signal)
+
+    # ---------------------------------------------------------------- snapshots
+    def build_snapshot(self, *, now: datetime | None = None) -> OperationsSnapshot:
+        now_ts = _coerce_timestamp(now) if now is not None else _now()
+        summaries: list[OperationalDomainSummary] = []
+        total_weight = 0.0
+        total_throughput = 0.0
+        total_cycle_time = 0.0
+        total_on_time = 0.0
+        total_quality = 0.0
+        total_incidents = 0.0
+        total_impact = 0.0
+        total_samples = 0
+        weighted_efficiency = 0.0
+        weighted_stability = 0.0
+        last_updated: datetime | None = None
+
+        for domain, queue in list(self._signals.items()):
+            self._purge_old(queue, reference=now_ts)
+            if not queue:
+                continue
+            summary = self._summarise_domain(domain, queue)
+            summaries.append(summary)
+            total_samples += summary.sample_count
+            total_weight += summary.total_weight
+            total_throughput += summary.average_throughput * summary.total_weight
+            total_cycle_time += summary.average_cycle_time * summary.total_weight
+            total_on_time += summary.average_on_time_rate * summary.total_weight
+            total_quality += summary.average_quality_score * summary.total_weight
+            total_incidents += summary.incident_rate * summary.total_weight
+            total_impact += summary.average_customer_impact * summary.total_weight
+            weighted_efficiency += summary.efficiency_index * summary.total_weight
+            weighted_stability += summary.stability_index * summary.total_weight
+            if summary.last_updated and (last_updated is None or summary.last_updated > last_updated):
+                last_updated = summary.last_updated
+
+        average_throughput = total_throughput / total_weight if total_weight else 0.0
+        average_cycle_time = total_cycle_time / total_weight if total_weight else 0.0
+        average_on_time = total_on_time / total_weight if total_weight else 0.0
+        average_quality = total_quality / total_weight if total_weight else 0.0
+        incident_rate = total_incidents / total_weight if total_weight else 0.0
+        average_impact = total_impact / total_weight if total_weight else 0.0
+        efficiency_index = weighted_efficiency / total_weight if total_weight else 0.0
+        stability_index = weighted_stability / total_weight if total_weight else 0.0
+
+        dominant_domain = None
+        if summaries:
+            dominant_domain = max(summaries, key=lambda item: item.health_index).domain
+
+        summaries.sort(key=lambda item: item.health_index, reverse=True)
+
+        return OperationsSnapshot(
+            total_domains=len(summaries),
+            total_samples=total_samples,
+            average_throughput=average_throughput,
+            average_cycle_time=average_cycle_time,
+            average_on_time_rate=average_on_time,
+            average_quality_score=average_quality,
+            incident_rate=incident_rate,
+            average_customer_impact=average_impact,
+            efficiency_index=efficiency_index,
+            stability_index=stability_index,
+            dominant_domain=dominant_domain,
+            last_updated=last_updated,
+            domains=tuple(summaries),
+        )
+
+    # ----------------------------------------------------------------- helpers
+    def _make_queue(self) -> Deque[OperationalSignal]:
+        return deque(maxlen=self.window_size)
+
+    def _purge_old(self, queue: Deque[OperationalSignal], *, reference: datetime | None = None) -> None:
+        if self.window_duration is None:
+            return
+        reference_ts = reference or _now()
+        threshold = reference_ts - self.window_duration
+        while queue and queue[0].timestamp < threshold:
+            queue.popleft()
+
+    def _summarise_domain(self, domain: str, queue: Deque[OperationalSignal]) -> OperationalDomainSummary:
+        signals = list(queue)
+        sample_count = len(signals)
+        total_weight = sum(signal.weight for signal in signals)
+        if total_weight <= 0:
+            total_weight = float(sample_count) or 1.0
+
+        weighted_throughput = sum(signal.throughput_per_day * signal.weight for signal in signals)
+        weighted_cycle_time = sum(signal.cycle_time_hours * signal.weight for signal in signals)
+        weighted_on_time = sum(signal.on_time_rate * signal.weight for signal in signals)
+        weighted_quality = sum(signal.quality_score * signal.weight for signal in signals)
+        weighted_incidents = sum(signal.incident_count * signal.weight for signal in signals)
+        weighted_impact = sum(signal.customer_impact * signal.weight for signal in signals)
+        weighted_efficiency = sum(signal.efficiency_score * signal.weight for signal in signals)
+        weighted_stability = sum(signal.stability_score * signal.weight for signal in signals)
+
+        average_throughput = weighted_throughput / total_weight if total_weight else 0.0
+        average_cycle_time = weighted_cycle_time / total_weight if total_weight else 0.0
+        average_on_time = weighted_on_time / total_weight if total_weight else 0.0
+        average_quality = weighted_quality / total_weight if total_weight else 0.0
+        incident_rate = weighted_incidents / total_weight if total_weight else 0.0
+        average_impact = weighted_impact / total_weight if total_weight else 0.0
+        efficiency_index = weighted_efficiency / total_weight if total_weight else 0.0
+        stability_index = weighted_stability / total_weight if total_weight else 0.0
+
+        last_updated = signals[-1].timestamp if signals else None
+
+        return OperationalDomainSummary(
+            domain=domain,
+            sample_count=sample_count,
+            total_weight=total_weight,
+            average_throughput=average_throughput,
+            average_cycle_time=average_cycle_time,
+            average_on_time_rate=average_on_time,
+            average_quality_score=average_quality,
+            incident_rate=incident_rate,
+            average_customer_impact=average_impact,
+            efficiency_index=efficiency_index,
+            stability_index=stability_index,
+            last_updated=last_updated,
+        )


### PR DESCRIPTION
## Summary
- add executive telemetry models and the `DynamicCEOAlgo` for leadership health snapshots
- implement finance and operations analytics through new `DynamicCFOAlgo` and `DynamicCOOAlgo`
- expose the new executive algorithms via `dynamic_algo.__init__`

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7b606333c83229e42b6a8f561cd33