### PR TITLE
feat: add dynamic CDN utilities module

### DIFF
--- a/dynamic_cdn/__init__.py
+++ b/dynamic_cdn/__init__.py
@@ -1,0 +1,20 @@
+"""Utilities for orchestrating Dynamic Capital CDN workflows."""
+
+from .assets import CDNAsset, build_asset_manifest
+from .client import CDNUploadError, DynamicCDNUploader, UploadReport
+from .config import CDNConfig
+from .purge import CDNCachePurgeError, parse_purge_paths, purge_cdn_cache
+from .spaces import resolve_spaces_endpoint
+
+__all__ = [
+    "CDNAsset",
+    "build_asset_manifest",
+    "CDNConfig",
+    "DynamicCDNUploader",
+    "UploadReport",
+    "CDNUploadError",
+    "CDNCachePurgeError",
+    "parse_purge_paths",
+    "purge_cdn_cache",
+    "resolve_spaces_endpoint",
+]

--- a/dynamic_cdn/assets.py
+++ b/dynamic_cdn/assets.py
@@ -1,0 +1,100 @@
+"""Asset manifest helpers for CDN uploads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import mimetypes
+import os
+import re
+_HASH_PATTERN = re.compile(r"\.[0-9a-f]{8,}\.", re.IGNORECASE)
+
+
+@dataclass(slots=True, frozen=True)
+class CDNAsset:
+    """Represents a single file prepared for CDN upload."""
+
+    key: str
+    path: Path
+    content_type: str
+    cache_control: str
+    size: int
+
+
+def _detect_content_type(key: str) -> str:
+    guessed, _ = mimetypes.guess_type(key)
+    return guessed or "application/octet-stream"
+
+
+def _is_immutable_asset(key: str) -> bool:
+    return bool(_HASH_PATTERN.search(key))
+
+
+def _resolve_cache_control(key: str, content_type: str) -> str:
+    if content_type.startswith("text/html"):
+        return "public, max-age=0, must-revalidate"
+    if _is_immutable_asset(key):
+        return "public, max-age=31536000, immutable"
+    return "public, max-age=0, must-revalidate"
+
+
+def _normalise_prefix(prefix: str) -> str:
+    cleaned = prefix.strip().strip("/")
+    return cleaned
+
+
+def build_asset_manifest(
+    root: os.PathLike[str] | str,
+    *,
+    prefix: str | None = None,
+    include_hidden: bool = False,
+) -> tuple[CDNAsset, ...]:
+    """Generate a deterministic manifest of CDN assets under ``root``.
+
+    Parameters
+    ----------
+    root:
+        Root directory containing the prepared static assets.
+    prefix:
+        Optional key prefix to prepend to every asset key in the manifest.
+    include_hidden:
+        Whether to include dot-prefixed files and directories. Defaults to
+        ``False`` to avoid leaking build artefacts.
+    """
+
+    base = Path(root).resolve()
+    if not base.exists():
+        raise FileNotFoundError(f"Asset root {base} does not exist")
+    if not base.is_dir():
+        raise NotADirectoryError(f"Asset root {base} is not a directory")
+
+    key_prefix = _normalise_prefix(prefix or "")
+    assets: list[CDNAsset] = []
+
+    for file_path in sorted(
+        (
+            candidate
+            for candidate in base.rglob("*")
+            if candidate.is_file()
+        ),
+        key=lambda path: path.relative_to(base).as_posix(),
+    ):
+        relative = file_path.relative_to(base)
+        if not include_hidden and any(part.startswith(".") for part in relative.parts):
+            continue
+        relative_key = relative.as_posix()
+        key = f"{key_prefix}/{relative_key}" if key_prefix else relative_key
+        content_type = _detect_content_type(key)
+        cache_control = _resolve_cache_control(key, content_type)
+        size = file_path.stat().st_size
+        assets.append(
+            CDNAsset(
+                key=key,
+                path=file_path,
+                content_type=content_type,
+                cache_control=cache_control,
+                size=size,
+            )
+        )
+
+    return tuple(assets)

--- a/dynamic_cdn/client.py
+++ b/dynamic_cdn/client.py
@@ -1,0 +1,80 @@
+"""Client abstractions for uploading assets to the CDN."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence
+
+from .assets import CDNAsset
+from .config import CDNConfig
+
+
+class _S3CompatibleClient(Protocol):
+    """Protocol describing the methods used from an S3 compatible client."""
+
+    def put_object(self, **kwargs: object) -> Mapping[str, object]:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass(slots=True)
+class UploadReport:
+    """Outcome for a single uploaded asset."""
+
+    asset: CDNAsset
+    success: bool
+    response_metadata: Mapping[str, object] | None = None
+    error: str | None = None
+
+
+class CDNUploadError(RuntimeError):
+    """Raised when uploading an asset to the CDN fails."""
+
+    def __init__(self, asset: CDNAsset, error: Exception) -> None:
+        super().__init__(f"Failed to upload {asset.key}: {error}")
+        self.asset = asset
+        self.__cause__ = error
+
+
+class DynamicCDNUploader:
+    """Uploads assets to an S3-compatible CDN such as DigitalOcean Spaces."""
+
+    def __init__(self, client: _S3CompatibleClient, config: CDNConfig) -> None:
+        self._client = client
+        self._config = config
+
+    @property
+    def bucket(self) -> str:
+        return self._config.bucket
+
+    def upload(
+        self,
+        assets: Sequence[CDNAsset],
+        *,
+        fail_fast: bool = True,
+    ) -> tuple[UploadReport, ...]:
+        """Upload all assets to the configured CDN bucket."""
+
+        reports: list[UploadReport] = []
+        for asset in assets:
+            try:
+                response = self._client.put_object(
+                    Bucket=self.bucket,
+                    Key=asset.key,
+                    Body=asset.path.read_bytes(),
+                    ACL="public-read",
+                    ContentType=asset.content_type,
+                    CacheControl=asset.cache_control,
+                )
+            except Exception as exc:  # pragma: no cover - surface error paths
+                reports.append(
+                    UploadReport(asset=asset, success=False, response_metadata=None, error=str(exc))
+                )
+                if fail_fast:
+                    raise CDNUploadError(asset, exc) from exc
+            else:
+                metadata = response.get("ResponseMetadata") if isinstance(response, Mapping) else None
+                reports.append(UploadReport(asset=asset, success=True, response_metadata=metadata))
+        return tuple(reports)
+
+
+__all__ = ["DynamicCDNUploader", "UploadReport", "CDNUploadError"]

--- a/dynamic_cdn/config.py
+++ b/dynamic_cdn/config.py
@@ -1,0 +1,77 @@
+"""Configuration helpers for CDN operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Mapping
+
+from .purge import parse_purge_paths
+from .spaces import resolve_spaces_endpoint
+
+
+def _read_env(source: Mapping[str, str], key: str) -> str | None:
+    value = source.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+@dataclass(slots=True, frozen=True)
+class CDNConfig:
+    """Normalised configuration required to interact with the CDN."""
+
+    bucket: str
+    region: str
+    access_key: str
+    secret_key: str
+    endpoint: str
+    endpoint_id: str | None = None
+    purge_paths: tuple[str, ...] = ()
+    digitalocean_token: str | None = None
+    user_agent: str = "dynamic-cdn/1.0"
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "CDNConfig":
+        source: Mapping[str, str] = env or os.environ
+
+        bucket = _read_env(source, "CDN_BUCKET")
+        access_key = _read_env(source, "CDN_ACCESS_KEY")
+        secret_key = _read_env(source, "CDN_SECRET_KEY")
+
+        if not bucket or not access_key or not secret_key:
+            raise ValueError(
+                "CDN_BUCKET, CDN_ACCESS_KEY, and CDN_SECRET_KEY must be provided to configure CDN uploads."
+            )
+
+        region = _read_env(source, "CDN_REGION") or "nyc3"
+        endpoint = resolve_spaces_endpoint(
+            _read_env(source, "CDN_ENDPOINT"), region=region, bucket=bucket
+        )
+
+        purge_paths = parse_purge_paths(_read_env(source, "CDN_PURGE_PATHS"))
+        token = _read_env(source, "DIGITALOCEAN_TOKEN")
+        endpoint_id = _read_env(source, "CDN_ENDPOINT_ID")
+
+        return cls(
+            bucket=bucket,
+            region=region,
+            access_key=access_key,
+            secret_key=secret_key,
+            endpoint=endpoint,
+            endpoint_id=endpoint_id,
+            purge_paths=purge_paths,
+            digitalocean_token=token,
+        )
+
+    @property
+    def has_purge_credentials(self) -> bool:
+        return bool(self.digitalocean_token and self.endpoint_id)
+
+    @property
+    def should_purge(self) -> bool:
+        return self.has_purge_credentials and bool(self.purge_paths)
+
+
+__all__ = ["CDNConfig"]

--- a/dynamic_cdn/purge.py
+++ b/dynamic_cdn/purge.py
@@ -1,0 +1,86 @@
+"""Cache purge helpers for the Dynamic CDN."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Iterable
+from urllib import error, request
+
+_PURGE_SPLIT_PATTERN = re.compile(r"[,\n]")
+
+
+class CDNCachePurgeError(RuntimeError):
+    """Raised when a CDN cache purge request fails."""
+
+
+def parse_purge_paths(value: str | None) -> tuple[str, ...]:
+    """Normalise a comma or newline separated list of purge paths."""
+
+    if not value:
+        return ()
+
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in _PURGE_SPLIT_PATTERN.split(value):
+        candidate = item.strip()
+        if not candidate:
+            continue
+        if candidate != "*" and not candidate.startswith("/"):
+            candidate = f"/{candidate}"
+        if candidate not in seen:
+            seen.add(candidate)
+            cleaned.append(candidate)
+    return tuple(cleaned)
+
+
+def purge_cdn_cache(
+    endpoint_id: str,
+    token: str,
+    files: Iterable[str],
+    *,
+    user_agent: str = "dynamic-cdn/1.0",
+    timeout: float = 30.0,
+) -> None:
+    """Issue a cache purge request to the DigitalOcean CDN API."""
+
+    if not endpoint_id:
+        raise ValueError("endpoint_id must be provided for CDN cache purges")
+    if not token:
+        raise ValueError("token must be provided for CDN cache purges")
+
+    payload = tuple(path.strip() for path in files if path.strip())
+    if not payload:
+        raise ValueError("files must contain at least one path to purge")
+
+    body = json.dumps({"files": list(payload)}).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": user_agent,
+    }
+    url = f"https://api.digitalocean.com/v2/cdn/endpoints/{endpoint_id}/cache"
+
+    req = request.Request(url, data=body, headers=headers)
+    req.get_method = lambda: "DELETE"  # type: ignore[assignment]
+
+    try:
+        with request.urlopen(req, timeout=timeout) as response:  # nosec: B310
+            status = getattr(response, "status", None)
+            if status is not None and status >= 400:
+                raise CDNCachePurgeError(
+                    f"DigitalOcean CDN cache purge failed with status {status}"
+                )
+    except error.HTTPError as exc:  # pragma: no cover - urllib error path
+        message = f"DigitalOcean API cache purge failed with status {exc.code}"
+        try:
+            payload = json.loads(exc.read().decode("utf-8"))
+        except Exception:  # pragma: no cover - defensive
+            payload = None
+        if isinstance(payload, dict) and payload.get("message"):
+            message = f"{message}: {payload['message']}"
+        raise CDNCachePurgeError(message) from exc
+
+
+__all__ = ["CDNCachePurgeError", "parse_purge_paths", "purge_cdn_cache"]

--- a/dynamic_cdn/spaces.py
+++ b/dynamic_cdn/spaces.py
@@ -1,0 +1,72 @@
+"""Helpers for DigitalOcean Spaces endpoints."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+import warnings
+
+
+def resolve_spaces_endpoint(
+    endpoint: str | None,
+    *,
+    region: str,
+    bucket: str | None = None,
+) -> str:
+    """Normalise a Spaces API endpoint suitable for uploads.
+
+    Follows the same heuristics as the JavaScript upload helper to guard
+    against accidentally targeting a CDN vanity domain instead of the S3 API.
+    """
+
+    fallback = f"https://{region}.digitaloceanspaces.com"
+    if endpoint is None:
+        return fallback
+
+    normalized = endpoint.strip()
+    if not normalized:
+        return fallback
+
+    if not normalized.lower().startswith(("http://", "https://")):
+        normalized = f"https://{normalized}"
+
+    try:
+        parsed = urlparse(normalized)
+    except ValueError:
+        warnings.warn(
+            "CDN_ENDPOINT is not a valid URL. Falling back to the regional Spaces endpoint.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return fallback
+
+    if parsed.path and parsed.path != "/":
+        warnings.warn(
+            "Ignoring path component on CDN_ENDPOINT. Using only the origin for uploads.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    host = (parsed.hostname or "").lower()
+    if "digitaloceanspaces.com" not in host:
+        warnings.warn(
+            "CDN_ENDPOINT does not reference the DigitalOcean Spaces API. Using regional endpoint instead.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return fallback
+
+    if bucket and host.startswith(f"{bucket.lower()}."):
+        warnings.warn(
+            "CDN_ENDPOINT references the bucket domain. Falling back to the regional endpoint to avoid signed URL issues.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return fallback
+
+    scheme = parsed.scheme or "https"
+    if parsed.port:
+        return f"{scheme}://{host}:{parsed.port}"
+    return f"{scheme}://{host}"
+
+
+__all__ = ["resolve_spaces_endpoint"]

--- a/tests/test_dynamic_cdn.py
+++ b/tests/test_dynamic_cdn.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+from urllib import error as urllib_error
+
+import pytest
+
+from dynamic_cdn import (
+    CDNConfig,
+    CDNCachePurgeError,
+    CDNUploadError,
+    DynamicCDNUploader,
+    build_asset_manifest,
+    parse_purge_paths,
+    purge_cdn_cache,
+    resolve_spaces_endpoint,
+)
+
+
+def test_resolve_spaces_endpoint_warns_and_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    warnings: list[str] = []
+
+    monkeypatch.setattr("warnings.warn", lambda msg, *args, **kwargs: warnings.append(str(msg)))
+
+    endpoint = resolve_spaces_endpoint("https://example.com/cdn", region="nyc3", bucket="static")
+
+    assert endpoint == "https://nyc3.digitaloceanspaces.com"
+    assert warnings, "expected at least one warning when falling back"
+
+
+def test_build_manifest(tmp_path: Path) -> None:
+    (tmp_path / "index.html").write_text("<html></html>")
+    (tmp_path / "app.1234abcd.js").write_text("console.log('ok');")
+
+    manifest = build_asset_manifest(tmp_path)
+
+    keys = [asset.key for asset in manifest]
+    assert keys == ["app.1234abcd.js", "index.html"]
+
+    html_asset = next(asset for asset in manifest if asset.key == "index.html")
+    assert html_asset.content_type.startswith("text/html")
+    assert html_asset.cache_control == "public, max-age=0, must-revalidate"
+
+    js_asset = next(asset for asset in manifest if asset.key.endswith(".js"))
+    assert js_asset.cache_control == "public, max-age=31536000, immutable"
+
+
+def test_dynamic_cdn_uploader_success(tmp_path: Path) -> None:
+    (tmp_path / "asset.txt").write_text("payload")
+    manifest = build_asset_manifest(tmp_path)
+    config = CDNConfig(
+        bucket="my-space",
+        region="nyc3",
+        access_key="key",
+        secret_key="secret",
+        endpoint="https://nyc3.digitaloceanspaces.com",
+    )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def put_object(self, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(kwargs)
+            return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    client = FakeClient()
+    uploader = DynamicCDNUploader(client, config)
+
+    reports = uploader.upload(manifest)
+
+    assert isinstance(reports, tuple)
+    assert len(reports) == 1
+    report = reports[0]
+    assert report.success is True
+    assert report.response_metadata == {"HTTPStatusCode": 200}
+    assert client.calls[0]["Bucket"] == "my-space"
+
+
+def test_dynamic_cdn_uploader_failure(tmp_path: Path) -> None:
+    (tmp_path / "asset.txt").write_text("payload")
+    manifest = build_asset_manifest(tmp_path)
+    config = CDNConfig(
+        bucket="my-space",
+        region="nyc3",
+        access_key="key",
+        secret_key="secret",
+        endpoint="https://nyc3.digitaloceanspaces.com",
+    )
+
+    class FailingClient:
+        def put_object(self, **kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+    uploader = DynamicCDNUploader(FailingClient(), config)
+
+    with pytest.raises(CDNUploadError):
+        uploader.upload(manifest, fail_fast=True)
+
+    reports = uploader.upload(manifest, fail_fast=False)
+    assert reports[0].success is False
+    assert reports[0].error == "boom"
+
+
+def test_parse_purge_paths() -> None:
+    assert parse_purge_paths("/index.html,asset.js, *") == ("/index.html", "/asset.js", "*")
+
+
+def test_purge_cdn_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeResponse:
+        status = 204
+
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def fake_urlopen(req: Any, timeout: float) -> FakeResponse:
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["headers"] = dict(req.headers)
+        assert timeout == 30.0
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    purge_cdn_cache("endpoint", "token", ["/index.html"])
+
+    assert captured["url"].endswith("/endpoint/cache")
+    assert captured["body"] == {"files": ["/index.html"]}
+    assert captured["headers"]["Authorization"] == "Bearer token"
+
+
+def test_purge_cdn_cache_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(req: Any, timeout: float) -> None:
+        fp = io.BytesIO(json.dumps({"message": "bad"}).encode("utf-8"))
+        raise urllib_error.HTTPError(req.full_url, 500, "error", {}, fp)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    with pytest.raises(CDNCachePurgeError) as excinfo:
+        purge_cdn_cache("endpoint", "token", ["/index.html"])
+
+    assert "bad" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- introduce a `dynamic_cdn` package with helpers for manifest generation, configuration normalisation, endpoint resolution, uploads, and cache purging
- export the CDN helper surface from the package entry point for consumers
- add focused pytest coverage for manifest creation, uploader success/error handling, and DigitalOcean CDN purge requests

## Testing
- pytest tests/test_dynamic_cdn.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d838b636c08322be9b5469a0ad9648