### PR TITLE
Fix progress accessibility and indeterminate behaviour

### DIFF
--- a/apps/web/components/ui/progress.tsx
+++ b/apps/web/components/ui/progress.tsx
@@ -42,8 +42,12 @@ export const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   ProgressProps
 >(
-  (
-    {
+  (componentProps, ref) => {
+    const hasValueProp = Object.prototype.hasOwnProperty.call(
+      componentProps,
+      "value",
+    );
+    const {
       className,
       wrapperClassName,
       indicatorClassName,
@@ -51,12 +55,10 @@ export const Progress = React.forwardRef<
       showLabel = Boolean(label),
       showValue = true,
       formatValue = (percentage) => `${Math.round(percentage)}%`,
-      value = 0,
+      value,
       max = 100,
       ...props
-    },
-    ref,
-  ) => {
+    } = componentProps;
     const {
       ["aria-label"]: ariaLabelProp,
       ["aria-labelledby"]: ariaLabelledbyProp,
@@ -66,20 +68,19 @@ export const Progress = React.forwardRef<
     const labelId = React.useId();
     const fallbackLabel = label ?? "Progress";
     const safeMax = typeof max === "number" && max > 0 ? max : 100;
-    const isIndeterminate = value == null;
+    const isIndeterminate = hasValueProp && value == null;
     const safeValue = isIndeterminate
       ? null
       : Math.min(Math.max(value ?? 0, 0), safeMax);
-    const percentage =
-      safeValue === null || safeMax === 0
-        ? null
-        : (safeValue / safeMax) * 100;
-    const displayValue =
-      typeof percentage === "number" ? formatValue(percentage) : null;
-    const ariaLabelledby =
-      ariaLabelledbyProp ?? (showLabel ? labelId : undefined);
-    const ariaLabel =
-      ariaLabelProp ?? (!showLabel ? fallbackLabel : undefined);
+    const percentage = safeValue === null || safeMax === 0
+      ? null
+      : (safeValue / safeMax) * 100;
+    const displayValue = typeof percentage === "number"
+      ? formatValue(percentage)
+      : null;
+    const ariaLabelledby = ariaLabelledbyProp ??
+      (showLabel ? labelId : undefined);
+    const ariaLabel = ariaLabelProp ?? (!showLabel ? fallbackLabel : undefined);
 
     return (
       <div className={cn("flex flex-col gap-2", wrapperClassName)}>
@@ -110,11 +111,9 @@ export const Progress = React.forwardRef<
               "h-full w-full flex-1 rounded-full bg-gradient-brand transition-transform duration-500 ease-out data-[state=indeterminate]:animate-pulse",
               indicatorClassName,
             )}
-            style={
-              typeof percentage === "number"
-                ? { transform: `translateX(-${100 - percentage}%)` }
-                : undefined
-            }
+            style={typeof percentage === "number"
+              ? { transform: `translateX(-${100 - percentage}%)` }
+              : undefined}
           />
         </ProgressPrimitive.Root>
       </div>

--- a/docs/ui/progress.md
+++ b/docs/ui/progress.md
@@ -13,5 +13,5 @@ animates instead of relying on a fixed width transform, and the formatted value
 is omitted so the UI does not imply a concrete percentage.
 
 ```tsx
-<Progress label="Loading data" showValue={false} value={null} />
+<Progress label="Loading data" showValue={false} value={null} />;
 ```


### PR DESCRIPTION
## Summary
- ensure the Progress component keeps an accessible name whether the visible label is rendered or hidden
- restore support for Radix's indeterminate progress state and add a pulse animation while omitting the formatted value
- document the updated accessibility and indeterminate usage guidance for Progress

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7dde5b1948322a7b6d57aef9c0c09