### PR TITLE
Add DynamicChatAgent for aggregated persona transcripts

### DIFF
--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -3,6 +3,9 @@
 from .agents import (
     Agent,
     AgentResult,
+    ChatAgentResult,
+    ChatTurn,
+    DynamicChatAgent,
     ExecutionAgent,
     ExecutionAgentResult,
     ResearchAgent,
@@ -38,6 +41,9 @@ from .hedge import (
 __all__ = [
     "Agent",
     "AgentResult",
+    "ChatAgentResult",
+    "ChatTurn",
+    "DynamicChatAgent",
     "AISignal",
     "DynamicFusionAlgo",
     "ExecutionAgent",


### PR DESCRIPTION
## Summary
- add a DynamicChatAgent persona that turns research, execution, and risk outputs into structured chat transcripts
- export the chat agent types from the dynamic_ai package for reuse by callers
- extend dynamic AI tests to cover chat transcript generation end-to-end

## Testing
- pytest tests/dynamic_ai/test_agents.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f2ade10083229eb5dd4180751c2f