### PR TITLE
Add Dynamic State engine for telemetry aggregation

### DIFF
--- a/dynamic_states/__init__.py
+++ b/dynamic_states/__init__.py
@@ -1,0 +1,10 @@
+"""Dynamic States toolkit for telemetry-driven posture analysis."""
+
+from .engine import DynamicStateEngine, StateDefinition, StateSignal, StateSnapshot
+
+__all__ = [
+    "DynamicStateEngine",
+    "StateSignal",
+    "StateDefinition",
+    "StateSnapshot",
+]

--- a/dynamic_states/engine.py
+++ b/dynamic_states/engine.py
@@ -1,0 +1,309 @@
+"""State telemetry aggregation for Dynamic Capital rituals."""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "StateSignal",
+    "StateDefinition",
+    "StateSnapshot",
+    "DynamicStateEngine",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float, upper: float) -> float:
+    if lower > upper:  # pragma: no cover - defensive guard
+        raise ValueError("lower bound must be <= upper bound")
+    return max(lower, min(upper, value))
+
+
+def _normalise_state_key(value: str) -> str:
+    normalised = value.strip().lower()
+    if not normalised:
+        raise ValueError("state name must not be empty")
+    return normalised
+
+
+def _normalise_display_name(value: str) -> str:
+    display = value.strip()
+    if not display:
+        raise ValueError("state name must not be empty")
+    return display
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            ordered.append(cleaned)
+    return tuple(ordered)
+
+
+def _coerce_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+@dataclass(slots=True)
+class StateSignal:
+    """Qualitative or quantitative observation influencing a state."""
+
+    state: str
+    intensity: float
+    confidence: float = 0.5
+    momentum: float = 0.0
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_utcnow)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.state = _normalise_state_key(self.state)
+        self.intensity = _clamp(float(self.intensity), lower=-1.0, upper=1.0)
+        self.confidence = _clamp(float(self.confidence), lower=0.0, upper=1.0)
+        self.momentum = _clamp(float(self.momentum), lower=-1.0, upper=1.0)
+        self.weight = max(float(self.weight), 0.0)
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.tags = _normalise_tags(self.tags)
+        self.metadata = _coerce_metadata(self.metadata)
+
+
+@dataclass(slots=True)
+class StateDefinition:
+    """Description and guardrails for a state."""
+
+    name: str
+    description: str = ""
+    baseline: float = 0.0
+    floor: float = -1.0
+    ceiling: float = 1.0
+    warmup: int = 3
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_display_name(self.name)
+        if self.floor >= self.ceiling:
+            raise ValueError("floor must be less than ceiling")
+        self.baseline = _clamp(float(self.baseline), lower=self.floor, upper=self.ceiling)
+        self.floor = float(self.floor)
+        self.ceiling = float(self.ceiling)
+        self.description = self.description.strip()
+        self.warmup = max(int(self.warmup), 0)
+
+
+@dataclass(slots=True)
+class StateSnapshot:
+    """Aggregated view of a state's current posture."""
+
+    state: str
+    value: float
+    change: float
+    trend: float
+    baseline: float
+    ready: bool
+    signals: tuple[StateSignal, ...]
+    tags: tuple[str, ...]
+    summary: str
+    metadata: Mapping[str, object]
+    definition: StateDefinition
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "state": self.state,
+            "value": self.value,
+            "change": self.change,
+            "trend": self.trend,
+            "baseline": self.baseline,
+            "ready": self.ready,
+            "signals": [asdict(signal) for signal in self.signals],
+            "tags": list(self.tags),
+            "summary": self.summary,
+            "metadata": dict(self.metadata),
+        }
+
+
+class DynamicStateEngine:
+    """Capture signals and compute blended state posture metrics."""
+
+    def __init__(
+        self,
+        *,
+        history: int = 60,
+        decay: float = 0.15,
+        definitions: Iterable[StateDefinition | Mapping[str, object]] | None = None,
+    ) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._history = int(history)
+        self._decay = _clamp(float(decay), lower=0.0, upper=0.5)
+        self._definitions: dict[str, StateDefinition] = {}
+        self._signals: dict[str, Deque[StateSignal]] = {}
+        if definitions:
+            for definition in definitions:
+                self.register(definition)
+
+    # ---------------------------------------------------------------- register
+    def register(self, definition: StateDefinition | Mapping[str, object]) -> StateDefinition:
+        resolved = self._coerce_definition(definition)
+        key = _normalise_state_key(resolved.name)
+        self._definitions[key] = resolved
+        self._signals.setdefault(key, deque(maxlen=self._history))
+        return resolved
+
+    # ----------------------------------------------------------------- capture
+    def capture(self, signal: StateSignal | Mapping[str, object]) -> StateSignal:
+        resolved = self._coerce_signal(signal)
+        definition = self._definitions.get(resolved.state)
+        if definition is None:
+            display = resolved.state.replace("_", " ").title()
+            definition = StateDefinition(
+                name=display,
+                description=f"Auto-generated state for '{display}'.",
+            )
+            self._definitions[resolved.state] = definition
+            self._signals[resolved.state] = deque(maxlen=self._history)
+        self._signals.setdefault(resolved.state, deque(maxlen=self._history)).append(resolved)
+        return resolved
+
+    def extend(self, signals: Iterable[StateSignal | Mapping[str, object]]) -> None:
+        for signal in signals:
+            self.capture(signal)
+
+    # ---------------------------------------------------------------- snapshot
+    def snapshot(self, state: str) -> StateSnapshot:
+        key = _normalise_state_key(state)
+        definition = self._definitions.get(key)
+        if definition is None:
+            definition = StateDefinition(
+                name=state,
+                description=f"Auto-generated state for '{_normalise_display_name(state)}'.",
+            )
+            self.register(definition)
+        history = tuple(self._signals.get(key, ()))
+        weighted_value = self._weighted_value(history)
+        value = _clamp(definition.baseline + weighted_value, lower=definition.floor, upper=definition.ceiling)
+        previous_value = definition.baseline
+        if len(history) > 1:
+            prior_weight = self._weighted_value(history[:-1])
+            previous_value = _clamp(
+                definition.baseline + prior_weight,
+                lower=definition.floor,
+                upper=definition.ceiling,
+            )
+        change = value - definition.baseline
+        trend = value - previous_value
+        ready = len(history) >= definition.warmup
+        tags = self._aggregate_tags(history)
+        summary = self._summarise(definition, value, change, trend, ready)
+        metadata: MutableMapping[str, object] = {
+            "state": definition.name,
+            "signal_count": len(history),
+            "baseline": definition.baseline,
+            "floor": definition.floor,
+            "ceiling": definition.ceiling,
+            "decay": self._decay,
+            "warmup": definition.warmup,
+        }
+        snapshot = StateSnapshot(
+            state=definition.name,
+            value=value,
+            change=change,
+            trend=trend,
+            baseline=definition.baseline,
+            ready=ready,
+            signals=history,
+            tags=tags,
+            summary=summary,
+            metadata=metadata,
+            definition=definition,
+        )
+        return snapshot
+
+    def overview(self) -> Mapping[str, StateSnapshot]:
+        return {key: self.snapshot(key) for key in sorted(self._definitions)}
+
+    # --------------------------------------------------------------- internals
+    def _coerce_signal(self, signal: StateSignal | Mapping[str, object]) -> StateSignal:
+        if isinstance(signal, StateSignal):
+            return signal
+        if isinstance(signal, Mapping):
+            payload: MutableMapping[str, object] = dict(signal)
+            payload.setdefault("timestamp", _utcnow())
+            return StateSignal(**payload)  # type: ignore[arg-type]
+        raise TypeError("signal must be StateSignal or mapping")
+
+    def _coerce_definition(self, definition: StateDefinition | Mapping[str, object]) -> StateDefinition:
+        if isinstance(definition, StateDefinition):
+            return definition
+        if isinstance(definition, Mapping):
+            payload: MutableMapping[str, object] = dict(definition)
+            return StateDefinition(**payload)  # type: ignore[arg-type]
+        raise TypeError("definition must be StateDefinition or mapping")
+
+    def _weighted_value(self, signals: Sequence[StateSignal]) -> float:
+        if not signals:
+            return 0.0
+        total_weight = 0.0
+        accumulator = 0.0
+        for index, signal in enumerate(reversed(signals)):
+            decay_factor = (1.0 - self._decay) ** index
+            weight = signal.confidence * signal.weight * decay_factor
+            total_weight += weight
+            adjusted = signal.intensity + 0.25 * signal.momentum
+            accumulator += adjusted * weight
+        if total_weight == 0.0:
+            return 0.0
+        return accumulator / total_weight
+
+    def _aggregate_tags(self, signals: Sequence[StateSignal]) -> tuple[str, ...]:
+        counter: Counter[str] = Counter()
+        for signal in signals:
+            counter.update(signal.tags)
+        ordered = sorted(counter.items(), key=lambda item: (-item[1], item[0]))
+        return tuple(tag for tag, _ in ordered)
+
+    def _summarise(
+        self,
+        definition: StateDefinition,
+        value: float,
+        change: float,
+        trend: float,
+        ready: bool,
+    ) -> str:
+        if change > 0.25:
+            posture = "elevated"
+        elif change < -0.25:
+            posture = "suppressed"
+        else:
+            posture = "stable"
+
+        if trend > 0.1:
+            direction = "improving"
+        elif trend < -0.1:
+            direction = "deteriorating"
+        else:
+            direction = "holding"
+
+        readiness = "calibrated" if ready else "warming"
+        return (
+            f"{definition.name} state is {posture} and {direction} at {value:.2f} "
+            f"(baseline {definition.baseline:.2f}, {readiness})."
+        )

--- a/tests/test_dynamic_states.py
+++ b/tests/test_dynamic_states.py
@@ -1,0 +1,71 @@
+"""Tests for the Dynamic State engine."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from dynamic_states import DynamicStateEngine, StateDefinition, StateSignal
+
+
+@pytest.fixture()
+def engine() -> DynamicStateEngine:
+    return DynamicStateEngine(history=5, decay=0.2)
+
+
+def test_snapshot_defaults_to_baseline(engine: DynamicStateEngine) -> None:
+    definition = StateDefinition(name="Momentum", description="Team execution energy", baseline=0.2)
+    engine.register(definition)
+
+    snapshot = engine.snapshot("momentum")
+
+    assert math.isclose(snapshot.value, 0.2)
+    assert math.isclose(snapshot.change, 0.0)
+    assert math.isclose(snapshot.trend, 0.0)
+    assert snapshot.ready is False
+    assert snapshot.signals == ()
+    assert "Momentum state" in snapshot.summary
+
+
+def test_signal_ingestion_and_trend(engine: DynamicStateEngine) -> None:
+    engine.register(StateDefinition(name="Focus", description="Trader focus bandwidth", baseline=0.1, warmup=2))
+
+    first = engine.capture(
+        {
+            "state": "focus",
+            "intensity": -0.5,
+            "confidence": 0.8,
+            "momentum": -0.2,
+            "tags": ["fatigue", "macro"],
+        }
+    )
+    assert isinstance(first, StateSignal)
+
+    snapshot_one = engine.snapshot("focus")
+    assert snapshot_one.value < 0.1
+    assert snapshot_one.trend < 0
+    assert snapshot_one.ready is False
+
+    engine.capture(StateSignal(state="FOCUS", intensity=0.7, confidence=0.9, momentum=0.3, tags=("reset",)))
+
+    snapshot_two = engine.snapshot("Focus")
+    assert snapshot_two.value > snapshot_one.value
+    assert snapshot_two.trend > 0
+    assert snapshot_two.ready is True
+    assert snapshot_two.metadata["signal_count"] == 2
+    assert snapshot_two.tags == ("fatigue", "macro", "reset")
+    payload = snapshot_two.as_dict()
+    assert payload["state"] == "Focus"
+    assert payload["metadata"]["signal_count"] == 2
+
+
+def test_overview_returns_all_states(engine: DynamicStateEngine) -> None:
+    engine.register(StateDefinition(name="Calm", description="Calm state", baseline=0.0))
+    engine.capture({"state": "alert", "intensity": 0.3, "confidence": 0.6})
+
+    overview = engine.overview()
+
+    assert set(overview.keys()) == {"alert", "calm"}
+    assert overview["alert"].summary.startswith("Alert state")
+    assert overview["calm"].value == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- introduce the DynamicStateEngine package with signal, definition, and snapshot primitives for telemetry-driven state posture calculations
- auto-register states on ingestion, aggregate tags, and expose overview snapshots
- cover baseline, trend, and overview behavior with new unit tests

## Testing
- pytest tests/test_dynamic_states.py

------
https://chatgpt.com/codex/tasks/task_e_68d811758b64832283b07aa16009eaac