### PR TITLE
feat: add dynamic badge component

### DIFF
--- a/apps/web/components/ui/dynamic-badge.tsx
+++ b/apps/web/components/ui/dynamic-badge.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { cn } from "@/utils";
+
+const dynamicBadgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-full border font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  {
+    variants: {
+      tone: {
+        neutral: "border-border/40 bg-muted/30 text-muted-foreground",
+        success: "border-success/30 bg-success/10 text-success",
+        warning: "border-warning/30 bg-warning/10 text-warning",
+        info: "border-info/30 bg-info/10 text-info",
+        brand: "border-dc-brand/30 bg-dc-brand/10 text-dc-brand-dark",
+      },
+      emphasis: {
+        soft: "",
+        solid: "",
+        outline: "bg-transparent",
+      },
+      size: {
+        default: "px-2.5 py-0.5 text-xs",
+        sm: "px-2 py-0.5 text-[11px]",
+        xs: "px-1.5 py-0.5 text-[10px]",
+      },
+    },
+    compoundVariants: [
+      {
+        tone: "neutral",
+        emphasis: "solid",
+        className: "border-border bg-muted text-foreground",
+      },
+      {
+        tone: "neutral",
+        emphasis: "outline",
+        className: "border-border/60 text-muted-foreground",
+      },
+      {
+        tone: "success",
+        emphasis: "solid",
+        className: "border-success bg-success text-success-foreground",
+      },
+      {
+        tone: "success",
+        emphasis: "outline",
+        className: "border-success/60 text-success",
+      },
+      {
+        tone: "warning",
+        emphasis: "solid",
+        className: "border-warning bg-warning text-warning-foreground",
+      },
+      {
+        tone: "warning",
+        emphasis: "outline",
+        className: "border-warning/60 text-warning",
+      },
+      {
+        tone: "info",
+        emphasis: "solid",
+        className: "border-info bg-info text-info-foreground",
+      },
+      {
+        tone: "info",
+        emphasis: "outline",
+        className: "border-info/60 text-info",
+      },
+      {
+        tone: "brand",
+        emphasis: "solid",
+        className: "border-dc-brand bg-dc-brand text-white",
+      },
+      {
+        tone: "brand",
+        emphasis: "outline",
+        className: "border-dc-brand/60 text-dc-brand-dark",
+      },
+    ],
+    defaultVariants: {
+      tone: "neutral",
+      emphasis: "soft",
+      size: "default",
+    },
+  },
+);
+
+export type DynamicBadgeTone = NonNullable<
+  VariantProps<typeof dynamicBadgeVariants>["tone"]
+>;
+export type DynamicBadgeEmphasis = NonNullable<
+  VariantProps<typeof dynamicBadgeVariants>["emphasis"]
+>;
+export type DynamicBadgeSize = NonNullable<
+  VariantProps<typeof dynamicBadgeVariants>["size"]
+>;
+
+export interface DynamicBadgeProps
+  extends
+    Omit<BadgeProps, "variant">,
+    VariantProps<typeof dynamicBadgeVariants> {
+  icon?: ReactNode;
+  iconPosition?: "start" | "end";
+  pulse?: boolean;
+}
+
+export function DynamicBadge({
+  tone,
+  emphasis,
+  size,
+  icon,
+  iconPosition = "start",
+  pulse = false,
+  className,
+  children,
+  ...props
+}: DynamicBadgeProps) {
+  const variant = emphasis === "outline" ? "outline" : "default";
+
+  const iconElement = icon
+    ? (
+      <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
+        {icon}
+      </span>
+    )
+    : null;
+
+  return (
+    <Badge
+      {...props}
+      variant={variant}
+      className={cn(
+        dynamicBadgeVariants({ tone, emphasis, size }),
+        pulse && "animate-[pulse_2s_ease-in-out_infinite]",
+        className,
+      )}
+    >
+      {iconElement && iconPosition === "start" ? iconElement : null}
+      {children}
+      {iconElement && iconPosition === "end" ? iconElement : null}
+    </Badge>
+  );
+}

--- a/apps/web/components/ui/system-health.tsx
+++ b/apps/web/components/ui/system-health.tsx
@@ -1,17 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef } from "react";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Skeleton } from '@/components/ui/skeleton';
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  DynamicBadge,
+  type DynamicBadgeEmphasis,
+  type DynamicBadgeSize,
+  type DynamicBadgeTone,
+} from "@/components/ui/dynamic-badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Activity,
   AlertCircle,
@@ -22,11 +27,11 @@ import {
   Shield,
   TrendingUp,
   Zap,
-} from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
-import { toast } from 'sonner';
-import { cn } from '@/utils';
-import { formatIsoTime } from '@/utils/isoFormat';
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/utils";
+import { formatIsoTime } from "@/utils/isoFormat";
 import {
   type SystemHealthCheck,
   type SystemHealthCheckKey,
@@ -34,13 +39,13 @@ import {
   type SystemHealthOverallStatus,
   type SystemHealthPerformance,
   type SystemHealthResponse,
-} from '@/types/system-health';
-import { useSystemHealth } from '@/hooks/useSystemHealth';
+} from "@/types/system-health";
+import { useSystemHealth } from "@/hooks/useSystemHealth";
 
 export type SystemHealthDisplayStatus =
   | SystemHealthOverallStatus
-  | 'loading'
-  | 'unknown';
+  | "loading"
+  | "unknown";
 
 interface SystemHealthProps {
   className?: string;
@@ -52,47 +57,51 @@ interface StatusMeta {
   description: string;
   icon: LucideIcon;
   iconClass: string;
-  badgeClass: string;
-  badgeVariant?: 'outline' | 'default';
+  tone: DynamicBadgeTone;
+  emphasis?: DynamicBadgeEmphasis;
+  size?: DynamicBadgeSize;
+  pulse?: boolean;
 }
 
 const STATUS_META: Record<SystemHealthDisplayStatus, StatusMeta> = {
   healthy: {
-    label: 'Healthy',
-    description: 'All systems are operating within expected thresholds.',
+    label: "Healthy",
+    description: "All systems are operating within expected thresholds.",
     icon: CheckCircle,
-    iconClass: 'text-success',
-    badgeClass: 'bg-success/10 text-success border-success/30',
+    iconClass: "text-success",
+    tone: "success",
   },
   degraded: {
-    label: 'Degraded',
-    description: 'Some checks require attention. Review the affected components.',
+    label: "Degraded",
+    description:
+      "Some checks require attention. Review the affected components.",
     icon: AlertTriangle,
-    iconClass: 'text-warning',
-    badgeClass: 'bg-warning/10 text-warning border-warning/30',
+    iconClass: "text-warning",
+    tone: "warning",
   },
   error: {
-    label: 'Error',
-    description: 'Critical issues detected. Immediate action recommended.',
+    label: "Error",
+    description: "Critical issues detected. Immediate action recommended.",
     icon: AlertCircle,
-    iconClass: 'text-dc-brand',
-    badgeClass: 'bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30',
+    iconClass: "text-dc-brand",
+    tone: "brand",
   },
   loading: {
-    label: 'Checking',
-    description: 'Fetching the latest system health status.',
+    label: "Checking",
+    description: "Fetching the latest system health status.",
     icon: RefreshCw,
-    iconClass: 'text-muted-foreground',
-    badgeClass: 'border-dashed border text-muted-foreground',
-    badgeVariant: 'outline',
+    iconClass: "text-muted-foreground",
+    tone: "neutral",
+    emphasis: "outline",
+    pulse: true,
   },
   unknown: {
-    label: 'Unknown',
-    description: 'System health could not be determined. Try refreshing.',
+    label: "Unknown",
+    description: "System health could not be determined. Try refreshing.",
     icon: Activity,
-    iconClass: 'text-muted-foreground',
-    badgeClass: 'border-dashed border text-muted-foreground',
-    badgeVariant: 'outline',
+    iconClass: "text-muted-foreground",
+    tone: "neutral",
+    emphasis: "outline",
   },
 };
 
@@ -106,45 +115,54 @@ interface CheckMeta {
 
 const CHECK_META: Record<SystemHealthCheckKey, CheckMeta> = {
   database: {
-    label: 'Database',
-    description: 'Primary Supabase cluster availability',
+    label: "Database",
+    description: "Primary Supabase cluster availability",
     icon: Database,
   },
   bot_content: {
-    label: 'Bot Content',
-    description: 'Content freshness and publishing pipeline',
+    label: "Bot Content",
+    description: "Content freshness and publishing pipeline",
     icon: Activity,
   },
   promotions: {
-    label: 'Promotions',
-    description: 'Active promo codes and campaigns',
+    label: "Promotions",
+    description: "Active promo codes and campaigns",
     icon: Zap,
   },
   rpc_functions: {
-    label: 'Edge Functions',
-    description: 'Critical RPC and edge function endpoints',
+    label: "Edge Functions",
+    description: "Critical RPC and edge function endpoints",
     icon: Shield,
   },
 };
 
 const CHECK_STATUS_META: Record<
   SystemHealthCheckStatus,
-  { label: string; icon: LucideIcon; className: string }
+  {
+    label: string;
+    icon: LucideIcon;
+    tone: DynamicBadgeTone;
+    emphasis?: DynamicBadgeEmphasis;
+    size?: DynamicBadgeSize;
+  }
 > = {
   ok: {
-    label: 'Operational',
+    label: "Operational",
     icon: CheckCircle,
-    className: 'bg-success/10 text-success border-success/30',
+    tone: "success",
+    size: "sm",
   },
   warning: {
-    label: 'Warning',
+    label: "Warning",
     icon: AlertTriangle,
-    className: 'bg-warning/10 text-warning border-warning/30',
+    tone: "warning",
+    size: "sm",
   },
   error: {
-    label: 'Error',
+    label: "Error",
     icon: AlertCircle,
-    className: 'bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30',
+    tone: "brand",
+    size: "sm",
   },
 };
 
@@ -160,12 +178,15 @@ export function SystemHealthStatusBadge({
   const meta = STATUS_META[status] ?? STATUS_META.unknown;
 
   return (
-    <Badge
-      variant={meta.badgeVariant}
-      className={cn('gap-1 px-2 py-1 text-xs', meta.badgeClass, className)}
+    <DynamicBadge
+      tone={meta.tone}
+      emphasis={meta.emphasis}
+      size={meta.size}
+      pulse={meta.pulse}
+      className={className}
     >
       {children ?? meta.label}
-    </Badge>
+    </DynamicBadge>
   );
 }
 
@@ -183,9 +204,9 @@ export function SystemHealthStatusIcon({
   return (
     <Icon
       className={cn(
-        'h-4 w-4',
+        "h-4 w-4",
         meta.iconClass,
-        (status === 'loading' || isRefreshing) && 'animate-spin',
+        (status === "loading" || isRefreshing) && "animate-spin",
         className,
       )}
     />
@@ -203,21 +224,26 @@ export function SystemHealthCheckStatusBadge({
   const Icon = meta.icon;
 
   return (
-    <Badge className={cn('gap-1 px-2 py-1 text-xs', meta.className, className)}>
-      <Icon className="h-3 w-3" />
+    <DynamicBadge
+      tone={meta.tone}
+      emphasis={meta.emphasis}
+      size={meta.size}
+      icon={<Icon className="h-3 w-3" />}
+      className={className}
+    >
       {meta.label}
-    </Badge>
+    </DynamicBadge>
   );
 }
 
 export function SystemHealthMetric({
   label,
   value,
-  tone = 'default',
+  tone = "default",
 }: {
   label: string;
   value: string | number | ReactNode;
-  tone?: 'default' | 'positive' | 'negative';
+  tone?: "default" | "positive" | "negative";
 }) {
   return (
     <div className="space-y-1 rounded-lg border border-border/40 bg-muted/30 p-3 text-center">
@@ -225,9 +251,9 @@ export function SystemHealthMetric({
         {label}
       </p>
       <p
-        className={cn('text-sm font-semibold', {
-          'text-success': tone === 'positive',
-          'text-dc-brand': tone === 'negative',
+        className={cn("text-sm font-semibold", {
+          "text-success": tone === "positive",
+          "text-dc-brand": tone === "negative",
         })}
       >
         {value}
@@ -254,7 +280,7 @@ export function SystemHealthMetrics({
       <SystemHealthMetric
         label="Failed checks"
         value={performance.failed_checks}
-        tone={performance.failed_checks > 0 ? 'negative' : 'positive'}
+        tone={performance.failed_checks > 0 ? "negative" : "positive"}
       />
     </div>
   );
@@ -281,7 +307,7 @@ export function SystemHealthCheckItem({
       </div>
       <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         <span>{check.response_time}ms</span>
-        {typeof check.active_count === 'number' && (
+        {typeof check.active_count === "number" && (
           <span>{check.active_count} active</span>
         )}
         <SystemHealthCheckStatusBadge status={check.status} />
@@ -304,7 +330,10 @@ export function SystemHealthRecommendations({
       <p className="text-sm font-medium">Recommendations</p>
       <div className="space-y-2">
         {recommendations.map((rec, index) => (
-          <Alert key={`${index}-${rec}`} className="border-warning/20 bg-warning/10">
+          <Alert
+            key={`${index}-${rec}`}
+            className="border-warning/20 bg-warning/10"
+          >
             <TrendingUp className="h-4 w-4 text-warning" />
             <AlertDescription className="text-sm text-warning">
               {rec}
@@ -361,7 +390,11 @@ function SystemHealthSummary({ data }: { data: SystemHealthResponse }) {
 
 function SystemHealthDetails({ data }: { data: SystemHealthResponse }) {
   const checkEntries = useMemo(
-    () => Object.entries(data.checks) as [SystemHealthCheckKey, SystemHealthCheck][],
+    () =>
+      Object.entries(data.checks) as [
+        SystemHealthCheckKey,
+        SystemHealthCheck,
+      ][],
     [data.checks],
   );
 
@@ -401,10 +434,10 @@ export function SystemHealth({
   const status: SystemHealthDisplayStatus = data
     ? data.overall_status
     : isLoading
-    ? 'loading'
+    ? "loading"
     : isError
-    ? 'unknown'
-    : 'loading';
+    ? "unknown"
+    : "loading";
 
   const lastChecked = data?.timestamp
     ? new Date(data.timestamp)
@@ -418,14 +451,16 @@ export function SystemHealth({
 
     previousStatusRef.current = data.overall_status;
 
-    if (data.overall_status === 'degraded') {
-      toast.warning('Some systems are experiencing issues');
-    } else if (data.overall_status === 'error') {
-      toast.error('System health check failed');
+    if (data.overall_status === "degraded") {
+      toast.warning("Some systems are experiencing issues");
+    } else if (data.overall_status === "error") {
+      toast.error("System health check failed");
     }
   }, [data]);
 
-  if (!showDetails && !isLoading && !isError && data?.overall_status === 'healthy') {
+  if (
+    !showDetails && !isLoading && !isError && data?.overall_status === "healthy"
+  ) {
     return null;
   }
 
@@ -457,7 +492,7 @@ export function SystemHealth({
               disabled={isFetching}
             >
               <RefreshCw
-                className={cn('h-4 w-4', isFetching && 'animate-spin')}
+                className={cn("h-4 w-4", isFetching && "animate-spin")}
               />
             </Button>
           </div>
@@ -473,20 +508,20 @@ export function SystemHealth({
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription className="text-sm">
-              {error?.message || 'Failed to load system health'}
+              {error?.message || "Failed to load system health"}
             </AlertDescription>
           </Alert>
         )}
 
-        {isLoading && !data ? (
-          <SystemHealthSkeleton showDetails={showDetails} />
-        ) : data ? (
-          showDetails ? (
-            <SystemHealthDetails data={data} />
-          ) : (
-            <SystemHealthSummary data={data} />
+        {isLoading && !data
+          ? <SystemHealthSkeleton showDetails={showDetails} />
+          : data
+          ? (
+            showDetails
+              ? <SystemHealthDetails data={data} />
+              : <SystemHealthSummary data={data} />
           )
-        ) : null}
+          : null}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add a reusable `DynamicBadge` component with tone, emphasis, and size variants for consistent badge styling
- refactor the system health UI to use the dynamic badge and simplify status metadata handling

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d825422b9483229a333b4fbbbbca18