### PR TITLE
Add Dynamic UI optimizer analytics page

### DIFF
--- a/apps/web/app/tools/dynamic-ui-optimizer/page.tsx
+++ b/apps/web/app/tools/dynamic-ui-optimizer/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
+
+import DynamicUiOptimizer from "@/components/tools/DynamicUiOptimizer";
+
+export default function DynamicUiOptimizerPage() {
+  return (
+    <Column gap="40" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={36} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Dynamic UI optimizer
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          Visualize readiness velocity, automation pipeline conversion, and
+          channel performance so you can prioritize the next rollout for the
+          desk.
+        </Text>
+      </Column>
+      <DynamicUiOptimizer />
+    </Column>
+  );
+}

--- a/apps/web/components/navigation/SiteFooter.tsx
+++ b/apps/web/components/navigation/SiteFooter.tsx
@@ -10,6 +10,7 @@ import { schema, social } from "@/resources";
 import NAV_ITEMS from "./nav-items";
 
 const QUICK_LINKS = [
+  { label: "Dynamic UI optimizer", href: "/tools/dynamic-ui-optimizer" },
   { label: "Dynamic market review", href: "/tools/dynamic-market-review" },
   { label: "Multi-LLM studio", href: "/tools/multi-llm" },
   { label: "Provider matrix", href: "/#provider-matrix" },

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -1,4 +1,5 @@
 import {
+  Gauge,
   LayoutDashboard,
   LineChart,
   type LucideIcon,
@@ -88,14 +89,26 @@ const extraNavItems: NavItem[] = [
     showOnMobile: true,
   },
   {
-    id: "market-review",
+    id: "ui-optimizer",
     step: `Step ${firstExtraStep + 2}`,
+    label: "Dynamic UI optimizer",
+    description: "Optimize readiness workflows and activation channels.",
+    icon: Gauge,
+    path: "/tools/dynamic-ui-optimizer",
+    ariaLabel: `Step ${
+      firstExtraStep + 2
+    }: Dynamic UI optimizer. Optimize readiness workflows and activation channels.`,
+    showOnMobile: true,
+  },
+  {
+    id: "market-review",
+    step: `Step ${firstExtraStep + 3}`,
     label: "Market review",
     description: "Track FX strength, volatility, and cross-asset watchlists.",
     icon: LineChart,
     path: "/tools/dynamic-market-review",
     ariaLabel: `Step ${
-      firstExtraStep + 2
+      firstExtraStep + 3
     }: Market review. Track FX strength, volatility, and cross-asset watchlists.`,
     showOnMobile: true,
   },

--- a/apps/web/components/tools/DynamicUiOptimizer.tsx
+++ b/apps/web/components/tools/DynamicUiOptimizer.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ReactNode } from "react";
+
+import {
+  Column,
+  Heading,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CountUp } from "@/components/ui/enhanced-typography";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipProps } from "recharts";
+
+const ACTIVATION_TREND = [
+  { month: "Apr", readiness: 52 },
+  { month: "May", readiness: 64 },
+  { month: "Jun", readiness: 78 },
+  { month: "Jul", readiness: 92 },
+  { month: "Aug", readiness: 118 },
+  { month: "Sep", readiness: 146 },
+  { month: "Oct", readiness: 173 },
+  { month: "Nov", readiness: 208 },
+  { month: "Dec", readiness: 244 },
+];
+
+const PIPELINE_DATA = [
+  { stage: "Signals trial", members: 86 },
+  { stage: "Automation setup", members: 124 },
+  { stage: "Mentor loop", members: 168 },
+  { stage: "Desk activated", members: 214 },
+];
+
+const CHANNEL_DATA = [
+  { channel: "Mentor referrals", value: 32 },
+  { channel: "Automation prompts", value: 26 },
+  { channel: "Performance reports", value: 18 },
+  { channel: "Community events", value: 14 },
+  { channel: "On-site CTAs", value: 10 },
+];
+
+const CHANNEL_COLORS = [
+  "#020617",
+  "#ff8f00",
+  "#00897b",
+  "#1e88e5",
+  "#d81b60",
+];
+
+const SUMMARY_STATS = [
+  {
+    label: "Workflow coverage",
+    value: 92,
+    suffix: "%",
+    description: "core desk workflows instrumented",
+  },
+  {
+    label: "Automation adoption",
+    value: 76,
+    suffix: "%",
+    description: "operators running automation end-to-end",
+  },
+  {
+    label: "Mentor satisfaction",
+    value: 97,
+    suffix: "%",
+    description: "positive mentor session feedback",
+  },
+] as const;
+
+interface ChartCardProps {
+  title: string;
+  description: string;
+  children: ReactNode;
+}
+
+function ChartCard({ title, description, children }: ChartCardProps) {
+  return (
+    <Card className="h-full border-border/60 bg-background/60 backdrop-blur">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold text-foreground">
+          {title}
+        </CardTitle>
+        <Text as="p" variant="body-default-s" onBackground="neutral-weak">
+          {description}
+        </Text>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="h-64 w-full">
+          {children}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TrendTooltip(
+  { active, payload, label }: TooltipProps<number, string>,
+) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const [{ value }] = payload;
+
+  return (
+    <div className="rounded-md border border-slate-800 bg-slate-950/90 px-3 py-2 text-xs text-slate-100 shadow-lg">
+      <p className="font-semibold">{label}</p>
+      <p className="mt-1 font-medium">Readiness score: {value}</p>
+    </div>
+  );
+}
+
+function PipelineTooltip(
+  { active, payload, label }: TooltipProps<number, string>,
+) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const [{ value }] = payload;
+
+  return (
+    <div className="rounded-md border border-slate-800 bg-slate-950/90 px-3 py-2 text-xs text-slate-100 shadow-lg">
+      <p className="font-semibold">{label}</p>
+      <p className="mt-1 font-medium">Members: {value}</p>
+    </div>
+  );
+}
+
+function ChannelTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const [{ name, value }] = payload;
+
+  return (
+    <div className="rounded-md border border-slate-800 bg-slate-950/90 px-3 py-2 text-xs text-slate-100 shadow-lg">
+      <p className="font-semibold">{name}</p>
+      <p className="mt-1 font-medium">Share: {value}%</p>
+    </div>
+  );
+}
+
+interface SummaryStatProps {
+  label: string;
+  value: number;
+  suffix: string;
+  description: string;
+}
+
+function SummaryStat({ label, value, suffix, description }: SummaryStatProps) {
+  return (
+    <Column
+      gap="8"
+      padding="16"
+      radius="m"
+      border="neutral-alpha-weak"
+      background="surface"
+      className="min-w-[160px]"
+    >
+      <Text variant="label-default-s" onBackground="neutral-medium">
+        {label}
+      </Text>
+      <Heading variant="display-strong-xs">
+        <CountUp end={value} suffix={suffix} />
+      </Heading>
+      <Text variant="body-default-xs" onBackground="neutral-weak">
+        {description}
+      </Text>
+    </Column>
+  );
+}
+
+export function DynamicUiOptimizer() {
+  const dominantChannel = useMemo(() => {
+    return CHANNEL_DATA.reduce(
+      (topChannel, current) =>
+        current.value > topChannel.value ? current : topChannel,
+      CHANNEL_DATA[0],
+    );
+  }, []);
+
+  return (
+    <Column gap="40" fillWidth>
+      <Column gap="16" align="start" maxWidth={48}>
+        <Tag size="s" background="brand-alpha-weak" prefixIcon="activity">
+          Dynamic UI activation
+        </Tag>
+        <Heading variant="display-strong-xs">
+          Optimize onboarding and automation coverage in one dashboard
+        </Heading>
+        <Text variant="body-default-m" onBackground="neutral-weak">
+          Track how members progress through readiness milestones, identify the
+          conversion gaps inside the automation pipeline, and highlight which
+          activation channels bring the most resilient desk operators.
+        </Text>
+        <Text variant="body-default-s" onBackground="brand-medium">
+          Top channel this quarter: {dominantChannel.channel} at{" "}
+          {dominantChannel.value}% of activations.
+        </Text>
+      </Column>
+
+      <Row gap="20" wrap>
+        {SUMMARY_STATS.map((stat) => (
+          <SummaryStat
+            key={stat.label}
+            label={stat.label}
+            value={stat.value}
+            suffix={stat.suffix}
+            description={stat.description}
+          />
+        ))}
+      </Row>
+
+      <Column gap="24">
+        <Row gap="24" wrap>
+          <ChartCard
+            title="Readiness velocity"
+            description="Weekly readiness score showing compounded automation coverage."
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={ACTIVATION_TREND}>
+                <CartesianGrid strokeDasharray="4 6" stroke="#1e293b" />
+                <XAxis
+                  dataKey="month"
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fill: "#94a3b8", fontSize: 12 }}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fill: "#94a3b8", fontSize: 12 }}
+                />
+                <Tooltip content={<TrendTooltip />} />
+                <Line
+                  type="monotone"
+                  dataKey="readiness"
+                  stroke="#020617"
+                  strokeWidth={3}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          <ChartCard
+            title="Pipeline conversion"
+            description="How many members land in each automation milestone this month."
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={PIPELINE_DATA}>
+                <CartesianGrid strokeDasharray="4 6" stroke="#1e293b" />
+                <XAxis
+                  dataKey="stage"
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fill: "#94a3b8", fontSize: 12 }}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fill: "#94a3b8", fontSize: 12 }}
+                />
+                <Tooltip content={<PipelineTooltip />} />
+                <Bar dataKey="members" radius={[8, 8, 0, 0]} fill="#020617" />
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        </Row>
+
+        <ChartCard
+          title="Activation sources"
+          description="Distribution of where qualified operators originate before joining the desk."
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Tooltip content={<ChannelTooltip />} />
+              <Legend
+                verticalAlign="bottom"
+                align="center"
+                iconType="circle"
+                wrapperStyle={{ color: "#94a3b8", fontSize: 12 }}
+              />
+              <Pie
+                dataKey="value"
+                data={CHANNEL_DATA}
+                innerRadius={60}
+                outerRadius={90}
+                paddingAngle={6}
+              >
+                {CHANNEL_DATA.map((entry, index) => (
+                  <Cell
+                    key={entry.channel}
+                    name={entry.channel}
+                    fill={CHANNEL_COLORS[index % CHANNEL_COLORS.length]}
+                  />
+                ))}
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </Column>
+    </Column>
+  );
+}
+
+export default DynamicUiOptimizer;

--- a/apps/web/resources/content.tsx
+++ b/apps/web/resources/content.tsx
@@ -108,15 +108,15 @@ const home: Home = {
           onBackground="brand-strong"
           className="ml-4 font-semibold tracking-tight"
         >
-          Launch update: Dynamic market review
+          Launch update: Dynamic UI optimizer
         </Text>
         <Line background="brand-alpha-strong" vert height="20" />
         <Text marginRight="4" onBackground="brand-medium">
-          Cross-asset intelligence with live FX, commodity, and index signals
+          Diagnose readiness velocity and activation channels in real time
         </Text>
       </Row>
     ),
-    href: "/tools/dynamic-market-review",
+    href: "/tools/dynamic-ui-optimizer",
   },
   subline: (
     <>


### PR DESCRIPTION
## Summary
- add a Dynamic UI optimizer dashboard component with readiness, pipeline, and channel charts
- expose the dashboard via a new /tools/dynamic-ui-optimizer route and promote it from the homepage feature slot
- surface the new tool in navigation quick links and the workspace tour menu

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d7e1add698832298d4cd46feef09a7