### PR TITLE
Broaden npm cache lockfile globs in workflows

### DIFF
--- a/.github/workflows/assets_audit.yml
+++ b/.github/workflows/assets_audit.yml
@@ -13,6 +13,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            apps/*/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Run assets audit (dry-run)

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,6 +11,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            apps/*/package-lock.json
       - name: Run Audit
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/.github/workflows/content-guard.yml
+++ b/.github/workflows/content-guard.yml
@@ -17,7 +17,12 @@ jobs:
           git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD > changed.txt
           cat changed.txt
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            apps/*/package-lock.json
       - name: Run content guard
         env:
           CHANGED_LIST: changed.txt

--- a/.github/workflows/ops-sync.yml
+++ b/.github/workflows/ops-sync.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            apps/*/package-lock.json
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x

--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            apps/*/package-lock.json
       - name: Install dependencies
         run: npm ci
       - name: Build landing


### PR DESCRIPTION
## Summary
- widen the npm cache dependency paths in workflow setup-node steps to cover workspace lockfiles

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d7ef77db9c83228fa2e39551dd0866