### PR TITLE
Handle None profits in treasury updates

### DIFF
--- a/dynamic_token/treasury.py
+++ b/dynamic_token/treasury.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
 from typing import Optional
 
 
@@ -37,7 +38,7 @@ class DynamicTreasuryAlgo:
         except (TypeError, ValueError):
             return None
 
-        if profit <= 0:
+        if not isfinite(profit) or profit <= 0:
             return None
 
         burn_amount = round(profit * 0.2, 2)

--- a/tests/dynamic_token/test_treasury_algo.py
+++ b/tests/dynamic_token/test_treasury_algo.py
@@ -48,6 +48,9 @@ def test_update_from_trade_happy_path(
         SimpleNamespace(retcode=SUCCESS_RETCODE, profit=0.0),
         SimpleNamespace(retcode=SUCCESS_RETCODE, profit=-10.0),
         SimpleNamespace(retcode=SUCCESS_RETCODE, profit=None),
+        SimpleNamespace(retcode=SUCCESS_RETCODE, profit="not-a-number"),
+        SimpleNamespace(retcode=SUCCESS_RETCODE, profit=float("nan")),
+        SimpleNamespace(retcode=SUCCESS_RETCODE, profit=float("inf")),
     ],
 )
 def test_update_from_trade_failure_cases(


### PR DESCRIPTION
## Summary
- guard treasury updates against missing or invalid profit values before coercing to float
- extend treasury algorithm tests to cover trades reporting a `None` profit

## Testing
- `pytest tests/dynamic_token/test_treasury_algo.py`


------
https://chatgpt.com/codex/tasks/task_e_68d82486b45883228b6240c7a331525f