### PR TITLE
feat: introduce dynamic pillars governance framework

### DIFF
--- a/dynamic_pillars/__init__.py
+++ b/dynamic_pillars/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic Pillars governance framework."""
+
+from .pillars import (
+    PillarDefinition,
+    PillarOverview,
+    PillarSignal,
+    PillarSnapshot,
+    DynamicPillarFramework,
+)
+
+__all__ = [
+    "PillarDefinition",
+    "PillarOverview",
+    "PillarSignal",
+    "PillarSnapshot",
+    "DynamicPillarFramework",
+]

--- a/dynamic_pillars/pillars.py
+++ b/dynamic_pillars/pillars.py
@@ -1,0 +1,356 @@
+"""Stewardship utilities for Dynamic Capital pillars."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "PillarSignal",
+    "PillarDefinition",
+    "PillarSnapshot",
+    "PillarOverview",
+    "DynamicPillarFramework",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_key(value: str) -> str:
+    cleaned = value.strip().lower()
+    if not cleaned:
+        raise ValueError("pillar key must not be empty")
+    return cleaned
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("text must not be empty")
+    return cleaned
+
+
+def _normalise_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            ordered.append(cleaned)
+    return tuple(ordered)
+
+
+def _normalise_tuple(items: Sequence[str] | None) -> tuple[str, ...]:
+    if not items:
+        return ()
+    normalised: list[str] = []
+    for item in items:
+        cleaned = item.strip()
+        if cleaned:
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+@dataclass(slots=True)
+class PillarSignal:
+    """Observation that influences a pillar's health."""
+
+    pillar: str
+    score: float
+    confidence: float = 0.5
+    momentum: float = 0.0
+    weight: float = 1.0
+    origin: str | None = None
+    timestamp: datetime = field(default_factory=_utcnow)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    narrative: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.pillar = _normalise_key(self.pillar)
+        self.score = _clamp(float(self.score))
+        self.confidence = _clamp(float(self.confidence))
+        self.momentum = _clamp(float(self.momentum), lower=-1.0, upper=1.0)
+        self.weight = max(float(self.weight), 0.0)
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.origin = _normalise_optional_text(self.origin)
+        self.tags = _normalise_tags(self.tags)
+        self.narrative = _normalise_optional_text(self.narrative)
+        self.metadata = _coerce_metadata(self.metadata)
+
+
+@dataclass(slots=True)
+class PillarDefinition:
+    """Guardrails that frame a pillar's contribution."""
+
+    key: str
+    title: str
+    description: str = ""
+    weight: float = 1.0
+    minimum_health: float = 0.45
+    target_health: float = 0.7
+    guardrails: tuple[str, ...] = field(default_factory=tuple)
+    lead_indicators: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.key = _normalise_key(self.key)
+        self.title = _normalise_text(self.title)
+        self.description = self.description.strip()
+        self.weight = max(float(self.weight), 0.0)
+        self.minimum_health = _clamp(float(self.minimum_health))
+        self.target_health = _clamp(float(self.target_health))
+        if self.minimum_health > self.target_health:
+            raise ValueError("minimum_health must not exceed target_health")
+        self.guardrails = _normalise_tuple(self.guardrails)
+        self.lead_indicators = _normalise_tuple(self.lead_indicators)
+
+
+@dataclass(slots=True)
+class PillarSnapshot:
+    """Aggregated view of a pillar's present posture."""
+
+    key: str
+    title: str
+    score: float
+    confidence: float
+    momentum: float
+    trend: float
+    status: str
+    summary: str
+    definition: PillarDefinition
+    signals: tuple[PillarSignal, ...]
+    tags: tuple[str, ...]
+    alerts: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "score": self.score,
+            "confidence": self.confidence,
+            "momentum": self.momentum,
+            "trend": self.trend,
+            "status": self.status,
+            "summary": self.summary,
+            "signals": [signal.__dict__ for signal in self.signals],
+            "tags": list(self.tags),
+            "alerts": list(self.alerts),
+        }
+
+
+@dataclass(slots=True)
+class PillarOverview:
+    """System level narrative that orchestrates all pillars."""
+
+    overall_health: float
+    stability: float
+    priorities: tuple[str, ...]
+    alerts: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "overall_health": self.overall_health,
+            "stability": self.stability,
+            "priorities": list(self.priorities),
+            "alerts": list(self.alerts),
+            "narrative": self.narrative,
+        }
+
+
+class DynamicPillarFramework:
+    """Capture pillar signals and synthesise governance insights."""
+
+    def __init__(
+        self,
+        *,
+        history: int = 40,
+        decay: float = 0.2,
+        definitions: Iterable[PillarDefinition | Mapping[str, object]] | None = None,
+    ) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._history = int(history)
+        self._decay = _clamp(float(decay), lower=0.0, upper=0.5)
+        self._definitions: dict[str, PillarDefinition] = {}
+        self._signals: dict[str, Deque[PillarSignal]] = {}
+        if definitions:
+            for definition in definitions:
+                self.register(definition)
+
+    @property
+    def definitions(self) -> Mapping[str, PillarDefinition]:
+        return dict(self._definitions)
+
+    def register(self, definition: PillarDefinition | Mapping[str, object]) -> PillarDefinition:
+        if isinstance(definition, Mapping):
+            definition = PillarDefinition(**definition)
+        if not isinstance(definition, PillarDefinition):  # pragma: no cover - defensive guard
+            raise TypeError("definition must be a PillarDefinition")
+        self._definitions[definition.key] = definition
+        self._signals.setdefault(definition.key, deque(maxlen=self._history))
+        return definition
+
+    def ingest(self, signals: PillarSignal | Iterable[PillarSignal]) -> None:
+        if isinstance(signals, PillarSignal):
+            stream = (signals,)
+        else:
+            stream = tuple(signals)
+        for signal in stream:
+            if not isinstance(signal, PillarSignal):
+                raise TypeError("signals must be PillarSignal instances")
+            if signal.pillar not in self._definitions:
+                raise KeyError(f"unknown pillar: {signal.pillar}")
+            self._signals[signal.pillar].append(signal)
+
+    def snapshot(self, pillar: str) -> PillarSnapshot:
+        key = _normalise_key(pillar)
+        if key not in self._definitions:
+            raise KeyError(f"unknown pillar: {key}")
+        definition = self._definitions[key]
+        signals = tuple(self._signals.get(key, ()))
+        if not signals:
+            summary = (
+                f"{definition.title} lacks recent telemetry; schedule a ritual to "
+                "collect fresh signals."
+            )
+            alerts = (f"{definition.title}: insufficient data",)
+            return PillarSnapshot(
+                key=definition.key,
+                title=definition.title,
+                score=0.0,
+                confidence=0.0,
+                momentum=0.0,
+                trend=0.0,
+                status="insufficient-data",
+                summary=summary,
+                definition=definition,
+                signals=(),
+                tags=definition.guardrails,
+                alerts=alerts,
+            )
+
+        weights: list[float] = []
+        scores: list[float] = []
+        confidences: list[float] = []
+        momenta: list[float] = []
+        tags: set[str] = set()
+        decay_base = 1.0 - self._decay
+        for index, signal in enumerate(reversed(signals)):
+            attenuation = decay_base**index
+            weight = max(signal.weight * attenuation, 0.0)
+            weights.append(weight)
+            scores.append(signal.score)
+            confidences.append(signal.confidence)
+            momenta.append(signal.momentum)
+            tags.update(signal.tags)
+        total_weight = sum(weights) or 1.0
+        score = sum(value * weight for value, weight in zip(scores, weights)) / total_weight
+        confidence = (
+            sum(value * weight for value, weight in zip(confidences, weights)) / total_weight
+        )
+        momentum = sum(value * weight for value, weight in zip(momenta, weights)) / total_weight
+        trend = signals[-1].score - signals[0].score if len(signals) > 1 else 0.0
+        status: str
+        alerts: list[str] = []
+        if score >= definition.target_health and confidence >= 0.55:
+            status = "healthy"
+        elif score >= definition.minimum_health:
+            status = "watch"
+            alerts.append(
+                f"{definition.title} is trending neutral; reinforce guardrails before drift occurs."
+            )
+        else:
+            status = "critical"
+            alerts.append(
+                f"{definition.title} breached the health threshold; deploy a recovery sprint."
+            )
+        if trend < -0.1:
+            alerts.append(f"{definition.title} trend is deteriorating ({trend:.2f}).")
+        if momentum < -0.15:
+            alerts.append(f"{definition.title} has negative momentum ({momentum:.2f}).")
+        summary = (
+            f"{definition.title} is {status} with a score of {score:.2f} and "
+            f"confidence {confidence:.2f}. Momentum {momentum:.2f}; trend {trend:.2f}."
+        )
+        return PillarSnapshot(
+            key=definition.key,
+            title=definition.title,
+            score=score,
+            confidence=confidence,
+            momentum=momentum,
+            trend=trend,
+            status=status,
+            summary=summary,
+            definition=definition,
+            signals=signals,
+            tags=tuple(sorted(tags)),
+            alerts=tuple(alerts),
+        )
+
+    def overview(self) -> PillarOverview:
+        if not self._definitions:
+            raise RuntimeError("no pillar definitions registered")
+        snapshots = [self.snapshot(key) for key in self._definitions]
+        total_weight = sum(snapshot.definition.weight for snapshot in snapshots) or 1.0
+        weighted_health = sum(
+            snapshot.score * snapshot.definition.weight for snapshot in snapshots
+        ) / total_weight
+        stability = sum(snapshot.confidence for snapshot in snapshots) / len(snapshots)
+        priorities = tuple(
+            snapshot.title
+            for snapshot in sorted(
+                snapshots,
+                key=lambda snap: (snap.status != "healthy", snap.score, -snap.confidence),
+            )
+            if snapshot.status != "healthy"
+        )
+        alerts: list[str] = []
+        for snapshot in snapshots:
+            alerts.extend(snapshot.alerts)
+        if priorities:
+            narrative = (
+                "Stabilise pillars "
+                + ", ".join(priorities)
+                + " while protecting healthy lanes."
+            )
+        else:
+            narrative = (
+                "All pillars are operating within guardrails; focus on compounding breakthroughs."
+            )
+        return PillarOverview(
+            overall_health=weighted_health,
+            stability=stability,
+            priorities=priorities,
+            alerts=tuple(alerts),
+            narrative=narrative,
+        )

--- a/tests/test_dynamic_pillars.py
+++ b/tests/test_dynamic_pillars.py
@@ -1,0 +1,129 @@
+"""Tests for the Dynamic Pillar framework."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from dynamic_pillars import (
+    DynamicPillarFramework,
+    PillarDefinition,
+    PillarSignal,
+)
+
+
+def _ts(minutes: int) -> datetime:
+    return datetime(2024, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=minutes)
+
+
+def test_snapshot_with_signals_generates_status_and_alerts() -> None:
+    framework = DynamicPillarFramework(
+        history=5,
+        decay=0.1,
+        definitions=[
+            PillarDefinition(
+                key="execution",
+                title="Execution",
+                description="Delivery velocity and ritual adherence",
+                minimum_health=0.4,
+                target_health=0.75,
+                guardrails=("cadence", "quality"),
+            )
+        ],
+    )
+    framework.ingest(
+        [
+            PillarSignal(
+                pillar="execution",
+                score=0.35,
+                confidence=0.55,
+                momentum=-0.2,
+                timestamp=_ts(0),
+                narrative="Sprint slipped due to blocked integrations",
+            ),
+            PillarSignal(
+                pillar="execution",
+                score=0.5,
+                confidence=0.65,
+                momentum=0.1,
+                timestamp=_ts(30),
+                narrative="Recovery plan deployed",
+            ),
+        ]
+    )
+
+    snapshot = framework.snapshot("execution")
+
+    assert snapshot.key == "execution"
+    assert 0.35 < snapshot.score < 0.55
+    assert snapshot.status == "watch"
+    assert any("guardrails" in alert or "Recovery" in alert for alert in snapshot.alerts)
+    assert "Execution is"[:5] == snapshot.summary[:5]
+
+
+def test_snapshot_without_signals_reports_insufficient_data() -> None:
+    definition = PillarDefinition(key="growth", title="Growth", description="")
+    framework = DynamicPillarFramework(definitions=[definition])
+
+    snapshot = framework.snapshot("growth")
+
+    assert snapshot.status == "insufficient-data"
+    assert snapshot.score == 0.0
+    assert snapshot.alerts == ("Growth: insufficient data",)
+
+
+def test_overview_prioritises_non_healthy_pillars() -> None:
+    framework = DynamicPillarFramework(
+        definitions=[
+            PillarDefinition(key="trust", title="Trust", target_health=0.8),
+            PillarDefinition(key="automation", title="Automation", target_health=0.7),
+        ]
+    )
+    framework.ingest(
+        [
+            PillarSignal(
+                pillar="trust",
+                score=0.85,
+                confidence=0.7,
+                momentum=0.1,
+                timestamp=_ts(10),
+            ),
+            PillarSignal(
+                pillar="automation",
+                score=0.3,
+                confidence=0.6,
+                momentum=-0.3,
+                timestamp=_ts(20),
+            ),
+        ]
+    )
+
+    overview = framework.overview()
+
+    assert overview.overall_health < 0.6
+    assert math.isclose(overview.stability, 0.65, rel_tol=1e-2)
+    assert overview.priorities == ("Automation",)
+    assert any("Automation" in alert for alert in overview.alerts)
+    assert "Stabilise pillars" in overview.narrative
+
+
+def test_overview_without_definitions_raises_runtime_error() -> None:
+    framework = DynamicPillarFramework()
+    with pytest.raises(RuntimeError):
+        framework.overview()
+
+
+def test_register_accepts_mapping() -> None:
+    framework = DynamicPillarFramework()
+    definition = framework.register(
+        {
+            "key": "resilience",
+            "title": "Resilience",
+            "guardrails": ("incident response",),
+        }
+    )
+
+    assert isinstance(definition, PillarDefinition)
+    assert "resilience" in framework.definitions


### PR DESCRIPTION
## Summary
- add a dynamic_pillars package that models pillar signals, definitions, and aggregated snapshots
- expose the governance framework through the package init for straightforward imports
- cover the new behaviours with targeted pytest cases

## Testing
- pytest tests/test_dynamic_pillars.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d82264d2088322aa774e1d5d9c8823