### PR TITLE
feat: enhance checkout plan handling

### DIFF
--- a/apps/web/components/checkout/PaymentMethodSelector.tsx
+++ b/apps/web/components/checkout/PaymentMethodSelector.tsx
@@ -1,10 +1,29 @@
 "use client";
 
 import React from "react";
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { Loader2, ExternalLink, CreditCard, Building, Coins } from "lucide-react";
+import {
+  Building,
+  Coins,
+  CreditCard,
+  ExternalLink,
+  Loader2,
+} from "lucide-react";
+import { formatPrice } from "@/utils";
 import type { PaymentMethod } from "./types";
 
 interface PaymentMethodSelectorProps {
@@ -13,6 +32,7 @@ interface PaymentMethodSelectorProps {
   handleCheckout: () => void;
   processingCheckout: boolean;
   finalPrice: number;
+  currency: string;
 }
 
 export const PaymentMethodSelector: React.FC<PaymentMethodSelectorProps> = ({
@@ -20,16 +40,22 @@ export const PaymentMethodSelector: React.FC<PaymentMethodSelectorProps> = ({
   setPaymentMethod,
   handleCheckout,
   processingCheckout,
-  finalPrice
+  finalPrice,
+  currency,
 }) => (
   <div className="space-y-4">
     <Card>
       <CardHeader>
         <CardTitle className="text-lg">Choose Payment Method</CardTitle>
-        <CardDescription>Select how you'd like to complete your payment</CardDescription>
+        <CardDescription>
+          Select how you'd like to complete your payment
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        <Select value={paymentMethod} onValueChange={(value: PaymentMethod) => setPaymentMethod(value)}>
+        <Select
+          value={paymentMethod}
+          onValueChange={(value: PaymentMethod) => setPaymentMethod(value)}
+        >
           <SelectTrigger>
             <SelectValue placeholder="Select payment method" />
           </SelectTrigger>
@@ -62,14 +88,19 @@ export const PaymentMethodSelector: React.FC<PaymentMethodSelectorProps> = ({
       disabled={processingCheckout}
       className="w-full h-12 text-lg font-semibold bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary/80 shadow-lg hover:shadow-xl transition-all duration-300"
     >
-      {processingCheckout ? (
-        <Loader2 className="h-5 w-5 animate-spin mr-2" />
-      ) : paymentMethod === "telegram" ? (
-        <ExternalLink className="h-5 w-5 mr-2" />
-      ) : (
-        <CreditCard className="h-5 w-5 mr-2" />
-      )}
-      {paymentMethod === "telegram" ? "Continue in Telegram" : `Pay with ${paymentMethod === "bank_transfer" ? "Bank Transfer" : "Crypto"}`} - ${finalPrice.toFixed(2)}
+      {processingCheckout
+        ? <Loader2 className="h-5 w-5 animate-spin mr-2" />
+        : paymentMethod === "telegram"
+        ? <ExternalLink className="h-5 w-5 mr-2" />
+        : <CreditCard className="h-5 w-5 mr-2" />}
+      {paymentMethod === "telegram"
+        ? "Continue in Telegram"
+        : `Pay with ${
+          paymentMethod === "bank_transfer" ? "Bank Transfer" : "Crypto"
+        }`} – {formatPrice(finalPrice, currency, "en-US", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })}
     </Button>
   </div>
 );

--- a/apps/web/components/checkout/PlanSummary.tsx
+++ b/apps/web/components/checkout/PlanSummary.tsx
@@ -9,90 +9,133 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Check, Clock, CreditCard, Shield, Users } from "lucide-react";
+import { formatPrice } from "@/utils";
 import type { Plan } from "@/types/plan";
+import type { PromoValidationResult } from "./types";
 
 interface PlanSummaryProps {
   plan: Plan;
   finalPrice: number;
-  promoValidation: any;
+  promoValidation: PromoValidationResult | null;
 }
 
-export const PlanSummary: React.FC<PlanSummaryProps> = (
-  { plan, finalPrice, promoValidation },
-) => (
-  <div className="space-y-4">
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <CreditCard className="h-5 w-5" />
-          {plan.name}
-        </CardTitle>
-        <CardDescription>
-          {plan.is_lifetime
-            ? "Lifetime access"
-            : `${plan.duration_months} month subscription`}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="flex justify-between items-center text-lg">
-          <span>Price:</span>
-          <div className="text-right">
-            <div className="font-bold text-primary">
-              ${finalPrice.toFixed(2)}
-            </div>
-            {promoValidation?.valid && finalPrice !== plan.price && (
-              <div className="text-sm text-muted-foreground line-through">
-                ${plan.price}
+export const PlanSummary: React.FC<PlanSummaryProps> = ({
+  plan,
+  finalPrice,
+  promoValidation,
+}) => {
+  const displayPrice = plan.pricing?.displayPrice ?? plan.price;
+  const basePrice = plan.pricing?.basePrice ?? plan.base_price ?? displayPrice;
+  const formattedFinalPrice = formatPrice(finalPrice, plan.currency, "en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const formattedDisplayPrice = formatPrice(
+    displayPrice,
+    plan.currency,
+    "en-US",
+    {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    },
+  );
+  const formattedBasePrice = formatPrice(basePrice, plan.currency, "en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const dctAmount = Number(
+    plan.pricing?.dctAmount ?? plan.dct_amount ?? displayPrice,
+  );
+  const tonAmount = Number(plan.pricing?.tonAmount);
+  const formattedDctAmount = Number.isFinite(dctAmount)
+    ? dctAmount.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+    : undefined;
+  const formattedTonAmount = Number.isFinite(tonAmount)
+    ? tonAmount.toLocaleString(undefined, {
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3,
+    })
+    : undefined;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CreditCard className="h-5 w-5" />
+            {plan.name}
+          </CardTitle>
+          <CardDescription>
+            {plan.is_lifetime
+              ? "Lifetime access"
+              : `${plan.duration_months} month subscription`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex justify-between items-center text-lg">
+            <span>Price:</span>
+            <div className="text-right space-y-1">
+              <div className="font-bold text-primary">
+                {formattedFinalPrice}
               </div>
-            )}
-            <div className="text-sm text-muted-foreground">
-              ≈ {(plan.pricing?.dctAmount ?? plan.dct_amount ?? plan.price)
-                .toFixed(2)} DCT
-              {typeof plan.pricing?.tonAmount === "number" &&
-                plan.pricing.tonAmount > 0 && (
-                <span className="ml-1">
-                  / {plan.pricing.tonAmount.toFixed(3)} TON
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {plan.features && plan.features.length > 0 && (
-          <div className="space-y-2">
-            <h4 className="font-medium">Included features:</h4>
-            <div className="space-y-1">
-              {plan.features.map((feature, idx) => (
-                <div key={idx} className="flex items-center gap-2 text-sm">
-                  <Check className="h-3 w-3 text-green-500" />
-                  <span>{feature}</span>
+              {promoValidation?.valid && finalPrice !== displayPrice && (
+                <div className="text-sm text-muted-foreground line-through">
+                  {formattedDisplayPrice}
                 </div>
-              ))}
+              )}
+              {!promoValidation?.valid && displayPrice !== basePrice && (
+                <div className="text-xs text-muted-foreground">
+                  Base price {formattedBasePrice}
+                </div>
+              )}
+              <div className="text-sm text-muted-foreground">
+                {formattedDctAmount ? `≈ ${formattedDctAmount} DCT` : ""}
+                {formattedTonAmount && (
+                  <span className="ml-1">/ {formattedTonAmount} TON</span>
+                )}
+              </div>
             </div>
           </div>
-        )}
-      </CardContent>
-    </Card>
 
-    <Card className="border-dashed">
-      <CardContent className="pt-6">
-        <div className="grid grid-cols-3 gap-4 text-center">
-          <div className="space-y-1">
-            <Shield className="w-5 h-5 mx-auto text-primary" />
-            <p className="text-xs text-muted-foreground">Secure</p>
+          {plan.features && plan.features.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="font-medium">Included features:</h4>
+              <div className="space-y-1">
+                {plan.features.map((feature, idx) => (
+                  <div key={idx} className="flex items-center gap-2 text-sm">
+                    <Check className="h-3 w-3 text-green-500" />
+                    <span>{feature}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-dashed">
+        <CardContent className="pt-6">
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <div className="space-y-1">
+              <Shield className="w-5 h-5 mx-auto text-primary" />
+              <p className="text-xs text-muted-foreground">Secure</p>
+            </div>
+            <div className="space-y-1">
+              <Clock className="w-5 h-5 mx-auto text-primary" />
+              <p className="text-xs text-muted-foreground">Instant</p>
+            </div>
+            <div className="space-y-1">
+              <Users className="w-5 h-5 mx-auto text-primary" />
+              <p className="text-xs text-muted-foreground">5000+ Users</p>
+            </div>
           </div>
-          <div className="space-y-1">
-            <Clock className="w-5 h-5 mx-auto text-primary" />
-            <p className="text-xs text-muted-foreground">Instant</p>
-          </div>
-          <div className="space-y-1">
-            <Users className="w-5 h-5 mx-auto text-primary" />
-            <p className="text-xs text-muted-foreground">5000+ Users</p>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  </div>
-);
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
 
 export default PlanSummary;

--- a/apps/web/components/checkout/PromoCodeForm.tsx
+++ b/apps/web/components/checkout/PromoCodeForm.tsx
@@ -1,60 +1,95 @@
 "use client";
 
 import React from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Loader2, Sparkles } from "lucide-react";
-import { cn } from "@/utils";
+import { cn, formatPrice } from "@/utils";
+import type { PromoValidationResult } from "./types";
 
 interface PromoCodeFormProps {
   promoCode: string;
   setPromoCode: (code: string) => void;
   validatePromoCode: () => void;
   validatingPromo: boolean;
-  promoValidation: any;
+  promoValidation: PromoValidationResult | null;
+  currency: string;
 }
 
-export const PromoCodeForm: React.FC<PromoCodeFormProps> = ({ promoCode, setPromoCode, validatePromoCode, validatingPromo, promoValidation }) => (
-  <Card>
-    <CardHeader>
-      <CardTitle className="flex items-center gap-2 text-lg">
-        <Sparkles className="h-5 w-5" />
-        Promo Code
-      </CardTitle>
-    </CardHeader>
-    <CardContent className="space-y-3">
-      <div className="flex gap-2">
-        <Input
-          placeholder="Enter promo code"
-          value={promoCode}
-          onChange={(e) => setPromoCode(e.target.value)}
-          className="flex-1"
-        />
-        <Button
-          onClick={validatePromoCode}
-          disabled={!promoCode.trim() || validatingPromo}
-          size="sm"
-        >
-          {validatingPromo ? <Loader2 className="h-4 w-4 animate-spin" /> : "Apply"}
-        </Button>
-      </div>
-      {promoValidation && (
+export const PromoCodeForm: React.FC<PromoCodeFormProps> = ({
+  promoCode,
+  setPromoCode,
+  validatePromoCode,
+  validatingPromo,
+  promoValidation,
+  currency,
+}) => {
+  const renderMessage = () => {
+    if (!promoValidation) return null;
+
+    if (promoValidation.valid) {
+      const discountLabel = promoValidation.discountType === "percentage"
+        ? `${promoValidation.discountValue ?? 0}%`
+        : formatPrice(promoValidation.discountValue ?? 0, currency, "en-US", {
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 2,
+        });
+
+      return (
         <div
           className={cn(
             "text-xs p-2 rounded",
-            promoValidation.valid
-              ? "bg-green-500/10 text-green-600 border border-green-500/20"
-              : "bg-dc-brand/10 text-dc-brand-dark border border-dc-brand/20"
+            "bg-green-500/10 text-green-600 border border-green-500/20",
           )}
         >
-          {promoValidation.valid
-            ? `${promoValidation.discount_type === 'percentage' ? promoValidation.discount_value + '%' : '$' + promoValidation.discount_value} discount applied!`
-            : promoValidation.reason}
+          {`${discountLabel} discount applied!`}
         </div>
-      )}
-    </CardContent>
-  </Card>
-);
+      );
+    }
+
+    return (
+      <div
+        className={cn(
+          "text-xs p-2 rounded",
+          "bg-dc-brand/10 text-dc-brand-dark border border-dc-brand/20",
+        )}
+      >
+        {promoValidation.reason || "Invalid promo code"}
+      </div>
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Sparkles className="h-5 w-5" />
+          Promo Code
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex gap-2">
+          <Input
+            placeholder="Enter promo code"
+            value={promoCode}
+            onChange={(e) => setPromoCode(e.target.value)}
+            className="flex-1"
+          />
+          <Button
+            onClick={validatePromoCode}
+            disabled={!promoCode.trim() || validatingPromo}
+            size="sm"
+          >
+            {validatingPromo
+              ? <Loader2 className="h-4 w-4 animate-spin" />
+              : "Apply"}
+          </Button>
+        </div>
+        {renderMessage()}
+      </CardContent>
+    </Card>
+  );
+};
 
 export default PromoCodeForm;

--- a/apps/web/components/checkout/WebCheckout.tsx
+++ b/apps/web/components/checkout/WebCheckout.tsx
@@ -1,19 +1,24 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AnimatePresence } from "framer-motion";
-import { Shield, AlertCircle, Loader2 } from "lucide-react";
+import { AlertCircle, Loader2, Shield } from "lucide-react";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { callEdgeFunction } from "@/config/supabase";
 import logger from "@/utils/logger";
 import type { Plan } from "@/types/plan";
-import { PaymentMethod, CheckoutStep, BankAccount } from "./types";
+import {
+  BankAccount,
+  CheckoutStep,
+  PaymentMethod,
+  PromoValidationResult,
+} from "./types";
 import PlanSummary from "./PlanSummary";
 import PromoCodeForm from "./PromoCodeForm";
 import PaymentMethodSelector from "./PaymentMethodSelector";
@@ -21,21 +26,121 @@ import PaymentInstructions from "./PaymentInstructions";
 import ReceiptUpload from "./ReceiptUpload";
 import PendingReview from "./PendingReview";
 import DigitalReceipt from "./DigitalReceipt";
+import { useSubscriptionPlans } from "@/hooks/useSubscriptionPlans";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import { formatPrice } from "@/utils";
 
 interface WebCheckoutProps {
   selectedPlanId?: string;
   promoCode?: string;
 }
 
+type RawPromoValidationResponse = {
+  valid?: boolean;
+  ok?: boolean;
+  discount_type?: string | null;
+  type?: string | null;
+  discount_value?: number | string | null;
+  value?: number | string | null;
+  final_amount?: number | string | null;
+  reason?: string | null;
+};
+
+const parseNumericValue = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const resolveDiscountTypeFromString = (
+  value?: string | null,
+): "percentage" | "fixed" | undefined => {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  if (normalized === "percentage" || normalized === "percent") {
+    return "percentage";
+  }
+  return "fixed";
+};
+
+const normalizePromoValidation = (
+  raw: RawPromoValidationResponse | null,
+): PromoValidationResult | null => {
+  if (!raw) return null;
+
+  const isValid = Boolean(raw.valid ?? raw.ok);
+  if (!isValid) {
+    return {
+      valid: false,
+      reason: typeof raw.reason === "string" ? raw.reason : undefined,
+    };
+  }
+
+  const discountType = resolveDiscountTypeFromString(
+    raw.discount_type ?? raw.type,
+  );
+  const discountValue = parseNumericValue(raw.discount_value ?? raw.value) ??
+    undefined;
+  const finalAmount = parseNumericValue(raw.final_amount) ?? undefined;
+
+  return {
+    valid: true,
+    discountType,
+    discountValue,
+    finalAmount,
+  };
+};
+
+const computeDiscountAmount = (
+  basePrice: number,
+  validation: PromoValidationResult,
+): number => {
+  if (!validation.valid) {
+    return 0;
+  }
+
+  if (typeof validation.finalAmount === "number") {
+    return Math.max(0, basePrice - validation.finalAmount);
+  }
+
+  if (
+    validation.discountType === "percentage" &&
+    typeof validation.discountValue === "number"
+  ) {
+    return Math.max(0, basePrice * (validation.discountValue / 100));
+  }
+
+  if (typeof validation.discountValue === "number") {
+    return Math.max(0, validation.discountValue);
+  }
+
+  return 0;
+};
+
 export const WebCheckout: React.FC<WebCheckoutProps> = ({
   selectedPlanId,
-  promoCode: initialPromoCode
+  promoCode: initialPromoCode,
 }) => {
-  const [plans, setPlans] = useState<Plan[]>([]);
+  const {
+    plans,
+    loading: plansLoading,
+    error: plansError,
+    hasData: plansLoaded,
+    refresh,
+  } = useSubscriptionPlans();
+  const { trackPlanView, trackCheckoutStart, trackPromoApplied } =
+    useAnalytics();
+
   const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
-  const [promoCode, setPromoCode] = useState(initialPromoCode || "");
-  const [promoValidation, setPromoValidation] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
+  const [promoCode, setPromoCode] = useState(initialPromoCode ?? "");
+  const [promoValidation, setPromoValidation] = useState<
+    PromoValidationResult | null
+  >(null);
   const [processingCheckout, setProcessingCheckout] = useState(false);
   const [validatingPromo, setValidatingPromo] = useState(false);
 
@@ -45,11 +150,20 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
   const [bankAccounts, setBankAccounts] = useState<BankAccount[]>([]);
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
-  const [uploadStatus, setUploadStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [uploadStatus, setUploadStatus] = useState<
+    "idle" | "success" | "error"
+  >("idle");
   const [retrying, setRetrying] = useState(false);
   const [isTelegram, setIsTelegram] = useState(false);
   const [telegramInitData, setTelegramInitData] = useState<string | null>(null);
   const [showReceipt, setShowReceipt] = useState(false);
+
+  const previousPlanId = useRef<string | null>(null);
+
+  const planCurrency = selectedPlan?.currency ?? "USD";
+  const basePlanPrice = selectedPlan
+    ? selectedPlan.pricing?.displayPrice ?? selectedPlan.price
+    : 0;
 
   useEffect(() => {
     if (currentStep === "pending") {
@@ -57,62 +171,147 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
     }
   }, [currentStep]);
 
-  const fetchPlans = useCallback(async () => {
-    try {
-      const { data, error } = await callEdgeFunction('PLANS');
-      if (error) {
-        throw new Error(error.message);
-      }
-      setPlans((data as any)?.plans || []);
-      if ((data as any)?.plans?.length > 0 && !selectedPlan) {
-        setSelectedPlan((data as any).plans[0]);
-      }
-    } catch (error) {
-      toast.error('Failed to load plans');
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedPlan]);
-
   useEffect(() => {
-    const isInTelegram = window.Telegram?.WebApp?.initData;
-    setIsTelegram(!!isInTelegram);
-    if (isInTelegram) {
-      setTelegramInitData(window.Telegram.WebApp.initData);
+    const telegramData = window.Telegram?.WebApp?.initData;
+    const isInTelegram = Boolean(telegramData);
+    setIsTelegram(isInTelegram);
+
+    if (isInTelegram && telegramData) {
+      setTelegramInitData(telegramData);
       logger.log("Running inside Telegram WebApp");
     }
-    fetchPlans();
-  }, [fetchPlans]);
+  }, []);
 
   useEffect(() => {
-    if (selectedPlanId && plans.length > 0) {
-      const plan = plans.find(p => p.id === selectedPlanId);
-      setSelectedPlan(plan || plans[0]);
+    if (plans.length === 0) {
+      setSelectedPlan(null);
+      return;
     }
-  }, [selectedPlanId, plans]);
+
+    setSelectedPlan((current) => {
+      if (selectedPlanId) {
+        const fromQuery = plans.find((plan) => plan.id === selectedPlanId);
+        if (fromQuery) {
+          return fromQuery;
+        }
+      }
+
+      if (current) {
+        const stillExists = plans.find((plan) => plan.id === current.id);
+        if (stillExists) {
+          return stillExists;
+        }
+      }
+
+      return plans[0];
+    });
+  }, [plans, selectedPlanId]);
+
+  useEffect(() => {
+    setPromoCode(initialPromoCode ?? "");
+    setPromoValidation(null);
+  }, [initialPromoCode]);
+
+  useEffect(() => {
+    if (!selectedPlan) {
+      return;
+    }
+
+    if (previousPlanId.current === selectedPlan.id) {
+      return;
+    }
+
+    previousPlanId.current = selectedPlan.id;
+    trackPlanView(selectedPlan.id, selectedPlan.name);
+    setPromoValidation(null);
+  }, [selectedPlan, trackPlanView]);
+
+  useEffect(() => {
+    if (!promoCode) {
+      setPromoValidation(null);
+    }
+  }, [promoCode]);
+
+  const finalPrice = useMemo(() => {
+    if (!selectedPlan) {
+      return 0;
+    }
+
+    if (!promoValidation?.valid) {
+      return basePlanPrice;
+    }
+
+    if (typeof promoValidation.finalAmount === "number") {
+      return Math.max(0, promoValidation.finalAmount);
+    }
+
+    if (
+      promoValidation.discountType === "percentage" &&
+      typeof promoValidation.discountValue === "number"
+    ) {
+      return Math.max(
+        0,
+        basePlanPrice * (1 - promoValidation.discountValue / 100),
+      );
+    }
+
+    if (typeof promoValidation.discountValue === "number") {
+      return Math.max(0, basePlanPrice - promoValidation.discountValue);
+    }
+
+    return basePlanPrice;
+  }, [basePlanPrice, promoValidation, selectedPlan]);
 
   const validatePromoCode = async () => {
-    if (!promoCode.trim() || !selectedPlan) return;
+    if (!selectedPlan) return;
+    const normalizedCode = promoCode.trim().toUpperCase();
+    if (!normalizedCode) return;
+
     setValidatingPromo(true);
     try {
-      const { data, error } = await callEdgeFunction('PROMO_VALIDATE', {
-        method: 'POST',
-        body: {
-          code: promoCode,
-          plan_id: selectedPlan.id,
+      const { data, error } = await callEdgeFunction<
+        RawPromoValidationResponse
+      >(
+        "PROMO_VALIDATE",
+        {
+          method: "POST",
+          body: {
+            code: normalizedCode,
+            plan_id: selectedPlan.id,
+          },
         },
-      });
+      );
+
       if (error) {
         throw new Error(error.message);
       }
-      setPromoValidation(data);
-      if ((data as any)?.valid) {
-        toast.success(`Promo code applied! ${(data as any).discount_type === 'percentage' ? (data as any).discount_value + '%' : '$' + (data as any).discount_value} discount`);
+
+      const normalized = normalizePromoValidation(data ?? null);
+      setPromoValidation(normalized);
+      setPromoCode(normalizedCode);
+
+      if (normalized?.valid) {
+        const discountAmount = computeDiscountAmount(basePlanPrice, normalized);
+        if (discountAmount > 0) {
+          trackPromoApplied(normalizedCode, selectedPlan.id, discountAmount);
+        } else {
+          trackPromoApplied(normalizedCode, selectedPlan.id);
+        }
+
+        const discountLabel = normalized.discountType === "percentage"
+          ? `${normalized.discountValue ?? 0}%`
+          : formatPrice(normalized.discountValue ?? 0, planCurrency, "en-US", {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 2,
+          });
+
+        toast.success(`Promo code applied! ${discountLabel} discount`);
       } else {
-        toast.error((data as any)?.reason || 'Invalid promo code');
+        toast.error(normalized?.reason || "Invalid promo code");
       }
     } catch (error) {
-      toast.error('Failed to validate promo code');
+      logger.error("Promo validation failed", error);
+      toast.error("Failed to validate promo code");
     } finally {
       setValidatingPromo(false);
     }
@@ -121,15 +320,21 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
   const handleCheckout = async () => {
     if (!selectedPlan) return;
 
+    trackCheckoutStart(selectedPlan.id, finalPrice);
+
     if (paymentMethod === "telegram") {
       setProcessingCheckout(true);
       try {
         const botUsername = "DynamicCapital_Support";
-        const telegramUrl = `https://t.me/${botUsername}?start=plan_${selectedPlan.id}${promoValidation?.valid ? `_promo_${promoCode}` : ''}`;
-        window.open(telegramUrl, '_blank');
-        toast.success('Redirecting to Telegram to complete purchase');
+        const promoSuffix = promoValidation?.valid
+          ? `_promo_${promoCode.trim().toUpperCase()}`
+          : "";
+        const telegramUrl =
+          `https://t.me/${botUsername}?start=plan_${selectedPlan.id}${promoSuffix}`;
+        window.open(telegramUrl, "_blank");
+        toast.success("Redirecting to Telegram to complete purchase");
       } catch (error) {
-        toast.error('Failed to initiate checkout');
+        toast.error("Failed to initiate checkout");
       } finally {
         setProcessingCheckout(false);
       }
@@ -149,29 +354,38 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
           telegramId = crypto.randomUUID();
         }
       }
-      const requestBody: any = {
+
+      const requestBody: Record<string, unknown> = {
         plan_id: selectedPlan.id,
-        method: paymentMethod
+        method: paymentMethod,
       };
+
       if (isTelegram && telegramInitData) {
         requestBody.initData = telegramInitData;
       } else if (telegramId) {
         requestBody.telegram_id = telegramId;
       }
-      const { data, error } = await supabase.functions.invoke('checkout-init', {
-        body: requestBody
-      });
+
+      const { data, error } = await supabase.functions.invoke(
+        "checkout-init",
+        {
+          body: requestBody,
+        },
+      );
+
       if (error) {
-        throw new Error(error.message || 'Failed to initialize payment');
+        throw new Error(error.message || "Failed to initialize payment");
       }
+
       setPaymentId(data.payment_id);
       if (data.instructions?.type === "bank_transfer") {
         setBankAccounts(data.instructions.banks || []);
       }
       setCurrentStep("instructions");
-      toast.success('Payment initiated successfully');
+      toast.success("Payment initiated successfully");
     } catch (error: any) {
-      toast.error(error.message || 'Failed to initiate checkout');
+      logger.error("Checkout initiation failed", error);
+      toast.error(error.message || "Failed to initiate checkout");
     } finally {
       setProcessingCheckout(false);
     }
@@ -180,52 +394,71 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
   const handleFileUpload = async () => {
     if (!uploadedFile || !paymentId) return;
     setUploading(true);
-    setUploadStatus('idle');
+    setUploadStatus("idle");
     try {
-      const uploadRequestBody: any = {
+      const uploadRequestBody: Record<string, unknown> = {
         payment_id: paymentId,
         filename: uploadedFile.name,
-        content_type: uploadedFile.type
+        content_type: uploadedFile.type,
       };
+
       if (isTelegram && telegramInitData) {
         uploadRequestBody.initData = telegramInitData;
       }
-      const { data: uploadData, error: uploadError } = await supabase.functions.invoke('receipt-upload-url', {
-        body: uploadRequestBody
-      });
+
+      const { data: uploadData, error: uploadError } = await supabase.functions
+        .invoke(
+          "receipt-upload-url",
+          {
+            body: uploadRequestBody,
+          },
+        );
+
       if (uploadError) throw uploadError;
       if (!uploadData?.upload_url) {
-        throw new Error('No upload URL received');
+        throw new Error("No upload URL received");
       }
+
       const uploadResponse = await fetch(uploadData.upload_url, {
-        method: 'PUT',
+        method: "PUT",
         body: uploadedFile,
         headers: {
-          'Content-Type': uploadedFile.type,
-          'x-amz-acl': 'private'
-        }
+          "Content-Type": uploadedFile.type,
+          "x-amz-acl": "private",
+        },
       });
+
       if (!uploadResponse.ok) {
         throw new Error(`Upload failed: ${uploadResponse.statusText}`);
       }
-      const submitRequestBody: any = {
+
+      const submitRequestBody: Record<string, unknown> = {
         payment_id: paymentId,
         file_path: uploadData.file_path,
-        bucket: uploadData.bucket
+        bucket: uploadData.bucket,
       };
+
       if (isTelegram && telegramInitData) {
         submitRequestBody.initData = telegramInitData;
       }
-      const { error: submitError } = await supabase.functions.invoke('receipt-submit', {
-        body: submitRequestBody
-      });
+
+      const { error: submitError } = await supabase.functions.invoke(
+        "receipt-submit",
+        {
+          body: submitRequestBody,
+        },
+      );
+
       if (submitError) throw submitError;
       setCurrentStep("pending");
-      setUploadStatus('success');
-      toast.success('Receipt uploaded successfully! Your payment is being reviewed.');
+      setUploadStatus("success");
+      toast.success(
+        "Receipt uploaded successfully! Your payment is being reviewed.",
+      );
     } catch (error: any) {
-      setUploadStatus('error');
-      toast.error(error.message || 'Failed to upload receipt');
+      setUploadStatus("error");
+      logger.error("Receipt upload failed", error);
+      toast.error(error.message || "Failed to upload receipt");
     } finally {
       setUploading(false);
     }
@@ -238,17 +471,9 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
     setRetrying(false);
   };
 
-  const calculateFinalPrice = () => {
-    if (!selectedPlan) return 0;
-    if (!promoValidation?.valid) return selectedPlan.price;
-    if (promoValidation.discount_type === 'percentage') {
-      return selectedPlan.price * (1 - promoValidation.discount_value / 100);
-    } else {
-      return Math.max(0, selectedPlan.price - promoValidation.discount_value);
-    }
-  };
+  const isInitialLoading = plansLoading && !plansLoaded;
 
-  if (loading) {
+  if (isInitialLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex items-center gap-2 text-muted-foreground">
@@ -261,16 +486,36 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
 
   if (!selectedPlan) {
     return (
-      <Alert>
-        <AlertCircle className="h-4 w-4" />
-        <AlertDescription>
-          No plan selected. Please select a plan to continue.
-        </AlertDescription>
-      </Alert>
+      <div className="space-y-4">
+        {plansError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Unable to load plans</AlertTitle>
+            <AlertDescription>
+              {plansError}
+              <div className="mt-3">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => refresh(true)}
+                >
+                  Retry loading plans
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            No plan selected. Please select a plan to continue.
+          </AlertDescription>
+        </Alert>
+      </div>
     );
   }
 
-  const finalPrice = calculateFinalPrice();
+  const plansExist = plans.length > 0;
 
   return (
     <>
@@ -288,32 +533,71 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
           </p>
         </div>
 
+        {plansError && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Unable to load plans</AlertTitle>
+            <AlertDescription className="space-y-2">
+              <p>{plansError}</p>
+              <Button size="sm" variant="outline" onClick={() => refresh(true)}>
+                Retry loading plans
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
         <div className="grid grid-cols-1 gap-6 sm:gap-8 lg:grid-cols-2">
-          <PlanSummary plan={selectedPlan} finalPrice={finalPrice} promoValidation={promoValidation} />
+          <PlanSummary
+            plan={selectedPlan}
+            finalPrice={finalPrice}
+            promoValidation={promoValidation}
+          />
 
           <div className="space-y-4">
-            {plans.length > 1 && (
+            {plansExist && plans.length > 1 && (
               <Card>
                 <CardHeader>
                   <CardTitle className="text-lg">Choose Plan</CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-2">
-                  {plans.map((plan) => (
-                    <Button
-                      key={plan.id}
-                      variant={selectedPlan.id === plan.id ? "default" : "outline"}
-                      className="w-full justify-between h-auto p-4"
-                      onClick={() => setSelectedPlan(plan)}
-                    >
-                      <div className="text-left">
-                        <div className="font-medium">{plan.name}</div>
-                        <div className="text-xs opacity-75">
-                          {plan.is_lifetime ? 'Lifetime' : `${plan.duration_months} months`}
+                  {plans.map((plan) => {
+                    const displayPrice = plan.pricing?.displayPrice ??
+                      plan.price;
+                    const formattedPrice = formatPrice(
+                      displayPrice,
+                      plan.currency,
+                      "en-US",
+                      {
+                        minimumFractionDigits: 0,
+                        maximumFractionDigits: 0,
+                      },
+                    );
+                    const isSelected = selectedPlan.id === plan.id;
+
+                    return (
+                      <Button
+                        key={plan.id}
+                        variant={isSelected ? "default" : "outline"}
+                        className="w-full justify-between h-auto p-4"
+                        onClick={() => {
+                          if (plan.id !== selectedPlan.id) {
+                            setSelectedPlan(plan);
+                            setPromoValidation(null);
+                          }
+                        }}
+                      >
+                        <div className="text-left">
+                          <div className="font-medium">{plan.name}</div>
+                          <div className="text-xs opacity-75">
+                            {plan.is_lifetime
+                              ? "Lifetime"
+                              : `${plan.duration_months} months`}
+                          </div>
                         </div>
-                      </div>
-                      <div className="font-bold">${plan.price}</div>
-                    </Button>
-                  ))}
+                        <div className="font-bold">{formattedPrice}</div>
+                      </Button>
+                    );
+                  })}
                 </CardContent>
               </Card>
             )}
@@ -324,6 +608,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
               validatePromoCode={validatePromoCode}
               validatingPromo={validatingPromo}
               promoValidation={promoValidation}
+              currency={planCurrency}
             />
 
             <Separator />
@@ -335,6 +620,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
                 handleCheckout={handleCheckout}
                 processingCheckout={processingCheckout}
                 finalPrice={finalPrice}
+                currency={planCurrency}
               />
             )}
 
@@ -358,11 +644,14 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
               />
             )}
 
-            {currentStep === "pending" && <PendingReview paymentId={paymentId} />}
+            {currentStep === "pending" && (
+              <PendingReview paymentId={paymentId} />
+            )}
 
             {currentStep === "method" && (
               <p className="text-xs text-center text-muted-foreground">
-                By proceeding, you agree to our Terms of Service and Privacy Policy.
+                By proceeding, you agree to our Terms of Service and Privacy
+                Policy.
               </p>
             )}
           </div>
@@ -373,7 +662,7 @@ export const WebCheckout: React.FC<WebCheckoutProps> = ({
           <DigitalReceipt
             plan={selectedPlan}
             finalPrice={finalPrice}
-            promoCode={promoCode}
+            promoCode={promoValidation?.valid ? promoCode : ""}
             onClose={() => setShowReceipt(false)}
           />
         )}

--- a/apps/web/components/checkout/types.ts
+++ b/apps/web/components/checkout/types.ts
@@ -7,3 +7,11 @@ export interface BankAccount {
   account_number: string;
   currency: string;
 }
+
+export interface PromoValidationResult {
+  valid: boolean;
+  discountType?: "percentage" | "fixed";
+  discountValue?: number;
+  finalAmount?: number;
+  reason?: string;
+}


### PR DESCRIPTION
## Summary
- swap the checkout page to load plans through the shared subscription plan hook with analytics and richer error handling
- normalize promo validation data so discount math, currency formatting, and telemetry stay consistent across components
- surface dynamic price context in the plan summary and payment method UI, including currency-aware messaging

## Testing
- npm run lint
- npm run typecheck *(fails: unresolved magic-portfolio imports in app/tools/dynamic-portfolio/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c6aad3908322a06218fc25be521c