### PR TITLE
Add environment-based dynamic node config loader

### DIFF
--- a/apps/web/config/node-configs.ts
+++ b/apps/web/config/node-configs.ts
@@ -1,0 +1,269 @@
+/**
+ * Load dynamic node configurations from environment variables.
+ *
+ * The configuration mirrors the `node_configs` Supabase table so workers and
+ * local scripts can bootstrap orchestration without querying the database.
+ * Each environment variable with the `NODE_CONFIG__` prefix is treated as a
+ * JSON payload describing a node. The suffix becomes the fallback `node_id`
+ * when the payload omits it.
+ */
+
+declare const process:
+  | { env?: Record<string, string | undefined> }
+  | undefined;
+declare const Deno:
+  | {
+    env?: {
+      toObject?(): Record<string, string>;
+      get?(name: string): string | undefined;
+    };
+  }
+  | undefined;
+
+const NODE_CONFIG_ENV_PREFIX = "NODE_CONFIG__" as const;
+const VALID_NODE_TYPES = [
+  "ingestion",
+  "processing",
+  "policy",
+  "community",
+] as const;
+
+export type NodeType = (typeof VALID_NODE_TYPES)[number];
+
+export interface NodeConfig {
+  nodeId: string;
+  type: NodeType;
+  enabled: boolean;
+  intervalSec: number;
+  dependencies: string[];
+  outputs: string[];
+  metadata: Record<string, unknown>;
+  weight: number | null;
+}
+
+export interface NodeConfigParseError {
+  key: string;
+  message: string;
+}
+
+export interface LoadNodeConfigsResult {
+  configs: NodeConfig[];
+  errors: NodeConfigParseError[];
+}
+
+function sanitizeString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    const text = String(value).trim();
+    return text.length > 0 ? text : undefined;
+  }
+  return undefined;
+}
+
+function normalizeCollection(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const normalised: string[] = [];
+  for (const entry of value) {
+    const text = sanitizeString(entry);
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    normalised.push(text);
+  }
+  return normalised;
+}
+
+function normalizeMetadata(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+function parseBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase();
+    if (!lowered) return fallback;
+    if (["false", "0", "no", "off", "disabled"].includes(lowered)) {
+      return false;
+    }
+    if (["true", "1", "yes", "on", "enabled"].includes(lowered)) {
+      return true;
+    }
+  }
+  return fallback;
+}
+
+function parseNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function ensureInterval(value: unknown, nodeId: string): number {
+  const parsed = parseNumber(value);
+  if (parsed === undefined) {
+    throw new Error(
+      `Node config ${nodeId} is missing required field 'interval_sec'`,
+    );
+  }
+  const integer = Math.trunc(parsed);
+  if (integer <= 0) {
+    throw new Error(
+      `Node config ${nodeId} must specify a positive interval_sec value`,
+    );
+  }
+  return integer;
+}
+
+function deriveNodeIdFromKey(key: string, prefix: string): string {
+  if (!key.startsWith(prefix)) {
+    throw new Error(
+      `Node config key '${key}' does not start with expected prefix '${prefix}'`,
+    );
+  }
+  const suffix = key.slice(prefix.length);
+  const slug = suffix
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/-$/, "")
+    .toLowerCase();
+  if (!slug) {
+    throw new Error(`Could not derive node_id from environment key '${key}'`);
+  }
+  return slug;
+}
+
+function resolveEnvSnapshot(): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  if (typeof process !== "undefined" && process?.env) {
+    for (const [key, value] of Object.entries(process.env)) {
+      if (typeof value === "string") {
+        snapshot[key] = value;
+      }
+    }
+  }
+  if (typeof Deno !== "undefined") {
+    const envApi = Deno.env;
+    if (envApi && typeof envApi.toObject === "function") {
+      try {
+        const entries = envApi.toObject();
+        for (const [key, value] of Object.entries(entries)) {
+          if (typeof value === "string" && !(key in snapshot)) {
+            snapshot[key] = value;
+          }
+        }
+      } catch {
+        // Access to Deno.env.toObject may be restricted; ignore.
+      }
+    }
+  }
+  return snapshot;
+}
+
+export function parseNodeConfigValue(
+  key: string,
+  rawValue: string,
+  options: { prefix?: string } = {},
+): NodeConfig {
+  const prefix = options.prefix ?? NODE_CONFIG_ENV_PREFIX;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawValue);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON for ${key}: ${message}`);
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error(`Node config ${key} must be a JSON object`);
+  }
+
+  const data = payload as Record<string, unknown>;
+
+  const explicitId = sanitizeString(data.node_id ?? data.nodeId);
+  const nodeId = explicitId ?? deriveNodeIdFromKey(key, prefix);
+
+  const typeRaw = sanitizeString(data.type);
+  if (!typeRaw) {
+    throw new Error(`Node config ${nodeId} is missing required field 'type'`);
+  }
+  const normalisedType = typeRaw.toLowerCase();
+  if (!VALID_NODE_TYPES.includes(normalisedType as NodeType)) {
+    throw new Error(
+      `Node config ${nodeId} has unsupported type '${typeRaw}'. Expected one of ${
+        VALID_NODE_TYPES.join(", ")
+      }`,
+    );
+  }
+
+  const interval = ensureInterval(
+    data.interval_sec ?? data.intervalSec,
+    nodeId,
+  );
+  const enabled = parseBoolean(data.enabled, true);
+  const dependencies = normalizeCollection(data.dependencies ?? data.deps);
+  const outputs = normalizeCollection(
+    data.outputs ?? data.result ?? data.output,
+  );
+  const metadata = normalizeMetadata(data.metadata);
+
+  const weightNumber = data.weight === undefined
+    ? undefined
+    : parseNumber(data.weight);
+  const weight = weightNumber === undefined ? null : weightNumber;
+
+  return {
+    nodeId,
+    type: normalisedType as NodeType,
+    enabled,
+    intervalSec: interval,
+    dependencies,
+    outputs,
+    metadata,
+    weight,
+  };
+}
+
+export function loadNodeConfigsFromEnv(
+  options: { prefix?: string } = {},
+): LoadNodeConfigsResult {
+  const prefix = options.prefix ?? NODE_CONFIG_ENV_PREFIX;
+  const snapshot = resolveEnvSnapshot();
+  const configs: NodeConfig[] = [];
+  const errors: NodeConfigParseError[] = [];
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (!key.startsWith(prefix)) continue;
+    if (typeof value !== "string") continue;
+    try {
+      const config = parseNodeConfigValue(key, value, { prefix });
+      configs.push(config);
+    } catch (error) {
+      errors.push({
+        key,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  configs.sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+  return { configs, errors };
+}
+
+export { NODE_CONFIG_ENV_PREFIX };

--- a/tests/node-configs-env.test.ts
+++ b/tests/node-configs-env.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import {
+  deepEqual as assertDeepEqual,
+  equal as assertEqual,
+  ok as assertOk,
+} from "node:assert/strict";
+import process from "node:process";
+
+import { freshImport } from "./utils/freshImport.ts";
+
+type EnvMap = Record<string, string | undefined>;
+
+async function withEnv(vars: EnvMap, run: () => Promise<void>) {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(vars)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+const importNodeConfigs = () =>
+  freshImport(new URL("../apps/web/config/node-configs.ts", import.meta.url));
+
+test("loadNodeConfigsFromEnv parses valid environment payloads", async () => {
+  await withEnv(
+    {
+      NODE_CONFIG__FUSION: JSON.stringify({
+        node_id: " Fusion ",
+        type: "Processing",
+        enabled: "false",
+        interval_sec: "60",
+        dependencies: [" ticks ", "Fusion", "ticks"],
+        outputs: [" Signals ", "signals"],
+        metadata: { source: "fusion" },
+        weight: "0.8",
+      }),
+      NODE_CONFIG__TREASURY_SNAPSHOT: JSON.stringify({
+        type: "processing",
+        interval_sec: 900,
+        outputs: ["treasury"],
+      }),
+    },
+    async () => {
+      const mod = await importNodeConfigs();
+      const result = mod.loadNodeConfigsFromEnv();
+
+      assertEqual(result.errors.length, 0);
+      assertEqual(result.configs.length, 2);
+
+      const [fusion, treasury] = result.configs;
+      assertEqual(fusion.nodeId, "Fusion");
+      assertEqual(fusion.type, "processing");
+      assertEqual(fusion.enabled, false);
+      assertEqual(fusion.intervalSec, 60);
+      assertDeepEqual(fusion.dependencies, ["ticks", "Fusion"]);
+      assertDeepEqual(fusion.outputs, ["Signals", "signals"]);
+      assertDeepEqual(fusion.metadata, { source: "fusion" });
+      assertEqual(fusion.weight, 0.8);
+
+      assertEqual(treasury.nodeId, "treasury-snapshot");
+      assertEqual(treasury.enabled, true);
+      assertEqual(treasury.intervalSec, 900);
+      assertDeepEqual(treasury.outputs, ["treasury"]);
+      assertEqual(treasury.weight, null);
+    },
+  );
+});
+
+test("loadNodeConfigsFromEnv captures parse errors", async () => {
+  await withEnv(
+    {
+      NODE_CONFIG__BROKEN_JSON: "{not-valid}",
+      NODE_CONFIG__MISSING_FIELDS: JSON.stringify({
+        type: "unknown",
+        interval_sec: 0,
+      }),
+    },
+    async () => {
+      const mod = await importNodeConfigs();
+      const result = mod.loadNodeConfigsFromEnv();
+
+      assertEqual(result.configs.length, 0);
+      assertEqual(result.errors.length, 2);
+      assertOk(
+        result.errors.some((error: { key: string; message: string }) =>
+          error.key.endsWith("BROKEN_JSON") &&
+          error.message.includes("Invalid JSON")
+        ),
+      );
+      assertOk(
+        result.errors.some((error: { key: string; message: string }) =>
+          error.key.endsWith("MISSING_FIELDS") &&
+          error.message.includes("unsupported type")
+        ),
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add a config helper that loads dynamic node definitions from NODE_CONFIG__* environment variables
- normalise identifiers, dependencies, outputs, and metadata while reporting invalid payloads
- cover the loader with focused tests for successful parsing and error handling

## Testing
- npm run lint
- npm run typecheck
- npm test -- tests/node-configs-env.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d837a6afe48322aec97fe3d11440bc