### PR TITLE
Load go-live automation env from dotenv files

### DIFF
--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -1,5 +1,25 @@
 # Go Live Checklist
 
+## Automation quick start
+
+Run the bundled automation helper to execute the scripted portions of the
+go-live validation. It covers the core checks by default; append
+`--include-optional` when you also need the longer-running smoke tests that
+operators run ahead of production rollouts.
+
+```bash
+npm run go-live
+
+# Include optional smoke tests
+npm run go-live -- --include-optional
+```
+
+> [!NOTE]
+> The automation helper now loads `.env.local` and `.env` before running. Ensure
+> `TELEGRAM_BOT_TOKEN` (and related Telegram secrets) are populated in one of
+> those files or exported in your shell so the webhook check can reach the
+> Telegram API.
+
 - [ ] Webhook set & verified. See the
       [Go-Live Validation Playbook](./go-live-validation-playbook.md#1-telegram-webhook-health)
       for the scripted check and health probe steps.

--- a/docs/dynamic-capital-checklist.md
+++ b/docs/dynamic-capital-checklist.md
@@ -38,32 +38,32 @@ repo health checks before audits, launches, or large merges. Track the results
 in your PR/issue notes so reviewers can see the evidence.
 
 - [x] Sync `.env` and `.env.local` with `.env.example` (`npm run sync-env`) to
-      ensure new environment keys are captured locally. _Ran with the
-      automation helper; 106 missing keys were appended to both `.env` and
-      `.env.local` from the template so local parity is restored._
+      ensure new environment keys are captured locally. _Ran with the automation
+      helper; 106 missing keys were appended to both `.env` and `.env.local`
+      from the template so local parity is restored._
 - [x] Run the repository test suite (`npm run test`) so Deno and Next.js smoke
       tests cover the latest changes. _Latest run passed 90 tests with one
       ignored case, matching the deno-based CI suite._
 - [ ] Execute the fix-and-check script (`bash scripts/fix_and_check.sh`) to
       apply formatting and rerun Deno format/lint/type checks. _Run surfaced
       pre-existing lint violations (for example `require-await` on storage
-      helpers in `tests/supabase-client-stub.ts`, `no-import-prefix` in
-      Supabase function entrypoints, and `no-explicit-any` usage in web hooks),
-      so the script still fails pending cleanup._
+      helpers in `tests/supabase-client-stub.ts`, `no-import-prefix` in Supabase
+      function entrypoints, and `no-explicit-any` usage in web hooks), so the
+      script still fails pending cleanup._
 - [x] Run the aggregated verification suite (`npm run verify`) for the bundled
       static, runtime, and integration safety checks. _`verify_all.sh` completed
       successfully and refreshed `.out/verify_report.md` with the latest
       results._
 - [x] Audit Supabase Edge function hosts
       (`deno run -A scripts/audit-edge-hosts.ts`) to detect environment drift
-      between deployments. _Check completed via `npx deno`; 17 URLs were
-      scanned and none deviated from the expected host pattern._
+      between deployments. _Check completed via `npx deno`; 17 URLs were scanned
+      and none deviated from the expected host pattern._
 - [ ] Check linkage across environment variables and outbound URLs
       (`deno run -A scripts/check-linkage.ts`) before promoting builds. _Helper
       now seeds Deno with the system trust store and proxy bundle so
       `getWebhookInfo.ok` resolves `true`, reporting the registered webhook as
-      `https://qeejuomcapbdlhnjqjcc.supabase.co/functions/v1/telegram-bot`.
-      The Supabase `linkage-audit` endpoint at
+      `https://qeejuomcapbdlhnjqjcc.supabase.co/functions/v1/telegram-bot`. The
+      Supabase `linkage-audit` endpoint at
       `https://qeejuomcapbdlhnjqjcc.functions.supabase.co/linkage-audit`
       continues to time out, so the host alignment work is still outstanding._
 - [ ] Verify the Telegram webhook configuration
@@ -96,11 +96,16 @@ in your PR/issue notes so reviewers can see the evidence.
 
 ## Go Live Checklist
 
-Run the `go-live` automation key
-(`npm run checklists -- --checklist go-live --include-optional`) and mirror the
-manual validations below before exposing updates to traders or admins. Use the
+Run `npm run go-live` (an alias for the `go-live` automation key) to execute the
+scripted checks. Pass `-- --include-optional` when you need the longer-running
+smoke tests alongside the core validations, then mirror the manual checks below
+before exposing updates to traders or admins. Use the
 [Go-Live Validation Playbook](./go-live-validation-playbook.md) for step-by-step
 runbooks, curl commands, and evidence templates.
+
+> [!TIP] Populate `TELEGRAM_BOT_TOKEN` (and related Telegram secrets) in
+> `.env.local` or `.env` so the automation can talk to the Telegram API when it
+> loads the configuration for webhook verification.
 
 1. [ ] Confirm the Telegram webhook is set and returning `200` responses for
        health pings (see

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "deno": "^2.5.0",
+        "dotenv": "^16.6.1",
         "supabase": "^2.40.7",
         "tsx": "^4.20.5",
         "yaml": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "do:sync-cdn": "node scripts/digitalocean/sync-cdn-config.mjs",
     "doctl:sync-site": "node scripts/doctl/sync-site-config.mjs",
     "checklists": "node scripts/run-checklists.js",
+    "go-live": "node scripts/run-checklists.js --checklist go-live",
     "export": "node scripts/npm-safe.mjs run build",
     "output": "node scripts/npm-safe.mjs -w apps/web run copy-static",
     "supabase:start": "supabase start",
@@ -65,6 +66,7 @@
   "devDependencies": {
     "chokidar-cli": "^3.0.0",
     "deno": "^2.5.0",
+    "dotenv": "^16.6.1",
     "supabase": "^2.40.7",
     "tsx": "^4.20.5",
     "yaml": "^2.8.1"

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -1,7 +1,29 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
 import { createSanitizedNpmEnv } from './utils/npm-env.mjs';
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(MODULE_DIR, '..');
+
+function loadEnvFile(relativePath) {
+  const absolutePath = path.join(PROJECT_ROOT, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    return;
+  }
+
+  const result = dotenv.config({ path: absolutePath, override: false });
+  if (result.error && result.error.code !== 'ENOENT') {
+    throw result.error;
+  }
+}
+
+loadEnvFile('.env.local');
+loadEnvFile('.env');
 
 const TASK_LIBRARY = {
   'sync-env': {


### PR DESCRIPTION
## Summary
- load `.env.local`/`.env` before running checklist automation so go-live picks up Telegram credentials
- document the requirement in the go-live runbooks so operators prepare the environment files
- add dotenv as a dev dependency to support the new loader

## Testing
- `TELEGRAM_WEBHOOK_INFO_PATH=scripts/fixtures/mock-telegram-webhook.json npm run go-live`


------
https://chatgpt.com/codex/tasks/task_e_68d7c5cd6e5483228d5e4613bc5c98d6