### PR TITLE
Add dynamic proof modules for burn history and reputation

### DIFF
--- a/dynamic_proof_of_burn/__init__.py
+++ b/dynamic_proof_of_burn/__init__.py
@@ -1,0 +1,10 @@
+"""Public interfaces for the Dynamic Proof of Burn module."""
+
+from .proof_of_burn import BurnEvent, BurnProof, BurnWindow, DynamicProofOfBurn
+
+__all__ = [
+    "BurnEvent",
+    "BurnProof",
+    "BurnWindow",
+    "DynamicProofOfBurn",
+]

--- a/dynamic_proof_of_burn/proof_of_burn.py
+++ b/dynamic_proof_of_burn/proof_of_burn.py
@@ -1,0 +1,325 @@
+"""Adaptive ledger utilities for Dynamic Proof of Burn."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "BurnEvent",
+    "BurnProof",
+    "BurnWindow",
+    "DynamicProofOfBurn",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_utc(value: datetime | None) -> datetime:
+    if value is None:
+        return _utcnow()
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _normalise_identifier(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("identifier must not be empty")
+    return cleaned
+
+
+def _normalise_asset(value: str) -> str:
+    return _normalise_identifier(value).upper()
+
+
+def _normalise_optional_identifier(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _coerce_numeric(value: float | int, *, minimum: float) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise TypeError("value must be numeric") from exc
+    if numeric < minimum:
+        raise ValueError(f"value must be >= {minimum}")
+    return numeric
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+def _serialise_timestamp(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_event(value: BurnEvent | Mapping[str, object]) -> BurnEvent:
+    if isinstance(value, BurnEvent):
+        return value
+    if not isinstance(value, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("event must be a BurnEvent or mapping")
+    return BurnEvent(**value)
+
+
+@dataclass(slots=True)
+class BurnEvent:
+    """Represents a single burn proof provided by a participant."""
+
+    asset: str
+    burner: str
+    amount: float
+    timestamp: datetime = field(default_factory=_utcnow)
+    tx_hash: str | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.asset = _normalise_asset(self.asset)
+        self.burner = _normalise_identifier(self.burner)
+        self.amount = _coerce_numeric(self.amount, minimum=0.0)
+        if self.amount <= 0:
+            raise ValueError("burn amount must be positive")
+        self.timestamp = _ensure_utc(self.timestamp)
+        self.tx_hash = _normalise_optional_identifier(self.tx_hash)
+        self.tags = _normalise_tags(self.tags)
+        self.metadata = _coerce_metadata(self.metadata)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "asset": self.asset,
+            "burner": self.burner,
+            "amount": self.amount,
+            "timestamp": _serialise_timestamp(self.timestamp),
+            "tx_hash": self.tx_hash,
+            "tags": self.tags,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(slots=True)
+class BurnWindow:
+    """Aggregated burn insight over a specified time interval."""
+
+    asset: str
+    start_at: datetime
+    end_at: datetime
+    total_burned: float
+    events_count: int
+    top_burners: tuple[tuple[str, float], ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "asset": self.asset,
+            "start_at": _serialise_timestamp(self.start_at),
+            "end_at": _serialise_timestamp(self.end_at),
+            "total_burned": self.total_burned,
+            "events_count": self.events_count,
+            "top_burners": self.top_burners,
+        }
+
+
+@dataclass(slots=True)
+class BurnProof:
+    """Canonical digest describing supply reduction for an asset."""
+
+    asset: str
+    total_supply: float
+    total_burned: float
+    remaining_supply: float
+    burn_ratio: float
+    events_count: int
+    first_burn_at: datetime | None
+    last_burn_at: datetime | None
+    burners: Mapping[str, float]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "asset": self.asset,
+            "total_supply": self.total_supply,
+            "total_burned": self.total_burned,
+            "remaining_supply": self.remaining_supply,
+            "burn_ratio": self.burn_ratio,
+            "events_count": self.events_count,
+            "first_burn_at": _serialise_timestamp(self.first_burn_at),
+            "last_burn_at": _serialise_timestamp(self.last_burn_at),
+            "burners": dict(self.burners),
+        }
+
+
+class DynamicProofOfBurn:
+    """Maintains verifiable burn attestations for dynamic assets."""
+
+    _TOLERANCE = 1e-9
+
+    def __init__(self, *, supplies: Mapping[str, float] | None = None) -> None:
+        self._supplies: dict[str, float] = {}
+        self._events: dict[str, list[BurnEvent]] = {}
+        if supplies:
+            for asset, supply in supplies.items():
+                self.register_asset(asset, supply)
+
+    def register_asset(self, asset: str, total_supply: float) -> None:
+        """Register or update an asset's circulating supply."""
+
+        normalised_asset = _normalise_asset(asset)
+        supply = _coerce_numeric(total_supply, minimum=0.0)
+        if supply <= 0:
+            raise ValueError("total supply must be positive")
+        burned = self.total_burned(normalised_asset)
+        if burned and supply + self._TOLERANCE < burned:
+            raise ValueError("new supply cannot be lower than burned total")
+        self._supplies[normalised_asset] = supply
+        self._events.setdefault(normalised_asset, [])
+
+    def record_burn(self, event: BurnEvent | Mapping[str, object]) -> BurnEvent:
+        """Record a burn event and ensure supply invariants are maintained."""
+
+        burn = _coerce_event(event)
+        if burn.asset not in self._supplies:
+            raise ValueError(f"asset '{burn.asset}' is not registered")
+
+        events = self._events.setdefault(burn.asset, [])
+        if events and burn.timestamp < events[-1].timestamp:
+            raise ValueError("burn events must be recorded in chronological order")
+
+        remaining = self.remaining_supply(burn.asset)
+        if burn.amount > remaining + self._TOLERANCE:
+            raise ValueError("burn exceeds remaining supply")
+
+        events.append(burn)
+        return burn
+
+    def record_burns(self, events: Iterable[BurnEvent | Mapping[str, object]]) -> None:
+        """Record multiple burns atomically."""
+
+        staged: list[BurnEvent] = []
+        for event in events:
+            staged.append(_coerce_event(event))
+        for burn in staged:
+            self.record_burn(burn)
+
+    def assets(self) -> tuple[str, ...]:
+        return tuple(sorted(self._supplies))
+
+    def total_supply(self, asset: str) -> float:
+        normalised_asset = _normalise_asset(asset)
+        if normalised_asset not in self._supplies:
+            raise ValueError(f"asset '{normalised_asset}' is not registered")
+        return self._supplies[normalised_asset]
+
+    def burn_history(self, asset: str) -> tuple[BurnEvent, ...]:
+        normalised_asset = _normalise_asset(asset)
+        return tuple(self._events.get(normalised_asset, ()))
+
+    def total_burned(self, asset: str) -> float:
+        normalised_asset = _normalise_asset(asset)
+        return sum(event.amount for event in self._events.get(normalised_asset, ()))
+
+    def remaining_supply(self, asset: str) -> float:
+        normalised_asset = _normalise_asset(asset)
+        if normalised_asset not in self._supplies:
+            raise ValueError(f"asset '{normalised_asset}' is not registered")
+        return max(self._supplies[normalised_asset] - self.total_burned(normalised_asset), 0.0)
+
+    def burn_ratio(self, asset: str) -> float:
+        normalised_asset = _normalise_asset(asset)
+        supply = self.total_supply(normalised_asset)
+        if supply <= self._TOLERANCE:
+            return 0.0
+        return self.total_burned(normalised_asset) / supply
+
+    def window(self, asset: str, start: datetime, end: datetime, *, top: int = 3) -> BurnWindow:
+        """Summarise burn activity inside an interval."""
+
+        normalised_asset = _normalise_asset(asset)
+        start_at = _ensure_utc(start)
+        end_at = _ensure_utc(end)
+        if end_at < start_at:
+            raise ValueError("end must not be earlier than start")
+
+        events = [
+            event
+            for event in self._events.get(normalised_asset, ())
+            if start_at <= event.timestamp <= end_at
+        ]
+        total_burned = sum(event.amount for event in events)
+        counter: Counter[str] = Counter()
+        for event in events:
+            counter[event.burner] += event.amount
+        top_burners = tuple(counter.most_common(max(top, 0)))
+        return BurnWindow(
+            asset=normalised_asset,
+            start_at=start_at,
+            end_at=end_at,
+            total_burned=total_burned,
+            events_count=len(events),
+            top_burners=top_burners,
+        )
+
+    def generate_proof(self, asset: str) -> BurnProof:
+        normalised_asset = _normalise_asset(asset)
+        total_supply = self.total_supply(normalised_asset)
+        events = self._events.get(normalised_asset, [])
+        total_burned = sum(event.amount for event in events)
+        remaining_supply = max(total_supply - total_burned, 0.0)
+        burn_ratio = 0.0 if total_supply <= self._TOLERANCE else total_burned / total_supply
+        burners = Counter({event.burner: 0.0 for event in events})
+        for event in events:
+            burners[event.burner] += event.amount
+        first_burn_at = events[0].timestamp if events else None
+        last_burn_at = events[-1].timestamp if events else None
+        return BurnProof(
+            asset=normalised_asset,
+            total_supply=total_supply,
+            total_burned=total_burned,
+            remaining_supply=remaining_supply,
+            burn_ratio=burn_ratio,
+            events_count=len(events),
+            first_burn_at=first_burn_at,
+            last_burn_at=last_burn_at,
+            burners=dict(burners),
+        )
+
+    def verify_proof(self, proof: BurnProof) -> bool:
+        """Verify a proof by recomputing it from the ledger."""
+
+        expected = self.generate_proof(proof.asset)
+        return (
+            abs(proof.total_supply - expected.total_supply) <= self._TOLERANCE
+            and abs(proof.total_burned - expected.total_burned) <= self._TOLERANCE
+            and abs(proof.remaining_supply - expected.remaining_supply) <= self._TOLERANCE
+            and abs(proof.burn_ratio - expected.burn_ratio) <= self._TOLERANCE
+            and proof.events_count == expected.events_count
+            and proof.first_burn_at == expected.first_burn_at
+            and proof.last_burn_at == expected.last_burn_at
+            and dict(proof.burners) == dict(expected.burners)
+        )

--- a/dynamic_proof_of_history/__init__.py
+++ b/dynamic_proof_of_history/__init__.py
@@ -1,0 +1,15 @@
+"""Exports for the Dynamic Proof of History module."""
+
+from .proof_of_history import (
+    DynamicProofOfHistory,
+    HistoricalEvent,
+    HistoryProof,
+    HistorySlice,
+)
+
+__all__ = [
+    "DynamicProofOfHistory",
+    "HistoricalEvent",
+    "HistoryProof",
+    "HistorySlice",
+]

--- a/dynamic_proof_of_history/proof_of_history.py
+++ b/dynamic_proof_of_history/proof_of_history.py
@@ -1,0 +1,303 @@
+"""Time-anchored attestations for Dynamic Proof of History."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "DynamicProofOfHistory",
+    "HistoricalEvent",
+    "HistoryProof",
+    "HistorySlice",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_utc(value: datetime | None) -> datetime:
+    if value is None:
+        return _utcnow()
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _normalise_identifier(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("identifier must not be empty")
+    return cleaned
+
+
+def _normalise_hash(value: str) -> str:
+    cleaned = value.strip().lower()
+    if not cleaned:
+        raise ValueError("hash must not be empty")
+    return cleaned
+
+
+def _coerce_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+def _normalise_payload(payload: Mapping[str, object] | Sequence[tuple[str, object]] | None) -> Mapping[str, object]:
+    if payload is None:
+        return {}
+    if isinstance(payload, Mapping):
+        return dict(payload)
+    normalised: dict[str, object] = {}
+    for key, value in payload:
+        key_normalised = _normalise_identifier(str(key))
+        normalised[key_normalised] = value
+    return normalised
+
+
+def _serialise_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _hash_payload(payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def _coerce_event(value: HistoricalEvent | Mapping[str, object]) -> HistoricalEvent:
+    if isinstance(value, HistoricalEvent):
+        return value
+    if not isinstance(value, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("event must be a HistoricalEvent or mapping")
+    return HistoricalEvent(**value)
+
+
+@dataclass(slots=True)
+class HistoricalEvent:
+    """A single chronological commitment in the history ledger."""
+
+    event_id: str
+    payload: Mapping[str, object]
+    timestamp: datetime = field(default_factory=_utcnow)
+    previous_hash: str = ""
+    metadata: Mapping[str, object] | None = None
+    hash: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.event_id = _normalise_identifier(self.event_id)
+        self.payload = _normalise_payload(self.payload)
+        self.timestamp = _ensure_utc(self.timestamp)
+        self.previous_hash = _normalise_hash(self.previous_hash) if self.previous_hash else "0" * 64
+        self.metadata = _coerce_metadata(self.metadata)
+        payload_hash = _hash_payload(self.payload)
+        encoded = "|".join(
+            (
+                self.event_id,
+                payload_hash,
+                self.previous_hash,
+                _serialise_timestamp(self.timestamp),
+            )
+        )
+        if self.metadata:
+            metadata_hash = _hash_payload(self.metadata)
+            encoded = f"{encoded}|{metadata_hash}"
+        self.hash = sha256(encoded.encode("utf-8")).hexdigest()
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "event_id": self.event_id,
+            "payload": dict(self.payload),
+            "timestamp": _serialise_timestamp(self.timestamp),
+            "previous_hash": self.previous_hash,
+            "hash": self.hash,
+            "metadata": dict(self.metadata) if self.metadata is not None else None,
+        }
+
+
+@dataclass(slots=True)
+class HistorySlice:
+    """A contiguous subset of events summarised for auditing."""
+
+    start_event: str
+    end_event: str
+    event_count: int
+    start_at: datetime
+    end_at: datetime
+    digests: tuple[tuple[str, str], ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "start_event": self.start_event,
+            "end_event": self.end_event,
+            "event_count": self.event_count,
+            "start_at": _serialise_timestamp(self.start_at),
+            "end_at": _serialise_timestamp(self.end_at),
+            "digests": self.digests,
+        }
+
+
+@dataclass(slots=True)
+class HistoryProof:
+    """Digest that attests to the integrity of the full history chain."""
+
+    root_hash: str
+    event_count: int
+    start_event: str
+    end_event: str
+    start_at: datetime
+    end_at: datetime
+    digests: tuple[tuple[str, str, str], ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "root_hash": self.root_hash,
+            "event_count": self.event_count,
+            "start_event": self.start_event,
+            "end_event": self.end_event,
+            "start_at": _serialise_timestamp(self.start_at),
+            "end_at": _serialise_timestamp(self.end_at),
+            "digests": self.digests,
+        }
+
+
+class DynamicProofOfHistory:
+    """Maintains a deterministic sequence of hashed historical events."""
+
+    def __init__(
+        self,
+        *,
+        genesis_event: str = "GENESIS",
+        payload: Mapping[str, object] | Sequence[tuple[str, object]] | None = None,
+        metadata: Mapping[str, object] | None = None,
+        timestamp: datetime | None = None,
+    ) -> None:
+        self._events: list[HistoricalEvent] = []
+        self._index: dict[str, int] = {}
+        self._append_genesis(genesis_event, payload=payload, metadata=metadata, timestamp=timestamp)
+
+    def _append_genesis(
+        self,
+        event_id: str,
+        *,
+        payload: Mapping[str, object] | Sequence[tuple[str, object]] | None,
+        metadata: Mapping[str, object] | None,
+        timestamp: datetime | None,
+    ) -> None:
+        genesis = HistoricalEvent(
+            event_id=event_id,
+            payload=_normalise_payload(payload),
+            timestamp=_ensure_utc(timestamp),
+            previous_hash="0" * 64,
+            metadata=_coerce_metadata(metadata),
+        )
+        self._events.append(genesis)
+        self._index[genesis.event_id] = 0
+
+    def events(self) -> tuple[HistoricalEvent, ...]:
+        return tuple(self._events)
+
+    def last_hash(self) -> str:
+        return self._events[-1].hash
+
+    def append(
+        self,
+        event_id: str,
+        payload: Mapping[str, object] | Sequence[tuple[str, object]] | None = None,
+        *,
+        timestamp: datetime | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> HistoricalEvent:
+        if event_id in self._index:
+            raise ValueError(f"event '{event_id}' already exists")
+        previous_hash = self._events[-1].hash
+        event = HistoricalEvent(
+            event_id=event_id,
+            payload=_normalise_payload(payload),
+            timestamp=_ensure_utc(timestamp),
+            previous_hash=previous_hash,
+            metadata=_coerce_metadata(metadata),
+        )
+        self._events.append(event)
+        self._index[event.event_id] = len(self._events) - 1
+        return event
+
+    def extend(self, events: Iterable[Mapping[str, object] | HistoricalEvent]) -> None:
+        for value in events:
+            event = _coerce_event(value)
+            self.append(
+                event.event_id,
+                payload=event.payload,
+                timestamp=event.timestamp,
+                metadata=event.metadata,
+            )
+
+    def slice(self, start: datetime, end: datetime) -> HistorySlice:
+        start_at = _ensure_utc(start)
+        end_at = _ensure_utc(end)
+        if end_at < start_at:
+            raise ValueError("end must not be earlier than start")
+        subset = [
+            event for event in self._events if start_at <= event.timestamp <= end_at
+        ]
+        if not subset:
+            raise ValueError("no events within the specified window")
+        digests = tuple((event.event_id, event.hash) for event in subset)
+        return HistorySlice(
+            start_event=subset[0].event_id,
+            end_event=subset[-1].event_id,
+            event_count=len(subset),
+            start_at=subset[0].timestamp,
+            end_at=subset[-1].timestamp,
+            digests=digests,
+        )
+
+    def generate_proof(self) -> HistoryProof:
+        events = self._events
+        digests = tuple(
+            (event.event_id, event.hash, _serialise_timestamp(event.timestamp))
+            for event in events
+        )
+        return HistoryProof(
+            root_hash=events[-1].hash,
+            event_count=len(events),
+            start_event=events[0].event_id,
+            end_event=events[-1].event_id,
+            start_at=events[0].timestamp,
+            end_at=events[-1].timestamp,
+            digests=digests,
+        )
+
+    def verify_chain(self) -> bool:
+        for index, event in enumerate(self._events[1:], start=1):
+            previous_hash = self._events[index - 1].hash
+            if event.previous_hash != previous_hash:
+                return False
+            recalculated = HistoricalEvent(
+                event_id=event.event_id,
+                payload=event.payload,
+                timestamp=event.timestamp,
+                previous_hash=event.previous_hash,
+                metadata=event.metadata,
+            )
+            if recalculated.hash != event.hash:
+                return False
+        return True
+
+    def verify_proof(self, proof: HistoryProof) -> bool:
+        local_proof = self.generate_proof()
+        return (
+            proof.root_hash == local_proof.root_hash
+            and proof.event_count == local_proof.event_count
+            and proof.start_event == local_proof.start_event
+            and proof.end_event == local_proof.end_event
+            and proof.start_at == local_proof.start_at
+            and proof.end_at == local_proof.end_at
+            and proof.digests == local_proof.digests
+        )

--- a/dynamic_proof_of_reputation/__init__.py
+++ b/dynamic_proof_of_reputation/__init__.py
@@ -1,0 +1,15 @@
+"""Interfaces for the Dynamic Proof of Reputation module."""
+
+from .proof_of_reputation import (
+    DynamicProofOfReputation,
+    ReputationProfile,
+    ReputationProof,
+    ReputationSignal,
+)
+
+__all__ = [
+    "DynamicProofOfReputation",
+    "ReputationProfile",
+    "ReputationProof",
+    "ReputationSignal",
+]

--- a/dynamic_proof_of_reputation/proof_of_reputation.py
+++ b/dynamic_proof_of_reputation/proof_of_reputation.py
@@ -1,0 +1,297 @@
+"""Signal synthesis for Dynamic Proof of Reputation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "DynamicProofOfReputation",
+    "ReputationProfile",
+    "ReputationProof",
+    "ReputationSignal",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_utc(value: datetime | None) -> datetime:
+    if value is None:
+        return _utcnow()
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _normalise_identifier(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("identifier must not be empty")
+    return cleaned
+
+
+def _normalise_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+def _coerce_score(value: float | int) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise TypeError("score must be numeric") from exc
+    if not -1.0 <= score <= 1.0:
+        raise ValueError("score must be between -1.0 and 1.0")
+    return score
+
+
+def _coerce_weight(value: float | int) -> float:
+    try:
+        weight = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise TypeError("weight must be numeric") from exc
+    if weight <= 0:
+        raise ValueError("weight must be positive")
+    return weight
+
+
+def _coerce_confidence(value: float | int) -> float:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise TypeError("confidence must be numeric") from exc
+    if not 0.0 <= confidence <= 1.0:
+        raise ValueError("confidence must be between 0.0 and 1.0")
+    return confidence
+
+
+def _coerce_signal(value: ReputationSignal | Mapping[str, object]) -> ReputationSignal:
+    if isinstance(value, ReputationSignal):
+        return value
+    if not isinstance(value, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("signal must be a ReputationSignal or mapping")
+    return ReputationSignal(**value)
+
+
+@dataclass(slots=True)
+class ReputationSignal:
+    """A single endorsement, critique, or attestment affecting reputation."""
+
+    subject: str
+    source: str
+    score: float
+    weight: float = 1.0
+    confidence: float = 0.5
+    timestamp: datetime = field(default_factory=_utcnow)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    summary: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.subject = _normalise_identifier(self.subject)
+        self.source = _normalise_identifier(self.source)
+        self.score = _coerce_score(self.score)
+        self.weight = _coerce_weight(self.weight)
+        self.confidence = _coerce_confidence(self.confidence)
+        self.timestamp = _ensure_utc(self.timestamp)
+        self.tags = _normalise_tags(self.tags)
+        self.summary = _normalise_optional_text(self.summary)
+        self.metadata = _coerce_metadata(self.metadata)
+
+    def weighted_score(self) -> float:
+        return self.score * self.weight * self.confidence
+
+    def influence(self) -> float:
+        return self.weight * self.confidence
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "subject": self.subject,
+            "source": self.source,
+            "score": self.score,
+            "weight": self.weight,
+            "confidence": self.confidence,
+            "timestamp": self.timestamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "tags": self.tags,
+            "summary": self.summary,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(slots=True)
+class ReputationProfile:
+    """Aggregated state for an entity's reputation."""
+
+    subject: str
+    trust_score: float
+    confidence: float
+    total_influence: float
+    positive_contributions: float
+    negative_contributions: float
+    sources: tuple[str, ...]
+    tags: tuple[str, ...]
+    last_updated: datetime | None
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "subject": self.subject,
+            "trust_score": self.trust_score,
+            "confidence": self.confidence,
+            "total_influence": self.total_influence,
+            "positive_contributions": self.positive_contributions,
+            "negative_contributions": self.negative_contributions,
+            "sources": self.sources,
+            "tags": self.tags,
+            "last_updated": self.last_updated.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+            if self.last_updated
+            else None,
+        }
+
+
+@dataclass(slots=True)
+class ReputationProof:
+    """Digest suitable for external verification of reputation."""
+
+    subject: str
+    trust_score: float
+    confidence: float
+    total_signals: int
+    issued_at: datetime
+    sources: tuple[str, ...]
+    tags: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "subject": self.subject,
+            "trust_score": self.trust_score,
+            "confidence": self.confidence,
+            "total_signals": self.total_signals,
+            "issued_at": self.issued_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "sources": self.sources,
+            "tags": self.tags,
+        }
+
+
+class DynamicProofOfReputation:
+    """Synthesises signals into resilient reputation attestations."""
+
+    _TOLERANCE = 1e-9
+
+    def __init__(self) -> None:
+        self._signals: dict[str, list[ReputationSignal]] = {}
+
+    def record(self, signal: ReputationSignal | Mapping[str, object]) -> ReputationSignal:
+        entry = _coerce_signal(signal)
+        bucket = self._signals.setdefault(entry.subject, [])
+        if bucket and entry.timestamp < bucket[-1].timestamp:
+            raise ValueError("signals must be recorded in chronological order")
+        bucket.append(entry)
+        return entry
+
+    def record_many(self, signals: Iterable[ReputationSignal | Mapping[str, object]]) -> None:
+        staged = [_coerce_signal(signal) for signal in signals]
+        for signal in staged:
+            self.record(signal)
+
+    def subjects(self) -> tuple[str, ...]:
+        return tuple(sorted(self._signals))
+
+    def signals(self, subject: str) -> tuple[ReputationSignal, ...]:
+        normalised = _normalise_identifier(subject)
+        return tuple(self._signals.get(normalised, ()))
+
+    def profile(self, subject: str) -> ReputationProfile:
+        normalised = _normalise_identifier(subject)
+        entries = self._signals.get(normalised, [])
+        if not entries:
+            return ReputationProfile(
+                subject=normalised,
+                trust_score=0.5,
+                confidence=0.0,
+                total_influence=0.0,
+                positive_contributions=0.0,
+                negative_contributions=0.0,
+                sources=(),
+                tags=(),
+                last_updated=None,
+            )
+
+        total_weighted = sum(entry.weighted_score() for entry in entries)
+        total_influence = sum(entry.influence() for entry in entries)
+        if total_influence <= self._TOLERANCE:
+            trust_score = 0.5
+        else:
+            average_score = total_weighted / max(total_influence, self._TOLERANCE)
+            trust_score = max(0.0, min(1.0, (average_score + 1.0) / 2.0))
+
+        positive = sum(
+            entry.weighted_score() for entry in entries if entry.weighted_score() > 0
+        )
+        negative = sum(
+            -entry.weighted_score() for entry in entries if entry.weighted_score() < 0
+        )
+        sources = tuple(sorted({entry.source for entry in entries}))
+        tags = tuple(sorted({tag for entry in entries for tag in entry.tags}))
+        last_updated = entries[-1].timestamp
+        confidence = min(1.0, total_influence / (total_influence + 5.0))
+        return ReputationProfile(
+            subject=normalised,
+            trust_score=trust_score,
+            confidence=confidence,
+            total_influence=total_influence,
+            positive_contributions=positive,
+            negative_contributions=negative,
+            sources=sources,
+            tags=tags,
+            last_updated=last_updated,
+        )
+
+    def generate_proof(self, subject: str) -> ReputationProof:
+        profile = self.profile(subject)
+        entries = self._signals.get(profile.subject, [])
+        issued_at = entries[-1].timestamp if entries else _utcnow()
+        return ReputationProof(
+            subject=profile.subject,
+            trust_score=profile.trust_score,
+            confidence=profile.confidence,
+            total_signals=len(entries),
+            issued_at=issued_at,
+            sources=profile.sources,
+            tags=profile.tags,
+        )
+
+    def verify_proof(self, proof: ReputationProof) -> bool:
+        regenerated = self.generate_proof(proof.subject)
+        return (
+            abs(proof.trust_score - regenerated.trust_score) <= self._TOLERANCE
+            and abs(proof.confidence - regenerated.confidence) <= self._TOLERANCE
+            and proof.total_signals == regenerated.total_signals
+            and proof.sources == regenerated.sources
+            and proof.tags == regenerated.tags
+        )


### PR DESCRIPTION
## Summary
- add a DynamicProofOfBurn ledger for recording burn events, aggregating windows, and generating verifiable proofs
- introduce DynamicProofOfHistory to maintain a hashed timeline, export chain proofs, and audit time slices
- create a DynamicProofOfReputation engine that fuses weighted signals into profiles and externally verifiable proofs

## Testing
- not run (logic-only modules)


------
https://chatgpt.com/codex/tasks/task_e_68d851be08e083228bb4eefa1b2ed745