### PR TITLE
Add S3 wrapper support for OneDrive manifest

### DIFF
--- a/apps/web/integrations/wrappers/index.ts
+++ b/apps/web/integrations/wrappers/index.ts
@@ -1,0 +1,143 @@
+import {
+  createClient,
+  type SupabaseClient,
+} from "@/integrations/supabase/client";
+import type {
+  ListAssetsOptions,
+  OneDriveAssetMeta,
+  OneDriveAssetRow,
+} from "./types";
+
+const ONE_DRIVE_ASSETS_TABLE = "one_drive_assets";
+
+function ensureServiceClient(client?: SupabaseClient) {
+  if (client) {
+    return client;
+  }
+  if (typeof window !== "undefined") {
+    throw new Error(
+      "Wrapper helpers require a server-side Supabase client with service role access.",
+    );
+  }
+  return createClient("service");
+}
+
+function parseTags(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function parseSize(raw: string | null): number | null {
+  if (!raw) return null;
+  const numeric = Number.parseInt(raw, 10);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function normalizeAsset(
+  row: OneDriveAssetRow | null,
+): OneDriveAssetMeta | null {
+  if (!row?.object_key) {
+    return null;
+  }
+  const title = row.title?.trim();
+  return {
+    key: row.object_key,
+    title: title && title.length > 0 ? title : row.object_key,
+    description: row.description?.trim() || null,
+    contentType: row.content_type?.trim() || null,
+    sizeBytes: parseSize(row.byte_size),
+    lastModified: row.last_modified?.trim() || null,
+    checksum: row.checksum?.trim() || null,
+    sourceUrl: row.source_url?.trim() || null,
+    tags: parseTags(row.tags),
+  } satisfies OneDriveAssetMeta;
+}
+
+function escapeLikePattern(input: string) {
+  return input.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+/**
+ * Fetches the list of mirrored OneDrive files exposed through the S3 wrapper manifest.
+ *
+ * @example
+ * ```ts
+ * import { listOneDriveAssets } from '@/integrations/wrappers';
+ *
+ * const files = await listOneDriveAssets({ prefix: 'docs/' });
+ * files.forEach((asset) => console.log(asset.key, asset.sourceUrl));
+ * ```
+ */
+export async function listOneDriveAssets(
+  options: ListAssetsOptions = {},
+  client?: SupabaseClient,
+): Promise<OneDriveAssetMeta[]> {
+  const supabase = ensureServiceClient(client);
+  const { prefix, search, limit } = options;
+
+  let query = supabase
+    .from(ONE_DRIVE_ASSETS_TABLE)
+    .select("*")
+    .order("object_key", { ascending: true });
+
+  if (prefix) {
+    const escapedPrefix = `${escapeLikePattern(prefix)}%`;
+    query = query.ilike("object_key", escapedPrefix);
+  }
+
+  if (search) {
+    const escapedSearch = `%${escapeLikePattern(search)}%`;
+    query = query.or(
+      `title.ilike.${escapedSearch},description.ilike.${escapedSearch},tags.ilike.${escapedSearch}`,
+    );
+  }
+
+  if (typeof limit === "number" && Number.isFinite(limit)) {
+    query = query.limit(Math.max(1, Math.floor(limit)));
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(
+      error.message || "Failed to list OneDrive assets through S3 wrapper.",
+    );
+  }
+
+  const rows = (data as OneDriveAssetRow[] | null) ?? [];
+
+  return rows
+    .map((row) => normalizeAsset(row))
+    .filter((asset): asset is OneDriveAssetMeta => Boolean(asset));
+}
+
+/**
+ * Loads a single OneDrive asset manifest entry by its object key.
+ */
+export async function getOneDriveAsset(
+  objectKey: string,
+  client?: SupabaseClient,
+): Promise<OneDriveAssetMeta | null> {
+  const supabase = ensureServiceClient(client);
+  const { data, error } = await supabase
+    .from(ONE_DRIVE_ASSETS_TABLE)
+    .select("*")
+    .eq("object_key", objectKey)
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return null;
+    }
+    throw new Error(
+      error.message || "Failed to load OneDrive asset manifest entry.",
+    );
+  }
+
+  return normalizeAsset((data as OneDriveAssetRow | null) ?? null);
+}
+
+export { ONE_DRIVE_ASSETS_TABLE };
+export type { ListAssetsOptions, OneDriveAssetMeta } from "./types";

--- a/apps/web/integrations/wrappers/types.ts
+++ b/apps/web/integrations/wrappers/types.ts
@@ -1,0 +1,65 @@
+export interface OneDriveAssetRow {
+  object_key: string | null;
+  title: string | null;
+  description: string | null;
+  content_type: string | null;
+  byte_size: string | null;
+  last_modified: string | null;
+  checksum: string | null;
+  source_url: string | null;
+  tags: string | null;
+}
+
+export interface OneDriveAssetMeta {
+  /**
+   * Storage key inside the OneDrive S3 mirror (for example `docs/overview.pdf`).
+   */
+  key: string;
+  /**
+   * Raw display title sourced from the manifest; falls back to the file name.
+   */
+  title: string;
+  /**
+   * Short description provided by the manifest, if any.
+   */
+  description: string | null;
+  /**
+   * MIME type reported by the manifest.
+   */
+  contentType: string | null;
+  /**
+   * Object size in bytes, when reported.
+   */
+  sizeBytes: number | null;
+  /**
+   * Last modified timestamp from the manifest or remote object metadata.
+   */
+  lastModified: string | null;
+  /**
+   * Integrity checksum (etag, md5, etc.).
+   */
+  checksum: string | null;
+  /**
+   * Direct download URL for the mirrored asset.
+   */
+  sourceUrl: string | null;
+  /**
+   * Comma-delimited tags describing the asset content.
+   */
+  tags: string[];
+}
+
+export interface ListAssetsOptions {
+  /**
+   * Restrict results to manifest entries whose keys start with the given prefix.
+   */
+  prefix?: string;
+  /**
+   * Perform a simple case-insensitive search against the title and description fields.
+   */
+  search?: string;
+  /**
+   * Limit the number of rows returned.
+   */
+  limit?: number;
+}

--- a/docs/WRAPPERS_INTEGRATION.md
+++ b/docs/WRAPPERS_INTEGRATION.md
@@ -1,6 +1,8 @@
 # Wrapper Integration
 
-This project can interact with external services through Postgres foreign data wrappers (FDWs). Wrappers let the app query APIs and storage services using regular SQL via Supabase.
+This project can interact with external services through Postgres foreign data
+wrappers (FDWs). Wrappers let the app query APIs and storage services using
+regular SQL via Supabase.
 
 ## Installation
 
@@ -11,6 +13,25 @@ CREATE EXTENSION IF NOT EXISTS redis_wrapper;
 CREATE EXTENSION IF NOT EXISTS auth0_wrapper;
 CREATE EXTENSION IF NOT EXISTS s3_wrapper;
 ```
+
+Dynamic Capital provisions the S3 wrapper through the migration
+`20251104090000_enable_s3_wrapper.sql`. Before applying it, configure the
+connection secrets as Postgres settings so the server definition can pull them
+at runtime:
+
+```sql
+-- Replace the placeholder values with the real OneDrive-backed S3 credentials.
+ALTER DATABASE postgres SET app.settings.one_drive_s3_endpoint = 'https://example-compat.endpoint';
+ALTER DATABASE postgres SET app.settings.one_drive_s3_region = 'us-east-1';
+ALTER DATABASE postgres SET app.settings.one_drive_s3_bucket = 'dynamic-ai-database';
+ALTER DATABASE postgres SET app.settings.one_drive_s3_prefix = 'knowledge/';
+ALTER DATABASE postgres SET app.settings.one_drive_s3_access_key_id = '<access-key-id>';
+ALTER DATABASE postgres SET app.settings.one_drive_s3_secret_access_key = '<secret-access-key>';
+ALTER DATABASE postgres SET app.settings.one_drive_s3_manifest = 'metadata.jsonl';
+```
+
+With the settings in place, run the migration to create the foreign server,
+manifest table, and runtime grants.
 
 Create servers for each service:
 
@@ -41,12 +62,31 @@ CREATE FOREIGN TABLE s3_files (
 ) SERVER s3_server;
 ```
 
+Dynamic Capital exposes the OneDrive manifest through the
+`public.one_drive_assets` table. Each row mirrors a JSONL entry describing a
+document, PDF, or image inside the remote knowledge bucket.
+
 ## Application Usage
 
-Wrapper-backed tables can be queried from both the Next.js app and the Telegram bot. Place shared helpers under `apps/web/integrations/` so they can be imported from the web dashboard and edge functions alike:
+Wrapper-backed tables can be queried from both the Next.js app and the Telegram
+bot. Place shared helpers under `apps/web/integrations/` so they can be imported
+from the web dashboard and edge functions alike:
 
 ```ts
-import { getRedisSession, getAuth0User, listS3Files } from "@/integrations/wrappers";
+import {
+  getAuth0User,
+  getRedisSession,
+  listS3Files,
+} from "@/integrations/wrappers";
 ```
 
-Use these functions to fetch cached sessions, authenticated users, or file metadata through the unified SQL interface.
+The repository now provides typed helpers for the OneDrive bucket:
+
+```ts
+import { listOneDriveAssets } from "@/integrations/wrappers";
+
+const assets = await listOneDriveAssets({ prefix: "docs/" });
+```
+
+Use these functions to fetch cached sessions, authenticated users, or file
+metadata through the unified SQL interface.

--- a/supabase/migrations/20251104090000_enable_s3_wrapper.sql
+++ b/supabase/migrations/20251104090000_enable_s3_wrapper.sql
@@ -1,0 +1,100 @@
+-- Enable wrappers and configure S3 access for the OneDrive knowledge bucket
+create schema if not exists extensions;
+
+create extension if not exists wrappers with schema extensions;
+create extension if not exists s3_wrapper with schema extensions;
+
+-- Create the foreign server using credentials stored in Postgres configuration.
+-- Administrators must set the following GUCs prior to running this migration:
+--   app.settings.one_drive_s3_endpoint
+--   app.settings.one_drive_s3_region (defaults to us-east-1 if omitted)
+--   app.settings.one_drive_s3_bucket
+--   app.settings.one_drive_s3_prefix (optional)
+--   app.settings.one_drive_s3_access_key_id
+--   app.settings.one_drive_s3_secret_access_key
+--   app.settings.one_drive_s3_manifest (defaults to metadata.jsonl)
+-- Optionally set app.settings.one_drive_s3_session_token when temporary credentials are used.
+
+DO $$
+DECLARE
+  v_endpoint text := current_setting('app.settings.one_drive_s3_endpoint', true);
+  v_region text := coalesce(current_setting('app.settings.one_drive_s3_region', true), 'us-east-1');
+  v_bucket text := current_setting('app.settings.one_drive_s3_bucket', true);
+  v_prefix text := coalesce(current_setting('app.settings.one_drive_s3_prefix', true), '');
+  v_access_key text := current_setting('app.settings.one_drive_s3_access_key_id', true);
+  v_secret_key text := current_setting('app.settings.one_drive_s3_secret_access_key', true);
+  v_session_token text := current_setting('app.settings.one_drive_s3_session_token', true);
+  v_options text;
+BEGIN
+  IF v_endpoint IS NULL OR v_bucket IS NULL OR v_access_key IS NULL OR v_secret_key IS NULL THEN
+    RAISE NOTICE 'Skipping creation of foreign server "onedrive_docs_s3"; configure app.settings.one_drive_s3_* GUCs and re-run.';
+  ELSIF NOT EXISTS (SELECT 1 FROM pg_foreign_server WHERE srvname = 'onedrive_docs_s3') THEN
+    v_options := format(
+      'endpoint %L, region %L, bucket %L, prefix %L, use_ssl %L, access_key_id %L, secret_access_key %L',
+      v_endpoint,
+      v_region,
+      v_bucket,
+      v_prefix,
+      'true',
+      v_access_key,
+      v_secret_key
+    );
+    IF v_session_token IS NOT NULL THEN
+      v_options := v_options || format(', session_token %L', v_session_token);
+    END IF;
+    EXECUTE format(
+      'CREATE SERVER onedrive_docs_s3 FOREIGN DATA WRAPPER s3_wrapper OPTIONS (%s);',
+      v_options
+    );
+  END IF;
+END;
+$$;
+
+-- Create a foreign table over the manifest that indexes OneDrive-backed assets.
+DO $$
+DECLARE
+  v_manifest text := coalesce(current_setting('app.settings.one_drive_s3_manifest', true), 'metadata.jsonl');
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_foreign_server WHERE srvname = 'onedrive_docs_s3') THEN
+    EXECUTE format(
+      $$CREATE FOREIGN TABLE IF NOT EXISTS public.one_drive_assets (
+        object_key      text,
+        title           text,
+        description     text,
+        content_type    text,
+        byte_size       text,
+        last_modified   text,
+        checksum        text,
+        source_url      text,
+        tags            text
+      )
+      SERVER onedrive_docs_s3
+      OPTIONS (
+        filename %L,
+        format 'jsonl',
+        compression 'auto'
+      );$$,
+      v_manifest
+    );
+  ELSE
+    RAISE NOTICE 'Skipping creation of foreign table public.one_drive_assets; server onedrive_docs_s3 does not exist yet.';
+  END IF;
+END;
+$$;
+
+-- Grant access to runtime roles when the table exists.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_foreign_table ft
+    JOIN pg_class c ON c.oid = ft.ftrelid
+    WHERE c.relname = 'one_drive_assets'
+      AND c.relnamespace = 'public'::regnamespace
+  ) THEN
+    EXECUTE 'GRANT USAGE ON FOREIGN SERVER onedrive_docs_s3 TO service_role';
+    EXECUTE 'GRANT SELECT ON public.one_drive_assets TO service_role';
+    EXECUTE 'GRANT SELECT ON public.one_drive_assets TO authenticated';
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- enable the wrappers and s3_wrapper extensions plus an onedrive_docs_s3 server and manifest table via a new Supabase migration
- add typed wrapper helpers for listing and fetching OneDrive assets from the manifest-backed foreign table
- update the wrapper integration guide with configuration details and usage examples for the new helpers

## Testing
- npm run lint
- npm run typecheck *(fails: Vitest and @testing-library packages are not installed in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fc3a585c8322a11262684420c277