### PR TITLE
Refine Machiavellian strategy psychology synthesis document

### DIFF
--- a/docs/dynamic-thinking-machiavelli.md
+++ b/docs/dynamic-thinking-machiavelli.md
@@ -1,0 +1,69 @@
+# Dynamic Thinking vs. Modern Psychology & Strategy
+
+## Why It Matters
+
+- Machiavelli’s pragmatism maps cleanly onto today’s behavioral psychology and
+  strategy playbooks.
+- Leaders who internalize this mapping can diagnose motives faster and design
+  systems that bend reality instead of wishing it away.
+
+## Quick Reference Matrix
+
+| Machiavellian Lens        | Modern Psychology & Strategy                                   | Operating Move                                                       |
+| ------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Judge actions, not ideals | System 1 biases overpower rational plans                       | Probe for real motives before negotiating or delegating              |
+| Loyalty is conditional    | Incentives, loss aversion, and time discounting shape behavior | Tie rewards, penalties, and status signals to desired habits         |
+| Virtù + fortuna           | Agility, scenario planning, antifragility                      | Pair bold bets with sensing mechanisms and redundancy                |
+| Ends can justify means    | People trade process purity for outcomes under pressure        | Define guardrails for hard pushes to protect trust                   |
+| Perception is currency    | Framing and halo effects steer narratives                      | Craft symbols and stories that align brand and execution             |
+| Stability beats chaos     | Clarity and consistency enable performance                     | Prune weak links fast and reinforce operating rhythms                |
+| History repeats           | Pattern recognition guides forecasting                         | Stress-test decisions with historical analogs and leading indicators |
+| Adapt or die              | Growth mindset drives resilience                               | Institutionalize experimentation and postmortems                     |
+
+## Application Playbook
+
+### 1. Map Motives
+
+- Audit stakeholder incentives across financial, status, and security needs.
+- Translate “stated values” into observable behaviors before making commitments.
+
+### 2. Design Feedback Loops
+
+- Instrument early-warning signals for market, customer, and competitor shifts.
+- Combine quantitative dashboards with qualitative sensing from frontline teams.
+
+### 3. Architect Incentives
+
+- Layer rewards, recognition, and consequences so desired behaviors become the
+  path of least resistance.
+- Refresh incentive structures when strategy pivots; don’t expect goodwill to
+  bridge structural gaps.
+
+### 4. Control the Narrative
+
+- Align external storytelling with internal execution priorities to prevent
+  dissonance.
+- Use framing intentionally—choose metaphors, origin stories, and artifacts that
+  make the desired behavior feel inevitable.
+
+### 5. Protect Stability
+
+- Diagnose where instability threatens execution (talent gaps, tech debt,
+  unclear decision rights) and act decisively.
+- Codify operating cadences that make high standards feel routine rather than
+  crisis-driven.
+
+### 6. Institutionalize Learning
+
+- Run systematic postmortems that search historical precedents and challenge
+  assumptions.
+- Reward adaptive behavior—rapid course correction should be celebrated, not
+  punished.
+
+## Modern Leadership Synthesis
+
+- Machiavelli anticipated behavioral insights by spotlighting real human
+  motives.
+- Dynamic strategists blend psychological realism with agile execution.
+- Modern leaders should think like psychologists, act like strategists, and
+  adapt like entrepreneurs.


### PR DESCRIPTION
## Summary
- streamline the Machiavellian dynamic thinking guide into a quick-reference matrix plus application playbook for faster strategic recall
- highlight actionable leadership loops that connect psychological realism with incentive design, narrative control, and adaptive learning

## Testing
- npm run format
- npx deno fmt docs/dynamic-thinking-machiavelli.md

------
https://chatgpt.com/codex/tasks/task_e_68d80ca515c88322b5d6401cd4134bcc