### PR TITLE
Add dynamic REST API endpoint

### DIFF
--- a/apps/web/app/api/dynamic-rest/route.ts
+++ b/apps/web/app/api/dynamic-rest/route.ts
@@ -1,0 +1,25 @@
+import { withApiMetrics } from "@/observability/server-metrics.ts";
+import { buildDynamicRestResponse } from "@/services/dynamic-rest";
+import { corsHeaders, jsonResponse, methodNotAllowed } from "@/utils/http.ts";
+
+const ROUTE_NAME = "/api/dynamic-rest";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  return withApiMetrics(req, ROUTE_NAME, async () => {
+    const payload = buildDynamicRestResponse();
+    return jsonResponse(payload, {}, req);
+  });
+}
+
+export const POST = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const DELETE = methodNotAllowed;
+export const HEAD = methodNotAllowed;
+
+export function OPTIONS(req: Request) {
+  const headers = corsHeaders(req, "GET");
+  return new Response(null, { status: 204, headers });
+}

--- a/tests/api/dynamic-rest.test.ts
+++ b/tests/api/dynamic-rest.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+
+type EndpointDescriptor = {
+  method: string;
+  path: string;
+};
+
+type InstrumentResource = {
+  total: number;
+  assetClasses: Record<string, { count: number; sample: unknown[] }>;
+  majorPairs: unknown[];
+};
+
+type TradingDeskResource = {
+  plansAvailable: number;
+  activePlans: Array<{ planSummary: unknown[] }>;
+};
+
+async function run() {
+  const { GET } = await import(
+    /* @vite-ignore */ "../../apps/web/app/api/dynamic-rest/route.ts"
+  );
+
+  const request = new Request("http://localhost/api/dynamic-rest");
+  const response = await GET(request);
+
+  assert.equal(response.status, 200);
+
+  const contentType = response.headers.get("content-type") ?? "";
+  assert.ok(
+    contentType.includes("application/json"),
+    `expected JSON response, received ${contentType}`,
+  );
+
+  const body = await response.json();
+
+  assert.equal(body.status, "ok");
+  assert.equal(body.metadata.version, 1);
+  assert.equal(body.metadata.repository, "Dynamic Capital");
+  assert.ok(typeof body.generatedAt === "string");
+  assert.ok(!Number.isNaN(Date.parse(body.generatedAt)));
+
+  const endpoints = body.endpoints as EndpointDescriptor[];
+  assert.ok(Array.isArray(endpoints));
+  assert.ok(
+    endpoints.some((endpoint) => endpoint.path === "/api/dynamic-rest"),
+    "primary endpoint descriptor missing",
+  );
+
+  const instruments = body.resources.instruments as InstrumentResource;
+  assert.ok(instruments.total > 0, "expected instrument inventory");
+  assert.ok(Object.keys(instruments.assetClasses).length >= 4);
+  assert.ok(
+    instruments.assetClasses.currencies?.count > 0,
+    "currency summary missing",
+  );
+  assert.ok(
+    instruments.majorPairs.length > 0,
+    "major FX pairs should be included",
+  );
+
+  const tradingDesk = body.resources.tradingDesk as TradingDeskResource;
+  assert.ok(
+    tradingDesk.plansAvailable >= tradingDesk.activePlans.length,
+    "plansAvailable should reflect activePlans length",
+  );
+  assert.ok(
+    tradingDesk.activePlans.some((plan) => plan.planSummary.length > 0),
+    "plan summaries should not be empty",
+  );
+}
+
+if (typeof Deno !== "undefined") {
+  Deno.test("GET /api/dynamic-rest returns aggregated resources", run);
+} else {
+  const { default: test } = await import(/* @vite-ignore */ "node:test");
+  test("GET /api/dynamic-rest returns aggregated resources", run);
+}


### PR DESCRIPTION
## Summary
- add a dynamic `/api/dynamic-rest` route that exposes aggregated Dynamic Capital datasets with CORS support
- implement a reusable service that composes instrument and trading desk summaries for the response payload
- add an API test to validate the response structure and key fields

## Testing
- npx deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check tests/api/dynamic-rest.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d8389e5a2c8322956a4eeee9b68682