### PR TITLE
Optimize dynamic UI motion preset memoization

### DIFF
--- a/apps/web/components/dynamic-ui/dynamic-container.tsx
+++ b/apps/web/components/dynamic-ui/dynamic-container.tsx
@@ -53,21 +53,48 @@ export const DynamicContainer = React.forwardRef<
     },
     ref,
   ) => {
-    const shouldApplyPreset = animateIn && animateProp === undefined;
-    const resolvedVariants = variantsProp ??
-      (shouldApplyPreset && variant
-        ? dynamicMotionVariants[variant]
-        : undefined);
+    const {
+      variants: resolvedVariants,
+      initial: initialValue,
+      whileInView: whileInViewValue,
+      viewport: resolvedViewport,
+    } = React.useMemo(() => {
+      const shouldApplyPreset = animateIn && animateProp === undefined;
+      const resolvedVariants = variantsProp ??
+        (shouldApplyPreset && variant
+          ? dynamicMotionVariants[variant]
+          : undefined);
 
-    const initialValue = shouldApplyPreset && resolvedVariants
-      ? initialProp ?? "hidden"
-      : initialProp;
-    const whileInViewValue = shouldApplyPreset && resolvedVariants
-      ? whileInViewProp ?? "visible"
-      : whileInViewProp;
-    const resolvedViewport = shouldApplyPreset && resolvedVariants
-      ? viewport ?? { once, amount: viewportAmount }
-      : viewport;
+      if (!resolvedVariants) {
+        return {
+          variants: variantsProp,
+          initial: initialProp,
+          whileInView: whileInViewProp,
+          viewport,
+        } as const;
+      }
+
+      return {
+        variants: resolvedVariants,
+        initial: shouldApplyPreset ? initialProp ?? "hidden" : initialProp,
+        whileInView: shouldApplyPreset
+          ? whileInViewProp ?? "visible"
+          : whileInViewProp,
+        viewport: shouldApplyPreset
+          ? viewport ?? { once, amount: viewportAmount }
+          : viewport,
+      } as const;
+    }, [
+      animateIn,
+      animateProp,
+      initialProp,
+      once,
+      variant,
+      variantsProp,
+      viewport,
+      viewportAmount,
+      whileInViewProp,
+    ]);
 
     return (
       <MotionDiv

--- a/apps/web/components/dynamic-ui/dynamic-motion.tsx
+++ b/apps/web/components/dynamic-ui/dynamic-motion.tsx
@@ -85,17 +85,31 @@ export const DynamicMotionFlex = React.forwardRef<
     ref,
   ) => {
     const { variants, initial, whileInView, viewport: resolvedViewport } =
-      resolveMotionPreset({
-        animateIn,
-        variant,
-        once,
-        viewportAmount,
-        animate: animateProp,
-        variants: variantsProp,
-        viewport,
-        initial: initialProp,
-        whileInView: whileInViewProp,
-      });
+      React.useMemo(
+        () =>
+          resolveMotionPreset({
+            animateIn,
+            variant,
+            once,
+            viewportAmount,
+            animate: animateProp,
+            variants: variantsProp,
+            viewport,
+            initial: initialProp,
+            whileInView: whileInViewProp,
+          }),
+        [
+          animateIn,
+          animateProp,
+          initialProp,
+          once,
+          variant,
+          variantsProp,
+          viewport,
+          viewportAmount,
+          whileInViewProp,
+        ],
+      );
 
     return (
       <MotionFlexBase
@@ -140,17 +154,31 @@ export const DynamicMotionColumn = React.forwardRef<
     ref,
   ) => {
     const { variants, initial, whileInView, viewport: resolvedViewport } =
-      resolveMotionPreset({
-        animateIn,
-        variant,
-        once,
-        viewportAmount,
-        animate: animateProp,
-        variants: variantsProp,
-        viewport,
-        initial: initialProp,
-        whileInView: whileInViewProp,
-      });
+      React.useMemo(
+        () =>
+          resolveMotionPreset({
+            animateIn,
+            variant,
+            once,
+            viewportAmount,
+            animate: animateProp,
+            variants: variantsProp,
+            viewport,
+            initial: initialProp,
+            whileInView: whileInViewProp,
+          }),
+        [
+          animateIn,
+          animateProp,
+          initialProp,
+          once,
+          variant,
+          variantsProp,
+          viewport,
+          viewportAmount,
+          whileInViewProp,
+        ],
+      );
 
     return (
       <MotionColumnBase
@@ -195,17 +223,31 @@ export const DynamicMotionRow = React.forwardRef<
     ref,
   ) => {
     const { variants, initial, whileInView, viewport: resolvedViewport } =
-      resolveMotionPreset({
-        animateIn,
-        variant,
-        once,
-        viewportAmount,
-        animate: animateProp,
-        variants: variantsProp,
-        viewport,
-        initial: initialProp,
-        whileInView: whileInViewProp,
-      });
+      React.useMemo(
+        () =>
+          resolveMotionPreset({
+            animateIn,
+            variant,
+            once,
+            viewportAmount,
+            animate: animateProp,
+            variants: variantsProp,
+            viewport,
+            initial: initialProp,
+            whileInView: whileInViewProp,
+          }),
+        [
+          animateIn,
+          animateProp,
+          initialProp,
+          once,
+          variant,
+          variantsProp,
+          viewport,
+          viewportAmount,
+          whileInViewProp,
+        ],
+      );
 
     return (
       <MotionRowBase


### PR DESCRIPTION
## Summary
- memoize dynamic motion preset resolution in DynamicContainer to keep animation presets stable without recreating objects
- apply the same memoization to DynamicMotion flex, column, and row wrappers for fewer layout recalculations

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7dd2345ac8322a6747c9e72ead865