### PR TITLE
Fix Once UI list ref forwarding

### DIFF
--- a/apps/web/types/once-ui-list-ref-example.tsx
+++ b/apps/web/types/once-ui-list-ref-example.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+import { List, ListItem } from "@once-ui-system/core";
+
+/**
+ * Example usage to document the ref behaviour for List and ListItem.
+ */
+export function OnceUIListRefExample() {
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const firstItemRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (listRef.current && firstItemRef.current) {
+      console.assert(firstItemRef.current.tagName === "LI");
+      console.assert(listRef.current.contains(firstItemRef.current));
+    }
+  }, []);
+
+  return (
+    <List ref={listRef} as="ul" gap="4">
+      <ListItem ref={firstItemRef}>Tracked Item</ListItem>
+      <ListItem>Supporting Item</ListItem>
+    </List>
+  );
+}

--- a/node_modules/@once-ui-system/core/dist/components/List.d.ts
+++ b/node_modules/@once-ui-system/core/dist/components/List.d.ts
@@ -1,0 +1,20 @@
+import React from "react";
+import type { ComponentPropsWithoutRef, ReactElement } from "react";
+import { Column } from ".";
+type ListElement = "ul" | "ol";
+type ColumnProps = ComponentPropsWithoutRef<typeof Column>;
+type InferListRef<T extends ListElement> = T extends "ol" ? HTMLOListElement : HTMLUListElement;
+type BaseListProps<T extends ListElement> = Omit<ColumnProps, "as"> & {
+    as?: T;
+    children?: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+};
+type ListComponent = (<T extends ListElement = "ul">(props: BaseListProps<T> & {
+    ref?: React.Ref<InferListRef<T>>;
+}) => ReactElement) & {
+    displayName: string;
+};
+declare const List: ListComponent;
+export { List };
+//# sourceMappingURL=List.d.ts.map

--- a/node_modules/@once-ui-system/core/dist/components/ListItem.d.ts
+++ b/node_modules/@once-ui-system/core/dist/components/ListItem.d.ts
@@ -1,0 +1,10 @@
+import React from "react";
+import { Text } from ".";
+interface ListItemProps extends React.ComponentPropsWithoutRef<typeof Text> {
+    children?: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+}
+declare const ListItem: React.ForwardRefExoticComponent<Omit<ListItemProps, "ref"> & React.RefAttributes<HTMLLIElement>>;
+export { ListItem };
+//# sourceMappingURL=ListItem.d.ts.map

--- a/node_modules/@once-ui-system/core/dist/components/ListItem.js
+++ b/node_modules/@once-ui-system/core/dist/components/ListItem.js
@@ -1,0 +1,13 @@
+"use client";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { forwardRef } from "react";
+import classNames from "classnames";
+import styles from "./List.module.scss";
+import { Text } from ".";
+const ListItem = forwardRef(({ className, children, style, ...props }, ref) => {
+    const listItemClass = classNames(styles.listItem, className);
+    return (_jsx(Text, { as: "li", paddingY: "0", paddingRight: "0", paddingLeft: "8", className: listItemClass, style: style, ref: ref, ...props, children: children }));
+});
+ListItem.displayName = "ListItem";
+export { ListItem };
+//# sourceMappingURL=ListItem.js.map

--- a/node_modules/@once-ui-system/core/dist/components/Text.d.ts
+++ b/node_modules/@once-ui-system/core/dist/components/Text.d.ts
@@ -1,0 +1,11 @@
+import { ElementType, ComponentPropsWithoutRef, ElementRef, Ref } from "react";
+import { TextProps, CommonProps, SpacingProps } from "../interfaces";
+type TypeProps<T extends ElementType> = TextProps<T> & CommonProps & SpacingProps & ComponentPropsWithoutRef<T>;
+type TextComponent = (<T extends ElementType = "span">({ as, variant, size, weight, onBackground, onSolid, align, wrap, padding, paddingLeft, paddingRight, paddingTop, paddingBottom, paddingX, paddingY, margin, marginLeft, marginRight, marginTop, marginBottom, marginX, marginY, children, style, className, truncate, ...props }: TypeProps<T> & {
+    ref?: Ref<ElementRef<T>>;
+}) => import("react/jsx-runtime").JSX.Element) & {
+    displayName: string;
+};
+declare const Text: TextComponent;
+export { Text };
+//# sourceMappingURL=Text.d.ts.map

--- a/node_modules/@once-ui-system/core/dist/components/Text.js
+++ b/node_modules/@once-ui-system/core/dist/components/Text.js
@@ -1,0 +1,40 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import { forwardRef } from "react";
+import classNames from "classnames";
+const Text = forwardRef(({ as, variant, size, weight, onBackground, onSolid, align, wrap, padding, paddingLeft, paddingRight, paddingTop, paddingBottom, paddingX, paddingY, margin, marginLeft, marginRight, marginTop, marginBottom, marginX, marginY, children, style, className, truncate, ...props }, ref) => {
+    const Component = as || "span";
+    if (variant && (size || weight)) {
+        console.warn("When 'variant' is set, 'size' and 'weight' are ignored.");
+    }
+    if (onBackground && onSolid) {
+        console.warn("You cannot use both 'onBackground' and 'onSolid' props simultaneously. Only one will be applied.");
+    }
+    const getVariantClasses = (variant) => {
+        const [fontType, weight, size] = variant.split("-");
+        return [`font-${fontType}`, `font-${weight}`, `font-${size}`];
+    };
+    const sizeClass = size ? `font-${size}` : "";
+    const weightClass = weight ? `font-${weight}` : "";
+    const classes = variant ? getVariantClasses(variant) : [sizeClass, weightClass];
+    let colorClass = "";
+    if (onBackground) {
+        const [scheme, weight] = onBackground.split("-");
+        colorClass = `${scheme}-on-background-${weight}`;
+    }
+    else if (onSolid) {
+        const [scheme, weight] = onSolid.split("-");
+        colorClass = `${scheme}-on-solid-${weight}`;
+    }
+    const generateClassName = (prefix, token) => {
+        return token ? `${prefix}-${token}` : undefined;
+    };
+    const combinedClasses = classNames(...classes, colorClass, className, generateClassName("p", padding), generateClassName("pl", paddingLeft), generateClassName("pr", paddingRight), generateClassName("pt", paddingTop), generateClassName("pb", paddingBottom), generateClassName("px", paddingX), generateClassName("py", paddingY), generateClassName("m", margin), generateClassName("ml", marginLeft), generateClassName("mr", marginRight), generateClassName("mt", marginTop), generateClassName("mb", marginBottom), generateClassName("mx", marginX), generateClassName("my", marginY), truncate && "truncate");
+    return (_jsx(Component, { ref: ref, className: combinedClasses, style: {
+            textAlign: align,
+            textWrap: wrap,
+            ...style,
+        }, ...props, children: children }));
+});
+Text.displayName = "Text";
+export { Text };
+//# sourceMappingURL=Text.js.map


### PR DESCRIPTION
## Summary
- forward Once UI Text and ListItem components so refs reach their rendered DOM nodes
- update List typings to return the correct semantic element refs and add an example that exercises the behavior

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7dd7b250883228a9a0a74fde4dabd