### PR TITLE
Add atmospheric dynamics modules

### DIFF
--- a/dynamic_exosphere/__init__.py
+++ b/dynamic_exosphere/__init__.py
@@ -1,0 +1,13 @@
+"""Exospheric escape analytics for Dynamic Capital."""
+
+from .model import (
+    ExosphericObservation,
+    ExosphericState,
+    DynamicExosphere,
+)
+
+__all__ = [
+    "ExosphericObservation",
+    "ExosphericState",
+    "DynamicExosphere",
+]

--- a/dynamic_exosphere/model.py
+++ b/dynamic_exosphere/model.py
@@ -1,0 +1,126 @@
+"""Assess exospheric escape and interface with interplanetary space."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable
+
+__all__ = [
+    "ExosphericObservation",
+    "ExosphericState",
+    "DynamicExosphere",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _mean(values: Iterable[float], *, default: float = 0.0) -> float:
+    collected = list(values)
+    if not collected:
+        return default
+    return fmean(collected)
+
+
+@dataclass(slots=True)
+class ExosphericObservation:
+    """Characterisation of exospheric boundary conditions."""
+
+    timestamp: datetime
+    temperature_k: float
+    hydrogen_density_m3: float
+    satellite_drag_coeff: float
+    escape_fraction: float
+    solar_wind_speed_km_s: float
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.temperature_k = max(float(self.temperature_k), 100.0)
+        self.hydrogen_density_m3 = max(float(self.hydrogen_density_m3), 0.0)
+        self.satellite_drag_coeff = max(float(self.satellite_drag_coeff), 0.0)
+        self.escape_fraction = _clamp(float(self.escape_fraction), lower=0.0, upper=1.0)
+        self.solar_wind_speed_km_s = max(float(self.solar_wind_speed_km_s), 0.0)
+
+
+@dataclass(slots=True)
+class ExosphericState:
+    """Aggregated exosphere metrics."""
+
+    escape_energy: float
+    outflow_flux: float
+    satellite_risk: float
+    boundary_instability: float
+    summary: str
+
+
+class DynamicExosphere:
+    """Compute exospheric dynamics from sparse observations."""
+
+    def __init__(self, *, window: int = 12) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._observations: Deque[ExosphericObservation] = deque(maxlen=int(window))
+
+    def add_observation(
+        self,
+        observation: ExosphericObservation | None = None,
+        /,
+        **kwargs: float,
+    ) -> ExosphericObservation:
+        if observation is None:
+            observation = ExosphericObservation(
+                timestamp=kwargs.get("timestamp", _utcnow()),
+                temperature_k=float(kwargs.get("temperature_k", 1200.0)),
+                hydrogen_density_m3=float(kwargs.get("hydrogen_density_m3", 5e7)),
+                satellite_drag_coeff=float(kwargs.get("satellite_drag_coeff", 0.5)),
+                escape_fraction=float(kwargs.get("escape_fraction", 0.05)),
+                solar_wind_speed_km_s=float(kwargs.get("solar_wind_speed_km_s", 350.0)),
+            )
+        elif kwargs:
+            raise TypeError("cannot provide both observation and keyword values")
+
+        self._observations.append(observation)
+        return observation
+
+    def state(self) -> ExosphericState:
+        if not self._observations:
+            raise RuntimeError("no observations available")
+
+        temperature = _mean((obs.temperature_k for obs in self._observations))
+        hydrogen_density = _mean((obs.hydrogen_density_m3 for obs in self._observations))
+        drag = _mean((obs.satellite_drag_coeff for obs in self._observations))
+        escape_fraction = _mean((obs.escape_fraction for obs in self._observations))
+        solar_wind = _mean((obs.solar_wind_speed_km_s for obs in self._observations))
+
+        escape_energy = _clamp((temperature - 700.0) / 1000.0 + solar_wind / 800.0, lower=0.0, upper=1.5)
+        outflow_flux = _clamp(hydrogen_density / 1e8 * escape_fraction * 4.0, lower=0.0, upper=1.5)
+        satellite_risk = _clamp(drag / 2.0 + hydrogen_density / 1e8, lower=0.0, upper=1.5)
+        boundary_instability = _clamp((solar_wind - 300.0) / 400.0 + escape_fraction * 2.0, lower=0.0, upper=1.5)
+
+        if outflow_flux > 1.0:
+            summary = "Hydrogen escape surge"
+        elif satellite_risk > 0.8:
+            summary = "Satellite drag sensitivity"
+        elif boundary_instability > 0.7:
+            summary = "Magnetopause buffeting"
+        else:
+            summary = "Exosphere steady"
+
+        return ExosphericState(
+            escape_energy=round(escape_energy, 3),
+            outflow_flux=round(outflow_flux, 3),
+            satellite_risk=round(satellite_risk, 3),
+            boundary_instability=round(boundary_instability, 3),
+            summary=summary,
+        )

--- a/dynamic_mesosphere/__init__.py
+++ b/dynamic_mesosphere/__init__.py
@@ -1,0 +1,13 @@
+"""Mesospheric analytics for Dynamic Capital's layered systems."""
+
+from .model import (
+    MesosphericObservation,
+    MesosphericState,
+    DynamicMesosphere,
+)
+
+__all__ = [
+    "MesosphericObservation",
+    "MesosphericState",
+    "DynamicMesosphere",
+]

--- a/dynamic_mesosphere/model.py
+++ b/dynamic_mesosphere/model.py
@@ -1,0 +1,128 @@
+"""Capture mesospheric behaviour such as meteoric burn and wave drag."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable
+
+__all__ = [
+    "MesosphericObservation",
+    "MesosphericState",
+    "DynamicMesosphere",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _mean(values: Iterable[float], *, default: float = 0.0) -> float:
+    collected = list(values)
+    if not collected:
+        return default
+    return fmean(collected)
+
+
+@dataclass(slots=True)
+class MesosphericObservation:
+    """Observation of mesospheric processes."""
+
+    timestamp: datetime
+    temperature_c: float
+    density_kg_m3: float
+    meteor_flux_per_hour: float
+    gravity_wave_amplitude_ms: float
+    noctilucent_probability: float
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.temperature_c = float(self.temperature_c)
+        self.density_kg_m3 = max(float(self.density_kg_m3), 1e-6)
+        self.meteor_flux_per_hour = max(float(self.meteor_flux_per_hour), 0.0)
+        self.gravity_wave_amplitude_ms = max(float(self.gravity_wave_amplitude_ms), 0.0)
+        self.noctilucent_probability = _clamp(float(self.noctilucent_probability), lower=0.0, upper=1.0)
+
+
+@dataclass(slots=True)
+class MesosphericState:
+    """Summary metrics for the mesosphere."""
+
+    thermal_variance: float
+    meteor_ablation_index: float
+    wave_drag_intensity: float
+    noctilucent_potential: float
+    summary: str
+
+
+class DynamicMesosphere:
+    """Blend mesospheric observations into actionable signals."""
+
+    def __init__(self, *, window: int = 20) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._observations: Deque[MesosphericObservation] = deque(maxlen=int(window))
+
+    def add_observation(
+        self,
+        observation: MesosphericObservation | None = None,
+        /,
+        **kwargs: float,
+    ) -> MesosphericObservation:
+        if observation is None:
+            observation = MesosphericObservation(
+                timestamp=kwargs.get("timestamp", _utcnow()),
+                temperature_c=float(kwargs.get("temperature_c", -80.0)),
+                density_kg_m3=float(kwargs.get("density_kg_m3", 1e-4)),
+                meteor_flux_per_hour=float(kwargs.get("meteor_flux_per_hour", 15.0)),
+                gravity_wave_amplitude_ms=float(kwargs.get("gravity_wave_amplitude_ms", 25.0)),
+                noctilucent_probability=float(kwargs.get("noctilucent_probability", 0.3)),
+            )
+        elif kwargs:
+            raise TypeError("cannot provide both observation and keyword values")
+
+        self._observations.append(observation)
+        return observation
+
+    def state(self) -> MesosphericState:
+        if not self._observations:
+            raise RuntimeError("no observations available")
+
+        temps = [obs.temperature_c for obs in self._observations]
+        mean_temp = _mean(temps)
+        variance = _mean(((value - mean_temp) ** 2 for value in temps), default=0.0)
+        thermal_variance = max(variance, 0.0) ** 0.5
+        meteor_flux = _mean((obs.meteor_flux_per_hour for obs in self._observations))
+        waves = _mean((obs.gravity_wave_amplitude_ms for obs in self._observations))
+        density = _mean((obs.density_kg_m3 for obs in self._observations))
+        noctilucent = _mean((obs.noctilucent_probability for obs in self._observations))
+
+        meteor_ablation_index = _clamp(meteor_flux / 40.0 + density * 50.0, lower=0.0, upper=1.5)
+        wave_drag_intensity = _clamp(waves / 60.0 + thermal_variance / 40.0, lower=0.0, upper=1.5)
+        noctilucent_potential = _clamp(noctilucent + max(-mean_temp, 60.0) / 100.0, lower=0.0, upper=1.2)
+
+        if meteor_ablation_index > 1.0:
+            summary = "Intense meteor ablation"
+        elif noctilucent_potential > 0.9:
+            summary = "Noctilucent clouds probable"
+        elif wave_drag_intensity > 0.8:
+            summary = "Strong gravity wave forcing"
+        else:
+            summary = "Mesosphere calm"
+
+        return MesosphericState(
+            thermal_variance=round(thermal_variance, 2),
+            meteor_ablation_index=round(meteor_ablation_index, 3),
+            wave_drag_intensity=round(wave_drag_intensity, 3),
+            noctilucent_potential=round(noctilucent_potential, 3),
+            summary=summary,
+        )

--- a/dynamic_stratosphere/__init__.py
+++ b/dynamic_stratosphere/__init__.py
@@ -1,0 +1,13 @@
+"""Stratospheric health modelling for Dynamic Capital."""
+
+from .model import (
+    StratosphericObservation,
+    StratosphericState,
+    DynamicStratosphere,
+)
+
+__all__ = [
+    "StratosphericObservation",
+    "StratosphericState",
+    "DynamicStratosphere",
+]

--- a/dynamic_stratosphere/model.py
+++ b/dynamic_stratosphere/model.py
@@ -1,0 +1,126 @@
+"""Monitor stratospheric stability, ozone strength and radiative balance."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable
+
+__all__ = [
+    "StratosphericObservation",
+    "StratosphericState",
+    "DynamicStratosphere",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _mean(values: Iterable[float], *, default: float = 0.0) -> float:
+    collected = list(values)
+    if not collected:
+        return default
+    return fmean(collected)
+
+
+@dataclass(slots=True)
+class StratosphericObservation:
+    """Observation of stratospheric vitality."""
+
+    timestamp: datetime
+    temperature_c: float
+    ozone_dobson: float
+    wind_speed_m_s: float
+    tropopause_pressure_hpa: float
+    sulfate_optical_depth: float
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.temperature_c = float(self.temperature_c)
+        self.ozone_dobson = max(float(self.ozone_dobson), 0.0)
+        self.wind_speed_m_s = max(float(self.wind_speed_m_s), 0.0)
+        self.tropopause_pressure_hpa = max(float(self.tropopause_pressure_hpa), 10.0)
+        self.sulfate_optical_depth = max(float(self.sulfate_optical_depth), 0.0)
+
+
+@dataclass(slots=True)
+class StratosphericState:
+    """Derived structure of the stratosphere."""
+
+    ozone_integrity: float
+    polar_vortex_strength: float
+    radiative_balance: float
+    stabilization_score: float
+    summary: str
+
+
+class DynamicStratosphere:
+    """Fuse stratospheric observations into a coherent signal."""
+
+    def __init__(self, *, window: int = 30) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._observations: Deque[StratosphericObservation] = deque(maxlen=int(window))
+
+    def add_observation(
+        self,
+        observation: StratosphericObservation | None = None,
+        /,
+        **kwargs: float,
+    ) -> StratosphericObservation:
+        if observation is None:
+            observation = StratosphericObservation(
+                timestamp=kwargs.get("timestamp", _utcnow()),
+                temperature_c=float(kwargs.get("temperature_c", -55.0)),
+                ozone_dobson=float(kwargs.get("ozone_dobson", 320.0)),
+                wind_speed_m_s=float(kwargs.get("wind_speed_m_s", 20.0)),
+                tropopause_pressure_hpa=float(kwargs.get("tropopause_pressure_hpa", 250.0)),
+                sulfate_optical_depth=float(kwargs.get("sulfate_optical_depth", 0.01)),
+            )
+        elif kwargs:
+            raise TypeError("cannot provide both observation and keyword values")
+
+        self._observations.append(observation)
+        return observation
+
+    def state(self) -> StratosphericState:
+        if not self._observations:
+            raise RuntimeError("no observations available")
+
+        ozone = _mean((obs.ozone_dobson for obs in self._observations))
+        vortex = _mean((obs.wind_speed_m_s for obs in self._observations))
+        tropopause_pressure = _mean((obs.tropopause_pressure_hpa for obs in self._observations))
+        aerosols = _mean((obs.sulfate_optical_depth for obs in self._observations))
+        temperature = _mean((obs.temperature_c for obs in self._observations))
+
+        ozone_integrity = _clamp((ozone - 200.0) / 200.0, lower=0.0, upper=1.5)
+        polar_vortex_strength = _clamp(vortex / 80.0, lower=0.0, upper=1.2)
+        radiative_balance = _clamp(1.0 - aerosols * 15.0 + (temperature + 55.0) / 100.0, lower=0.0, upper=1.2)
+        stabilization_score = _clamp((tropopause_pressure - 150.0) / 150.0, lower=0.0, upper=1.2)
+
+        if ozone_integrity < 0.4:
+            summary = "Severe ozone depletion"
+        elif radiative_balance < 0.6:
+            summary = "Perturbed by aerosols"
+        elif polar_vortex_strength > 0.9:
+            summary = "Strong polar vortex"
+        else:
+            summary = "Stratosphere stable"
+
+        return StratosphericState(
+            ozone_integrity=round(ozone_integrity, 3),
+            polar_vortex_strength=round(polar_vortex_strength, 3),
+            radiative_balance=round(radiative_balance, 3),
+            stabilization_score=round(stabilization_score, 3),
+            summary=summary,
+        )

--- a/dynamic_thermosphere/__init__.py
+++ b/dynamic_thermosphere/__init__.py
@@ -1,0 +1,13 @@
+"""Thermospheric energy orchestration for Dynamic Capital."""
+
+from .model import (
+    ThermosphericObservation,
+    ThermosphericState,
+    DynamicThermosphere,
+)
+
+__all__ = [
+    "ThermosphericObservation",
+    "ThermosphericState",
+    "DynamicThermosphere",
+]

--- a/dynamic_thermosphere/model.py
+++ b/dynamic_thermosphere/model.py
@@ -1,0 +1,126 @@
+"""Quantify thermospheric heating, drag and auroral excitation."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable
+
+__all__ = [
+    "ThermosphericObservation",
+    "ThermosphericState",
+    "DynamicThermosphere",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _mean(values: Iterable[float], *, default: float = 0.0) -> float:
+    collected = list(values)
+    if not collected:
+        return default
+    return fmean(collected)
+
+
+@dataclass(slots=True)
+class ThermosphericObservation:
+    """High-altitude thermospheric diagnostics."""
+
+    timestamp: datetime
+    temperature_k: float
+    solar_flux_sfu: float
+    geomagnetic_index: float
+    neutral_density_kg_m3: float
+    auroral_power_gw: float
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.temperature_k = max(float(self.temperature_k), 100.0)
+        self.solar_flux_sfu = max(float(self.solar_flux_sfu), 0.0)
+        self.geomagnetic_index = max(float(self.geomagnetic_index), 0.0)
+        self.neutral_density_kg_m3 = max(float(self.neutral_density_kg_m3), 0.0)
+        self.auroral_power_gw = max(float(self.auroral_power_gw), 0.0)
+
+
+@dataclass(slots=True)
+class ThermosphericState:
+    """Characterisation of thermospheric forcing."""
+
+    heat_content: float
+    satellite_drag_factor: float
+    geomagnetic_activity: float
+    auroral_activity: float
+    summary: str
+
+
+class DynamicThermosphere:
+    """Fuse thermospheric inputs into planning signals."""
+
+    def __init__(self, *, window: int = 15) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._observations: Deque[ThermosphericObservation] = deque(maxlen=int(window))
+
+    def add_observation(
+        self,
+        observation: ThermosphericObservation | None = None,
+        /,
+        **kwargs: float,
+    ) -> ThermosphericObservation:
+        if observation is None:
+            observation = ThermosphericObservation(
+                timestamp=kwargs.get("timestamp", _utcnow()),
+                temperature_k=float(kwargs.get("temperature_k", 900.0)),
+                solar_flux_sfu=float(kwargs.get("solar_flux_sfu", 110.0)),
+                geomagnetic_index=float(kwargs.get("geomagnetic_index", 3.0)),
+                neutral_density_kg_m3=float(kwargs.get("neutral_density_kg_m3", 1e-12)),
+                auroral_power_gw=float(kwargs.get("auroral_power_gw", 20.0)),
+            )
+        elif kwargs:
+            raise TypeError("cannot provide both observation and keyword values")
+
+        self._observations.append(observation)
+        return observation
+
+    def state(self) -> ThermosphericState:
+        if not self._observations:
+            raise RuntimeError("no observations available")
+
+        temperature = _mean((obs.temperature_k for obs in self._observations))
+        solar_flux = _mean((obs.solar_flux_sfu for obs in self._observations))
+        geomag = _mean((obs.geomagnetic_index for obs in self._observations))
+        density = _mean((obs.neutral_density_kg_m3 for obs in self._observations))
+        aurora = _mean((obs.auroral_power_gw for obs in self._observations))
+
+        heat_content = _clamp((temperature - 500.0) / 800.0 + solar_flux / 300.0, lower=0.0, upper=1.5)
+        satellite_drag_factor = _clamp(density * 5e13 + temperature / 3000.0, lower=0.0, upper=1.5)
+        geomagnetic_activity = _clamp(geomag / 9.0 + solar_flux / 400.0, lower=0.0, upper=1.5)
+        auroral_activity = _clamp(aurora / 50.0 + geomag / 12.0, lower=0.0, upper=1.5)
+
+        if geomagnetic_activity > 1.0:
+            summary = "Geomagnetic storm in progress"
+        elif satellite_drag_factor > 0.8:
+            summary = "Elevated thermospheric drag"
+        elif auroral_activity > 0.7:
+            summary = "Auroral oval energized"
+        else:
+            summary = "Thermosphere quiet"
+
+        return ThermosphericState(
+            heat_content=round(heat_content, 3),
+            satellite_drag_factor=round(satellite_drag_factor, 3),
+            geomagnetic_activity=round(geomagnetic_activity, 3),
+            auroral_activity=round(auroral_activity, 3),
+            summary=summary,
+        )

--- a/dynamic_troposphere/__init__.py
+++ b/dynamic_troposphere/__init__.py
@@ -1,0 +1,13 @@
+"""Tropospheric diagnostics for Dynamic Capital's atmospheric metaphor."""
+
+from .model import (
+    TroposphericObservation,
+    TroposphericState,
+    DynamicTroposphere,
+)
+
+__all__ = [
+    "TroposphericObservation",
+    "TroposphericState",
+    "DynamicTroposphere",
+]

--- a/dynamic_troposphere/model.py
+++ b/dynamic_troposphere/model.py
@@ -1,0 +1,145 @@
+"""Compute tropospheric state from high frequency field observations."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable
+
+__all__ = [
+    "TroposphericObservation",
+    "TroposphericState",
+    "DynamicTroposphere",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _mean(values: Iterable[float], *, default: float = 0.0) -> float:
+    collected = list(values)
+    if not collected:
+        return default
+    return fmean(collected)
+
+
+@dataclass(slots=True)
+class TroposphericObservation:
+    """Snapshot of near-surface conditions feeding the troposphere."""
+
+    timestamp: datetime
+    temperature_c: float
+    dew_point_c: float
+    humidity: float
+    pressure_hpa: float
+    wind_speed_m_s: float
+    vertical_velocity_m_s: float
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.humidity = _clamp(float(self.humidity), lower=0.0, upper=1.0)
+        self.temperature_c = float(self.temperature_c)
+        self.dew_point_c = float(self.dew_point_c)
+        self.pressure_hpa = float(self.pressure_hpa)
+        self.wind_speed_m_s = max(float(self.wind_speed_m_s), 0.0)
+        self.vertical_velocity_m_s = float(self.vertical_velocity_m_s)
+
+
+@dataclass(slots=True)
+class TroposphericState:
+    """Aggregated tropospheric posture."""
+
+    lapse_rate_c_per_km: float
+    precipitation_potential: float
+    storm_risk: float
+    cloud_base_km: float
+    summary: str
+
+
+class DynamicTroposphere:
+    """Blend tropospheric observations into an actionable state."""
+
+    def __init__(self, *, window: int = 24) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._window = int(window)
+        self._observations: Deque[TroposphericObservation] = deque(maxlen=self._window)
+
+    def add_observation(self, observation: TroposphericObservation | None = None, /, **kwargs: float) -> TroposphericObservation:
+        """Register a new observation.
+
+        The caller can either pass an explicit ``TroposphericObservation`` or the
+        numeric components as keyword arguments. Missing keyword arguments default
+        to reasonable values for calm, dry conditions.
+        """
+
+        if observation is None:
+            observation = TroposphericObservation(
+                timestamp=kwargs.get("timestamp", _utcnow()),
+                temperature_c=float(kwargs.get("temperature_c", 18.0)),
+                dew_point_c=float(kwargs.get("dew_point_c", 10.0)),
+                humidity=float(kwargs.get("humidity", 0.55)),
+                pressure_hpa=float(kwargs.get("pressure_hpa", 1013.0)),
+                wind_speed_m_s=float(kwargs.get("wind_speed_m_s", 3.0)),
+                vertical_velocity_m_s=float(kwargs.get("vertical_velocity_m_s", 0.05)),
+            )
+        elif kwargs:
+            raise TypeError("cannot provide both observation and keyword values")
+
+        self._observations.append(observation)
+        return observation
+
+    def state(self) -> TroposphericState:
+        """Compute the blended tropospheric state."""
+
+        if not self._observations:
+            raise RuntimeError("no observations available")
+
+        latest = self._observations[-1]
+        temp_gradient = _mean(
+            (
+                obs.temperature_c - obs.dew_point_c
+                for obs in self._observations
+            ),
+            default=latest.temperature_c - latest.dew_point_c,
+        )
+        lapse_rate = _mean(
+            (
+                (obs.temperature_c - latest.temperature_c) * 0.18
+                for obs in self._observations
+            ),
+            default=6.0,
+        )
+        lift = _mean((obs.vertical_velocity_m_s for obs in self._observations), default=latest.vertical_velocity_m_s)
+        humidity = _mean((obs.humidity for obs in self._observations), default=latest.humidity)
+
+        precipitation_potential = _clamp((1.0 - temp_gradient / 15.0) * humidity + lift * 2.0, lower=0.0, upper=1.0)
+        storm_risk = _clamp((lift * 3.0) + (humidity - 0.6) * 1.5 + (8.0 - lapse_rate) / 10.0, lower=0.0, upper=1.0)
+        cloud_base_km = max((latest.temperature_c - latest.dew_point_c) * 0.125, 0.1)
+
+        if storm_risk > 0.7:
+            summary = "Deep convection likely"
+        elif precipitation_potential > 0.5:
+            summary = "Showery regime forming"
+        elif lapse_rate < 5.0:
+            summary = "Stable with stratiform clouds"
+        else:
+            summary = "Quiet boundary layer"
+
+        return TroposphericState(
+            lapse_rate_c_per_km=round(lapse_rate, 2),
+            precipitation_potential=round(precipitation_potential, 3),
+            storm_risk=round(storm_risk, 3),
+            cloud_base_km=round(cloud_base_km, 2),
+            summary=summary,
+        )


### PR DESCRIPTION
## Summary
- add a tropospheric diagnostics package that blends observations into actionable stability metrics
- introduce stratosphere, mesosphere, thermosphere, and exosphere modules with typed observation/state models
- provide consistent package exports for the new atmospheric layers

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d842ddd7e08322b6e808a57cf3aa17