### PR TITLE
feat: integrate dynamic checkout experience

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,13 @@ import {
   Routes,
   useNavigate,
 } from "react-router-dom";
+import Providers from "@/app/providers";
 import { DynamicButton } from "./components/DynamicButton";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
-const queryClient = new QueryClient();
+import CheckoutPage from "~/pages/CheckoutPage";
+import NotFoundPage from "~/pages/NotFoundPage";
 
 function AppProviders({ children }: { children: ReactNode }) {
-  return <>{children}</>;
+  return <Providers>{children}</Providers>;
 }
 
 function HomePage() {
@@ -36,36 +36,6 @@ function HomePage() {
   );
 }
 
-function CheckoutPage() {
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="container mx-auto px-4 py-8">
-        <h1 className="text-4xl font-bold text-center mb-8">
-          Checkout
-        </h1>
-        <p className="text-center">
-          Checkout functionality coming soon...
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function NotFoundPage() {
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="container mx-auto px-4 py-8">
-        <h1 className="text-4xl font-bold text-center mb-8">
-          404 - Page Not Found
-        </h1>
-        <p className="text-center">
-          The page you're looking for doesn't exist.
-        </p>
-      </div>
-    </div>
-  );
-}
-
 function SiteFooter() {
   return (
     <footer className="bg-muted border-t">
@@ -80,22 +50,20 @@ function SiteFooter() {
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <AppProviders>
-        <Router>
-          <div className="min-h-screen flex flex-col">
-            <main className="flex-1">
-              <Routes>
-                <Route path="/" element={<HomePage />} />
-                <Route path="/checkout" element={<CheckoutPage />} />
-                <Route path="*" element={<NotFoundPage />} />
-              </Routes>
-            </main>
-            <SiteFooter />
-          </div>
-        </Router>
-      </AppProviders>
-    </QueryClientProvider>
+    <AppProviders>
+      <Router>
+        <div className="min-h-screen flex flex-col">
+          <main className="flex-1">
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/checkout" element={<CheckoutPage />} />
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </main>
+          <SiteFooter />
+        </div>
+      </Router>
+    </AppProviders>
   );
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,7 @@ export default {
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
     "./lib/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'apps/web'),
+      '~': path.resolve(__dirname, 'src'),
       'next/font/google': path.resolve(
         __dirname,
         'src/stubs/next-font-google.ts',


### PR DESCRIPTION
## Summary
- swap the placeholder checkout route for the shared WebCheckout experience and wrap the app with the real provider stack
- add the missing Vite/Tailwind aliases so the React preview app can resolve shared modules and utility classes

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d82f72ae9c8322bab7b72026996dda