### PR TITLE
Add wrappers for Dynamic Agents, Keepers, and Bots

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -1,0 +1,39 @@
+"""Dynamic Agents public interface.
+
+This module re-exports the core persona agents that power Dynamic
+Capital's orchestration cycle.  The concrete implementations live in
+:mod:`dynamic_ai`, but several downstream consumers expect a dedicated
+``dynamic_agents`` package.  Keeping this thin wrapper avoids import
+errors while maintaining a single source of truth for the agent
+implementations.
+"""
+
+from dynamic_ai import (
+    Agent,
+    AgentResult,
+    ChatAgentResult,
+    ChatTurn,
+    DynamicChatAgent,
+    ExecutionAgent,
+    ExecutionAgentResult,
+    ResearchAgent,
+    ResearchAgentResult,
+    RiskAgent,
+    RiskAgentResult,
+)
+from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
+
+__all__ = [
+    "Agent",
+    "AgentResult",
+    "ChatAgentResult",
+    "ChatTurn",
+    "DynamicChatAgent",
+    "ExecutionAgent",
+    "ExecutionAgentResult",
+    "ResearchAgent",
+    "ResearchAgentResult",
+    "RiskAgent",
+    "RiskAgentResult",
+    "run_dynamic_agent_cycle",
+]

--- a/dynamic_bots/__init__.py
+++ b/dynamic_bots/__init__.py
@@ -1,0 +1,13 @@
+"""Dynamic Bots helpers and integrations.
+
+Only a handful of bot helpers exist today, primarily the Telegram
+integration used for trade and operations notifications.  This wrapper
+provides a consistent entry-point that mirrors other ``dynamic_*``
+packages and unlocks imports such as ``from dynamic_bots import
+DynamicTelegramBot`` without reaching into the ``integrations`` module
+structure.
+"""
+
+from integrations.telegram_bot import DynamicTelegramBot
+
+__all__ = ["DynamicTelegramBot"]

--- a/dynamic_keepers/__init__.py
+++ b/dynamic_keepers/__init__.py
@@ -1,0 +1,42 @@
+"""Dynamic Keepers orchestration surface.
+
+The keeper algorithms live under :mod:`algorithms.python` and provide
+structured sync reports for different surfaces (API, backend, frontend,
+channels, groups, and routing) along with the master time keeper.  This
+package exposes a stable import path that mirrors other ``dynamic_*``
+modules in the repository.
+"""
+
+from algorithms.python import (
+    ApiKeeperSyncResult,
+    BackendKeeperSyncResult,
+    ChannelKeeperSyncResult,
+    DynamicAPIKeeperAlgorithm,
+    DynamicBackendKeeperAlgorithm,
+    DynamicChannelKeeperAlgorithm,
+    DynamicFrontendKeeperAlgorithm,
+    DynamicGroupKeeperAlgorithm,
+    DynamicRouteKeeperAlgorithm,
+    DynamicTimeKeeperAlgorithm,
+    FrontendKeeperSyncResult,
+    GroupKeeperSyncResult,
+    RouteKeeperSyncResult,
+    TimeKeeperSyncResult,
+)
+
+__all__ = [
+    "ApiKeeperSyncResult",
+    "BackendKeeperSyncResult",
+    "ChannelKeeperSyncResult",
+    "DynamicAPIKeeperAlgorithm",
+    "DynamicBackendKeeperAlgorithm",
+    "DynamicChannelKeeperAlgorithm",
+    "DynamicFrontendKeeperAlgorithm",
+    "DynamicGroupKeeperAlgorithm",
+    "DynamicRouteKeeperAlgorithm",
+    "DynamicTimeKeeperAlgorithm",
+    "FrontendKeeperSyncResult",
+    "GroupKeeperSyncResult",
+    "RouteKeeperSyncResult",
+    "TimeKeeperSyncResult",
+]


### PR DESCRIPTION
## Summary
- add a `dynamic_agents` package that re-exports the core persona agents and cycle helper
- surface the keeper algorithms through a new `dynamic_keepers` package for a consistent import path
- expose the Telegram integration behind a lightweight `dynamic_bots` package

## Testing
- pytest tests/dynamic_ai/test_agents.py

------
https://chatgpt.com/codex/tasks/task_e_68d82d17062083228a4f35d83f3e93fa