### PR TITLE
Optimize Next.js icon imports

### DIFF
--- a/apps/web/components/telegram/FeatureCard.tsx
+++ b/apps/web/components/telegram/FeatureCard.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
-import { LucideIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 interface FeatureCardProps {
   icon: LucideIcon;
@@ -11,13 +11,13 @@ interface FeatureCardProps {
   accent?: "blue" | "green" | "purple" | "orange" | "red" | "teal";
 }
 
-export const FeatureCard = ({ 
-  icon: Icon, 
-  title, 
-  description, 
+export const FeatureCard = ({
+  icon: Icon,
+  title,
+  description,
   onClick,
   badge,
-  accent = "blue"
+  accent = "blue",
 }: FeatureCardProps) => {
   const getAccentColor = () => {
     switch (accent) {
@@ -67,8 +67,12 @@ export const FeatureCard = ({
           </div>
         )}
         <div className="relative">
-          <div className={`bot-icon-wrapper w-20 h-20 ${getAccentBg()} rounded-3xl group-hover:scale-110`}>
-            <Icon className={`w-10 h-10 ${getAccentColor()} transition-transform group-hover:scale-110`} />
+          <div
+            className={`bot-icon-wrapper w-20 h-20 ${getAccentBg()} rounded-3xl group-hover:scale-110`}
+          >
+            <Icon
+              className={`w-10 h-10 ${getAccentColor()} transition-transform group-hover:scale-110`}
+            />
           </div>
           <div className="absolute -top-1 -right-1 w-6 h-6 bg-telegram rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
         </div>

--- a/apps/web/components/telegram/StatusCard.tsx
+++ b/apps/web/components/telegram/StatusCard.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { LucideIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 interface StatusCardProps {
   icon: LucideIcon;
@@ -12,13 +12,13 @@ interface StatusCardProps {
   loading?: boolean;
 }
 
-export const StatusCard = ({ 
-  icon: Icon, 
-  title, 
-  value, 
-  status = "success", 
+export const StatusCard = ({
+  icon: Icon,
+  title,
+  value,
+  status = "success",
   description,
-  loading = false 
+  loading = false,
 }: StatusCardProps) => {
   const getStatusColor = () => {
     switch (status) {
@@ -40,11 +40,21 @@ export const StatusCard = ({
   const getStatusBadge = () => {
     switch (status) {
       case "online":
-        return <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100">✅ Online</Badge>;
+        return (
+          <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100">
+            ✅ Online
+          </Badge>
+        );
       case "offline":
-        return <Badge className="bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100">⚠️ Offline</Badge>;
+        return (
+          <Badge className="bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-100">
+            ⚠️ Offline
+          </Badge>
+        );
       case "loading":
-        return <Badge variant="outline" className="animate-pulse">Loading...</Badge>;
+        return (
+          <Badge variant="outline" className="animate-pulse">Loading...</Badge>
+        );
       default:
         return null;
     }
@@ -53,26 +63,32 @@ export const StatusCard = ({
   return (
     <Card className="bot-card p-6 group">
       <div className="flex items-center gap-4">
-        <div className={`bot-icon-wrapper p-3 w-16 h-16 ${getStatusColor()}/10 group-hover:${getStatusColor()}/20`}>
-          <Icon className={`w-8 h-8 ${getStatusColor()} transition-transform group-hover:scale-110`} />
+        <div
+          className={`bot-icon-wrapper p-3 w-16 h-16 ${getStatusColor()}/10 group-hover:${getStatusColor()}/20`}
+        >
+          <Icon
+            className={`w-8 h-8 ${getStatusColor()} transition-transform group-hover:scale-110`}
+          />
         </div>
         <div className="flex-1 min-w-0">
           <p className="bot-label">{title}</p>
           <div className="flex items-center gap-3 mt-2">
-            {status === "online" || status === "offline" || status === "loading" ? (
-              getStatusBadge()
-            ) : (
-              <p className="bot-metric">
-                {loading ? (
-                  <span className="animate-pulse">...</span>
-                ) : (
-                  <span className="animate-fade-in">{value}</span>
-                )}
-              </p>
-            )}
+            {status === "online" || status === "offline" || status === "loading"
+              ? (
+                getStatusBadge()
+              )
+              : (
+                <p className="bot-metric">
+                  {loading
+                    ? <span className="animate-pulse">...</span>
+                    : <span className="animate-fade-in">{value}</span>}
+                </p>
+              )}
           </div>
           {description && (
-            <p className="text-xs text-muted-foreground mt-1 truncate">{description}</p>
+            <p className="text-xs text-muted-foreground mt-1 truncate">
+              {description}
+            </p>
           )}
         </div>
       </div>

--- a/apps/web/components/ui/icon.tsx
+++ b/apps/web/components/ui/icon.tsx
@@ -1,16 +1,22 @@
 import * as React from "react";
-import { icons, LucideProps } from "lucide-react";
+import type { LucideIcon, LucideProps } from "lucide-react";
+import { icons as lucideIcons } from "lucide-react/dist/esm/lucide-react";
 import { cn } from "@/utils";
 
-export type IconName = keyof typeof icons;
+const iconLibrary: Record<string, LucideIcon> = lucideIcons as Record<
+  string,
+  LucideIcon
+>;
+
+export type IconName = keyof typeof iconLibrary;
 
 // Standardized icon sizes based on universal theme
 const iconSizes = {
-  xs: "icon-xs",     // w-3 h-3
-  sm: "icon-sm",     // w-4 h-4  
+  xs: "icon-xs", // w-3 h-3
+  sm: "icon-sm", // w-4 h-4
   base: "icon-base", // w-5 h-5
-  lg: "icon-lg",     // w-6 h-6
-  xl: "icon-xl",     // w-8 h-8
+  lg: "icon-lg", // w-6 h-6
+  xl: "icon-xl", // w-8 h-8
 };
 
 export interface IconProps extends Omit<LucideProps, "ref"> {
@@ -21,13 +27,16 @@ export interface IconProps extends Omit<LucideProps, "ref"> {
 }
 
 const Icon = React.forwardRef<SVGSVGElement, IconProps>(
-  ({ name, size = "base", animation = "none", title, className, ...props }, ref) => {
-    const LucideIcon = icons[name];
+  (
+    { name, size = "base", animation = "none", title, className, ...props },
+    ref,
+  ) => {
+    const LucideIcon = iconLibrary[name];
 
     const animationClasses = {
       none: "",
       pulse: "animate-pulse",
-      float: "animate-float", 
+      float: "animate-float",
       wiggle: "animate-wiggle",
       glow: "animate-pulse-glow",
     };
@@ -39,13 +48,13 @@ const Icon = React.forwardRef<SVGSVGElement, IconProps>(
           iconSizes[size],
           animationClasses[animation],
           "transition-all duration-200",
-          className
+          className,
         )}
         aria-label={title}
         {...props}
       />
     );
-  }
+  },
 );
 
 Icon.displayName = "Icon";

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -166,10 +166,23 @@ process.env.ALLOWED_ORIGINS = ALLOWED_ORIGINS;
 process.env.DEFAULT_LOCALE = DEFAULT_LOCALE;
 process.env.NEXT_PUBLIC_DEFAULT_LOCALE = DEFAULT_LOCALE;
 
+const optimizePackageImports = ['lucide-react'];
+
+const modularizeImportRules = {
+  'lucide-react': {
+    transform: 'lucide-react/dist/esm/icons/{{member}}',
+    skipDefaultConversion: true,
+  },
+};
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
+  experimental: {
+    optimizePackageImports,
+  },
+  modularizeImports: modularizeImportRules,
   env: {
     SUPABASE_URL,
     SUPABASE_ANON_KEY,


### PR DESCRIPTION
## Summary
- enable Next.js optimizePackageImports and modularize lucide-react icons for better tree-shaking during builds
- update the shared icon helper to load icons from lucide submodules while keeping consuming components type-safe
- convert lucide-react consumers in Telegram UI components to type-only imports to avoid bundler regressions

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7d82449a083228236baf6fd42d3e2