### PR TITLE
Wrap admin page content in a fragment

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from "react";
+
 import { Column, Heading, Text } from "@/components/dynamic-ui-system";
 
 import { AdminGate } from "@/components/admin/AdminGate";
@@ -5,22 +7,36 @@ import { AdminDashboard } from "@/components/admin/AdminDashboard";
 
 export const metadata = {
   title: "Admin Dashboard – Dynamic Capital",
-  description: "Monitor VIP members, payments, and bot health from the Dynamic Capital control room.",
+  description:
+    "Monitor VIP members, payments, and bot health from the Dynamic Capital control room.",
 };
 
 export default function AdminPage() {
   return (
     <AdminGate>
-      <Column gap="24" paddingY="32" align="center" horizontal="center" fillWidth>
-        <Column maxWidth={28} gap="12" align="center" horizontal="center">
-          <Heading variant="display-strong-s" align="center">
-            Admin control room
-          </Heading>
-          <Text variant="body-default-m" onBackground="neutral-weak" align="center">
-            Review payments, manage VIP seats, and operate the Telegram bot infrastructure.
-          </Text>
-        </Column>
-        <AdminDashboard />
+      <Column
+        gap="24"
+        paddingY="32"
+        align="center"
+        horizontal="center"
+        fillWidth
+      >
+        <Fragment>
+          <Column maxWidth={28} gap="12" align="center" horizontal="center">
+            <Heading variant="display-strong-s" align="center">
+              Admin control room
+            </Heading>
+            <Text
+              variant="body-default-m"
+              onBackground="neutral-weak"
+              align="center"
+            >
+              Review payments, manage VIP seats, and operate the Telegram bot
+              infrastructure.
+            </Text>
+          </Column>
+          <AdminDashboard />
+        </Fragment>
       </Column>
     </AdminGate>
   );


### PR DESCRIPTION
## Summary
- wrap the admin page layout content in a React fragment so the Column receives a single child
- add the Fragment import needed for the new wrapper

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7b8a74f6c8322b66ecfdae634656a