### PR TITLE
Guard optional Ollama dependency and refine fusion consensus

### DIFF
--- a/dynamic_ai/core.py
+++ b/dynamic_ai/core.py
@@ -725,20 +725,33 @@ class DynamicFusionAlgo:
         if not context.indicator_panel:
             return 0.0
 
+        indicator_values = [
+            value
+            for name, value in context.indicator_panel
+            if name != "resolved_signal_bias"
+        ]
+
+        if not indicator_values:
+            return 0.0
+
         action_score = self._action_to_score(action)
         threshold = 0.15
 
-        values = [value for _, value in context.indicator_panel]
-
         if action_score == 0.0:
-            strong_bias = sum(1 for value in values if abs(value) > 0.4)
-            neutral_support = sum(1 for value in values if abs(value) <= threshold)
-            return (neutral_support - strong_bias) / len(values)
+            strong_bias = sum(1 for value in indicator_values if abs(value) > 0.4)
+            neutral_support = sum(
+                1 for value in indicator_values if abs(value) <= threshold
+            )
+            return (neutral_support - strong_bias) / len(indicator_values)
 
-        aligned = sum(1 for value in values if value * action_score > threshold)
-        conflicting = sum(1 for value in values if value * action_score < -threshold)
+        aligned = sum(
+            1 for value in indicator_values if value * action_score > threshold
+        )
+        conflicting = sum(
+            1 for value in indicator_values if value * action_score < -threshold
+        )
 
-        return (aligned - conflicting) / len(values)
+        return (aligned - conflicting) / len(indicator_values)
 
     def _build_consensus_provider(
         self, context: "PreparedMarketContext"


### PR DESCRIPTION
## Summary
- prevent resolved-signal bias from boosting consensus so confidence scores stay aligned with expectations
- defer the requests import inside the Ollama adapter and raise a clear error when the optional dependency is missing

## Testing
- pytest tests/dynamic_ai/test_dynamic_fusion_algo.py tests/dynamic_token/test_treasury_algo.py algorithms/python/tests/test_dynamic_ai_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d8582168088322812541786f0464a2