### PR TITLE
Add table of contents to DCT jetton README

### DIFF
--- a/dynamic-capital-ton/contracts/README.md
+++ b/dynamic-capital-ton/contracts/README.md
@@ -14,6 +14,17 @@ standard jetton template with the following extensions:
 - **Transfer tax hook** — an optional 0-100 bps tax can be enabled and routed to
   the treasury address once the timelock action executes.
 
+## Table of Contents
+
+<!-- TOC:START -->
+
+- [Deployment checklist](#deployment-checklist)
+- [Theme collection deployment](#theme-collection-deployment)
+  - [Updating content](#updating-content)
+  - [Freezing metadata](#freezing-metadata)
+
+<!-- TOC:END -->
+
 ## Deployment checklist
 
 1. Configure the `admin`, `treasury`, and `dexRouter` addresses when deploying


### PR DESCRIPTION
## Summary
- add an explicit table of contents to the Dynamic Capital Token jetton README for quicker navigation

## Testing
- npx deno fmt dynamic-capital-ton/contracts/README.md

------
https://chatgpt.com/codex/tasks/task_e_68d826b876d48322953117e34d072a0e