### PR TITLE
fix: allow nextauth to trust host header

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -13,7 +13,12 @@ const { handlers } = NextAuth({
       clientSecret: process.env.GITHUB_SECRET || "",
     }),
   ],
+  /**
+   * Allow NextAuth to trust the host header when NEXTAUTH_URL is not set.
+   * This keeps local development flows working on arbitrary ports such as
+   * http://127.0.0.1:53682/auth?state=... without requiring additional envs.
+   */
+  trustHost: true,
 });
 
 export const { GET, POST } = handlers;
-

--- a/tests/api/auth-route-config.test.ts
+++ b/tests/api/auth-route-config.test.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from "node:assert";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const projectRoot = join(__dirname, "..", "..");
+
+async function run() {
+  const routePath = join(
+    projectRoot,
+    "apps",
+    "web",
+    "app",
+    "api",
+    "auth",
+    "[...nextauth]",
+    "route.ts",
+  );
+  const source = await readFile(routePath, "utf8");
+  assert.ok(
+    source.includes("trustHost: true"),
+    "Auth route should enable trustHost to support dynamic hosts",
+  );
+}
+
+if (typeof Deno !== "undefined") {
+  Deno.test("Auth route enables trustHost for dynamic hosts", run);
+} else {
+  const { default: test } = await import(/* @vite-ignore */ "node:test");
+  test("Auth route enables trustHost for dynamic hosts", run);
+}


### PR DESCRIPTION
## Summary
- enable the NextAuth API route to trust the host header when NEXTAUTH_URL is unset so local callbacks keep working
- add a regression test that ensures the auth route continues to export the trustHost flag

## Testing
- npm test -- --filter "Auth route"
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8083c85ec832285788616c838119c