### PR TITLE
Enhance login flow with redirect awareness

### DIFF
--- a/apps/web/components/auth/AuthForm.tsx
+++ b/apps/web/components/auth/AuthForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import {
   Button,
@@ -34,12 +35,82 @@ const INITIAL_STATE: AuthFormState = {
 };
 
 export function AuthForm() {
-  const { signIn, signUp } = useAuth();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { signIn, signUp, session, loading: authLoading } = useAuth();
   const { toast } = useToast();
   const [mode, setMode] = useState<AuthMode>("signin");
-  const [loading, setLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState<AuthFormState>(INITIAL_STATE);
+
+  const redirectParam = searchParams.get("redirect");
+  const redirectPath = useMemo(() => {
+    if (!redirectParam) {
+      return null;
+    }
+
+    if (!redirectParam.startsWith("/") || redirectParam.startsWith("//")) {
+      return null;
+    }
+
+    return redirectParam;
+  }, [redirectParam]);
+
+  const resolvedRedirect = useMemo(
+    () => redirectPath ?? "/investor",
+    [redirectPath],
+  );
+
+  const resolvedRedirectLabel = useMemo(() => {
+    if (resolvedRedirect === "/investor") {
+      return "investor overview";
+    }
+
+    if (resolvedRedirect === "/") {
+      return "home page";
+    }
+
+    const normalized = resolvedRedirect.startsWith("/")
+      ? resolvedRedirect.slice(1)
+      : resolvedRedirect;
+
+    return `${normalized.replace(/-/g, " ")} page`;
+  }, [resolvedRedirect]);
+
+  const modeParam = searchParams.get("mode");
+  useEffect(() => {
+    if (modeParam === "signup" || modeParam === "signin") {
+      setMode(modeParam);
+      setError(null);
+    }
+  }, [modeParam]);
+
+  useEffect(() => {
+    if (!authLoading && session) {
+      router.replace(resolvedRedirect);
+      router.refresh();
+    }
+  }, [authLoading, resolvedRedirect, router, session]);
+
+  const dynamicDescription = useMemo(() => {
+    if (redirectPath?.startsWith("/investor")) {
+      return "Sign in to review investor performance, token burns, and allocation analytics.";
+    }
+
+    if (redirectPath) {
+      const normalized = redirectPath.startsWith("/")
+        ? redirectPath.slice(1)
+        : redirectPath;
+      return `Sign in to continue to the ${
+        normalized.replace(/-/g, " ")
+      } page.`;
+    }
+
+    return "Access your trading dashboard, manage VIP membership, and review your automation settings.";
+  }, [redirectPath]);
+
+  const hasInvalidRedirect = redirectParam != null && !redirectPath;
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -53,22 +124,27 @@ export function AuthForm() {
 
   const handleSignIn = async (event: React.FormEvent) => {
     event.preventDefault();
-    setLoading(true);
+    setIsSubmitting(true);
     setError(null);
 
     if (!formData.email || !formData.password) {
       setError("Please enter your email and password");
-      setLoading(false);
+      setIsSubmitting(false);
       return;
     }
 
     try {
-      const { error: signInError } = await signIn(formData.email, formData.password);
+      const { error: signInError } = await signIn(
+        formData.email,
+        formData.password,
+      );
       if (signInError) {
         if (signInError.message.includes("Invalid login credentials")) {
           setError("Invalid email or password. Please try again.");
         } else if (signInError.message.includes("Email not confirmed")) {
-          setError("Check your inbox and confirm your email before signing in.");
+          setError(
+            "Check your inbox and confirm your email before signing in.",
+          );
         } else {
           setError(signInError.message);
         }
@@ -76,36 +152,40 @@ export function AuthForm() {
         resetForm();
         toast({
           title: "Welcome back",
-          description: "You’re signed in. Head to the dashboard to continue.",
+          description: resolvedRedirect === "/investor"
+            ? "You’re signed in. Routing you to the investor overview."
+            : `You’re signed in. Taking you to the ${resolvedRedirectLabel}.`,
         });
+        router.replace(resolvedRedirect);
+        router.refresh();
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unexpected error");
     } finally {
-      setLoading(false);
+      setIsSubmitting(false);
     }
   };
 
   const handleSignUp = async (event: React.FormEvent) => {
     event.preventDefault();
-    setLoading(true);
+    setIsSubmitting(true);
     setError(null);
 
     if (!formData.email || !formData.password || !formData.firstName) {
       setError("Please fill in all required fields");
-      setLoading(false);
+      setIsSubmitting(false);
       return;
     }
 
     if (formData.password !== formData.confirmPassword) {
       setError("Passwords do not match");
-      setLoading(false);
+      setIsSubmitting(false);
       return;
     }
 
     if (formData.password.length < 6) {
       setError("Password must be at least 6 characters long");
-      setLoading(false);
+      setIsSubmitting(false);
       return;
     }
 
@@ -119,14 +199,17 @@ export function AuthForm() {
 
       if (signUpError) {
         if (signUpError.message.includes("User already registered")) {
-          setError("An account with this email already exists. Please sign in instead.");
+          setError(
+            "An account with this email already exists. Please sign in instead.",
+          );
         } else {
           setError(signUpError.message);
         }
       } else {
         toast({
           title: "Account created",
-          description: "Check your email to confirm your account and unlock access.",
+          description:
+            "Check your email to confirm your account and unlock access.",
         });
         resetForm();
         setMode("signin");
@@ -134,7 +217,7 @@ export function AuthForm() {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unexpected error");
     } finally {
-      setLoading(false);
+      setIsSubmitting(false);
     }
   };
 
@@ -162,9 +245,26 @@ export function AuthForm() {
       >
         <Column gap="12" align="center">
           <Heading variant="display-strong-xs">Dynamic Capital</Heading>
-          <Text variant="body-default-m" onBackground="neutral-weak" align="center">
-            Access your trading dashboard, manage VIP membership, and review your automation settings.
+          <Text
+            variant="body-default-m"
+            onBackground="neutral-weak"
+            align="center"
+          >
+            {dynamicDescription}
           </Text>
+          {hasInvalidRedirect
+            ? (
+              <Text
+                variant="body-default-s"
+                onBackground="brand-weak"
+                align="center"
+              >
+                We couldn’t verify the requested redirect, so you’ll land on the
+                {" "}
+                {resolvedRedirectLabel} after signing in.
+              </Text>
+            )
+            : null}
         </Column>
         <Row gap="12" horizontal="center" wrap>
           <Button
@@ -194,37 +294,39 @@ export function AuthForm() {
         </Row>
         <form onSubmit={onSubmit}>
           <Column gap="16">
-            {mode === "signup" ? (
-              <Row gap="12" wrap>
-                <Column flex={1} minWidth={12} gap="4">
-                  <Text variant="body-default-s" onBackground="neutral-weak">
-                    First name
-                  </Text>
-                  <Input
-                    id="firstName"
-                    name="firstName"
-                    value={formData.firstName}
-                    onChange={handleInputChange}
-                    placeholder="Noah"
-                    aria-label="First name"
-                    required
-                  />
-                </Column>
-                <Column flex={1} minWidth={12} gap="4">
-                  <Text variant="body-default-s" onBackground="neutral-weak">
-                    Last name
-                  </Text>
-                  <Input
-                    id="lastName"
-                    name="lastName"
-                    value={formData.lastName}
-                    onChange={handleInputChange}
-                    placeholder="Sterling"
-                    aria-label="Last name"
-                  />
-                </Column>
-              </Row>
-            ) : null}
+            {mode === "signup"
+              ? (
+                <Row gap="12" wrap>
+                  <Column flex={1} minWidth={12} gap="4">
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      First name
+                    </Text>
+                    <Input
+                      id="firstName"
+                      name="firstName"
+                      value={formData.firstName}
+                      onChange={handleInputChange}
+                      placeholder="Noah"
+                      aria-label="First name"
+                      required
+                    />
+                  </Column>
+                  <Column flex={1} minWidth={12} gap="4">
+                    <Text variant="body-default-s" onBackground="neutral-weak">
+                      Last name
+                    </Text>
+                    <Input
+                      id="lastName"
+                      name="lastName"
+                      value={formData.lastName}
+                      onChange={handleInputChange}
+                      placeholder="Sterling"
+                      aria-label="Last name"
+                    />
+                  </Column>
+                </Row>
+              )
+              : null}
             <Column gap="4">
               <Text variant="body-default-s" onBackground="neutral-weak">
                 Email
@@ -248,35 +350,48 @@ export function AuthForm() {
               onChange={handleInputChange}
               required
             />
-            {mode === "signup" ? (
-              <PasswordInput
-                id="confirmPassword"
-                name="confirmPassword"
-                label="Confirm password"
-                value={formData.confirmPassword}
-                onChange={handleInputChange}
-                required
-              />
-            ) : null}
-            {error ? (
-              <Text variant="body-default-s" onBackground="brand-weak">
-                {error}
-              </Text>
-            ) : null}
+            {mode === "signup"
+              ? (
+                <PasswordInput
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  label="Confirm password"
+                  value={formData.confirmPassword}
+                  onChange={handleInputChange}
+                  required
+                />
+              )
+              : null}
+            {error
+              ? (
+                <Text variant="body-default-s" onBackground="brand-weak">
+                  {error}
+                </Text>
+              )
+              : null}
             <Button
               type="submit"
               size="m"
               variant="secondary"
               data-border="rounded"
-              disabled={loading}
+              disabled={isSubmitting}
             >
-              {loading ? "Processing…" : mode === "signin" ? "Sign in" : "Create account"}
+              {isSubmitting
+                ? "Processing…"
+                : mode === "signin"
+                ? "Sign in"
+                : "Create account"}
             </Button>
           </Column>
         </form>
         <Column gap="8" align="center">
-          <Text variant="body-default-s" onBackground="neutral-weak" align="center">
-            By continuing you agree to desk security policies and trading disclaimers.
+          <Text
+            variant="body-default-s"
+            onBackground="neutral-weak"
+            align="center"
+          >
+            By continuing you agree to desk security policies and trading
+            disclaimers.
           </Text>
         </Column>
       </Column>


### PR DESCRIPTION
## Summary
- add redirect-aware logic to the login form, including query param parsing and automatic routing for authenticated users
- update messaging to reflect destination context and warn when an invalid redirect falls back to a safe default
- improve submission UX with explicit state tracking and destination-specific success toasts

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d82f6809f48322b87328fd60521803