### PR TITLE
docs: convert onedrive workflow to checklist

### DIFF
--- a/docs/onedrive-supabase-training-workflow.md
+++ b/docs/onedrive-supabase-training-workflow.md
@@ -2,7 +2,26 @@
 
 This playbook outlines the recommended way to connect Microsoft OneDrive storage
 to Dynamic Capital's Supabase-centric data platform so the Dynamic AI (DAI)
-training agents can consume curated datasets reliably.
+training agents can consume curated datasets reliably. Follow the phased
+checklists below in sequence—each phase produces the artefacts needed by the
+next, guiding you from OneDrive sync to production retraining.
+
+## Step-by-Step Implementation Overview
+
+1. **Harden access:** create an Azure AD application and build a token helper so
+   you can authenticate Graph API calls non-interactively.
+2. **Organise storage:** standardise OneDrive folders so datasets, checkpoints,
+   and ETL staging assets are predictable and versioned.
+3. **Ingest & transform:** automate Graph API syncs into Supabase staging tables
+   using a manifest-driven ETL script.
+4. **Materialise curated data:** promote validated datasets into Supabase
+   schemas optimised for training and embeddings.
+5. **Train from Supabase:** update trainers to fetch curated tables, not raw
+   files, and push checkpoints back to OneDrive for collaboration.
+6. **Track experiments:** pair Supabase data with DVC or MLflow metadata to keep
+   reproducibility high as models evolve.
+7. **Monitor & secure:** wrap the integration with observability and security
+   guardrails so the sync never silently drifts or leaks data.
 
 ## 1. Prepare Microsoft Graph Access
 
@@ -43,13 +62,22 @@ training agents can consume curated datasets reliably.
 - [ ] Cache dataset fingerprints (hash + version) so that retraining triggers only when underlying data changes.
 - [ ] Push model checkpoints and experiment artifacts back to `model-checkpoints/` after each training run.
 
-## 6. Observability and Governance
+## 6. Versioning and Experiment Tracking
+
+- [ ] Configure DVC remotes pointing to the OneDrive `datasets/` folder so
+      dataset snapshots can be promoted or rolled back.
+- [ ] Mirror MLflow or Weights & Biases artifact stores into
+      `model-checkpoints/` so experiment metadata sits beside weights.
+- [ ] Capture Supabase dataset fingerprints (hash + version + schema) in your
+      experiment tracker for reproducibility audits.
+
+## 7. Observability and Governance
 
 - [ ] Log each ETL run (records processed, failures) to Supabase's `etl_runs` table and expose alerts through the existing observability stack.
 - [ ] Validate dataset schemas with Great Expectations or Supabase triggers before promoting to curated tables.
 - [ ] Include OneDrive sync health in the weekly data quality review—check API rate limits, storage quotas, and stale cursors.
 
-## 7. Security Checklist
+## 8. Security Checklist
 
 - [ ] Rotate the Azure AD client secret quarterly and update CI secrets promptly.
 - [ ] Encrypt sensitive intermediate files at rest if they reside outside Supabase (for example local staging directories).


### PR DESCRIPTION
## Summary
- convert the OneDrive and Supabase integration playbook into actionable checklists for each phase of the workflow
- keep the existing guidance while making it easier to track completion of Graph access, ETL, training, and security tasks

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d7f5d27e808322912a16fb650abf52