### PR TITLE
Add Dynamic Wallet landing section and page

### DIFF
--- a/apps/web/app/wallet/page.tsx
+++ b/apps/web/app/wallet/page.tsx
@@ -1,0 +1,244 @@
+import {
+  Column,
+  Heading,
+  Icon,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+
+const HERO_HIGHLIGHTS = [
+  {
+    icon: "sparkles" as const,
+    text:
+      "TonConnect handshake completes in under 30 seconds across supported wallets.",
+  },
+  {
+    icon: "repeat" as const,
+    text:
+      "Supabase keeps linked wallet records in sync with investor permissions.",
+  },
+  {
+    icon: "shield" as const,
+    text:
+      "RLS policies and admin tooling guard treasury operations around the clock.",
+  },
+] as const;
+
+const ONBOARDING_STEPS = [
+  {
+    icon: "sparkles" as const,
+    title: "Launch TonConnect inside Telegram",
+    description:
+      "Investors tap the Mini App link and authenticate with Tonkeeper, MyTonWallet, or Tonhub without leaving Telegram.",
+  },
+  {
+    icon: "check" as const,
+    title: "Verify the handshake with Supabase",
+    description:
+      "The link-wallet edge function validates Telegram identity, ensures the address is unique, and stores the public key.",
+  },
+  {
+    icon: "rocket" as const,
+    title: "Unlock the Dynamic Capital desk",
+    description:
+      "Once linked, investors gain access to staking, VIP plans, and automation triggers that respond to their wallet state.",
+  },
+] as const;
+
+const SECURITY_FEATURES = [
+  {
+    icon: "shield" as const,
+    title: "Role-based policies",
+    description:
+      "Wallet updates require Supabase auth tokens tied to verified Telegram IDs, and every admin override is logged.",
+  },
+  {
+    icon: "repeat" as const,
+    title: "On-chain reconciliation",
+    description:
+      "Background jobs compare deposits against expected wallets before releasing auto-invest units or VIP credits.",
+  },
+  {
+    icon: "sparkles" as const,
+    title: "Session hygiene",
+    description:
+      "Stale handshakes are rotated automatically so the trading desk always acts on fresh wallet attestations.",
+  },
+] as const;
+
+const AUTOMATION_EVENTS = [
+  "Auto-invest subscriptions store expected wallet addresses before any TON transfer is accepted.",
+  "Process-subscription functions compare incoming payments to the registered wallet before crediting staking units.",
+  "Link-wallet flows reject duplicate addresses so every investor maintains a single, auditable entry in Supabase.",
+  "Treasury monitoring jobs mirror intake and operations wallets to keep capital allocations accountable.",
+] as const;
+
+const SUPPORTED_WALLETS = [
+  {
+    name: "Tonkeeper",
+    description:
+      "Mobile-first wallet with TonConnect 2.0 support for instant Mini App onboarding.",
+  },
+  {
+    name: "MyTonWallet",
+    description:
+      "Browser extension and desktop flows for operators who prefer workstation trading.",
+  },
+  {
+    name: "Tonhub",
+    description:
+      "Lightweight mobile wallet ideal for community members joining from Telegram.",
+  },
+] as const;
+
+export const metadata = {
+  title: "Dynamic Capital Wallet",
+  description:
+    "Link TON wallets to Dynamic Capital in seconds with TonConnect, Supabase guardrails, and automation-ready ledgers.",
+};
+
+export default function WalletPage() {
+  return (
+    <Column
+      gap="40"
+      paddingY="48"
+      paddingX="16"
+      align="center"
+      horizontal="center"
+      fillWidth
+    >
+      <Column maxWidth={32} gap="12" align="center" horizontal="center">
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="sparkles">
+          Dynamic wallet
+        </Tag>
+        <Heading variant="display-strong-s" align="center">
+          Dynamic Capital Wallet
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          A TonConnect-powered wallet experience that keeps treasury operations,
+          auto-invest subscriptions, and VIP access in sync for every investor.
+        </Text>
+        <Row gap="16" wrap horizontal="center">
+          {HERO_HIGHLIGHTS.map((highlight) => (
+            <Row
+              key={highlight.text}
+              gap="8"
+              background="page"
+              border="neutral-alpha-medium"
+              radius="l"
+              padding="12"
+              vertical="center"
+            >
+              <Icon name={highlight.icon} onBackground="brand-medium" />
+              <Text variant="label-strong-s">{highlight.text}</Text>
+            </Row>
+          ))}
+        </Row>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">Frictionless onboarding</Heading>
+        <Column gap="16">
+          {ONBOARDING_STEPS.map((step) => (
+            <Row
+              key={step.title}
+              gap="16"
+              background="surface"
+              border="neutral-alpha-medium"
+              radius="l"
+              padding="16"
+              horizontal="start"
+              className="items-start"
+            >
+              <span className="mt-1 flex h-8 w-8 items-center justify-center rounded-full bg-primary/15 text-primary">
+                <Icon name={step.icon} size="s" />
+              </span>
+              <Column gap="4">
+                <Heading variant="heading-strong-xs">{step.title}</Heading>
+                <Text variant="body-default-s" onBackground="neutral-weak">
+                  {step.description}
+                </Text>
+              </Column>
+            </Row>
+          ))}
+        </Column>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">Security guardrails</Heading>
+        <Row gap="16" wrap className="gap-6">
+          {SECURITY_FEATURES.map((feature) => (
+            <Column
+              key={feature.title}
+              gap="12"
+              padding="20"
+              radius="l"
+              background="surface"
+              border="neutral-alpha-medium"
+              data-border="rounded"
+              className="flex-1 min-w-[240px] bg-background/70 shadow-lg shadow-primary/5"
+            >
+              <Icon name={feature.icon} size="m" />
+              <Heading variant="heading-strong-xs">{feature.title}</Heading>
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                {feature.description}
+              </Text>
+            </Column>
+          ))}
+        </Row>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">Automation-ready ledger</Heading>
+        <Column gap="12" as="ul">
+          {AUTOMATION_EVENTS.map((event) => (
+            <Row
+              key={event}
+              gap="12"
+              as="li"
+              horizontal="start"
+              className="items-start"
+            >
+              <span className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-primary">
+                <Icon name="check" size="s" />
+              </span>
+              <Text variant="body-default-m" onBackground="neutral-strong">
+                {event}
+              </Text>
+            </Row>
+          ))}
+        </Column>
+      </Column>
+
+      <Column gap="24" maxWidth={40} fillWidth>
+        <Heading variant="heading-strong-l">
+          Wallets your community already trusts
+        </Heading>
+        <Row gap="16" wrap className="gap-6">
+          {SUPPORTED_WALLETS.map((wallet) => (
+            <Column
+              key={wallet.name}
+              gap="8"
+              padding="16"
+              radius="m"
+              background="page"
+              border="neutral-alpha-medium"
+              data-border="rounded"
+              className="flex-1 min-w-[220px]"
+            >
+              <Text variant="label-strong-m">{wallet.name}</Text>
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                {wallet.description}
+              </Text>
+            </Column>
+          ))}
+        </Row>
+      </Column>
+    </Column>
+  );
+}

--- a/apps/web/components/landing/MultiLlmLandingPage.tsx
+++ b/apps/web/components/landing/MultiLlmLandingPage.tsx
@@ -50,6 +50,33 @@ const TOKEN_FEATURES = [
   },
 ];
 
+const WALLET_FEATURES = [
+  {
+    title: "TonConnect onboarding",
+    description:
+      "Investors connect Tonkeeper, MyTonWallet, or Tonhub in seconds through the Mini App without leaving Telegram.",
+    icon: "sparkles" as const,
+  },
+  {
+    title: "Supabase-synced ledger",
+    description:
+      "Linked addresses flow into Supabase so staking rewards, VIP access, and automation triggers stay consistent across surfaces.",
+    icon: "repeat" as const,
+  },
+  {
+    title: "Automation ready",
+    description:
+      "Auto-invest pools and subscription webhooks read the wallet table directly to approve desk allocations in real time.",
+    icon: "rocket" as const,
+  },
+] as const;
+
+const WALLET_GUARDRAILS = [
+  "Row Level Security ensures only verified Telegram IDs can read or update wallet entries.",
+  "Background reconciliation catches deposits that land in the wrong address before credits are issued.",
+  "Admins can revoke or rotate wallets from the desk console with a complete audit trail.",
+] as const;
+
 const MARKET_WIDGETS = [
   {
     symbol: "OANDA:XAUUSD",
@@ -467,6 +494,78 @@ export function MultiLlmLandingPage() {
               </Column>
             ))}
           </Row>
+        </Column>
+      </Section>
+
+      <Section anchor={HOME_NAV_SECTION_IDS.wallet}>
+        <Column gap="20">
+          <Column gap="12">
+            <Tag variant="brand" size="m">
+              Dynamic wallet
+            </Tag>
+            <Heading variant="heading-strong-m">
+              One TonConnect handshake powers every surface
+            </Heading>
+            <Text
+              variant="body-default-m"
+              onBackground="neutral-weak"
+              wrap="balance"
+              className="max-w-3xl"
+            >
+              Link wallets from Telegram, store them in Supabase, and unlock
+              staking, VIP plans, and automation without duplicating onboarding
+              flows.
+            </Text>
+          </Column>
+          <Row gap="16" wrap className="gap-6">
+            {WALLET_FEATURES.map((feature) => (
+              <Column
+                key={feature.title}
+                gap="12"
+                padding="20"
+                radius="l"
+                background="surface"
+                border="neutral-alpha-weak"
+                data-border="rounded"
+                className="flex-1 min-w-[240px] bg-background/70 shadow-lg shadow-primary/5"
+              >
+                <Icon name={feature.icon} size="m" />
+                <Heading variant="heading-strong-xs">{feature.title}</Heading>
+                <Text
+                  variant="body-default-s"
+                  onBackground="neutral-weak"
+                  wrap="balance"
+                >
+                  {feature.description}
+                </Text>
+              </Column>
+            ))}
+          </Row>
+          <Column gap="12" className="max-w-3xl">
+            <Heading variant="heading-strong-s">Guardrails baked in</Heading>
+            <Column gap="8" as="ul">
+              {WALLET_GUARDRAILS.map((guardrail) => (
+                <Row
+                  key={guardrail}
+                  gap="12"
+                  as="li"
+                  horizontal="start"
+                  className="items-start"
+                >
+                  <span className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-primary/15 text-primary">
+                    <Icon name="check" size="s" />
+                  </span>
+                  <Text
+                    variant="body-default-m"
+                    onBackground="neutral-strong"
+                    wrap="balance"
+                  >
+                    {guardrail}
+                  </Text>
+                </Row>
+              ))}
+            </Column>
+          </Column>
         </Column>
       </Section>
 

--- a/apps/web/components/landing/home-navigation-config.ts
+++ b/apps/web/components/landing/home-navigation-config.ts
@@ -8,11 +8,13 @@ import {
   ServerCog,
   ShieldCheck,
   UsersRound,
+  Wallet,
 } from "lucide-react";
 
 export const HOME_NAV_SECTION_IDS = {
   overview: "overview",
   token: "dct-token",
+  wallet: "dynamic-wallet",
   markets: "live-markets",
   community: "community-trust",
   miniApp: "investor-mini-app",
@@ -48,6 +50,13 @@ export const HOME_NAV_SECTIONS: HomeNavSection[] = [
     description: "Understand burns, rewards, and transparency.",
     icon: Coins,
     href: `/#${HOME_NAV_SECTION_IDS.token}`,
+  },
+  {
+    id: "wallet",
+    label: "Dynamic Wallet",
+    description: "Link TON addresses with Supabase guardrails.",
+    icon: Wallet,
+    href: `/#${HOME_NAV_SECTION_IDS.wallet}`,
   },
   {
     id: "markets",
@@ -116,11 +125,9 @@ type SectionIdsFromConfig = (typeof HOME_NAV_SECTIONS)[number]["id"];
 type MissingSections = Exclude<HomeNavSectionId, SectionIdsFromConfig>;
 type UnexpectedSections = Exclude<SectionIdsFromConfig, HomeNavSectionId>;
 
-type AssertAllSectionsCovered = MissingSections extends never
-  ? true
+type AssertAllSectionsCovered = MissingSections extends never ? true
   : ["Missing HOME_NAV_SECTIONS entry for", MissingSections];
-type AssertNoUnexpectedSections = UnexpectedSections extends never
-  ? true
+type AssertNoUnexpectedSections = UnexpectedSections extends never ? true
   : ["Unexpected HOME_NAV_SECTIONS id", UnexpectedSections];
 
 const _assertAllSectionsCovered: AssertAllSectionsCovered = true;

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -1,8 +1,8 @@
 import {
   LayoutDashboard,
   LineChart,
-  PieChart,
   type LucideIcon,
+  PieChart,
 } from "lucide-react";
 
 import {
@@ -25,6 +25,7 @@ export interface NavItem {
 const DESK_NAV_SECTION_ORDER: HomeNavSectionId[] = [
   "overview",
   "token",
+  "wallet",
   "markets",
   "community",
   "miniApp",


### PR DESCRIPTION
## Summary
- add a dedicated /wallet page detailing onboarding, security and automation features for TonConnect investors
- surface the Dynamic Wallet section in the landing experience and primary navigation
- highlight wallet guardrails alongside new feature cards on the landing page

## Testing
- npm run lint
- npm run typecheck *(fails: missing @/components/magic-portfolio/* modules referenced by app/tools/dynamic-portfolio/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c69130508322bccd18a9b04aba14