### PR TITLE
Enhance trading instrument support and simulation

### DIFF
--- a/algorithms/python/dynamic_ai_sync.py
+++ b/algorithms/python/dynamic_ai_sync.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 from typing_extensions import Literal
 
 from dynamic_ai import ExecutionAgent, ResearchAgent, RiskAgent
-from dynamic_algo.trading_core import DynamicTradingAlgo, TradeExecutionResult
+from dynamic_algo.trading_core import DynamicTradingAlgo, TradeExecutionResult, normalise_symbol
 
 try:  # pragma: no cover - optional dependency for treasury actions
     from dynamic_token.treasury import DynamicTreasuryAlgo, TreasuryEvent
@@ -159,8 +159,7 @@ def run_dynamic_agent_cycle(context: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def _coerce_symbol(value: Any, default: str = "XAUUSD") -> str:
-    symbol = str(value or "").strip().upper()
-    return symbol or default
+    return normalise_symbol(value or default)
 
 
 def _coerce_lot(value: Any, default: float = 0.1) -> float:

--- a/dynamic_algo/__init__.py
+++ b/dynamic_algo/__init__.py
@@ -6,6 +6,8 @@ from .trading_core import (
     SUCCESS_RETCODE,
     TradeExecutionResult,
     DynamicTradingAlgo,
+    InstrumentProfile,
+    normalise_symbol,
 )
 from .market_flow import DynamicMarketFlow, MarketFlowSnapshot, MarketFlowTrade
 from .middleware import (
@@ -111,6 +113,8 @@ __all__ = [
     "SUCCESS_RETCODE",
     "TradeExecutionResult",
     "DynamicTradingAlgo",
+    "InstrumentProfile",
+    "normalise_symbol",
     "DynamicMarketFlow",
     "MarketFlowSnapshot",
     "MarketFlowTrade",

--- a/dynamic_algo/trading_core.py
+++ b/dynamic_algo/trading_core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, Mapping, Optional
 
 try:  # pragma: no cover - optional dependency
     from integrations.mt5_connector import MT5Connector  # type: ignore
@@ -16,7 +16,367 @@ ORDER_ACTION_SELL = "SELL"
 SUCCESS_RETCODE = 10009
 
 
-@dataclass
+@dataclass(slots=True, frozen=True)
+class InstrumentProfile:
+    """Trading instrument metadata used for normalisation and simulation."""
+
+    symbol: str
+    asset_class: str
+    pip_value: float
+    volatility: float
+    spread_cost: float
+    tick_size: float
+    price_precision: int
+    reference_price: float
+    min_lot: float = 0.01
+    max_lot: float = 100.0
+    aliases: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        symbol = str(self.symbol).strip().upper()
+        if not symbol:
+            raise ValueError("symbol must not be empty")
+        object.__setattr__(self, "symbol", symbol)
+
+        asset_class = str(self.asset_class).strip().lower() or "multi_asset"
+        object.__setattr__(self, "asset_class", asset_class)
+
+        pip_value = float(self.pip_value)
+        volatility = float(self.volatility)
+        spread_cost = float(self.spread_cost)
+        tick_size = float(self.tick_size)
+        reference_price = float(self.reference_price)
+        min_lot = float(self.min_lot)
+        max_lot = float(self.max_lot)
+        price_precision = int(self.price_precision)
+
+        if pip_value <= 0:
+            raise ValueError("pip_value must be positive")
+        if volatility <= 0:
+            raise ValueError("volatility must be positive")
+        if spread_cost < 0:
+            raise ValueError("spread_cost cannot be negative")
+        if tick_size <= 0:
+            raise ValueError("tick_size must be positive")
+        if reference_price <= 0:
+            raise ValueError("reference_price must be positive")
+        if min_lot <= 0:
+            raise ValueError("min_lot must be positive")
+        if max_lot < min_lot:
+            raise ValueError("max_lot must be greater than or equal to min_lot")
+        if price_precision < 0:
+            raise ValueError("price_precision cannot be negative")
+
+        object.__setattr__(self, "pip_value", pip_value)
+        object.__setattr__(self, "volatility", volatility)
+        object.__setattr__(self, "spread_cost", spread_cost)
+        object.__setattr__(self, "tick_size", tick_size)
+        object.__setattr__(self, "reference_price", reference_price)
+        object.__setattr__(self, "min_lot", min_lot)
+        object.__setattr__(self, "max_lot", max_lot)
+        object.__setattr__(self, "price_precision", price_precision)
+
+        alias_tokens = tuple(
+            str(alias).strip().upper()
+            for alias in self.aliases
+            if str(alias).strip()
+        )
+        object.__setattr__(self, "aliases", alias_tokens)
+
+
+_SYMBOL_SANITISE = str.maketrans({
+    "-": "",
+    "_": "",
+    "/": "",
+    " ": "",
+    ":": "",
+    ".": "",
+    "=": "",
+})
+
+
+def _normalise_symbol_token(symbol: Any) -> str:
+    if symbol is None:
+        return ""
+    token = str(symbol).strip().upper().translate(_SYMBOL_SANITISE)
+    if token.endswith("USDT"):
+        usd_variant = token[:-4] + "USD"
+        if usd_variant:
+            token = usd_variant
+    return token
+
+
+def _derive_generic_profile(symbol: str) -> InstrumentProfile:
+    token = _normalise_symbol_token(symbol) or DEFAULT_SYMBOL
+    if token.endswith("USD") and len(token) == 6:
+        return InstrumentProfile(
+            symbol=token,
+            asset_class="fx_major",
+            pip_value=10.0,
+            volatility=40.0,
+            spread_cost=0.8,
+            tick_size=0.0001,
+            price_precision=5,
+            reference_price=1.0,
+            min_lot=0.01,
+            max_lot=200.0,
+        )
+    if token.endswith("USD"):
+        return InstrumentProfile(
+            symbol=token,
+            asset_class="crypto",
+            pip_value=4.0,
+            volatility=220.0,
+            spread_cost=6.0,
+            tick_size=1.0,
+            price_precision=2,
+            reference_price=100.0,
+            min_lot=0.01,
+            max_lot=100.0,
+        )
+    return InstrumentProfile(
+        symbol=token,
+        asset_class="multi_asset",
+        pip_value=25.0,
+        volatility=80.0,
+        spread_cost=1.0,
+        tick_size=0.01,
+        price_precision=3,
+        reference_price=10.0,
+        min_lot=0.01,
+        max_lot=100.0,
+    )
+
+
+def _build_alias_index(profiles: Mapping[str, InstrumentProfile]) -> Dict[str, str]:
+    index: Dict[str, str] = {}
+    for profile in profiles.values():
+        canonical_token = _normalise_symbol_token(profile.symbol)
+        if canonical_token:
+            index[canonical_token] = profile.symbol
+        for alias in profile.aliases:
+            alias_token = _normalise_symbol_token(alias)
+            if alias_token and alias_token not in index:
+                index[alias_token] = profile.symbol
+    return index
+
+
+_DEFAULT_PROFILE_LIST = [
+    InstrumentProfile(
+        symbol="EURUSD",
+        asset_class="fx_major",
+        pip_value=10.0,
+        volatility=45.0,
+        spread_cost=0.7,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=1.085,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("EUR/USD", "FX:EURUSD", "EUR-USD", "EURUSDT"),
+    ),
+    InstrumentProfile(
+        symbol="GBPUSD",
+        asset_class="fx_major",
+        pip_value=10.0,
+        volatility=55.0,
+        spread_cost=0.8,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=1.27,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("GBP/USD", "FX:GBPUSD", "GBP-USD", "GBPUSDT"),
+    ),
+    InstrumentProfile(
+        symbol="USDJPY",
+        asset_class="fx_major",
+        pip_value=9.1,
+        volatility=55.0,
+        spread_cost=0.9,
+        tick_size=0.01,
+        price_precision=3,
+        reference_price=147.5,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("USD/JPY", "FX:USDJPY", "USD-JPY", "USDJPY.", "USDJPY=")
+    ),
+    InstrumentProfile(
+        symbol="USDCHF",
+        asset_class="fx_major",
+        pip_value=10.0,
+        volatility=38.0,
+        spread_cost=0.7,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=0.9,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("USD/CHF", "FX:USDCHF", "USD-CHF"),
+    ),
+    InstrumentProfile(
+        symbol="USDCAD",
+        asset_class="fx_major",
+        pip_value=10.0,
+        volatility=40.0,
+        spread_cost=0.75,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=1.36,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("USD/CAD", "FX:USDCAD", "USD-CAD"),
+    ),
+    InstrumentProfile(
+        symbol="AUDUSD",
+        asset_class="fx_major",
+        pip_value=10.0,
+        volatility=45.0,
+        spread_cost=0.75,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=0.66,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("AUD/USD", "FX:AUDUSD", "AUD-USD", "AUDUSDT"),
+    ),
+    InstrumentProfile(
+        symbol="NZDUSD",
+        asset_class="fx_major",
+        pip_value=10.0,
+        volatility=40.0,
+        spread_cost=0.75,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=0.61,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("NZD/USD", "FX:NZDUSD", "NZD-USD", "NZDUSDT"),
+    ),
+    InstrumentProfile(
+        symbol="XAUUSD",
+        asset_class="metal",
+        pip_value=100.0,
+        volatility=25.0,
+        spread_cost=1.2,
+        tick_size=0.1,
+        price_precision=2,
+        reference_price=2350.0,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("GOLD", "XAU", "XAU/USD", "XAUUSDT", "GOLDUSD"),
+    ),
+    InstrumentProfile(
+        symbol="XAGUSD",
+        asset_class="metal",
+        pip_value=50.0,
+        volatility=30.0,
+        spread_cost=0.9,
+        tick_size=0.01,
+        price_precision=3,
+        reference_price=28.0,
+        min_lot=0.01,
+        max_lot=200.0,
+        aliases=("SILVER", "XAG", "XAG/USD", "XAGUSDT", "SILVERUSD"),
+    ),
+    InstrumentProfile(
+        symbol="BTCUSD",
+        asset_class="crypto",
+        pip_value=5.0,
+        volatility=600.0,
+        spread_cost=15.0,
+        tick_size=1.0,
+        price_precision=2,
+        reference_price=65000.0,
+        min_lot=0.01,
+        max_lot=50.0,
+        aliases=("BTCUSDT", "BTC/USD", "BTC-USD", "XBTUSD"),
+    ),
+    InstrumentProfile(
+        symbol="ETHUSD",
+        asset_class="crypto",
+        pip_value=4.0,
+        volatility=220.0,
+        spread_cost=8.0,
+        tick_size=1.0,
+        price_precision=2,
+        reference_price=3200.0,
+        min_lot=0.01,
+        max_lot=100.0,
+        aliases=("ETHUSDT", "ETH/USD", "ETH-USD"),
+    ),
+    InstrumentProfile(
+        symbol="XRPUSD",
+        asset_class="crypto",
+        pip_value=1.5,
+        volatility=80.0,
+        spread_cost=2.0,
+        tick_size=0.001,
+        price_precision=4,
+        reference_price=0.6,
+        min_lot=1.0,
+        max_lot=500000.0,
+        aliases=("XRPUSDT", "XRP/USD", "XRP-USD"),
+    ),
+    InstrumentProfile(
+        symbol="BNBUSD",
+        asset_class="crypto",
+        pip_value=4.0,
+        volatility=90.0,
+        spread_cost=5.0,
+        tick_size=0.1,
+        price_precision=2,
+        reference_price=600.0,
+        min_lot=0.01,
+        max_lot=100.0,
+        aliases=("BNBUSDT", "BNB/USD", "BNB-USD"),
+    ),
+    InstrumentProfile(
+        symbol="TONUSD",
+        asset_class="crypto",
+        pip_value=3.0,
+        volatility=70.0,
+        spread_cost=3.0,
+        tick_size=0.01,
+        price_precision=3,
+        reference_price=6.0,
+        min_lot=0.1,
+        max_lot=1000.0,
+        aliases=("TONUSDT", "TON/USD", "TON-USD", "TONCOINUSD", "TONCOINUSDT", "TON"),
+    ),
+    InstrumentProfile(
+        symbol="DCTTON",
+        asset_class="crypto",
+        pip_value=1.0,
+        volatility=150.0,
+        spread_cost=2.5,
+        tick_size=0.0001,
+        price_precision=5,
+        reference_price=0.12,
+        min_lot=1.0,
+        max_lot=250000.0,
+        aliases=("DCT/TON", "DCT-TON", "DCTTONUSD", "DCT"),
+    ),
+]
+
+DEFAULT_INSTRUMENT_PROFILES: Dict[str, InstrumentProfile] = {
+    profile.symbol: profile for profile in _DEFAULT_PROFILE_LIST
+}
+DEFAULT_ALIAS_INDEX = _build_alias_index(DEFAULT_INSTRUMENT_PROFILES)
+DEFAULT_SYMBOL = "XAUUSD"
+
+
+def normalise_symbol(symbol: Any, *, default: str = DEFAULT_SYMBOL) -> str:
+    token = _normalise_symbol_token(symbol)
+    if token:
+        return DEFAULT_ALIAS_INDEX.get(token, token)
+    default_token = _normalise_symbol_token(default)
+    if default_token:
+        return DEFAULT_ALIAS_INDEX.get(default_token, default_token)
+    return DEFAULT_SYMBOL
+
+
+@dataclass(slots=True)
 class TradeExecutionResult:
     """Normalised view of a trading execution attempt."""
 
@@ -37,65 +397,125 @@ class TradeExecutionResult:
 class _PaperBroker:
     """Fallback connector that simulates fills when MT5 is unavailable."""
 
-    def execute(self, action: str, symbol: str, lot: float) -> TradeExecutionResult:
-        drift = random.uniform(-1.0, 1.0)
-        base_profit = lot * 100
-        profit = base_profit * (1 if action == ORDER_ACTION_BUY else 0.6) + drift
+    def execute(
+        self, action: str, symbol: str, lot: float, profile: InstrumentProfile
+    ) -> TradeExecutionResult:
+        pip_move = random.uniform(-profile.volatility, profile.volatility)
+        direction = 1.0 if action == ORDER_ACTION_BUY else -1.0
+        gross = pip_move * profile.pip_value * lot * direction
+        spread = profile.spread_cost * lot
+        noise = random.uniform(-profile.pip_value * 0.1, profile.pip_value * 0.1)
+        profit = round(gross - spread + noise, 2)
+
+        price_move = pip_move * profile.tick_size
+        execution_price = profile.reference_price + price_move
+        if execution_price <= 0:
+            execution_price = profile.reference_price
+        price = round(execution_price, profile.price_precision)
+
         message = f"Simulated {action} order executed"
 
         return TradeExecutionResult(
             retcode=SUCCESS_RETCODE,
             message=message,
-            profit=round(profit, 2),
+            profit=profit,
             ticket=random.randint(10_000, 99_999),
             symbol=symbol,
             lot=lot,
+            price=price,
         )
 
-    def open_hedge(self, symbol: str, lot: float, side: str) -> TradeExecutionResult:
+    def open_hedge(
+        self, symbol: str, lot: float, side: str, profile: InstrumentProfile
+    ) -> TradeExecutionResult:
         action = ORDER_ACTION_BUY if side.upper() == "LONG_HEDGE" else ORDER_ACTION_SELL
-        return self.execute(action, symbol, lot)
+        return self.execute(action, symbol, lot, profile)
 
-    def close_hedge(self, symbol: str, lot: float, side: str) -> TradeExecutionResult:
+    def close_hedge(
+        self, symbol: str, lot: float, side: str, profile: InstrumentProfile
+    ) -> TradeExecutionResult:
         action = ORDER_ACTION_SELL if side.upper() == "LONG_HEDGE" else ORDER_ACTION_BUY
-        return self.execute(action, symbol, lot)
+        return self.execute(action, symbol, lot, profile)
 
 
 class DynamicTradingAlgo:
     """High-level trade executor that orchestrates MT5 or paper trades."""
 
-    def __init__(self, connector: Optional[Any] = None) -> None:
+    def __init__(
+        self,
+        connector: Optional[Any] = None,
+        *,
+        instrument_profiles: Mapping[str, InstrumentProfile] | None = None,
+        default_symbol: Optional[str] = None,
+    ) -> None:
+        base_profiles = dict(DEFAULT_INSTRUMENT_PROFILES)
+        if instrument_profiles:
+            for profile in instrument_profiles.values():
+                if not isinstance(profile, InstrumentProfile):
+                    raise TypeError("instrument_profiles must contain InstrumentProfile values")
+                base_profiles[profile.symbol] = profile
+
+        self.instrument_profiles: Dict[str, InstrumentProfile] = base_profiles
+        self._alias_index: Dict[str, str] = _build_alias_index(self.instrument_profiles)
+        candidate_default = default_symbol or DEFAULT_SYMBOL
+        default_token = _normalise_symbol_token(candidate_default)
+        canonical_default = self._alias_index.get(default_token) if default_token else None
+        if canonical_default is None:
+            canonical_default = default_token or DEFAULT_SYMBOL
+
+        if canonical_default not in self.instrument_profiles:
+            profile = _derive_generic_profile(canonical_default)
+            self.instrument_profiles[canonical_default] = profile
+            token = _normalise_symbol_token(canonical_default)
+            if token:
+                self._alias_index[token] = canonical_default
+
+        self.default_symbol = canonical_default
+        self._paper_broker = _PaperBroker()
         self.connector = connector or self._bootstrap_connector()
 
+    # ----------------------------------------------------------------- execution
     def execute_trade(self, signal: Any, *, lot: float, symbol: str) -> TradeExecutionResult:
         action = self._extract_action(signal)
+        canonical_symbol, profile = self._resolve_symbol(symbol)
+        adjusted_lot = self._clamp_lot(lot, profile)
 
         if action == ORDER_ACTION_BUY:
-            return self._buy(symbol, lot)
+            return self._buy(canonical_symbol, adjusted_lot, profile=profile)
         if action == ORDER_ACTION_SELL:
-            return self._sell(symbol, lot)
+            return self._sell(canonical_symbol, adjusted_lot, profile=profile)
 
         return TradeExecutionResult(
             retcode=0,
             message="No trade executed for neutral signal",
             profit=0.0,
-            symbol=symbol,
-            lot=lot,
+            symbol=canonical_symbol,
+            lot=adjusted_lot,
         )
 
-    def _buy(self, symbol: str, lot: float) -> TradeExecutionResult:
+    def _buy(
+        self, symbol: str, lot: float, *, profile: InstrumentProfile | None = None
+    ) -> TradeExecutionResult:
+        resolved_profile = profile or self._resolve_symbol(symbol)[1]
+        adjusted_lot = self._clamp_lot(lot, resolved_profile)
+
         if self.connector and hasattr(self.connector, "buy"):
-            response = self.connector.buy(symbol, lot)
-            return self._normalise_response(response, symbol=symbol, lot=lot)
+            response = self.connector.buy(symbol, adjusted_lot)
+            return self._normalise_response(response, symbol=symbol, lot=adjusted_lot)
 
-        return self._paper_execute(ORDER_ACTION_BUY, symbol, lot)
+        return self._paper_execute(ORDER_ACTION_BUY, symbol, adjusted_lot, resolved_profile)
 
-    def _sell(self, symbol: str, lot: float) -> TradeExecutionResult:
+    def _sell(
+        self, symbol: str, lot: float, *, profile: InstrumentProfile | None = None
+    ) -> TradeExecutionResult:
+        resolved_profile = profile or self._resolve_symbol(symbol)[1]
+        adjusted_lot = self._clamp_lot(lot, resolved_profile)
+
         if self.connector and hasattr(self.connector, "sell"):
-            response = self.connector.sell(symbol, lot)
-            return self._normalise_response(response, symbol=symbol, lot=lot)
+            response = self.connector.sell(symbol, adjusted_lot)
+            return self._normalise_response(response, symbol=symbol, lot=adjusted_lot)
 
-        return self._paper_execute(ORDER_ACTION_SELL, symbol, lot)
+        return self._paper_execute(ORDER_ACTION_SELL, symbol, adjusted_lot, resolved_profile)
 
     def execute_hedge(
         self,
@@ -107,29 +527,52 @@ class DynamicTradingAlgo:
     ) -> TradeExecutionResult:
         """Execute a hedge open/close instruction."""
 
-        if close:
-            return self._close_hedge(symbol, lot, side)
-        return self._open_hedge(symbol, lot, side)
+        canonical_symbol, profile = self._resolve_symbol(symbol)
+        adjusted_lot = self._clamp_lot(lot, profile)
 
-    def _open_hedge(self, symbol: str, lot: float, side: str) -> TradeExecutionResult:
+        if close:
+            return self._close_hedge(canonical_symbol, adjusted_lot, side, profile=profile)
+        return self._open_hedge(canonical_symbol, adjusted_lot, side, profile=profile)
+
+    def _open_hedge(
+        self,
+        symbol: str,
+        lot: float,
+        side: str,
+        *,
+        profile: InstrumentProfile,
+    ) -> TradeExecutionResult:
         if self.connector and hasattr(self.connector, "open_hedge"):
             response = self.connector.open_hedge(symbol, lot, side)
             return self._normalise_response(response, symbol=symbol, lot=lot)
 
         action = ORDER_ACTION_BUY if side.upper() == "LONG_HEDGE" else ORDER_ACTION_SELL
-        return self._paper_execute(action, symbol, lot)
+        return self._paper_execute(action, symbol, lot, profile)
 
-    def _close_hedge(self, symbol: str, lot: float, side: str) -> TradeExecutionResult:
+    def _close_hedge(
+        self,
+        symbol: str,
+        lot: float,
+        side: str,
+        *,
+        profile: InstrumentProfile,
+    ) -> TradeExecutionResult:
         if self.connector and hasattr(self.connector, "close_hedge"):
             response = self.connector.close_hedge(symbol, lot, side)
             return self._normalise_response(response, symbol=symbol, lot=lot)
 
         action = ORDER_ACTION_SELL if side.upper() == "LONG_HEDGE" else ORDER_ACTION_BUY
-        return self._paper_execute(action, symbol, lot)
+        return self._paper_execute(action, symbol, lot, profile)
 
-    def _paper_execute(self, action: str, symbol: str, lot: float) -> TradeExecutionResult:
-        broker = _PaperBroker()
-        return broker.execute(action, symbol, lot)
+    # ------------------------------------------------------------------ helpers
+    def _paper_execute(
+        self,
+        action: str,
+        symbol: str,
+        lot: float,
+        profile: InstrumentProfile,
+    ) -> TradeExecutionResult:
+        return self._paper_broker.execute(action, symbol, lot, profile)
 
     def _normalise_response(self, response: Any, *, symbol: str, lot: float) -> TradeExecutionResult:
         if isinstance(response, TradeExecutionResult):
@@ -159,10 +602,49 @@ class DynamicTradingAlgo:
             return str(signal["action"]).upper()
         return str(signal).upper()
 
+    def _resolve_symbol(self, symbol: Optional[str]) -> tuple[str, InstrumentProfile]:
+        candidate = symbol if symbol is not None else self.default_symbol
+        token = _normalise_symbol_token(candidate)
+        if not token:
+            token = _normalise_symbol_token(self.default_symbol)
+        canonical = self._alias_index.get(token)
+        if canonical is None:
+            canonical = token or self.default_symbol
+
+        profile = self.instrument_profiles.get(canonical)
+        if profile is None:
+            profile = _derive_generic_profile(canonical)
+            self.instrument_profiles[canonical] = profile
+            canonical_token = _normalise_symbol_token(canonical)
+            if canonical_token:
+                self._alias_index[canonical_token] = canonical
+
+        return canonical, profile
+
+    def _clamp_lot(self, lot: float, profile: InstrumentProfile) -> float:
+        try:
+            value = float(lot)
+        except (TypeError, ValueError):
+            value = profile.min_lot
+        if value <= 0:
+            value = profile.min_lot
+        return round(min(max(value, profile.min_lot), profile.max_lot), 4)
+
     def _bootstrap_connector(self) -> Any:
         if MT5Connector is None:
-            return _PaperBroker()
+            return self._paper_broker
         try:
             return MT5Connector()
         except Exception:
-            return _PaperBroker()
+            return self._paper_broker
+
+
+__all__ = [
+    "InstrumentProfile",
+    "DynamicTradingAlgo",
+    "TradeExecutionResult",
+    "ORDER_ACTION_BUY",
+    "ORDER_ACTION_SELL",
+    "SUCCESS_RETCODE",
+    "normalise_symbol",
+]

--- a/tests/test_dynamic_trading_algo.py
+++ b/tests/test_dynamic_trading_algo.py
@@ -1,0 +1,107 @@
+import types
+
+import pytest
+
+from dynamic_algo.trading_core import (
+    ORDER_ACTION_BUY,
+    SUCCESS_RETCODE,
+    DynamicTradingAlgo,
+    TradeExecutionResult,
+    normalise_symbol,
+)
+
+
+@pytest.mark.parametrize(
+    "alias, expected",
+    [
+        ("eur/usd", "EURUSD"),
+        ("GBPUSDT", "GBPUSD"),
+        ("usd-jpy", "USDJPY"),
+        ("gold", "XAUUSD"),
+        ("silver", "XAGUSD"),
+        ("btc-usdt", "BTCUSD"),
+        ("eth/usd", "ETHUSD"),
+        ("xrpusd", "XRPUSD"),
+        ("bnb-usd", "BNBUSD"),
+        ("toncoinusdt", "TONUSD"),
+        ("dct-ton", "DCTTON"),
+        ("", "XAUUSD"),
+    ],
+)
+def test_normalise_symbol_aliases(alias: str, expected: str) -> None:
+    assert normalise_symbol(alias) == expected
+
+
+class StubConnector:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, float]] = []
+
+    def buy(self, symbol: str, lot: float) -> types.SimpleNamespace:
+        self.calls.append((symbol, lot))
+        return types.SimpleNamespace(
+            retcode=SUCCESS_RETCODE,
+            comment="ok",
+            profit=123.4,
+            order=42,
+            price=1.2345,
+        )
+
+
+class StubHedgeConnector:
+    def __init__(self) -> None:
+        self.open_calls: list[tuple[str, float, str]] = []
+        self.close_calls: list[tuple[str, float, str]] = []
+
+    def open_hedge(self, symbol: str, lot: float, side: str) -> types.SimpleNamespace:
+        self.open_calls.append((symbol, lot, side))
+        return types.SimpleNamespace(retcode=SUCCESS_RETCODE, comment="open", profit=0.0, order=10)
+
+    def close_hedge(self, symbol: str, lot: float, side: str) -> types.SimpleNamespace:
+        self.close_calls.append((symbol, lot, side))
+        return types.SimpleNamespace(retcode=SUCCESS_RETCODE, comment="close", profit=0.0, order=11)
+
+
+def test_execute_trade_normalises_symbol_and_uses_connector() -> None:
+    connector = StubConnector()
+    algo = DynamicTradingAlgo(connector=connector)
+
+    result = algo.execute_trade({"action": ORDER_ACTION_BUY}, lot=0.05, symbol="eur/usdt")
+
+    assert connector.calls == [("EURUSD", 0.05)]
+    assert isinstance(result, TradeExecutionResult)
+    assert result.symbol == "EURUSD"
+    assert result.lot == pytest.approx(0.05)
+
+
+def test_execute_trade_uses_instrument_profile_for_paper(monkeypatch: pytest.MonkeyPatch) -> None:
+    algo = DynamicTradingAlgo(connector=None)
+    values = iter([10.0, 0.5])
+
+    def fake_uniform(_a: float, _b: float) -> float:
+        return next(values)
+
+    monkeypatch.setattr("dynamic_algo.trading_core.random.uniform", fake_uniform)
+    monkeypatch.setattr("dynamic_algo.trading_core.random.randint", lambda _a, _b: 12345)
+
+    result = algo.execute_trade({"action": "sell"}, lot=0.001, symbol="xrp/usdt")
+
+    assert result.symbol == "XRPUSD"
+    assert result.lot == pytest.approx(1.0)
+    assert result.profit == pytest.approx(-16.5)
+    assert result.price == pytest.approx(0.61, rel=0, abs=1e-9)
+    assert result.ticket == 12345
+
+
+def test_execute_hedge_normalises_symbol_and_clamps_lot() -> None:
+    connector = StubHedgeConnector()
+    algo = DynamicTradingAlgo(connector=connector)
+
+    open_result = algo.execute_hedge(symbol="tonusdt", lot=0.01, side="long_hedge")
+    close_result = algo.execute_hedge(symbol="tonusdt", lot=0.01, side="long_hedge", close=True)
+
+    assert connector.open_calls == [("TONUSD", 0.1, "long_hedge")]
+    assert connector.close_calls == [("TONUSD", 0.1, "long_hedge")]
+    assert open_result.symbol == "TONUSD"
+    assert close_result.symbol == "TONUSD"
+    assert open_result.lot == pytest.approx(0.1)
+    assert close_result.lot == pytest.approx(0.1)


### PR DESCRIPTION
## Summary
- add instrument profiles and symbol normalisation to the trading core so majors, metals, and requested crypto pairs resolve cleanly
- improve paper execution realism with instrument-aware pricing, lot clamping, and export the new helpers through the dynamic algo package
- update the AI sync symbol coercion and add regression tests covering alias normalisation, paper fills, and hedging calls

## Testing
- pytest tests/test_dynamic_trading_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68d82bc3eac08322b6036eb48de20cc7