### PR TITLE
Fix OneDrive share ID encoding

### DIFF
--- a/docs/microsoft-onedrive-share.md
+++ b/docs/microsoft-onedrive-share.md
@@ -1,0 +1,27 @@
+# Microsoft OneDrive Share Fetcher
+
+Use the `fetch-drive-item` helper to inspect the metadata for a shared OneDrive
+file or folder through the Microsoft Graph API.
+
+## Prerequisites
+
+- A Microsoft Graph access token with permission to read the shared item.
+- The share link you want to inspect (for example, a link copied from OneDrive).
+
+## Usage
+
+1. Export the access token for the current shell session:
+
+   ```bash
+   export ONEDRIVE_ACCESS_TOKEN="<token>"
+   ```
+
+2. Fetch the drive item payload with `tsx`:
+
+   ```bash
+   tsx scripts/onedrive/fetch-drive-item.ts "https://1drv.ms/f/..."
+   ```
+
+The helper converts the share link to the Base64-URL identifier expected by
+Microsoft Graph before requesting the item. It prints the JSON response to
+`stdout`, matching the behaviour of the original Python snippet.

--- a/scripts/onedrive/fetch-drive-item.ts
+++ b/scripts/onedrive/fetch-drive-item.ts
@@ -1,0 +1,62 @@
+import { Buffer } from "node:buffer";
+import process from "node:process";
+
+const { env, argv } = process;
+
+function toShareId(shareLink: string): string {
+  const base64 = Buffer.from(shareLink, "utf-8").toString("base64");
+  const base64Url = base64.replace(/\+/g, "-").replace(/\//g, "_").replace(
+    /=+$/u,
+    "",
+  );
+  return `u!${base64Url}`;
+}
+
+async function fetchDriveItem(shareLink: string, accessToken: string) {
+  const shareId = toShareId(shareLink);
+  const url = `https://graph.microsoft.com/v1.0/shares/${shareId}/driveItem`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Microsoft Graph request failed with ${response.status} ${response.statusText}: ${body}`,
+    );
+  }
+
+  return response.json();
+}
+
+async function main() {
+  const [, , shareLink] = argv;
+
+  if (!shareLink) {
+    console.error(
+      "Usage: tsx scripts/onedrive/fetch-drive-item.ts <share-link>",
+    );
+    process.exit(1);
+  }
+
+  const accessToken = env.ONEDRIVE_ACCESS_TOKEN;
+
+  if (!accessToken) {
+    console.error(
+      "Set the ONEDRIVE_ACCESS_TOKEN environment variable before running this script.",
+    );
+    process.exit(1);
+  }
+
+  try {
+    const driveItem = await fetchDriveItem(shareLink, accessToken);
+    console.log(JSON.stringify(driveItem, null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- convert the OneDrive share link encoding to the Base64-URL format expected by Microsoft Graph
- document the encoding behavior in the OneDrive helper usage guide

## Testing
- npm run lint
- npm run typecheck *(fails: apps/web tests depend on Vitest and Testing Library type definitions that are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fcebec4483228167ad4a971bada2