### PR TITLE
Optimize dynamic agents lazy loading

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -1,27 +1,18 @@
-"""Dynamic Agents public interface.
+"""Dynamic Agents public interface with lazy loading.
 
-This module re-exports the core persona agents that power Dynamic
-Capital's orchestration cycle.  The concrete implementations live in
-:mod:`dynamic_ai`, but several downstream consumers expect a dedicated
-``dynamic_agents`` package.  Keeping this thin wrapper avoids import
-errors while maintaining a single source of truth for the agent
-implementations.
+Downstream code historically relied on the :mod:`dynamic_agents`
+namespace, but the concrete implementations now live in
+:mod:`dynamic_ai`.  Importing the heavy agent stack eagerly adds a
+noticeable startup penalty for lightweight scripts.  To keep backwards
+compatibility *and* reduce the import overhead, this module proxies the
+symbols via :func:`importlib.import_module` so objects are materialised
+only when they are first accessed.
 """
 
-from dynamic_ai import (
-    Agent,
-    AgentResult,
-    ChatAgentResult,
-    ChatTurn,
-    DynamicChatAgent,
-    ExecutionAgent,
-    ExecutionAgentResult,
-    ResearchAgent,
-    ResearchAgentResult,
-    RiskAgent,
-    RiskAgentResult,
-)
-from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "Agent",
@@ -37,3 +28,49 @@ __all__ = [
     "RiskAgentResult",
     "run_dynamic_agent_cycle",
 ]
+
+_AGENT_EXPORTS = {
+    "Agent",
+    "AgentResult",
+    "ChatAgentResult",
+    "ChatTurn",
+    "DynamicChatAgent",
+    "ExecutionAgent",
+    "ExecutionAgentResult",
+    "ResearchAgent",
+    "ResearchAgentResult",
+    "RiskAgent",
+    "RiskAgentResult",
+}
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
+    from dynamic_ai import (
+        Agent,
+        AgentResult,
+        ChatAgentResult,
+        ChatTurn,
+        DynamicChatAgent,
+        ExecutionAgent,
+        ExecutionAgentResult,
+        ResearchAgent,
+        ResearchAgentResult,
+        RiskAgent,
+        RiskAgentResult,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose objects from the modern implementation modules."""
+
+    if name == "run_dynamic_agent_cycle":
+        module = import_module("algorithms.python.dynamic_ai_sync")
+        return getattr(module, name)
+    if name in _AGENT_EXPORTS:
+        module = import_module("dynamic_ai")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_agents/base.py
+++ b/dynamic_agents/base.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing shared agent contracts lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["Agent", "AgentResult"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import Agent, AgentResult
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.base' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_agents/chat.py
+++ b/dynamic_agents/chat.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing the chat persona lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["ChatAgentResult", "ChatTurn", "DynamicChatAgent"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import ChatAgentResult, ChatTurn, DynamicChatAgent
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.chat' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_agents/cycle.py
+++ b/dynamic_agents/cycle.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing the synchronous orchestration helper lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["run_dynamic_agent_cycle"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
+
+
+def __getattr__(name: str) -> Any:
+    if name == "run_dynamic_agent_cycle":
+        module = import_module("algorithms.python.dynamic_ai_sync")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.cycle' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_agents/execution.py
+++ b/dynamic_agents/execution.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing the execution persona lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["ExecutionAgent", "ExecutionAgentResult"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import ExecutionAgent, ExecutionAgentResult
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.execution' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_agents/research.py
+++ b/dynamic_agents/research.py
@@ -1,0 +1,29 @@
+"""Compatibility shim exposing the research persona lazily.
+
+The historical automation stack imported the research agent from the
+``dynamic_agents`` namespace.  The implementation now lives under
+:mod:`dynamic_ai.agents`, and this wrapper keeps the import path stable
+while deferring the heavy dependency graph until an attribute is
+accessed.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["ResearchAgent", "ResearchAgentResult"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import ResearchAgent, ResearchAgentResult
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.research' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_agents/risk.py
+++ b/dynamic_agents/risk.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing the risk persona lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["RiskAgent", "RiskAgentResult"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import RiskAgent, RiskAgentResult
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.risk' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))


### PR DESCRIPTION
## Summary
- lazily proxy the legacy `dynamic_agents` namespace to the modern implementations so heavy dependencies load on demand
- add consistent module metadata helpers (TYPE_CHECKING imports and `__dir__`) across the compatibility shims

## Testing
- python -m compileall dynamic_agents
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d858526d58832281dbde3b119ca059