### PR TITLE
Add dynamic wave catalog module and document automation usage

### DIFF
--- a/docs/guides/electromagnetic-optimization.md
+++ b/docs/guides/electromagnetic-optimization.md
@@ -1,0 +1,151 @@
+# Electromagnetic Spectrum Deployment Playbook
+
+Translate high-level knowledge of electromagnetic waves into project-ready execution. Each phase below turns raw spectrum facts into actionable decisions, while the quick reference and risk guardrails keep the team aligned on feasibility, safety, and regulatory readiness.
+
+## Quick Reference Matrix
+
+| Band | Core Strengths | High-Leverage Uses | Optimization Levers | Readiness Check |
+| --- | --- | --- | --- | --- |
+| Gamma (< 0.01 nm) | Deep penetration, cell destruction | Radiotherapy, sterilizing sealed equipment, astrophysics instruments | Precision collimation, fractionated dosing, robotic handling | Dose planning validated with medical physicist; shielded vault commissioned |
+| X-Ray (0.01–10 nm) | High-resolution imaging through dense materials | Medical diagnostics, industrial nondestructive testing, cargo scanning | Spectral filtration, detector binning, automated positioning | ALARA protocol approved; maintenance cycle aligned with uptime targets |
+| Ultraviolet (10–400 nm) | Surface sterilization, fluorescence, photochemistry | UV-C disinfection, forensic inspection, vitamin D synthesis, UV curing | Band-specific emitters, reflective chamber design, dwell-time automation | Material compatibility signed off; PPE inventory above minimum stock |
+| Visible (400–700 nm) | Direct human perception, precise optical control | Vision systems, microscopy, laser machining, fiber communications | Adaptive optics, beam shaping, automated alignment | Laser safety officer assigned; optical alignment SOP trialed |
+| Infrared (700 nm–1 mm) | Thermal mapping, through-smoke visibility | Thermal imaging, remote sensing, medical diagnostics, HVAC monitoring | Multi-spectral fusion, emissivity calibration, active cooling | Calibration fixtures sourced; data pipeline meets latency budget |
+| Microwaves (1 mm–30 cm) | Efficient excitation of water, short-range links | Microwave ovens, Wi-Fi/Bluetooth, radar, satellite uplinks | Beam steering, phased-array optimization, thermal management | RF exposure study completed; interference survey logged |
+| Radio (30 cm–km) | Long-range propagation, spectrum flexibility | Broadcasting, cellular, GPS, deep-space communications, RF astronomy | Spectrum agile modulation, antenna siting models, redundant links | Spectrum license secured; propagation model validated with field test |
+
+### Optimization Goal Map
+
+| Project Goal | Recommended Bands | Acceleration Plays |
+| --- | --- | --- |
+| Maximize diagnostic throughput | X-Ray, Visible, Infrared | Multi-energy imaging, parallel workstation scheduling, automated QA |
+| Reduce facility infection risk | Gamma, Ultraviolet | Closed-loop sterilization cycles, UV-C robotics, occupancy-triggered exposure |
+| Extend connectivity across campuses | Microwaves, Radio | Mesh backhaul, smart beam steering, dynamic spectrum allocation |
+| Enhance situational awareness | Visible, Infrared, Microwaves | Sensor fusion, real-time analytics, resilient telemetry |
+| Capture extreme astrophysical events | Gamma, X-Ray, Radio | Coordinated observation windows, hardened payload design, autonomous anomaly detection |
+
+## Phase 0 – Frame the Opportunity
+- **Objective.** Confirm the business or research outcome that electromagnetic waves will unlock.
+- **Inputs.** Problem statement, beneficiary personas, key constraints (cost, timeline, regulatory).
+- **Outputs.**
+  - Mission-aligned use case statement (e.g., "Increase early cancer detection throughput by 20% using low-dose X-ray CT").
+  - Success metrics tied to measurable system performance (resolution, throughput, uptime, safety incidents).
+- **Checklist.**
+  - [ ] Stakeholders agree on the user journey and transformation.
+  - [ ] Non-negotiables documented (safety thresholds, bandwidth needs, environmental limits).
+  - [ ] Optimization thesis drafted (time-to-value, cost reduction, or performance uplift).
+  - [ ] Target state visualized via high-level system storyboard.
+
+## Phase 1 – Map Objectives to Spectrum Bands
+- **Objective.** Translate requirements into plausible wavelength candidates.
+- **Plays.**
+  - Use the quick reference matrix to shortlist 1–2 bands per objective.
+  - Evaluate signal penetration, energy levels, and available hardware for each candidate.
+  - Call out multi-band pairings (e.g., visible imaging + IR thermography) that deliver complementary data.
+- **Decision Gate.** Produce a spectrum selection brief summarizing chosen band(s), rationale, and eliminated alternatives.
+- **Optimization Levers.**
+  - Quantify benefit-versus-cost for each band using a simple weighted scoring model.
+  - Run tabletop simulations to confirm workflow fit (coverage, cycle time, staffing).
+  - Pre-stage vendor technical evaluations to accelerate procurement once a band is locked.
+- **Signals & Metrics.** At least one validated supplier or instrument exists per shortlisted band; regulatory pathway identified for top choice.
+
+## Phase 2 – Prototype & Validate
+- **Objective.** Build confidence that the selected band can deliver the required performance safely.
+- **Plays.**
+  - Design small experiments capturing baseline signal-to-noise, exposure duration, or data rate.
+  - Stress-test materials and sensors against expected operating conditions (temperature, humidity, vibration).
+  - Establish calibration routines (phantoms for imaging, known thermal targets for IR, frequency sweeps for RF).
+- **Optimization Levers.**
+  - Automate data capture so each experiment feeds a shared analytics workspace.
+  - Pre-compute maintainability metrics (mean time to repair, consumable burn rate).
+  - Pilot closed-loop controls where feasible to reduce operator burden.
+- **Deliverables.** Prototype report with pass/fail against success metrics, updated risk log, and bill of materials draft.
+- **Metrics.** Prototype achieves ≥80% of target metric; safety measures validated through peer review.
+
+## Phase 3 – Integrate into the Program Roadmap
+- **Objective.** Embed the spectrum solution inside the broader product, operations, or research workflow.
+- **Plays.**
+  - Align manufacturing and maintenance processes with the chosen band (lamp replacement cycles, detector recalibration cadence, antenna retuning intervals).
+  - Update onboarding manuals so operators understand exposure limits, PPE, and emergency procedures.
+  - Plan data infrastructure: storage formats, telemetry frequency, analytics dashboards.
+- **Decision Gate.** Cross-functional review (engineering, safety, compliance, operations) signs off on the integration plan.
+- **Optimization Levers.**
+  - Create a sprint backlog that sequences hardware readiness, data ingestion, and training deliverables.
+  - Embed continuous improvement KPIs (throughput, downtime, accuracy) into program dashboards.
+  - Negotiate service level agreements with vendors to secure spare parts and escalation paths.
+- **Metrics.** Deployment schedule synchronized with dependent teams; cost of ownership modeled over 12–24 months.
+
+## Phase 4 – Operate, Monitor, and Iterate
+- **Objective.** Ensure sustained performance while adapting to real-world feedback.
+- **Plays.**
+  - Instrument continuous monitoring (dose meters, temperature sensors, signal quality KPIs).
+  - Schedule periodic audits of shielding, firmware, and calibration records.
+  - Capture lessons learned in a living knowledge base; revisit alternative bands if KPIs stagnate.
+- **Optimization Levers.**
+  - Compare operational telemetry against design baselines weekly to surface drift early.
+  - Launch operator feedback loops (surveys, retrospectives) to prioritize incremental upgrades.
+  - Pre-plan capacity expansions (additional scanners, antennas, sensors) with trigger thresholds.
+- **Metrics.**
+  - Safety incidents remain at zero; audits close action items within SLA.
+  - Performance metrics trend toward or exceed success thresholds.
+  - New use cases or optimizations logged quarterly.
+
+## Risk Guardrails
+
+| Risk Category | High-Risk Bands | Mitigation Toolkit |
+| --- | --- | --- |
+| Ionizing exposure | Gamma, X-Ray, parts of UV | Dose planning software, interlocks, shielding audits, medical/industrial compliance checks |
+| Biological impact | UV (skin/eye damage), IR (thermal burns) | PPE, exposure timers, auto-shutoff, training certification |
+| Electromagnetic interference | Microwaves, Radio | Spectrum surveys, shielding enclosures, regulatory filings, redundant communication paths |
+| Data fidelity | Visible, IR, Microwave | Calibration routines, environmental normalization, sensor redundancy |
+
+## Implementation Backbone
+
+| Workstream | Owner | Cadence | Tooling | Success Signal |
+| --- | --- | --- | --- | --- |
+| Strategy alignment | Product or research lead | Bi-weekly | Opportunity canvas, decision log | Scope changes approved within one meeting cycle |
+| Technical validation | Systems engineering | Weekly | Simulation stack, lab notebooks, issue tracker | ≥90% of experiments auto-logged with reproducible configs |
+| Regulatory & safety | Compliance officer | Monthly | Risk register, training LMS, audit tracker | Zero overdue mitigations; certification milestones on track |
+| Operations enablement | Program manager | Bi-weekly | RACI board, onboarding runbooks | Readiness checklist stays ≥85% complete pre-launch |
+| Data lifecycle | Analytics lead | Weekly | Data catalog, telemetry dashboards | Insight latency under agreed SLA; quality scores ≥95% |
+
+### Backlog of Core Plays
+
+1. **Establish the Spectrum Optimization Canvas.** Capture target metrics, enabling technologies, constraints, and regulatory considerations on a single page. Revisit after each phase gate.
+2. **Stand up the Experiment Factory.** Instrument prototypes with automated logging, create templated notebooks, and enable rapid what-if simulations to accelerate learning cycles.
+3. **Build the Integration Runway.** Reserve installation windows, secure change-management approvals, and stage training content in the LMS before hardware arrives.
+4. **Operationalize Feedback Loops.** Configure telemetry dashboards, incident intake routes, and quarterly business reviews that convert observations into backlog items.
+5. **Institutionalize Knowledge.** Version-control SOPs, calibration procedures, and vendor certifications so teams onboarding later inherit the optimized practices.
+
+## Operational Checkpoints
+- Mission review confirms the solution still advances the desired transformation each quarter.
+- Hypothesis tracker updated whenever the team shifts bands or modifies exposure parameters.
+- Incident response drills rehearse spectrum-specific emergencies (e.g., UV overexposure, RF interference).
+- Procurement maintains at least two qualified vendors for critical emitters, detectors, or shielding materials.
+
+Use this playbook as a living document—update phase deliverables, risks, and guardrails as new electromagnetic insights or regulatory changes emerge.
+
+## Dynamic Wave Catalog Automation
+
+Leverage the `dynamic_wave` module to ensure every deployment plan starts with a complete, named inventory of spectrum bands. The catalog seeds all core bands, generates deterministic dynamic names for project tracking, and exposes a serialisable summary for dashboards or program logs.
+
+```python
+from dynamic_wave import DynamicWaveCatalog
+
+catalog = DynamicWaveCatalog()
+catalog.optimise(project="spectrum-initiative")
+for wave in catalog.summary():
+    print(wave["band"], wave["dynamic_name"])
+```
+
+| Band | Example Dynamic Name (`project="spectrum-initiative"`) |
+| --- | --- |
+| Gamma | Gamma-Ara-se-9818990b-spectrum-initiat |
+| X-Ray | X-Ray-Flux-wa-b70b9cdc-spectrum-initiat |
+| Ultraviolet | Ultraviolet-Vela-ca-da9ed830-spectrum-initiat |
+| Visible | Visible-Quanta-ki-5f88df51-spectrum-initiat |
+| Infrared | Infrared-Spire-ra-7974d4d8-spectrum-initiat |
+| Microwave | Microwave-Vela-pa-3f9843cc-spectrum-initiat |
+| Radio | Radio-Nova-to-a24cb462-spectrum-initiat |
+
+Use the generated names to tag experiments, procurement tracks, or telemetry feeds so stakeholders can trace decisions back to their originating band without ambiguity.

--- a/dynamic_wave/__init__.py
+++ b/dynamic_wave/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic wave catalog and generation utilities."""
+
+from .catalog import (
+    DynamicWave,
+    DynamicWaveCatalog,
+    WaveBlueprint,
+    WaveUseProfile,
+    generate_dynamic_wave_name,
+)
+
+__all__ = [
+    "DynamicWave",
+    "DynamicWaveCatalog",
+    "WaveBlueprint",
+    "WaveUseProfile",
+    "generate_dynamic_wave_name",
+]

--- a/dynamic_wave/catalog.py
+++ b/dynamic_wave/catalog.py
@@ -1,0 +1,316 @@
+"""Catalog electromagnetic waves and generate dynamic names for project use."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Dict, Iterable, List, Mapping, Tuple
+
+__all__ = [
+    "DynamicWave",
+    "DynamicWaveCatalog",
+    "WaveBlueprint",
+    "WaveUseProfile",
+    "generate_dynamic_wave_name",
+]
+
+
+@dataclass(slots=True)
+class WaveUseProfile:
+    """Describe the operational posture required for a wave band."""
+
+    strengths: Tuple[str, ...]
+    high_leverage_uses: Tuple[str, ...]
+    safeguards: Tuple[str, ...]
+
+
+@dataclass(slots=True)
+class WaveBlueprint:
+    """Baseline specification for an electromagnetic wave band."""
+
+    band: str
+    wavelength_nm: Tuple[float | None, float | None]
+    frequency_hz: Tuple[float | None, float | None]
+    profile: WaveUseProfile
+
+
+@dataclass(slots=True)
+class DynamicWave:
+    """Concrete wave entry with a dynamic, project-specific name."""
+
+    blueprint: WaveBlueprint
+    dynamic_name: str = ""
+
+    def ensure_dynamic_name(self, *, project: str | None = None, seed: str | None = None) -> str:
+        """Populate ``dynamic_name`` when empty and return it."""
+
+        if not self.dynamic_name:
+            self.dynamic_name = generate_dynamic_wave_name(
+                self.blueprint.band,
+                project=project,
+                seed=seed,
+            )
+        return self.dynamic_name
+
+
+_DEFAULT_BLUEPRINTS: Dict[str, WaveBlueprint] = {}
+
+
+def _hz_from_nm(lower_nm: float | None, upper_nm: float | None) -> Tuple[float | None, float | None]:
+    """Convert wavelength nanometres to approximate frequency in hertz."""
+
+    speed_of_light = 299_792_458.0
+    lower_hz: float | None
+    upper_hz: float | None
+    if upper_nm:
+        lower_hz = speed_of_light / (upper_nm * 1e-9)
+    else:
+        lower_hz = None
+    if lower_nm:
+        upper_hz = speed_of_light / (lower_nm * 1e-9)
+    else:
+        upper_hz = None
+    return (lower_hz, upper_hz)
+
+
+_DEF_WAVE_DATA: Tuple[Tuple[str, Tuple[float | None, float | None], Tuple[str, ...], Tuple[str, ...], Tuple[str, ...]], ...] = (
+    (
+        "Gamma",
+        (None, 0.01),
+        (
+            "Deep penetration for material disruption",
+            "Cellular-level energy delivery",
+        ),
+        (
+            "Radiotherapy beam shaping",
+            "Sterilising sealed equipment",
+            "Astrophysical burst analysis",
+        ),
+        (
+            "Medical physicist dose planning",
+            "Vault shielding audits",
+            "Robotic handling for source containment",
+        ),
+    ),
+    (
+        "X-Ray",
+        (0.01, 10.0),
+        (
+            "High resolution through dense matter",
+            "Rapid capture of anatomical detail",
+        ),
+        (
+            "Diagnostic imaging",
+            "Industrial non-destructive testing",
+            "Security scanning",
+        ),
+        (
+            "ALARA compliance",
+            "Calibrated detector maintenance",
+            "Operator exposure tracking",
+        ),
+    ),
+    (
+        "Ultraviolet",
+        (10.0, 400.0),
+        (
+            "Surface sterilisation",
+            "Photochemical activation",
+        ),
+        (
+            "UV-C disinfection",
+            "Forensic fluorescence",
+            "Industrial UV curing",
+        ),
+        (
+            "Material compatibility checks",
+            "PPE stock monitoring",
+            "Exposure timers and interlocks",
+        ),
+    ),
+    (
+        "Visible",
+        (400.0, 700.0),
+        (
+            "Direct human perception",
+            "Precision optical control",
+        ),
+        (
+            "Vision systems",
+            "Laser machining",
+            "Fiber communications",
+        ),
+        (
+            "Laser safety programme",
+            "Optical alignment SOPs",
+            "Protective eyewear enforcement",
+        ),
+    ),
+    (
+        "Infrared",
+        (700.0, 1_000_000.0),
+        (
+            "Thermal mapping",
+            "Visibility through particulates",
+        ),
+        (
+            "Thermal imaging",
+            "Remote sensing",
+            "Medical diagnostics",
+        ),
+        (
+            "Emissivity calibration",
+            "Sensor cooling",
+            "Data pipeline hardening",
+        ),
+    ),
+    (
+        "Microwave",
+        (1_000_000.0, 3e8),
+        (
+            "Efficient molecular excitation",
+            "Short to mid-range data links",
+        ),
+        (
+            "Communications backhaul",
+            "Radar operations",
+            "Microwave heating",
+        ),
+        (
+            "RF exposure surveys",
+            "Interference logging",
+            "Thermal management audits",
+        ),
+    ),
+    (
+        "Radio",
+        (3e8, None),
+        (
+            "Long-range propagation",
+            "Spectrum agility",
+        ),
+        (
+            "Broadcasting",
+            "Cellular connectivity",
+            "Deep-space communication",
+        ),
+        (
+            "Spectrum licensing",
+            "Redundant link design",
+            "Antenna siting assessments",
+        ),
+    ),
+)
+
+
+for band, wavelength_nm, strengths, uses, safeguards in _DEF_WAVE_DATA:
+    _DEFAULT_BLUEPRINTS[band.lower()] = WaveBlueprint(
+        band=band,
+        wavelength_nm=wavelength_nm,
+        frequency_hz=_hz_from_nm(*wavelength_nm),
+        profile=WaveUseProfile(
+            strengths=strengths,
+            high_leverage_uses=uses,
+            safeguards=safeguards,
+        ),
+    )
+
+
+class DynamicWaveCatalog:
+    """Manage dynamic waves and ensure the canonical bands are present."""
+
+    def __init__(self, *, waves: Iterable[DynamicWave] | None = None) -> None:
+        self._waves: Dict[str, DynamicWave] = {}
+        if waves:
+            for wave in waves:
+                key = wave.blueprint.band.lower()
+                self._waves[key] = wave
+        self.ensure_default_waves()
+
+    @property
+    def waves(self) -> Mapping[str, DynamicWave]:
+        return self._waves
+
+    def ensure_default_waves(self) -> None:
+        """Populate any missing canonical bands."""
+
+        for key, blueprint in _DEFAULT_BLUEPRINTS.items():
+            if key not in self._waves:
+                self._waves[key] = DynamicWave(blueprint=blueprint)
+
+    def optimise(self, *, project: str | None = None) -> None:
+        """Ensure each wave has a dynamic project name and consistent ordering."""
+
+        for wave in self._waves.values():
+            wave.ensure_dynamic_name(project=project)
+
+    def as_sorted_list(self) -> List[DynamicWave]:
+        """Return waves sorted by descending frequency."""
+
+        def _sort_key(item: DynamicWave) -> float:
+            lower, upper = item.blueprint.frequency_hz
+            # Prefer higher frequency bands first, fallback to 0 when unknown.
+            candidates = [value for value in (upper, lower) if value is not None]
+            return -max(candidates, default=0.0)
+
+        return sorted(self._waves.values(), key=_sort_key)
+
+    def summary(self) -> List[Dict[str, object]]:
+        """Provide a serialisable summary of the catalog."""
+
+        result: List[Dict[str, object]] = []
+        for wave in self.as_sorted_list():
+            bp = wave.blueprint
+            result.append(
+                {
+                    "band": bp.band,
+                    "dynamic_name": wave.dynamic_name,
+                    "wavelength_nm": bp.wavelength_nm,
+                    "frequency_hz": bp.frequency_hz,
+                    "strengths": list(bp.profile.strengths),
+                    "uses": list(bp.profile.high_leverage_uses),
+                    "safeguards": list(bp.profile.safeguards),
+                }
+            )
+        return result
+
+
+def generate_dynamic_wave_name(band: str, *, project: str | None = None, seed: str | None = None) -> str:
+    """Create a deterministic but distinctive name for a wave band."""
+
+    base = "::".join(
+        filter(
+            None,
+            (
+                band.strip().lower(),
+                project.strip().lower() if project else None,
+                seed.strip().lower() if seed else None,
+            ),
+        )
+    )
+    digest = sha256(base.encode("utf-8")).digest()
+    syllables = (
+        "ara",
+        "dyn",
+        "flux",
+        "ion",
+        "nova",
+        "quanta",
+        "spire",
+        "vela",
+    )
+    consonants = "bcdfghjklmnpqrstvwxyz"
+    vowels = "aeiou"
+
+    idx = digest[0] % len(syllables)
+    syllable = syllables[idx]
+    consonant = consonants[digest[1] % len(consonants)]
+    vowel = vowels[digest[2] % len(vowels)]
+    token = digest[3:7].hex()
+
+    name_parts = [band.split()[0].title(), syllable.title(), f"{consonant}{vowel}", token]
+    dynamic_name = "-".join(name_parts)
+
+    if project:
+        dynamic_name = f"{dynamic_name}-{project.strip().lower().replace(' ', '-')[:16]}"
+    return dynamic_name


### PR DESCRIPTION
## Summary
- add a `dynamic_wave` package that seeds canonical electromagnetic bands and generates deterministic dynamic names
- compute derived frequency ranges and expose catalog summarisation helpers for automation pipelines
- extend the electromagnetic optimisation guide with catalog usage instructions and example dynamic wave names

## Testing
- python -m compileall dynamic_wave

------
https://chatgpt.com/codex/tasks/task_e_68d84744049c83228fa84b581f6b6166