### PR TITLE
Add reusable dynamic button component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
 import { type ReactNode } from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Route,
+  Routes,
+  useNavigate,
+} from "react-router-dom";
+import { DynamicButton } from "./components/DynamicButton";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const queryClient = new QueryClient();
@@ -9,6 +15,8 @@ function AppProviders({ children }: { children: ReactNode }) {
 }
 
 function HomePage() {
+  const navigate = useNavigate();
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="container mx-auto px-4 py-8">
@@ -19,12 +27,9 @@ function HomePage() {
           Fast deposits for traders. Bank & crypto, verified.
         </p>
         <div className="text-center">
-          <a 
-            href="/checkout" 
-            className="inline-block bg-primary text-primary-foreground px-6 py-3 rounded-lg hover:opacity-90 transition-opacity"
-          >
+          <DynamicButton onClick={() => navigate("/checkout")}>
             Get Started
-          </a>
+          </DynamicButton>
         </div>
       </div>
     </div>

--- a/src/components/DynamicButton.tsx
+++ b/src/components/DynamicButton.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { motion } from "framer-motion";
+
+import { cn } from "@/utils";
+import { dynamicMotionVariants } from "@/lib/motion-variants";
+
+type MotionButtonProps = React.ComponentPropsWithoutRef<typeof motion.button>;
+
+export interface DynamicButtonProps extends MotionButtonProps {
+  /**
+   * Applies the Dynamic UI button skin. Defaults to the solid primary button.
+   */
+  variant?: "primary" | "outline";
+  /**
+   * Uses the compact padding defined in dynamic-ui.css.
+   */
+  size?: "default" | "small";
+}
+
+const MotionButton = motion.button;
+
+export const DynamicButton = React.forwardRef<
+  HTMLButtonElement,
+  DynamicButtonProps
+>(
+  (
+    {
+      variant = "primary",
+      size = "default",
+      className,
+      disabled,
+      children,
+      variants: variantsProp,
+      initial: initialProp,
+      animate: animateProp,
+      whileHover: whileHoverProp,
+      whileTap: whileTapProp,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { type: buttonType, ...otherProps } = rest;
+    const motionVariants = variantsProp ?? dynamicMotionVariants.button;
+    const initialValue = initialProp ?? "initial";
+    const animateValue = animateProp ?? (disabled ? "disabled" : "initial");
+    const hoverValue = disabled ? undefined : whileHoverProp ?? "hover";
+    const tapValue = disabled ? undefined : whileTapProp ?? "tap";
+
+    return (
+      <MotionButton
+        ref={ref}
+        className={cn(
+          "dynamic-btn",
+          variant,
+          size === "small" && "small",
+          className,
+        )}
+        disabled={disabled}
+        type={buttonType ?? "button"}
+        variants={motionVariants}
+        initial={initialValue}
+        animate={animateValue}
+        whileHover={hoverValue}
+        whileTap={tapValue}
+        {...otherProps}
+      >
+        {children}
+      </MotionButton>
+    );
+  },
+);
+
+DynamicButton.displayName = "DynamicButton";

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "../apps/web/resources/custom.css";
 @import "../apps/web/resources/brand-tokens.css";
+@import "../apps/web/app/dynamic-ui.css";
 
 @tailwind base;
 @tailwind components;
@@ -12,8 +13,9 @@
 
   body {
     @apply bg-background text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-      "Helvetica Neue", Arial, sans-serif;
+    font-family:
+      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+      Arial, sans-serif;
     background: var(--gradient-motion-bg);
     min-height: 100vh;
   }


### PR DESCRIPTION
## Summary
- add a reusable `DynamicButton` motion component that applies Dynamic UI styling in the Vite shell
- import the Dynamic UI stylesheet and adopt the new button on the home page CTA

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d82a55b5d48322a218a5e850682100