### PR TITLE
Add Dynamic Capital Code of Conduct documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ documenting which assets were consulted.
 | 1.10 | [INVENTORY.csv](./INVENTORY.csv)                                               | CSV export that tracks documentation counts, line totals, and repo metrics.                                                |
 | 1.11 | [CHANGELOG.md](./CHANGELOG.md)                                                 | Chronological release notes maintained by the release automation.                                                          |
 | 1.12 | [dynamic-capital-ecosystem-anatomy.md](./dynamic-capital-ecosystem-anatomy.md) | Biological metaphor guide detailing how every subsystem, feedback loop, and TradingView bridge maps to automation pillars. |
+| 1.13 | [dynamic-capital-code-of-conduct.md](./dynamic-capital-code-of-conduct.md)     | Community behavior expectations, reporting paths, and enforcement process.                                                 |
 
 ## 2. Development Workflow & Standards
 
@@ -141,16 +142,16 @@ documenting which assets were consulted.
 
 ## 9. Checklists & Automation
 
-| Ref | Document                                                                           | Summary                                                                   |
-| --- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| 9.1 | [CHECKLISTS.md](./CHECKLISTS.md)                                                   | Master directory of automation-aware checklists with priority guidance.   |
-| 9.2 | [dynamic-capital-checklist.md](./dynamic-capital-checklist.md)                     | Umbrella repo health tracker covering setup, automation, and QA.          |
-| 9.3 | [coding-efficiency-checklist.md](./coding-efficiency-checklist.md)                 | Repeatable template for feature delivery hygiene.                         |
-| 9.4 | [git-branch-organization-checklist.md](./git-branch-organization-checklist.md)     | Steps for aligning Git branches with deployable services.                 |
-| 9.5 | [dynamic-ui-development-checklist.md](./dynamic-ui-development-checklist.md)       | Checklist for Dynamic UI powered surfaces (landing, dashboard, Mini App). |
-| 9.6 | [VARIABLES_AND_LINKS_CHECKLIST.md](./VARIABLES_AND_LINKS_CHECKLIST.md)             | Environment variable and outbound link audit.                             |
-| 9.7 | [dynamic_codex_integration_checklist.md](./dynamic_codex_integration_checklist.md) | Historic plan for folding Dynamic Codex into the monorepo.                |
-| 9.8 | [project-updater.md](./project-updater.md)                                         | Automation suite that regenerates release docs and project metadata.      |
+| Ref | Document                                                                           | Summary                                                                     |
+| --- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 9.1 | [CHECKLISTS.md](./CHECKLISTS.md)                                                   | Master directory of automation-aware checklists with priority guidance.     |
+| 9.2 | [dynamic-capital-checklist.md](./dynamic-capital-checklist.md)                     | Umbrella repo health tracker covering setup, automation, and QA.            |
+| 9.3 | [coding-efficiency-checklist.md](./coding-efficiency-checklist.md)                 | Repeatable template for feature delivery hygiene.                           |
+| 9.4 | [git-branch-organization-checklist.md](./git-branch-organization-checklist.md)     | Steps for aligning Git branches with deployable services.                   |
+| 9.5 | [dynamic-ui-development-checklist.md](./dynamic-ui-development-checklist.md)       | Checklist for Dynamic UI powered surfaces (landing, dashboard, Mini App).   |
+| 9.6 | [VARIABLES_AND_LINKS_CHECKLIST.md](./VARIABLES_AND_LINKS_CHECKLIST.md)             | Environment variable and outbound link audit.                               |
+| 9.7 | [dynamic_codex_integration_checklist.md](./dynamic_codex_integration_checklist.md) | Historic plan for folding Dynamic Codex into the monorepo.                  |
+| 9.8 | [project-updater.md](./project-updater.md)                                         | Automation suite that regenerates release docs and project metadata.        |
 | 9.9 | [whitepaper-pipeline.md](./whitepaper-pipeline.md)                                 | Workflow for generating whitepapers from JSON configs and review checklist. |
 
 ## 10. Reference, Content & Growth

--- a/docs/dynamic-capital-code-of-conduct.md
+++ b/docs/dynamic-capital-code-of-conduct.md
@@ -1,0 +1,132 @@
+# Dynamic Capital Code of Conduct
+
+The Dynamic Capital community thrives when every contributor, partner, and
+customer feels safe, respected, and empowered to share ideas. This Code of
+Conduct sets shared expectations for how we collaborate across repositories,
+chat channels, trading desks, and live events. By participating in any Dynamic
+Capital program you agree to uphold these standards and to support others in
+doing the same.
+
+## Scope
+
+This policy applies to all Dynamic Capital spaces, including but not limited to:
+
+- Git repositories, pull requests, and issue trackers within the Dynamic Capital
+  organization.
+- Real-time conversations across Telegram, Discord, Slack, and voice or video
+  calls.
+- Internal documentation, dashboards, analytics surfaces, and operations
+  consoles.
+- In-person meetings, hackathons, conferences, or field work conducted under
+  Dynamic Capital branding.
+- Third-party venues (e.g., partner communities, service desks) when
+  representing Dynamic Capital or using company resources.
+
+## Core Principles
+
+We anchor our collaboration on the following values:
+
+1. **Integrity** – Act honestly, document decisions transparently, and disclose
+   conflicts of interest.
+2. **Respect** – Value people and ideas, especially across cultures, time zones,
+   and seniority levels.
+3. **Accountability** – Own your commitments, deliver on timelines, and
+   communicate risks early.
+4. **Security First** – Protect sensitive data, follow the documented security
+   checklists, and raise incidents immediately.
+5. **Continuous Learning** – Share knowledge, mentor teammates, and remain open
+   to feedback.
+
+## Expected Behavior
+
+All participants are expected to:
+
+- Follow published runbooks, checklists, and guardrails that secure customer
+  trust.
+- Use inclusive language and ensure communication is clear, constructive, and
+  professional.
+- Default to transparency: document decisions, cite data sources, and capture
+  system changes in the appropriate logs.
+- Respect boundaries around working hours, response times, and escalation paths.
+- Seek consent before recording meetings, screen sharing, or posting private
+  information.
+- Support teammates who raise questions or concerns, and offer mentorship when
+  gaps are identified.
+- Credit the contributions of others and ask for permission before reusing
+  proprietary assets.
+- Practice good digital hygiene: lock devices, rotate credentials per policy,
+  and report phishing or suspicious behavior.
+
+## Unacceptable Behavior
+
+Dynamic Capital has zero tolerance for:
+
+- Harassment, intimidation, discrimination, or disrespectful conduct targeting
+  individuals or groups.
+- Sharing confidential, regulated, or customer-identifiable data outside
+  authorized channels.
+- Manipulating markets, falsifying results, or misrepresenting trading
+  performance.
+- Bypassing security controls, ignoring access boundaries, or exploiting
+  vulnerabilities without proper disclosure.
+- Retaliation against anyone who reports misconduct, vulnerabilities, or policy
+  violations in good faith.
+- Insubordination, sabotage, or deliberate disruption of services, tools, or
+  operations.
+
+## Reporting an Issue
+
+If you experience or witness behavior that violates this Code of Conduct:
+
+1. Document what happened (dates, participants, screenshots, logs) while
+   respecting confidentiality.
+2. Notify the Code of Conduct committee via the private security channel or the
+   `security@dynamiccapital.ai` mailbox.
+3. For urgent safety issues, escalate immediately through the on-call escalation
+   tree or call emergency services as appropriate.
+4. If the incident involves a committee member, contact the designated
+   ombudsperson listed in the security escalation matrix.
+
+Reports are reviewed within one business day. You will receive confirmation of
+receipt, a summary of next steps, and a follow-up timeline. All reports are
+handled discreetly; details are shared only with those who need to know.
+
+## Investigation & Enforcement
+
+The Code of Conduct committee, in partnership with legal and security leads, may
+take any of the following actions based on the severity and context of a
+violation:
+
+- Coaching or facilitated conversations to restore trust and clarify
+  expectations.
+- Written warnings and remediation plans with clear deadlines.
+- Temporary or permanent revocation of repository, infrastructure, or
+  communication access.
+- Suspension or termination of employment, contracts, or contributor agreements.
+- Escalation to law enforcement or regulators when required by law or
+  contractual obligations.
+
+All actions are documented for audit purposes. Appeals can be submitted to the
+ombudsperson within 10 business days of receiving an enforcement decision.
+
+## Protection from Retaliation
+
+Dynamic Capital prohibits retaliation against anyone who reports an issue,
+participates in an investigation, or provides witness testimony. Retaliatory
+actions—including demotions, assignment changes, exclusion from meetings, or
+negative performance reviews—will be treated as independent violations with
+separate disciplinary consequences.
+
+## Continuous Improvement
+
+The Code of Conduct is reviewed quarterly or after any major incident. Feedback
+is welcome via the documentation issue tracker or direct outreach to the
+committee. Updates are communicated through release notes, internal broadcasts,
+and the documentation changelog.
+
+## Acknowledgment
+
+Participation in Dynamic Capital projects, programs, and events constitutes
+acknowledgment of this Code of Conduct. Team leads are responsible for ensuring
+new contributors read and agree to the policy during onboarding, and for
+refreshing awareness during recurring security and compliance training.


### PR DESCRIPTION
## Summary
- add a dedicated Dynamic Capital Code of Conduct outlining expectations, reporting, and enforcement
- link the new policy from the documentation index and normalize the affected table formatting

## Testing
- node_modules/.bin/deno fmt docs/dynamic-capital-code-of-conduct.md docs/README.md

------
https://chatgpt.com/codex/tasks/task_e_68d7be5566008322bd25ba129cbe3774