### PR TITLE
Preserve dynamic node runtime state on updates

### DIFF
--- a/dynamic_algo/dynamic_nodes.py
+++ b/dynamic_algo/dynamic_nodes.py
@@ -172,6 +172,20 @@ class DynamicNodeRegistry:
 
         if isinstance(node, Mapping):
             dynamic_node = DynamicNode(**node)  # type: ignore[arg-type]
+            existing = self._nodes.get(dynamic_node.node_id)
+            if existing is not None:
+                if existing.node_id != dynamic_node.node_id:  # pragma: no cover - defensive
+                    raise NodeConfigError("node_id cannot be changed for existing nodes")
+
+                existing.type = dynamic_node.type
+                existing.interval_sec = dynamic_node.interval_sec
+                existing.enabled = dynamic_node.enabled
+                existing.dependencies = dynamic_node.dependencies
+                existing.outputs = dynamic_node.outputs
+                existing.metadata = dynamic_node.metadata
+                existing.weight = dynamic_node.weight
+
+                dynamic_node = existing
         elif isinstance(node, DynamicNode):
             dynamic_node = node
         else:  # pragma: no cover - defensive guardrail


### PR DESCRIPTION
## Summary
- preserve runtime telemetry when updating existing dynamic nodes by merging new config into the stored instance
- add unit coverage ensuring re-registration keeps last outputs while updating scheduling fields

## Testing
- pytest tests/test_dynamic_nodes_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c0ed05a88322bfbe56b899e51219