### PR TITLE
Add Dynamic Algo alignment adapter to AI sync pipeline

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -256,7 +256,9 @@ from .dynamic_ai_sync import (
     DynamicAISyncReport,
     DynamicAISynchroniser,
     dynamic_agent_cycle_adapter,
+    dynamic_algo_sync_adapter,
     run_dynamic_agent_cycle,
+    run_dynamic_algo_alignment,
 )
 from .dynamic_market_outlook import (
     DynamicMarketOutlookEngine,
@@ -438,7 +440,9 @@ __all__ = _trade_exports + [
     "DynamicAISyncReport",
     "DynamicAISynchroniser",
     "dynamic_agent_cycle_adapter",
+    "dynamic_algo_sync_adapter",
     "run_dynamic_agent_cycle",
+    "run_dynamic_algo_alignment",
     "DailyRoutineAllocator",
     "DynamicMarketOutlookEngine",
     "MarketOutlookReport",

--- a/algorithms/python/tests/test_dynamic_ai_sync.py
+++ b/algorithms/python/tests/test_dynamic_ai_sync.py
@@ -4,8 +4,15 @@ import json
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Sequence
 
-from algorithms.python.dynamic_ai_sync import AlgorithmSyncAdapter, DynamicAISynchroniser
+from algorithms.python.dynamic_ai_sync import (
+    AlgorithmSyncAdapter,
+    DynamicAISynchroniser,
+    dynamic_algo_sync_adapter,
+    run_dynamic_algo_alignment,
+)
 from algorithms.python.multi_llm import LLMConfig
+from dynamic_algo.trading_core import SUCCESS_RETCODE, TradeExecutionResult
+from dynamic_token.treasury import TreasuryEvent
 
 
 class StubClient:
@@ -108,4 +115,198 @@ def test_synchroniser_handles_errors_and_textual_summary() -> None:
     assert report.summary.summary == "Narrative summary without JSON"
     assert report.summary.actions == []
     assert report.status_counts == {"success": 1, "error": 1}
+
+
+def _research_payload() -> Dict[str, Any]:
+    return {
+        "technical": {
+            "trend": "bullish",
+            "momentum": 0.6,
+            "volatility": 0.2,
+            "rsi": 58,
+            "adx": 28,
+            "support": 1.08,
+            "resistance": 1.12,
+        },
+        "fundamental": {
+            "eps_growth": 0.12,
+            "revenue_growth": 0.18,
+            "valuation": 0.1,
+            "debt_ratio": 0.25,
+        },
+        "sentiment": {
+            "bullish": 0.7,
+            "bearish": 0.2,
+            "news": [
+                {"score": 0.4, "summary": "Analysts issue bullish upgrade"},
+                {"score": 0.2, "summary": "growth tailwinds"},
+            ],
+        },
+        "macro": {
+            "gdp_trend": 0.15,
+            "inflation": 0.02,
+            "dollar_index": -0.05,
+            "employment": 0.3,
+        },
+    }
+
+
+def _market_payload() -> Dict[str, Any]:
+    return {
+        "signal": "BUY",
+        "momentum": 0.7,
+        "trend": "bullish",
+        "sentiment": 0.4,
+        "volatility": 0.25,
+        "news": ["FOMC minutes hint at dovish stance"],
+        "confidence": 0.62,
+        "risk_score": 0.1,
+        "drawdown": 0.0,
+        "human_bias": "BUY",
+    }
+
+
+def _risk_payload() -> Dict[str, Any]:
+    return {
+        "risk_context": {
+            "daily_drawdown": -0.01,
+            "treasury_utilisation": 0.3,
+            "treasury_health": 1.0,
+            "volatility": 0.25,
+        },
+        "risk_parameters": {
+            "max_daily_drawdown": 0.08,
+            "treasury_utilisation_cap": 0.75,
+            "circuit_breaker_drawdown": 0.15,
+        },
+        "market_state": {
+            "volatility": {
+                "EURUSD": {"symbol": "EURUSD", "atr": 0.0012, "close": 1.1, "median_ratio": 0.0008},
+            },
+            "news": [],
+        },
+        "account_state": {
+            "mode": "hedging",
+            "exposures": [],
+            "hedges": [],
+            "drawdown_r": 0.1,
+            "risk_capital": 100_000,
+        },
+    }
+
+
+class StubTrader:
+    def __init__(self) -> None:
+        self.calls: list[Dict[str, Any]] = []
+
+    def execute_trade(self, signal: Mapping[str, Any], *, lot: float, symbol: str) -> TradeExecutionResult:
+        self.calls.append({"signal": dict(signal), "lot": lot, "symbol": symbol})
+        return TradeExecutionResult(
+            retcode=SUCCESS_RETCODE,
+            message="filled",
+            profit=42.5,
+            ticket=12345,
+            symbol=symbol,
+            lot=lot,
+        )
+
+
+class StubTreasury:
+    def __init__(self) -> None:
+        self.calls: list[TradeExecutionResult] = []
+
+    def update_from_trade(self, trade_result: TradeExecutionResult) -> TreasuryEvent:
+        self.calls.append(trade_result)
+        return TreasuryEvent(burned=1.0, rewards_distributed=2.0, profit_retained=3.0)
+
+
+def test_run_dynamic_algo_alignment_executes_trade_and_treasury() -> None:
+    trader = StubTrader()
+    treasury = StubTreasury()
+
+    result = run_dynamic_algo_alignment(
+        {
+            "symbol": "EURUSD",
+            "lot": 0.5,
+            "research_payload": _research_payload(),
+            "market_payload": _market_payload(),
+            "risk_payload": _risk_payload(),
+            "trader": trader,
+            "treasury": treasury,
+        }
+    )
+
+    assert trader.calls and trader.calls[0]["lot"] == 0.5
+    assert result["trade"]["status"] == "executed"
+    assert result["trade"]["symbol"] == "EURUSD"
+    assert result["treasury_event"] == {"burned": 1.0, "rewards_distributed": 2.0, "profit_retained": 3.0}
+    assert result["optimisation"]["risk_flags"] == ()
+    assert result["optimisation"]["hedges_recommended"] == 0
+
+
+def test_run_dynamic_algo_alignment_reuses_existing_cycle() -> None:
+    trader = StubTrader()
+
+    agent_cycle = {
+        "agents": {
+            "research": {"agent": "research", "rationale": "stub", "confidence": 0.5, "analysis": {}},
+            "execution": {
+                "agent": "execution",
+                "rationale": "stub",
+                "confidence": 0.8,
+                "signal": {"action": "BUY", "confidence": 0.8},
+            },
+            "risk": {
+                "agent": "risk",
+                "rationale": "risk stable",
+                "confidence": 0.7,
+                "adjusted_signal": {"action": "BUY", "confidence": 0.7, "risk_notes": ["stable"]},
+                "hedge_decisions": (),
+                "escalations": (),
+            },
+        },
+        "decision": {"action": "BUY", "confidence": 0.7, "rationale": "alignment"},
+    }
+
+    class FailingAgent:
+        def run(self, payload: Mapping[str, Any]) -> None:  # pragma: no cover - guard
+            raise AssertionError("agent should not execute")
+
+    result = run_dynamic_algo_alignment(
+        {
+            "symbol": "BTCUSD",
+            "lot": 0.2,
+            "agent_cycle": agent_cycle,
+            "trader": trader,
+            "research_agent": FailingAgent(),
+            "execution_agent": FailingAgent(),
+            "risk_agent": FailingAgent(),
+        }
+    )
+
+    assert result["decision"]["action"] == "BUY"
+    assert result["trade"]["symbol"] == "BTCUSD"
+    assert result["trade"]["lot"] == 0.2
+    assert result["optimisation"]["risk_notes"] == ("stable",)
+
+
+def test_dynamic_algo_sync_adapter_wraps_alignment() -> None:
+    trader = StubTrader()
+
+    adapter_result = dynamic_algo_sync_adapter.execute(
+        {
+            "symbol": "GBPUSD",
+            "lot": 0.3,
+            "research_payload": _research_payload(),
+            "market_payload": _market_payload(),
+            "risk_payload": _risk_payload(),
+            "trader": trader,
+        }
+    )
+
+    assert adapter_result.status == "success"
+    payload = adapter_result.payload
+    assert payload["trade"]["status"] == "executed"
+    assert payload["trade"]["symbol"] == "GBPUSD"
+    assert adapter_result.metadata["chain"] == ("research", "execution", "risk", "trading")
 


### PR DESCRIPTION
## Summary
- add an alignment helper that reuses the Dynamic AI persona cycle to drive Dynamic Algo execution and treasury hooks
- expose a reusable AlgorithmSyncAdapter for the new bridge and surface it through the algorithms package exports
- expand Dynamic AI sync tests to cover the alignment helper, adapter metadata, and optimisation payloads

## Testing
- pytest algorithms/python/tests/test_dynamic_ai_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d8187e26b88322ac6def7c290c8747