### PR TITLE
feat: integrate ollama reasoning adapter into dynamic ai core

### DIFF
--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -21,6 +21,7 @@ from .dolphin_adapter import (
     DolphinSamplingConfig,
     LLMIntegrationError,
 )
+from .ollama_adapter import OllamaAdapter, OllamaConfig, OllamaPromptTemplate
 from .analysis import AnalysisComponent, DynamicAnalysis
 from .fusion import (
     FusionEngine,
@@ -58,6 +59,9 @@ __all__ = [
     "DolphinPromptTemplate",
     "DolphinSamplingConfig",
     "LLMIntegrationError",
+    "OllamaAdapter",
+    "OllamaConfig",
+    "OllamaPromptTemplate",
     "ExecutionAgent",
     "ExecutionAgentResult",
     "AnalysisComponent",

--- a/dynamic_ai/ollama_adapter.py
+++ b/dynamic_ai/ollama_adapter.py
@@ -1,0 +1,144 @@
+"""Ollama integration helpers for Dynamic AI reasoning enhancements."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
+
+import requests
+
+from .dolphin_adapter import LLMIntegrationError
+
+
+@dataclass(slots=True)
+class OllamaConfig:
+    """Configuration describing how to contact an Ollama server."""
+
+    host: str = "http://localhost:11434"
+    model: str = "llama3"
+    keep_alive: float | None = None
+    options: MutableMapping[str, Any] = field(default_factory=dict)
+    headers: Mapping[str, str] | None = None
+
+
+@dataclass(slots=True)
+class OllamaPromptTemplate:
+    """Prompt template tailored for Ollama compatible models."""
+
+    system_prompt: str = (
+        "You are an institutional trading co-pilot. Refine the reasoning while keeping it concise."
+    )
+    instruction_suffix: str = (
+        "Summarise the action, justify the confidence level, and surface one key risk or validation datapoint."
+    )
+
+    def build_prompt(
+        self,
+        *,
+        action: str,
+        confidence: float,
+        base_reasoning: str,
+        market_context: Mapping[str, Any],
+        prior_dialogue: Sequence[tuple[str, str]] | None = None,
+    ) -> str:
+        """Compose a structured prompt for the Ollama API."""
+
+        serialized_context = json.dumps(market_context, default=str, ensure_ascii=False)
+        dialogue_lines: list[str] = []
+        if prior_dialogue:
+            for user, assistant in prior_dialogue:
+                dialogue_lines.append(f"User: {user}")
+                dialogue_lines.append(f"Assistant: {assistant}")
+
+        dialogue_block = "\n".join(dialogue_lines)
+        if dialogue_block:
+            dialogue_block = f"\nPrevious dialogue:\n{dialogue_block}\n"
+
+        return (
+            f"{self.system_prompt}\n"
+            f"Action: {action}\n"
+            f"Confidence: {confidence:.2f}\n"
+            f"Prior reasoning: {base_reasoning}\n"
+            f"Context JSON: {serialized_context}\n"
+            f"{dialogue_block}"
+            f"Instructions: {self.instruction_suffix}"
+        )
+
+
+@dataclass
+class OllamaAdapter:
+    """Adapter that communicates with a running Ollama instance."""
+
+    config: OllamaConfig = field(default_factory=OllamaConfig)
+    prompt_template: OllamaPromptTemplate = field(default_factory=OllamaPromptTemplate)
+    timeout: float = 30.0
+
+    def enhance_reasoning(
+        self,
+        *,
+        action: str,
+        confidence: float,
+        base_reasoning: str,
+        market_context: Mapping[str, Any],
+        prior_dialogue: Sequence[tuple[str, str]] | None = None,
+    ) -> str:
+        """Call the Ollama generate endpoint and return enhanced reasoning."""
+
+        payload: Dict[str, Any] = {
+            "model": self.config.model,
+            "prompt": self.prompt_template.build_prompt(
+                action=action,
+                confidence=confidence,
+                base_reasoning=base_reasoning,
+                market_context=market_context,
+                prior_dialogue=prior_dialogue,
+            ),
+            "stream": False,
+        }
+
+        if self.config.keep_alive is not None:
+            payload["keep_alive"] = self.config.keep_alive
+
+        if self.config.options:
+            payload["options"] = dict(self.config.options)
+
+        url = f"{self.config.host.rstrip('/')}/api/generate"
+
+        try:
+            response = requests.post(
+                url,
+                json=payload,
+                headers=self.config.headers,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise LLMIntegrationError(f"Failed to call Ollama generate endpoint at {url}") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:  # pragma: no cover - invalid payload
+            raise LLMIntegrationError("Ollama response was not valid JSON") from exc
+
+        text = self._extract_response_text(data)
+        if not text:
+            raise LLMIntegrationError("Ollama response did not include any text output")
+
+        return text.strip()
+
+    @staticmethod
+    def _extract_response_text(data: Mapping[str, Any]) -> str:
+        """Extract the generated text from the Ollama response payload."""
+
+        if "response" in data and isinstance(data["response"], str):
+            return data["response"]
+
+        # Some Ollama builds nest the message content
+        message = data.get("message")
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+
+        return ""


### PR DESCRIPTION
## Summary
- add an Ollama-backed reasoning adapter that talks to the local API for enhanced signal narratives
- generalize the fusion core to accept any reasoning adapter and export the new Ollama helpers from the package

## Testing
- npm run format
- npm run lint
- npm run typecheck
- python -m compileall dynamic_ai

------
https://chatgpt.com/codex/tasks/task_e_68d82d92ccb88322b96f355f9c3b4feb