### PR TITLE
feat: add dynamic dependency engine

### DIFF
--- a/dynamic_dependency/__init__.py
+++ b/dynamic_dependency/__init__.py
@@ -1,0 +1,15 @@
+"""Dynamic dependency modeling primitives."""
+
+from .engine import (
+    DependencyEdge,
+    DependencyImpulse,
+    DependencyNode,
+    DynamicDependencyEngine,
+)
+
+__all__ = [
+    "DependencyEdge",
+    "DependencyImpulse",
+    "DependencyNode",
+    "DynamicDependencyEngine",
+]

--- a/dynamic_dependency/engine.py
+++ b/dynamic_dependency/engine.py
@@ -1,0 +1,320 @@
+"""Dynamic dependency orchestration engine."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, Iterable, Iterator, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "DependencyNode",
+    "DependencyEdge",
+    "DependencyImpulse",
+    "DynamicDependencyEngine",
+]
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_key(value: str) -> str:
+    return _normalise_text(value).lower()
+
+
+def _normalise_tuple(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    normalised: list[str] = []
+    for value in values:
+        cleaned = value.strip()
+        if cleaned:
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+@dataclass(slots=True)
+class DependencyNode:
+    """Represents a system component with intrinsic readiness."""
+
+    name: str
+    readiness: float = 0.5
+    resilience: float = 0.5
+    criticality: float = 0.5
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.readiness = _clamp(float(self.readiness))
+        self.resilience = _clamp(float(self.resilience))
+        self.criticality = _clamp(float(self.criticality))
+        self.tags = _normalise_tuple(self.tags)
+        self.metadata = _coerce_mapping(self.metadata)
+
+    @property
+    def key(self) -> str:
+        return _normalise_key(self.name)
+
+
+@dataclass(slots=True)
+class DependencyEdge:
+    """Directional relationship between upstream and downstream nodes."""
+
+    upstream: str
+    downstream: str
+    weight: float = 0.5
+    coupling: float = 0.5
+    latency_penalty: float = 0.0
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.upstream = _normalise_text(self.upstream)
+        self.downstream = _normalise_text(self.downstream)
+        if self.upstream.lower() == self.downstream.lower():
+            raise ValueError("dependency edge cannot be self-referential")
+        self.weight = _clamp(float(self.weight))
+        self.coupling = _clamp(float(self.coupling))
+        self.latency_penalty = _clamp(float(self.latency_penalty))
+        self.metadata = _coerce_mapping(self.metadata)
+
+    @property
+    def influence(self) -> float:
+        return self.weight * self.coupling * (1.0 - self.latency_penalty)
+
+    @property
+    def upstream_key(self) -> str:
+        return _normalise_key(self.upstream)
+
+    @property
+    def downstream_key(self) -> str:
+        return _normalise_key(self.downstream)
+
+
+@dataclass(slots=True)
+class DependencyImpulse:
+    """Signal describing a stressor or boost to propagate through the graph."""
+
+    origin: str
+    amplitude: float = 1.0
+    urgency: float = 0.5
+    confidence: float = 0.5
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.origin = _normalise_text(self.origin)
+        self.amplitude = _clamp(float(self.amplitude))
+        self.urgency = _clamp(float(self.urgency))
+        self.confidence = _clamp(float(self.confidence))
+        self.tags = _normalise_tuple(self.tags)
+        self.metadata = _coerce_mapping(self.metadata)
+
+    @property
+    def intensity(self) -> float:
+        return self.amplitude * self.urgency * self.confidence
+
+    @property
+    def origin_key(self) -> str:
+        return _normalise_key(self.origin)
+
+
+class DynamicDependencyEngine:
+    """Manages dependency nodes, edges, and risk propagation."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, DependencyNode] = {}
+        self._dependents: Dict[str, list[DependencyEdge]] = {}
+        self._dependencies: Dict[str, list[DependencyEdge]] = {}
+
+    # -- registration -------------------------------------------------
+    def register_node(self, node: DependencyNode | Mapping[str, object]) -> DependencyNode:
+        coerced = self._coerce_node(node)
+        self._nodes[coerced.key] = coerced
+        self._dependents.setdefault(coerced.key, [])
+        self._dependencies.setdefault(coerced.key, [])
+        return coerced
+
+    def register_nodes(self, nodes: Iterable[DependencyNode | Mapping[str, object]]) -> None:
+        for node in nodes:
+            self.register_node(node)
+
+    def connect(self, edge: DependencyEdge | Mapping[str, object]) -> DependencyEdge:
+        coerced = self._coerce_edge(edge)
+        if coerced.upstream_key not in self._nodes:
+            raise KeyError(f"unknown upstream node: {coerced.upstream}")
+        if coerced.downstream_key not in self._nodes:
+            raise KeyError(f"unknown downstream node: {coerced.downstream}")
+
+        dependents = self._dependents.setdefault(coerced.upstream_key, [])
+        dependencies = self._dependencies.setdefault(coerced.downstream_key, [])
+
+        # replace existing edge if present
+        for existing in dependents:
+            if existing.downstream_key == coerced.downstream_key:
+                dependents.remove(existing)
+                break
+        for existing in dependencies:
+            if existing.upstream_key == coerced.upstream_key:
+                dependencies.remove(existing)
+                break
+
+        dependents.append(coerced)
+        dependencies.append(coerced)
+        return coerced
+
+    def connect_many(self, edges: Iterable[DependencyEdge | Mapping[str, object]]) -> None:
+        for edge in edges:
+            self.connect(edge)
+
+    def disconnect(self, upstream: str, downstream: str) -> None:
+        upstream_key = _normalise_key(upstream)
+        downstream_key = _normalise_key(downstream)
+        if upstream_key not in self._dependents or downstream_key not in self._dependencies:
+            return
+        self._dependents[upstream_key] = [
+            edge for edge in self._dependents[upstream_key] if edge.downstream_key != downstream_key
+        ]
+        self._dependencies[downstream_key] = [
+            edge for edge in self._dependencies[downstream_key] if edge.upstream_key != upstream_key
+        ]
+
+    # -- accessors ----------------------------------------------------
+    def get_node(self, name: str) -> DependencyNode:
+        key = _normalise_key(name)
+        try:
+            return self._nodes[key]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise KeyError(f"unknown node: {name}") from exc
+
+    def nodes(self) -> Iterator[DependencyNode]:
+        return iter(self._nodes.values())
+
+    def dependencies_of(self, name: str) -> tuple[DependencyEdge, ...]:
+        return tuple(self._dependencies.get(_normalise_key(name), ()))
+
+    def dependents_of(self, name: str) -> tuple[DependencyEdge, ...]:
+        return tuple(self._dependents.get(_normalise_key(name), ()))
+
+    # -- analytics ----------------------------------------------------
+    def readiness(self, name: str) -> float:
+        memo: Dict[str, float] = {}
+        return self._readiness_recursive(_normalise_key(name), memo, set())
+
+    def readiness_profile(self) -> Dict[str, float]:
+        memo: Dict[str, float] = {}
+        for key in self._nodes:
+            if key not in memo:
+                self._readiness_recursive(key, memo, set())
+        return {self._nodes[key].name: memo[key] for key in memo}
+
+    def topological_order(self) -> tuple[DependencyNode, ...]:
+        indegree: Dict[str, int] = {key: 0 for key in self._nodes}
+        for edges in self._dependents.values():
+            for edge in edges:
+                indegree[edge.downstream_key] = indegree.get(edge.downstream_key, 0) + 1
+
+        queue: Deque[str] = deque(key for key, degree in indegree.items() if degree == 0)
+        ordered: list[DependencyNode] = []
+
+        while queue:
+            key = queue.popleft()
+            ordered.append(self._nodes[key])
+            for edge in self._dependents.get(key, ()):  # pragma: no branch - simple loop
+                downstream_key = edge.downstream_key
+                indegree[downstream_key] -= 1
+                if indegree[downstream_key] == 0:
+                    queue.append(downstream_key)
+
+        if len(ordered) != len(self._nodes):
+            raise RuntimeError("dependency graph contains a cycle")
+        return tuple(ordered)
+
+    def propagate(self, impulse: DependencyImpulse, *, attenuation: float = 0.85, max_depth: int = 5) -> Dict[str, float]:
+        if attenuation <= 0.0 or attenuation > 1.0:
+            raise ValueError("attenuation must be within (0, 1]")
+        if max_depth < 1:
+            raise ValueError("max_depth must be at least 1")
+
+        if impulse.origin_key not in self._nodes:
+            raise KeyError(f"unknown origin node: {impulse.origin}")
+
+        impact: Dict[str, float] = {impulse.origin: impulse.intensity}
+        queue: Deque[tuple[str, float, int]] = deque([(impulse.origin_key, impulse.intensity, 0)])
+
+        while queue:
+            current_key, current_intensity, depth = queue.popleft()
+            if depth >= max_depth:
+                continue
+            for edge in self._dependents.get(current_key, ()):  # pragma: no branch - simple loop
+                downstream = self._nodes[edge.downstream_key]
+                propagated = current_intensity * edge.influence * attenuation
+                if propagated <= 0.0:
+                    continue
+                impact[downstream.name] = impact.get(downstream.name, 0.0) + propagated
+                queue.append((edge.downstream_key, propagated, depth + 1))
+
+        return impact
+
+    # -- internal helpers ---------------------------------------------
+    def _coerce_node(self, node: DependencyNode | Mapping[str, object]) -> DependencyNode:
+        if isinstance(node, DependencyNode):
+            return node
+        data = dict(node)
+        return DependencyNode(**data)
+
+    def _coerce_edge(self, edge: DependencyEdge | Mapping[str, object]) -> DependencyEdge:
+        if isinstance(edge, DependencyEdge):
+            return edge
+        data = dict(edge)
+        return DependencyEdge(**data)
+
+    def _readiness_recursive(
+        self,
+        key: str,
+        memo: MutableMapping[str, float],
+        trail: set[str],
+    ) -> float:
+        if key in memo:
+            return memo[key]
+        if key in trail:
+            raise RuntimeError("cycle detected during readiness evaluation")
+        trail.add(key)
+
+        node = self._nodes[key]
+        dependencies = self._dependencies.get(key, ())
+        if not dependencies:
+            score = node.readiness
+        else:
+            weighted_sum = 0.0
+            total_weight = 0.0
+            for edge in dependencies:
+                upstream_score = self._readiness_recursive(edge.upstream_key, memo, trail)
+                weight = edge.influence or 1e-6
+                weighted_sum += upstream_score * weight
+                total_weight += weight
+            dependency_score = weighted_sum / total_weight if total_weight else 0.0
+            intrinsic = node.readiness * node.resilience
+            external = dependency_score * (1.0 - node.resilience)
+            penalty = (1.0 - dependency_score) * node.criticality * 0.5
+            score = _clamp(intrinsic + external - penalty)
+
+        memo[key] = score
+        trail.remove(key)
+        return score
+

--- a/tests/test_dynamic_dependency.py
+++ b/tests/test_dynamic_dependency.py
@@ -1,0 +1,120 @@
+"""Tests for the Dynamic dependency engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from dynamic_dependency import (
+    DependencyEdge,
+    DependencyImpulse,
+    DependencyNode,
+    DynamicDependencyEngine,
+)
+
+
+def build_engine() -> DynamicDependencyEngine:
+    engine = DynamicDependencyEngine()
+    engine.register_nodes(
+        [
+            {"name": "Identity Service", "readiness": 0.9, "resilience": 0.7, "criticality": 0.8},
+            {"name": "Risk Scoring", "readiness": 0.6, "resilience": 0.5, "criticality": 0.6},
+            {"name": "Settlement", "readiness": 0.75, "resilience": 0.4, "criticality": 0.9},
+        ]
+    )
+    engine.connect_many(
+        [
+            {"upstream": "Identity Service", "downstream": "Risk Scoring", "weight": 0.9, "coupling": 0.8},
+            {
+                "upstream": "Risk Scoring",
+                "downstream": "Settlement",
+                "weight": 0.85,
+                "coupling": 0.7,
+                "latency_penalty": 0.2,
+            },
+        ]
+    )
+    return engine
+
+
+class TestDependencyNode:
+    def test_normalises_node_inputs(self) -> None:
+        node = DependencyNode(
+            name="  Core Ledger  ",
+            readiness=1.2,
+            resilience=-0.1,
+            criticality=2.0,
+            tags=(" finance ", "core"),
+            metadata={"team": "ops"},
+        )
+        assert node.name == "Core Ledger"
+        assert node.readiness == pytest.approx(1.0)
+        assert node.resilience == pytest.approx(0.0)
+        assert node.criticality == pytest.approx(1.0)
+        assert node.tags == ("finance", "core")
+        assert node.metadata == {"team": "ops"}
+
+
+class TestDependencyEdge:
+    def test_rejects_self_referential_edges(self) -> None:
+        with pytest.raises(ValueError):
+            DependencyEdge(upstream="Ledger", downstream="ledger")
+
+    def test_influence_combines_weight_and_latency(self) -> None:
+        edge = DependencyEdge(
+            upstream="Ledger",
+            downstream="Risk",
+            weight=0.8,
+            coupling=0.5,
+            latency_penalty=0.25,
+        )
+        assert edge.influence == pytest.approx(0.8 * 0.5 * (1 - 0.25))
+
+
+class TestDynamicDependencyEngine:
+    def test_readiness_blends_intrinsic_and_dependencies(self) -> None:
+        engine = build_engine()
+        settlement = engine.readiness("Settlement")
+        risk = engine.readiness("Risk Scoring")
+        identity = engine.readiness("Identity Service")
+
+        assert identity == pytest.approx(0.9, rel=1e-6)
+        assert 0.55 < risk < identity
+        assert settlement < risk
+
+    def test_readiness_detects_cycles(self) -> None:
+        engine = build_engine()
+        engine.register_node({"name": "Reconciliation"})
+        engine.connect({"upstream": "Settlement", "downstream": "Reconciliation", "weight": 0.7})
+        engine.connect({"upstream": "Reconciliation", "downstream": "Identity Service", "weight": 0.6})
+        with pytest.raises(RuntimeError):
+            engine.readiness("Identity Service")
+
+    def test_topological_order_detects_cycles(self) -> None:
+        engine = build_engine()
+        assert tuple(node.name for node in engine.topological_order()) == (
+            "Identity Service",
+            "Risk Scoring",
+            "Settlement",
+        )
+        engine.connect({"upstream": "Settlement", "downstream": "Identity Service", "weight": 0.3})
+        with pytest.raises(RuntimeError):
+            engine.topological_order()
+
+    def test_propagation_accumulates_impacts(self) -> None:
+        engine = build_engine()
+        impulse = DependencyImpulse(origin="Identity Service", amplitude=0.9, urgency=0.8, confidence=0.75)
+        impact = engine.propagate(impulse, attenuation=0.9, max_depth=4)
+        assert impact["Identity Service"] == pytest.approx(0.9 * 0.8 * 0.75)
+        assert impact["Risk Scoring"] > impact["Settlement"]
+        assert "Settlement" in impact
+
+    def test_propagate_rejects_invalid_parameters(self) -> None:
+        engine = build_engine()
+        impulse = DependencyImpulse(origin="Identity Service")
+        with pytest.raises(ValueError):
+            engine.propagate(impulse, attenuation=0.0)
+        with pytest.raises(ValueError):
+            engine.propagate(impulse, max_depth=0)
+        with pytest.raises(KeyError):
+            engine.propagate(DependencyImpulse(origin="Unknown"))
+


### PR DESCRIPTION
## Summary
- add a dynamic_dependency package that models nodes, edges, and impulses for dependency graphs
- implement readiness evaluation, propagation analysis, and cycle detection utilities
- cover the dependency engine with targeted pytest scenarios

## Testing
- npm run format
- pytest tests/test_dynamic_dependency.py

------
https://chatgpt.com/codex/tasks/task_e_68d8326e9e348322a2c67f4c12f8bcc9