### PR TITLE
Refine mini app home experience

### DIFF
--- a/apps/web/components/miniapp/HomeLanding.tsx
+++ b/apps/web/components/miniapp/HomeLanding.tsx
@@ -1,8 +1,18 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowRight, Clock, Gift, Megaphone, Sparkles } from "lucide-react";
+import {
+  ArrowRight,
+  BarChart3,
+  Clock,
+  Gift,
+  Megaphone,
+  RefreshCw,
+  Send,
+  Sparkles,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -94,6 +104,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
   const [loading, setLoading] = useState(true);
 
   const deskClock = useDeskClock();
+  const router = useRouter();
   const isInTelegram = typeof window !== "undefined" &&
     Boolean(window.Telegram?.WebApp);
 
@@ -242,6 +253,23 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
     [services],
   );
 
+  const primaryInsight = useMemo(() => {
+    if (insights.length === 0) return null;
+    return (
+      insights.find((insight) => insight.emphasis === "popularity") ??
+        insights[0]
+    );
+  }, [insights]);
+
+  const handleExplorePlans = useCallback(() => {
+    router.push("/miniapp/fund");
+  }, [router]);
+
+  const handleTalkToDesk = useCallback(() => {
+    if (typeof window === "undefined") return;
+    window.open("https://t.me/DynamicCapital_Support", "_blank", "noopener");
+  }, []);
+
   const lastSyncedLabel = useMemo(() => {
     if (!lastSyncedAt) {
       return "just now";
@@ -262,6 +290,30 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
     return `${days} day${days === 1 ? "" : "s"} ago`;
   }, [deskClock.now, lastSyncedAt]);
 
+  const heroHighlights = useMemo(
+    () => [
+      {
+        id: "session",
+        label: "Session",
+        value: isInTelegram ? "Telegram" : "Web",
+        Icon: Send,
+      },
+      {
+        id: "desk-time",
+        label: "Desk time",
+        value: deskClock.formatted,
+        Icon: Clock,
+      },
+      {
+        id: "sync",
+        label: "Last sync",
+        value: lastSyncedLabel,
+        Icon: RefreshCw,
+      },
+    ],
+    [deskClock.formatted, isInTelegram, lastSyncedLabel],
+  );
+
   if (loading) {
     return (
       <div className="space-y-5 py-10">
@@ -278,34 +330,101 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, ease: "easeOut" }}
-        className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/15 via-background to-background px-5 py-6 text-left shadow-[0_20px_60px_rgba(0,0,0,0.25)]"
+        className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/20 via-background/95 to-background px-5 py-6 text-left shadow-[0_26px_70px_rgba(15,23,42,0.55)]"
       >
-        <div className="absolute inset-y-0 right-0 w-1/2 translate-x-1/4 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_55%)]" />
-        <div className="space-y-4 relative z-10">
-          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.28),_transparent_55%)]" />
+        <div className="relative z-10 space-y-6">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <Badge variant="outline" className="bg-primary/15 text-primary">
               <Sparkles className="mr-1 h-3 w-3" /> Live trading desk
+            </Badge>
+            <Badge
+              variant="outline"
+              className="border-border/40 bg-background/40"
+            >
+              <Megaphone className="mr-1 h-3 w-3" />{" "}
+              {announcement.split(" ")[0] ?? "Announcement"}
             </Badge>
             <span className="flex items-center gap-1">
               <Clock className="h-3 w-3" /> Desk time {deskClock.formatted}
             </span>
-            <span className="flex items-center gap-1">
-              <Megaphone className="h-3 w-3" />{" "}
-              {isInTelegram ? "Telegram" : "Web"} session
+          </div>
+
+          <div className="space-y-4">
+            <h1 className="text-2xl font-semibold leading-tight text-foreground md:text-3xl">
+              Command your trading edge with Dynamic Capital
+            </h1>
+            <p className="text-sm text-muted-foreground whitespace-pre-line md:text-base">
+              {about}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {serviceHighlights.map((item) => (
+                <Badge
+                  key={item}
+                  variant="secondary"
+                  className="bg-background/80 text-foreground/90"
+                >
+                  {item}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            {heroHighlights.map(({ id, label, value, Icon }) => (
+              <div
+                key={id}
+                className="rounded-2xl border border-border/40 bg-background/80 p-4 backdrop-blur"
+              >
+                <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <Icon className="h-3.5 w-3.5 text-primary" /> {label}
+                </div>
+                <p className="mt-2 text-lg font-semibold text-foreground">
+                  {value ?? "just now"}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          {primaryInsight && (
+            <Card className="border-primary/20 bg-background/70">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-sm text-primary">
+                  <BarChart3 className="h-4 w-4" /> Trending market insight
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  {primaryInsight.message}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              size="sm"
+              onClick={handleExplorePlans}
+              className="touch-target"
+            >
+              Explore plans
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleTalkToDesk}
+              className="touch-target"
+            >
+              Talk to our desk
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {lastSyncedLabel && `Synced ${lastSyncedLabel}`}
             </span>
           </div>
 
-          <div className="space-y-3">
-            <h1 className="text-2xl font-semibold leading-tight text-foreground">
-              Command your trading edge with Dynamic Capital
-            </h1>
-            <p className="text-sm text-muted-foreground whitespace-pre-line">
-              {about}
-            </p>
-          </div>
-
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-2xl border border-border/40 bg-background/70 p-4 backdrop-blur">
+            <div className="rounded-2xl border border-border/40 bg-background/80 p-4 backdrop-blur">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-wide text-primary">
@@ -319,7 +438,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
               </div>
             </div>
 
-            <div className="rounded-2xl border border-border/40 bg-background/70 p-4 backdrop-blur">
+            <div className="rounded-2xl border border-border/40 bg-background/80 p-4 backdrop-blur">
               <p className="text-xs font-semibold uppercase tracking-wide text-primary">
                 Core services
               </p>
@@ -335,7 +454,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
           </div>
 
           {activePromo && (
-            <Card className="border-primary/20 bg-primary/10">
+            <Card className="border-primary/25 bg-primary/10">
               <CardHeader className="pb-2">
                 <CardTitle className="flex items-center gap-2 text-sm text-primary">
                   <Gift className="h-4 w-4" /> Limited-time offer

--- a/apps/web/components/miniapp/StatusSection.tsx
+++ b/apps/web/components/miniapp/StatusSection.tsx
@@ -1,26 +1,31 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { motion } from "framer-motion";
+import { useCallback, useEffect, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { 
-  CheckCircle, 
-  AlertCircle, 
-  Clock, 
-  Star,
-  RefreshCw,
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  AlertCircle,
+  CheckCircle,
+  Clock,
   ExternalLink,
+  RefreshCw,
+  Star,
+  TrendingUp,
   Users,
-  TrendingUp
 } from "lucide-react";
 import { MotionCard } from "@/components/ui/motion-card";
 import { FadeInOnView } from "@/components/ui/fade-in-on-view";
-import { cardVariants } from "@/lib/motion-variants";
 import { toast } from "sonner";
 import { callEdgeFunction } from "@/config/supabase";
+import { AnimatedStatusDisplay } from "./AnimatedStatusDisplay";
 
 interface SubscriptionStatus {
   is_vip: boolean;
@@ -36,11 +41,13 @@ interface StatusSectionProps {
 }
 
 export default function StatusSection({ telegramData }: StatusSectionProps) {
-  const [subscription, setSubscription] = useState<SubscriptionStatus | null>(null);
+  const [subscription, setSubscription] = useState<SubscriptionStatus | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  const isInTelegram = typeof window !== 'undefined' && window.Telegram?.WebApp;
+  const isInTelegram = typeof window !== "undefined" && window.Telegram?.WebApp;
 
   const fetchSubscriptionStatus = useCallback(async () => {
     if (!isInTelegram || !telegramData?.user?.id) {
@@ -49,19 +56,19 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
     }
 
     try {
-      const { data, status } = await callEdgeFunction('SUBSCRIPTION_STATUS', {
-        method: 'POST',
+      const { data, status } = await callEdgeFunction("SUBSCRIPTION_STATUS", {
+        method: "POST",
         body: { telegram_id: telegramData.user.id },
       });
 
       if (status !== 200 || !data) {
-        throw new Error('Failed to fetch subscription status');
+        throw new Error("Failed to fetch subscription status");
       }
 
       setSubscription(data as SubscriptionStatus);
     } catch (error) {
-      console.error('Error fetching subscription:', error);
-      toast.error('Failed to load subscription status');
+      console.error("Error fetching subscription:", error);
+      toast.error("Failed to load subscription status");
     } finally {
       setLoading(false);
     }
@@ -75,34 +82,72 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
     setRefreshing(true);
     await fetchSubscriptionStatus();
     setRefreshing(false);
-    toast.success('Status refreshed');
+    toast.success("Status refreshed");
   };
 
   const getStatusBadge = () => {
     if (!subscription) {
-      return <Badge variant="outline" className="bg-gray-500/10 text-gray-600 border-gray-500/30">Not Connected</Badge>;
+      return (
+        <Badge
+          variant="outline"
+          className="bg-muted/40 text-muted-foreground border-border/40"
+        >
+          Not connected
+        </Badge>
+      );
     }
-    
+
     if (subscription.is_expired) {
-      return <Badge variant="destructive" className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30">Expired</Badge>;
+      return (
+        <Badge
+          variant="destructive"
+          className="bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30"
+        >
+          Expired
+        </Badge>
+      );
     }
-    
+
     if (subscription.is_vip) {
-      return <Badge className="bg-gradient-to-r from-yellow-500 to-orange-500 text-white border-yellow-500/30">VIP Active</Badge>;
+      return (
+        <Badge className="bg-gradient-to-r from-yellow-500 to-orange-500 text-white border-yellow-500/30">
+          VIP Active
+        </Badge>
+      );
     }
-    
-    if (subscription.payment_status === 'pending') {
-      return <Badge variant="secondary" className="bg-yellow-500/10 text-yellow-600 border-yellow-500/30">Payment Pending</Badge>;
+
+    if (subscription.payment_status === "pending") {
+      return (
+        <Badge
+          variant="secondary"
+          className="bg-yellow-500/10 text-yellow-600 border-yellow-500/30"
+        >
+          Payment Pending
+        </Badge>
+      );
     }
-    
-    return <Badge variant="outline" className="bg-blue-500/10 text-blue-600 border-blue-500/30">Free</Badge>;
+
+    return (
+      <Badge
+        variant="outline"
+        className="bg-blue-500/10 text-blue-600 border-blue-500/30"
+      >
+        Free
+      </Badge>
+    );
   };
 
   const getStatusIcon = () => {
     if (!subscription) return <AlertCircle className="h-5 w-5 text-gray-500" />;
-    if (subscription.is_expired) return <AlertCircle className="h-5 w-5 text-destructive" />;
-    if (subscription.is_vip) return <CheckCircle className="h-5 w-5 text-green-500" />;
-    if (subscription.payment_status === 'pending') return <Clock className="h-5 w-5 text-yellow-500" />;
+    if (subscription.is_expired) {
+      return <AlertCircle className="h-5 w-5 text-destructive" />;
+    }
+    if (subscription.is_vip) {
+      return <CheckCircle className="h-5 w-5 text-green-500" />;
+    }
+    if (subscription.payment_status === "pending") {
+      return <Clock className="h-5 w-5 text-yellow-500" />;
+    }
     return <Users className="h-5 w-5 text-blue-500" />;
   };
 
@@ -117,6 +162,11 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
     if (days <= 30) return "text-yellow-600";
     return "text-green-600";
   };
+
+  const normalizedDaysRemaining =
+    typeof subscription?.days_remaining === "number"
+      ? subscription.days_remaining
+      : undefined;
 
   if (loading) {
     return (
@@ -136,6 +186,16 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
   return (
     <FadeInOnView>
       <div className="space-y-4">
+        <AnimatedStatusDisplay
+          className="border border-border/40"
+          isVip={Boolean(subscription?.is_vip)}
+          planName={subscription?.plan_name ??
+            (subscription ? "Free" : "No plan")}
+          daysRemaining={normalizedDaysRemaining}
+          paymentStatus={subscription?.payment_status ?? undefined}
+          showBackground={false}
+        />
+
         {/* Main Status Card */}
         <MotionCard variant="glass" className="border-primary/20">
           <CardHeader>
@@ -144,7 +204,9 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
                 {getStatusIcon()}
                 <div>
                   <CardTitle className="text-lg">Account Status</CardTitle>
-                  <CardDescription>Your current subscription status</CardDescription>
+                  <CardDescription>
+                    Your current subscription status
+                  </CardDescription>
                 </div>
               </div>
               <Button
@@ -154,110 +216,132 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
                 disabled={refreshing}
                 className="hover:bg-accent"
               >
-                <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
+                <RefreshCw
+                  className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`}
+                />
               </Button>
             </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            {/* Connection Status */}
-            <div className="flex justify-between items-center p-3 bg-muted/30 rounded-lg">
-              <span className="text-sm font-medium text-muted-foreground">Connection:</span>
-              {isInTelegram ? (
-                <Badge variant="outline" className="bg-green-500/10 text-green-600 border-green-500/30">
-                  <CheckCircle className="w-3 h-3 mr-1" />
-                  Connected
-                </Badge>
-              ) : (
-                <Badge variant="outline" className="bg-orange-500/10 text-orange-600 border-orange-500/30">
-                  <ExternalLink className="w-3 h-3 mr-1" />
-                  Web Browser
-                </Badge>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between rounded-xl border border-border/40 bg-muted/30 px-4 py-3">
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Connection
+                </span>
+                {isInTelegram
+                  ? (
+                    <Badge
+                      variant="outline"
+                      className="bg-green-500/10 text-green-600 border-green-500/30"
+                    >
+                      <CheckCircle className="w-3 h-3 mr-1" /> Connected
+                    </Badge>
+                  )
+                  : (
+                    <Badge
+                      variant="outline"
+                      className="bg-orange-500/10 text-orange-600 border-orange-500/30"
+                    >
+                      <ExternalLink className="w-3 h-3 mr-1" /> Web browser
+                    </Badge>
+                  )}
+              </div>
+
+              <div className="flex items-center justify-between rounded-xl border border-border/40 bg-muted/30 px-4 py-3">
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Status
+                </span>
+                {getStatusBadge()}
+              </div>
+
+              {subscription && (
+                <div className="grid gap-2">
+                  <div className="flex items-center justify-between rounded-xl border border-border/30 bg-background/60 px-4 py-3">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Plan
+                    </span>
+                    <span className="text-sm font-medium">
+                      {subscription.plan_name || "No active plan"}
+                    </span>
+                  </div>
+
+                  {subscription.subscription_end_date && (
+                    <div className="flex items-center justify-between rounded-xl border border-border/30 bg-background/60 px-4 py-3">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Expires
+                      </span>
+                      <span className="text-sm font-medium">
+                        {formatDate(subscription.subscription_end_date)}
+                      </span>
+                    </div>
+                  )}
+
+                  {typeof subscription.days_remaining === "number" && (
+                    <div className="flex items-center justify-between rounded-xl border border-border/30 bg-background/60 px-4 py-3">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Days remaining
+                      </span>
+                      <span
+                        className={`text-sm font-semibold ${
+                          getDaysRemainingColor(subscription.days_remaining)
+                        }`}
+                      >
+                        {subscription.days_remaining} days
+                      </span>
+                    </div>
+                  )}
+
+                  {subscription.payment_status && (
+                    <div className="flex items-center justify-between rounded-xl border border-border/30 bg-background/60 px-4 py-3">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Payment
+                      </span>
+                      <Badge
+                        variant={subscription.payment_status === "completed"
+                          ? "default"
+                          : "secondary"}
+                        className={subscription.payment_status === "completed"
+                          ? "bg-green-500/10 text-green-600 border-green-500/30"
+                          : subscription.payment_status === "pending"
+                          ? "bg-yellow-500/10 text-yellow-600 border-yellow-500/30"
+                          : "bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30"}
+                      >
+                        {subscription.payment_status}
+                      </Badge>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
 
-            {/* Subscription Status */}
-            <div className="flex justify-between items-center p-3 bg-muted/30 rounded-lg">
-              <span className="text-sm font-medium text-muted-foreground">Status:</span>
-              {getStatusBadge()}
-            </div>
-
-            {subscription && (
-              <>
-                {/* Plan Details */}
-                <div className="flex justify-between items-center p-3 bg-muted/30 rounded-lg">
-                  <span className="text-sm font-medium text-muted-foreground">Plan:</span>
-                  <span className="text-sm font-medium">
-                    {subscription.plan_name || "No active plan"}
-                  </span>
-                </div>
-
-                {/* Expiry Date */}
-                {subscription.subscription_end_date && (
-                  <div className="flex justify-between items-center p-3 bg-muted/30 rounded-lg">
-                    <span className="text-sm font-medium text-muted-foreground">Expires:</span>
-                    <span className="text-sm font-medium">
-                      {formatDate(subscription.subscription_end_date)}
-                    </span>
-                  </div>
-                )}
-
-                {/* Days Remaining */}
-                {subscription.days_remaining !== null && (
-                  <div className="flex justify-between items-center p-3 bg-muted/30 rounded-lg">
-                    <span className="text-sm font-medium text-muted-foreground">Days remaining:</span>
-                    <span className={`text-sm font-medium ${getDaysRemainingColor(subscription.days_remaining)}`}>
-                      {subscription.days_remaining} days
-                    </span>
-                  </div>
-                )}
-
-                {/* Payment Status */}
-                {subscription.payment_status && (
-                  <div className="flex justify-between items-center p-3 bg-muted/30 rounded-lg">
-                    <span className="text-sm font-medium text-muted-foreground">Payment:</span>
-                    <Badge 
-                      variant={subscription.payment_status === 'completed' ? 'default' : 'secondary'}
-                      className={
-                        subscription.payment_status === 'completed' 
-                          ? 'bg-green-500/10 text-green-600 border-green-500/30'
-                          : subscription.payment_status === 'pending'
-                          ? 'bg-yellow-500/10 text-yellow-600 border-yellow-500/30'
-                          : 'bg-dc-brand/10 text-dc-brand-dark border-dc-brand/30'
-                      }
-                    >
-                      {subscription.payment_status}
-                    </Badge>
-                  </div>
-                )}
-              </>
-            )}
-
-            {/* Action Buttons */}
-            <div className="flex flex-col sm:flex-row gap-2 pt-2">
+            <div className="flex flex-col sm:flex-row gap-2 pt-3">
               {(!subscription?.is_vip || subscription?.is_expired) && (
-                <Button 
-                  size="sm" 
+                <Button
+                  size="sm"
                   responsive
                   onClick={() => {
                     const url = new URL(window.location.href);
-                    url.searchParams.set('tab', 'plan');
-                    window.history.pushState({}, '', url.toString());
-                    window.dispatchEvent(new PopStateEvent('popstate'));
+                    url.searchParams.set("tab", "plan");
+                    window.history.pushState({}, "", url.toString());
+                    window.dispatchEvent(new PopStateEvent("popstate"));
                   }}
                   className="touch-target flex-1"
                 >
                   <Star className="h-4 w-4 mr-2" />
-                  {subscription?.is_expired ? 'Renew Plan' : 'Upgrade Now'}
+                  {subscription?.is_expired ? "Renew Plan" : "Upgrade Now"}
                 </Button>
               )}
-              
+
               {isInTelegram && (
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   size="sm"
                   responsive
                   onClick={() => {
-                    window.open('https://t.me/DynamicCapital_Support', '_blank');
+                    window.open(
+                      "https://t.me/DynamicCapital_Support",
+                      "_blank",
+                    );
                   }}
                   className="touch-target flex-1"
                 >
@@ -274,10 +358,10 @@ export default function StatusSection({ telegramData }: StatusSectionProps) {
           <Alert className="border-blue-500/20 bg-blue-500/10">
             <ExternalLink className="h-4 w-4" />
             <AlertDescription className="text-blue-600">
-              💡 For real-time subscription status and payments,{' '}
+              💡 For real-time subscription status and payments,{" "}
               <a
                 href="https://t.me/DynamicCapital_Support"
-                target="_blank" 
+                target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-blue-800"
               >


### PR DESCRIPTION
## Summary
- refresh the mini app home hero with richer highlights, insight chips, and guided actions
- enhance the subscription status section with the animated summary card and clearer detail blocks

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8335c73008322a8c128997f6f0638