### PR TITLE
fix: render Pulse children

### DIFF
--- a/apps/web/components/dynamic-ui-system/Pulse.tsx
+++ b/apps/web/components/dynamic-ui-system/Pulse.tsx
@@ -1,0 +1,71 @@
+import { type ComponentProps, forwardRef, type ReactNode } from "react";
+import { Row } from "@once-ui-system/core/components";
+import styles from "@once-ui-system/core/dist/components/Pulse.module.scss";
+import type {
+  Colors,
+  ColorScheme,
+  CondensedTShirtSizes,
+} from "@once-ui-system/core";
+
+interface PulseProps extends ComponentProps<typeof Row> {
+  variant?: ColorScheme;
+  size?: CondensedTShirtSizes;
+  children?: ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const Pulse = forwardRef<HTMLDivElement, PulseProps>(
+  (
+    {
+      children,
+      className,
+      style,
+      size = "m",
+      variant = "brand",
+      ...flex
+    },
+    ref,
+  ) => {
+    const dotSize = size === "s" ? "32" : size === "m" ? "48" : "64";
+    const indicatorSize = size === "s" ? "4" : size === "m" ? "8" : "12";
+    const containerSize = size === "s" ? "16" : size === "m" ? "24" : "32";
+
+    const mediumSolid = `${variant}-medium` as Colors;
+    const strongSolid = `${variant}-strong` as Colors;
+
+    return (
+      <Row
+        ref={ref}
+        minWidth={containerSize}
+        minHeight={containerSize}
+        center
+        data-solid="color"
+        className={className}
+        style={style}
+        {...flex}
+      >
+        <Row position="absolute" className={styles.position}>
+          <Row
+            solid={mediumSolid}
+            radius="full"
+            className={styles.dot}
+            width={dotSize}
+            height={dotSize}
+          />
+        </Row>
+        <Row
+          solid={strongSolid}
+          minWidth={indicatorSize}
+          minHeight={indicatorSize}
+          radius="full"
+        />
+        {children}
+      </Row>
+    );
+  },
+);
+
+Pulse.displayName = "Pulse";
+
+export { Pulse };

--- a/apps/web/components/dynamic-ui-system/index.ts
+++ b/apps/web/components/dynamic-ui-system/index.ts
@@ -1,1 +1,2 @@
 export * from "@once-ui-system/core";
+export { Pulse } from "./Pulse";


### PR DESCRIPTION
## Summary
- add a local Pulse wrapper that mirrors the Once UI styling while rendering passed children
- export the patched Pulse from the dynamic UI system barrel to override the package version

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d7de12a2c08322bdb60ae122fef472