### PR TITLE
Add dynamic NFT minter module

### DIFF
--- a/dynamic_token/__init__.py
+++ b/dynamic_token/__init__.py
@@ -1,5 +1,6 @@
 """Dynamic Capital token economy helpers."""
 
+from .nft import DynamicNFTMinter, MintedDynamicNFT
 from .treasury import DynamicTreasuryAlgo
 
-__all__ = ["DynamicTreasuryAlgo"]
+__all__ = ["DynamicTreasuryAlgo", "DynamicNFTMinter", "MintedDynamicNFT"]

--- a/dynamic_token/nft.py
+++ b/dynamic_token/nft.py
@@ -1,0 +1,246 @@
+"""Dynamic NFT utilities for trading intelligence snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, MutableMapping, Sequence
+
+try:  # pragma: no cover - exercised indirectly when dependency is available
+    from dynamic_algo.dynamic_metadata import (  # type: ignore
+        DynamicMetadataAlgo as _DynamicMetadataAlgo,
+    )
+except Exception:  # pragma: no cover - fallback path for isolated test runs
+    _DynamicMetadataAlgo = None
+
+
+def _coerce_timestamp(value: datetime | str | None) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    raise TypeError("timestamp value must be datetime, ISO string, or None")
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class _FallbackDynamicMetadataAlgo:
+    RESERVED_KEYS = {
+        "name",
+        "symbol",
+        "description",
+        "timestamp",
+        "attributes",
+        "scores",
+        "tags",
+        "sources",
+    }
+
+    def __init__(self, *, max_attributes: int = 16) -> None:
+        self.max_attributes = max(1, int(max_attributes))
+
+    def build(
+        self,
+        *,
+        symbol: str,
+        analysis: Mapping[str, Any] | None = None,
+        flow: Mapping[str, Any] | None = None,
+        pool: Mapping[str, Any] | None = None,
+        risk: Mapping[str, Any] | None = None,
+        tags: Sequence[str] | None = None,
+        extra: Mapping[str, Any] | None = None,
+        timestamp: datetime | str | None = None,
+    ) -> MutableMapping[str, Any]:
+        iso_timestamp = _coerce_timestamp(timestamp).isoformat()
+        symbol_upper = symbol.upper()
+
+        attributes: list[MutableMapping[str, Any]] = []
+        if analysis:
+            action = str(analysis.get("action", "")).upper() or "NEUTRAL"
+            attributes.append({"trait_type": "AI Action", "value": action})
+
+            confidence = _coerce_float(analysis.get("confidence"))
+            if confidence is not None:
+                attributes.append(
+                    {
+                        "trait_type": "AI Confidence",
+                        "value": round(max(0.0, min(1.0, confidence)), 4),
+                        "display_type": "number",
+                    }
+                )
+
+        payload: MutableMapping[str, Any] = {
+            "name": f"{symbol_upper} dynamic intelligence snapshot",
+            "symbol": symbol_upper,
+            "description": f"Dynamic intelligence snapshot for {symbol_upper}.",
+            "timestamp": iso_timestamp,
+            "attributes": attributes[: self.max_attributes],
+            "scores": {},
+            "tags": list(tags or []),
+            "sources": {
+                "analysis": analysis is not None,
+                "market_flow": flow is not None,
+                "pool": pool is not None,
+                "risk": risk is not None,
+            },
+        }
+
+        if extra:
+            for key, value in extra.items():
+                if key not in self.RESERVED_KEYS:
+                    payload[key] = value
+
+        return payload
+
+
+DynamicMetadataAlgo = (
+    _DynamicMetadataAlgo if _DynamicMetadataAlgo is not None else _FallbackDynamicMetadataAlgo
+)
+
+__all__ = ["MintedDynamicNFT", "DynamicNFTMinter"]
+
+
+@dataclass(slots=True)
+class MintedDynamicNFT:
+    """In-memory representation of a freshly minted dynamic NFT."""
+
+    token_id: int
+    owner: str
+    metadata: MutableMapping[str, Any]
+    minted_at: datetime
+
+    def as_dict(self) -> MutableMapping[str, Any]:
+        """Return a serialisable dictionary for off-chain persistence."""
+
+        payload: MutableMapping[str, Any] = {
+            "token_id": self.token_id,
+            "owner": self.owner,
+            "minted_at": self.minted_at.isoformat(),
+            "metadata": self.metadata,
+        }
+        return payload
+
+
+class DynamicNFTMinter:
+    """Produce metadata-backed NFTs that evolve with market telemetry."""
+
+    def __init__(self, symbol: str, *, metadata_algo: DynamicMetadataAlgo | None = None) -> None:
+        if not isinstance(symbol, str) or not symbol.strip():
+            raise ValueError("symbol must be a non-empty string")
+
+        self.symbol = symbol.upper()
+        self._metadata_algo = metadata_algo or DynamicMetadataAlgo()
+        self._next_token_id = 1
+        self._tokens: dict[int, MintedDynamicNFT] = {}
+
+    def mint(
+        self,
+        owner: str,
+        *,
+        analysis: Mapping[str, Any] | None = None,
+        flow: Mapping[str, Any] | None = None,
+        pool: Mapping[str, Any] | None = None,
+        risk: Mapping[str, Any] | None = None,
+        tags: Sequence[str] | None = None,
+        extra: Mapping[str, Any] | None = None,
+        timestamp: datetime | str | None = None,
+    ) -> MintedDynamicNFT:
+        """Mint a new NFT with metadata snapshot of the current context."""
+
+        if not isinstance(owner, str) or not owner.strip():
+            raise ValueError("owner must be a non-empty string")
+
+        token_id = self._next_token_id
+        self._next_token_id += 1
+
+        minted_at = datetime.now(timezone.utc)
+        metadata = self._metadata_algo.build(
+            symbol=self.symbol,
+            analysis=analysis,
+            flow=flow,
+            pool=pool,
+            risk=risk,
+            tags=tags,
+            extra=extra,
+            timestamp=timestamp or minted_at,
+        )
+
+        nft = MintedDynamicNFT(
+            token_id=token_id,
+            owner=owner,
+            metadata=metadata,
+            minted_at=minted_at,
+        )
+        self._tokens[token_id] = nft
+        return nft
+
+    def refresh_metadata(
+        self,
+        token_id: int,
+        *,
+        analysis: Mapping[str, Any] | None = None,
+        flow: Mapping[str, Any] | None = None,
+        pool: Mapping[str, Any] | None = None,
+        risk: Mapping[str, Any] | None = None,
+        tags: Sequence[str] | None = None,
+        extra: Mapping[str, Any] | None = None,
+        timestamp: datetime | str | None = None,
+    ) -> MutableMapping[str, Any]:
+        """Regenerate metadata for an existing NFT using fresh telemetry."""
+
+        nft = self._tokens.get(int(token_id))
+        if nft is None:
+            raise KeyError(f"Unknown token_id {token_id}")
+
+        metadata = self._metadata_algo.build(
+            symbol=self.symbol,
+            analysis=analysis,
+            flow=flow,
+            pool=pool,
+            risk=risk,
+            tags=tags,
+            extra=extra,
+            timestamp=timestamp,
+        )
+        nft.metadata = metadata
+        return metadata
+
+    def transfer(self, token_id: int, new_owner: str) -> MintedDynamicNFT:
+        """Transfer ownership of a minted NFT."""
+
+        if not isinstance(new_owner, str) or not new_owner.strip():
+            raise ValueError("new_owner must be a non-empty string")
+
+        nft = self._tokens.get(int(token_id))
+        if nft is None:
+            raise KeyError(f"Unknown token_id {token_id}")
+
+        nft.owner = new_owner
+        return nft
+
+    def get(self, token_id: int) -> MintedDynamicNFT:
+        """Return a minted NFT by ``token_id``."""
+
+        nft = self._tokens.get(int(token_id))
+        if nft is None:
+            raise KeyError(f"Unknown token_id {token_id}")
+        return nft
+
+    def all_tokens(self) -> list[MintedDynamicNFT]:
+        """Return all minted NFTs ordered by ``token_id``."""
+
+        return [self._tokens[key] for key in sorted(self._tokens)]

--- a/tests/dynamic_token/test_dynamic_nft.py
+++ b/tests/dynamic_token/test_dynamic_nft.py
@@ -1,0 +1,66 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from dynamic_token.nft import DynamicNFTMinter
+
+
+@pytest.fixture()
+def minter() -> DynamicNFTMinter:
+    return DynamicNFTMinter("dct")
+
+
+def test_mint_creates_metadata(minter: DynamicNFTMinter) -> None:
+    minted = minter.mint(
+        "0xabc",
+        analysis={"action": "buy", "confidence": 0.75},
+        tags=["ai", "trade"],
+    )
+
+    assert minted.token_id == 1
+    assert minted.owner == "0xabc"
+    assert minted.metadata["symbol"] == "DCT"
+    assert minted.metadata["sources"]["analysis"] is True
+    assert minted.metadata["attributes"][0] == {
+        "trait_type": "AI Action",
+        "value": "BUY",
+    }
+    assert minted.metadata["attributes"][1]["trait_type"] == "AI Confidence"
+    assert minted.metadata["attributes"][1]["value"] == pytest.approx(0.75)
+    assert datetime.fromisoformat(minted.metadata["timestamp"])  # parses
+
+
+def test_refresh_updates_metadata(minter: DynamicNFTMinter) -> None:
+    minted = minter.mint("0xabc", analysis={"action": "buy"})
+    original_timestamp = minted.metadata["timestamp"]
+
+    updated = minter.refresh_metadata(minted.token_id, analysis={"action": "sell"})
+
+    assert updated["attributes"][0]["value"] == "SELL"
+    assert updated["timestamp"] != original_timestamp
+    assert minter.get(minted.token_id).metadata is updated
+
+
+def test_transfer_changes_owner(minter: DynamicNFTMinter) -> None:
+    minted = minter.mint("0xabc", analysis={"action": "buy"})
+
+    transferred = minter.transfer(minted.token_id, "0xdef")
+
+    assert transferred.owner == "0xdef"
+    assert minter.get(minted.token_id).owner == "0xdef"
+
+
+@pytest.mark.parametrize("bad_symbol", ["", "   ", None])
+def test_invalid_symbol_raises(bad_symbol) -> None:
+    with pytest.raises(ValueError):
+        DynamicNFTMinter(bad_symbol)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_owner", ["", "   ", None])
+def test_invalid_owner_raises(minter: DynamicNFTMinter, bad_owner) -> None:
+    with pytest.raises(ValueError):
+        minter.mint(bad_owner)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add a DynamicNFTMinter with metadata snapshot generation and fallback metadata handling
- expose the NFT utilities from the token package and cover mint/refresh/transfer flows with tests

## Testing
- pytest tests/dynamic_token/test_dynamic_nft.py
- pytest tests/dynamic_token/test_treasury_algo.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8556a0b488322b82de02beeb8192d