### PR TITLE
Add dynamic text orchestration engine

### DIFF
--- a/dynamic_text/__init__.py
+++ b/dynamic_text/__init__.py
@@ -1,0 +1,10 @@
+"""Dynamic text intelligence package."""
+
+from .engine import DynamicTextEngine, TextContext, TextDigest, TextFragment
+
+__all__ = [
+    "TextFragment",
+    "TextContext",
+    "TextDigest",
+    "DynamicTextEngine",
+]

--- a/dynamic_text/engine.py
+++ b/dynamic_text/engine.py
@@ -1,0 +1,283 @@
+"""Dynamic text intelligence primitives for orchestrated messaging."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "TextFragment",
+    "TextContext",
+    "TextDigest",
+    "DynamicTextEngine",
+]
+
+
+# ---------------------------------------------------------------------------
+# helper utilities
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_lower(value: str) -> str:
+    return _normalise_text(value).lower()
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+# ---------------------------------------------------------------------------
+# dataclasses
+
+
+@dataclass(slots=True)
+class TextFragment:
+    """Single fragment of text awaiting orchestration."""
+
+    channel: str
+    content: str
+    voice: str
+    clarity: float = 0.5
+    warmth: float = 0.5
+    boldness: float = 0.5
+    novelty: float = 0.5
+    tempo: float = 0.5
+    emphasis: float = 0.5
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_utcnow)
+    intents: tuple[str, ...] = field(default_factory=tuple)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.channel = _normalise_lower(self.channel)
+        self.content = _normalise_text(self.content)
+        self.voice = _normalise_text(self.voice)
+        self.clarity = _clamp(float(self.clarity))
+        self.warmth = _clamp(float(self.warmth))
+        self.boldness = _clamp(float(self.boldness))
+        self.novelty = _clamp(float(self.novelty))
+        self.tempo = _clamp(float(self.tempo))
+        self.emphasis = _clamp(float(self.emphasis))
+        self.weight = max(float(self.weight), 0.0)
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.intents = _normalise_tags(self.intents)
+        self.tags = _normalise_tags(self.tags)
+        self.metadata = _coerce_mapping(self.metadata)
+
+    @property
+    def signal_strength(self) -> float:
+        base = (
+            self.clarity * 0.25
+            + self.warmth * 0.2
+            + self.boldness * 0.2
+            + self.novelty * 0.2
+            + self.emphasis * 0.15
+        )
+        weighted = base * max(self.weight, 0.1)
+        return _clamp(weighted)
+
+    @property
+    def is_priority(self) -> bool:
+        return self.signal_strength >= 0.65
+
+
+@dataclass(slots=True)
+class TextContext:
+    """Context describing the text initiative."""
+
+    initiative: str
+    audience: str
+    channel: str
+    urgency: float
+    personalization: float
+    risk_appetite: float
+    emphasis_tags: tuple[str, ...] = field(default_factory=tuple)
+    guardrail_tags: tuple[str, ...] = field(default_factory=tuple)
+    highlight_limit: int = 3
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.initiative = _normalise_text(self.initiative)
+        self.audience = _normalise_text(self.audience)
+        self.channel = _normalise_lower(self.channel)
+        self.urgency = _clamp(float(self.urgency))
+        self.personalization = _clamp(float(self.personalization))
+        self.risk_appetite = _clamp(float(self.risk_appetite))
+        self.emphasis_tags = _normalise_tags(self.emphasis_tags)
+        self.guardrail_tags = _normalise_tags(self.guardrail_tags)
+        limit = int(self.highlight_limit)
+        if limit <= 0:
+            raise ValueError("highlight_limit must be positive")
+        self.highlight_limit = limit
+        self.metadata = _coerce_mapping(self.metadata)
+
+    @property
+    def is_high_urgency(self) -> bool:
+        return self.urgency >= 0.6
+
+    @property
+    def needs_personal_touch(self) -> bool:
+        return self.personalization >= 0.55
+
+
+@dataclass(slots=True)
+class TextDigest:
+    """Digest of the most relevant text fragments for a context."""
+
+    context: TextContext
+    fragments: Deque[TextFragment] = field(default_factory=deque)
+    metrics: MutableMapping[str, float] = field(default_factory=dict)
+
+    def add_fragment(self, fragment: TextFragment) -> None:
+        self.fragments.append(fragment)
+
+    def extend(self, fragments: Iterable[TextFragment]) -> None:
+        for fragment in fragments:
+            self.add_fragment(fragment)
+
+    def top_fragments(self) -> tuple[TextFragment, ...]:
+        return tuple(self.fragments)
+
+    def as_payload(self) -> Mapping[str, object]:
+        return {
+            "initiative": self.context.initiative,
+            "audience": self.context.audience,
+            "channel": self.context.channel,
+            "fragments": [
+                {
+                    "content": fragment.content,
+                    "voice": fragment.voice,
+                    "signal_strength": fragment.signal_strength,
+                    "intents": fragment.intents,
+                    "tags": fragment.tags,
+                    "timestamp": fragment.timestamp.isoformat(),
+                }
+                for fragment in self.fragments
+            ],
+            "metrics": dict(self.metrics),
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicTextEngine:
+    """Engine that curates text fragments into actionable digests."""
+
+    def __init__(self, *, history_limit: int = 200) -> None:
+        if history_limit <= 0:
+            raise ValueError("history_limit must be positive")
+        self._history: Deque[TextFragment] = deque(maxlen=history_limit)
+        self._metrics: MutableMapping[str, float] = {}
+
+    @property
+    def history(self) -> tuple[TextFragment, ...]:
+        return tuple(self._history)
+
+    def prime(self, fragments: Iterable[TextFragment]) -> None:
+        for fragment in fragments:
+            self.ingest(fragment)
+
+    def ingest(self, fragment: TextFragment) -> None:
+        self._history.append(fragment)
+        self._update_metrics(fragment)
+
+    def compose(self, context: TextContext, *, sample_size: int = 60) -> TextDigest:
+        digest = TextDigest(context)
+        if not self._history:
+            digest.metrics.update({
+                "history_size": 0.0,
+                "available_fragments": 0.0,
+                "mean_signal_strength": 0.0,
+            })
+            return digest
+
+        candidates = list(self._history)[-sample_size:]
+        scored = sorted(
+            candidates,
+            key=lambda fragment: self._score_fragment(fragment, context),
+            reverse=True,
+        )
+        digest.extend(scored[: context.highlight_limit])
+        digest.metrics.update(self._metrics)
+        digest.metrics.update(
+            {
+                "history_size": float(len(self._history)),
+                "available_fragments": float(len(candidates)),
+                "mean_signal_strength": (
+                    fmean(fragment.signal_strength for fragment in digest.fragments)
+                    if digest.fragments
+                    else 0.0
+                ),
+            }
+        )
+        return digest
+
+    def _update_metrics(self, fragment: TextFragment) -> None:
+        history_size = len(self._history)
+        mean_novelty = fmean(item.novelty for item in self._history)
+        mean_clarity = fmean(item.clarity for item in self._history)
+        mean_warmth = fmean(item.warmth for item in self._history)
+        self._metrics.update(
+            {
+                "history_size": float(history_size),
+                "mean_novelty": mean_novelty,
+                "mean_clarity": mean_clarity,
+                "mean_warmth": mean_warmth,
+            }
+        )
+
+    def _score_fragment(self, fragment: TextFragment, context: TextContext) -> float:
+        score = fragment.signal_strength
+        if fragment.channel == context.channel:
+            score += 0.08
+        if context.is_high_urgency:
+            score += fragment.tempo * 0.05
+        if context.needs_personal_touch:
+            score += fragment.warmth * 0.05
+        emphasis_matches = len(set(context.emphasis_tags) & set(fragment.tags))
+        guardrail_conflicts = len(set(context.guardrail_tags) & set(fragment.tags))
+        score += 0.04 * emphasis_matches
+        score -= 0.06 * guardrail_conflicts
+        risk_adjustment = (context.risk_appetite - 0.5) * fragment.boldness * 0.1
+        score += risk_adjustment
+        return _clamp(score)

--- a/tests/test_dynamic_text.py
+++ b/tests/test_dynamic_text.py
@@ -1,0 +1,169 @@
+from datetime import datetime
+
+import pytest
+
+from dynamic_text import DynamicTextEngine, TextContext, TextFragment
+
+
+def test_text_fragment_normalisation() -> None:
+    fragment = TextFragment(
+        channel="  Email  ",
+        content="  Lead update for liquidity partners  ",
+        voice="  Empathetic strategist  ",
+        clarity=1.4,
+        warmth=-0.3,
+        boldness=1.7,
+        novelty=-0.4,
+        tempo=1.8,
+        emphasis=1.2,
+        weight=-2.0,
+        timestamp=datetime(2024, 1, 1, 8, 30),
+        intents=(" Welcome  ", "welcome"),
+        tags=(" Liquidity  ", ""),
+        metadata={"owner": " Comms Guild "},
+    )
+
+    assert fragment.channel == "email"
+    assert fragment.content == "Lead update for liquidity partners"
+    assert fragment.voice == "Empathetic strategist"
+    assert 0.0 <= fragment.clarity <= 1.0
+    assert 0.0 <= fragment.warmth <= 1.0
+    assert 0.0 <= fragment.boldness <= 1.0
+    assert 0.0 <= fragment.novelty <= 1.0
+    assert 0.0 <= fragment.tempo <= 1.0
+    assert 0.0 <= fragment.emphasis <= 1.0
+    assert fragment.weight == 0.0
+    assert fragment.timestamp.tzinfo is not None
+    assert fragment.intents == ("welcome",)
+    assert fragment.tags == ("liquidity",)
+    assert fragment.metadata == {"owner": " Comms Guild "}
+    assert 0.0 <= fragment.signal_strength <= 1.0
+    assert isinstance(fragment.is_priority, bool)
+
+
+def test_compose_generates_digest_with_metrics() -> None:
+    engine = DynamicTextEngine(history_limit=5)
+    engine.prime(
+        [
+            TextFragment(
+                channel="email",
+                content="Alpha launch debrief",
+                voice="Strategic",
+                clarity=0.9,
+                warmth=0.7,
+                boldness=0.6,
+                novelty=0.65,
+                tempo=0.7,
+                emphasis=0.85,
+                tags=("liquidity", "partners"),
+            ),
+            TextFragment(
+                channel="email",
+                content="Liquidity partner outreach",
+                voice="Empathetic",
+                clarity=0.8,
+                warmth=0.8,
+                boldness=0.55,
+                novelty=0.6,
+                tempo=0.75,
+                emphasis=0.8,
+                tags=("liquidity", "priority"),
+            ),
+            TextFragment(
+                channel="sms",
+                content="Ops checkpoint",
+                voice="Direct",
+                clarity=0.7,
+                warmth=0.4,
+                boldness=0.5,
+                novelty=0.5,
+                tempo=0.9,
+                emphasis=0.4,
+                tags=("operations",),
+            ),
+        ]
+    )
+
+    context = TextContext(
+        initiative="Treasury partner cadence",
+        audience="Growth desk",
+        channel="email",
+        urgency=0.7,
+        personalization=0.6,
+        risk_appetite=0.55,
+        emphasis_tags=("liquidity",),
+        guardrail_tags=("legacy",),
+        highlight_limit=2,
+    )
+
+    digest = engine.compose(context, sample_size=4)
+
+    fragments = digest.top_fragments()
+    assert len(fragments) == 2
+    assert all(fragment.channel == "email" for fragment in fragments)
+    assert digest.metrics["history_size"] >= len(fragments)
+    assert 0.0 <= digest.metrics["mean_signal_strength"] <= 1.0
+    assert digest.metrics["available_fragments"] <= 4
+    payload = digest.as_payload()
+    assert payload["initiative"] == context.initiative
+    assert len(payload["fragments"]) == 2
+
+
+def test_guardrail_penalty_affects_ranking() -> None:
+    engine = DynamicTextEngine(history_limit=3)
+    safe_fragment = TextFragment(
+        channel="email",
+        content="Priority partner follow-up",
+        voice="Warm",
+        clarity=0.8,
+        warmth=0.85,
+        boldness=0.5,
+        novelty=0.6,
+        tempo=0.6,
+        emphasis=0.9,
+        tags=("priority",),
+    )
+    guard_fragment = TextFragment(
+        channel="email",
+        content="Legacy program recap",
+        voice="Warm",
+        clarity=0.8,
+        warmth=0.85,
+        boldness=0.5,
+        novelty=0.6,
+        tempo=0.6,
+        emphasis=0.9,
+        tags=("legacy",),
+    )
+
+    engine.ingest(safe_fragment)
+    engine.ingest(guard_fragment)
+
+    context = TextContext(
+        initiative="Partner uplift",
+        audience="Executive guild",
+        channel="email",
+        urgency=0.5,
+        personalization=0.4,
+        risk_appetite=0.5,
+        emphasis_tags=("priority",),
+        guardrail_tags=("legacy",),
+        highlight_limit=1,
+    )
+
+    digest = engine.compose(context)
+
+    top_fragment = digest.top_fragments()[0]
+    assert top_fragment is safe_fragment
+    assert guard_fragment not in digest.top_fragments()
+
+    with pytest.raises(ValueError):
+        TextContext(
+            initiative="Invalid",
+            audience="Test",
+            channel="email",
+            urgency=0.5,
+            personalization=0.5,
+            risk_appetite=0.5,
+            highlight_limit=0,
+        )


### PR DESCRIPTION
## Summary
- add a `dynamic_text` package with an orchestration engine, data models, and scoring helpers for message fragments
- expose the engine via the package `__init__` for simpler imports
- cover the new engine with unit tests that exercise normalization, digest composition, and guardrail ranking

## Testing
- pytest tests/test_dynamic_text.py
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d831919d7c8322958d52240cc65ae6