### PR TITLE
Update DCT tokenomics documentation

### DIFF
--- a/content/whitepapers/dct.json
+++ b/content/whitepapers/dct.json
@@ -37,7 +37,7 @@
   "tokenomics": {
     "intro": [
       "DCT tokenomics are meticulously designed to balance protocol liquidity with long-run alignment between traders, contributors, and the treasury. The supply is hard capped at 100,000,000 DCT under a time-locked multi-signature controller; any future adjustments require an on-chain governance vote with delayed execution safeguards. This mirrors the deployment configuration for the jetton, anchoring monetary policy in auditable on-chain parameters.",
-      "At launch, circulating supply is constrained to the public circulation allocation that fuels community growth initiatives alongside the dedicated liquidity provision buffer. Treasury, team, advisor, staking, and liquidity allocations are escrowed in TON vesting contracts with transparent cliffs and drip schedules that mirror the table below. Unlock schedules are published ahead of time, and governance can pause or re-sequence emissions if security or market stability concerns arise."
+      "At launch, 10% of supply unlocks at TGE — 3% for community distribution, 5% to bootstrap liquidity, and 2% for near-term partnerships. The remaining allocations are escrowed in TON vesting contracts with transparent cliffs: investor pool tokens observe a six-month cliff before linearly vesting over the following 24 months, the founding team vests linearly over 36 months after a 12-month cliff, partnerships and liquidity incentives vest over 24 months, and treasury reserves stream out across 60 months. Ecosystem and staking incentives deliver 40,000,000 DCT over five years via decaying annual buckets of 12M, 10M, 8M, 6M, and 4M. Unlock schedules are published ahead of time, and governance can pause or re-sequence emissions if security or market stability concerns arise."
     ],
     "policies": [
       "Treasury policies route a governed share of protocol fees toward buybacks and liquidity programs, reinforcing price stability while re-circulating value to active contributors.",
@@ -94,66 +94,76 @@
   },
   "distributionTable": [
     {
-      "allocation": "Public Circulation",
-      "amount": 50000000,
-      "percent": 50,
-      "schedule": "Sales, airdrops, and ecosystem incentives"
+      "allocation": "Ecosystem & Staking",
+      "amount": 40000000,
+      "percent": 40,
+      "schedule": "Five-year emissions using decaying annual buckets (12M, 10M, 8M, 6M, 4M)"
     },
     {
-      "allocation": "Treasury",
-      "amount": 20000000,
-      "percent": 20,
-      "schedule": "Governance-gated deployments"
+      "allocation": "Investor Pool / Fund Ops",
+      "amount": 25000000,
+      "percent": 25,
+      "schedule": "6-month cliff, then 24-month linear vesting"
     },
     {
-      "allocation": "Team & Advisors",
+      "allocation": "Founders & Team",
       "amount": 15000000,
       "percent": 15,
-      "schedule": "12-month cliff, 36-month vesting"
+      "schedule": "12-month cliff, then 36-month linear vesting"
     },
     {
-      "allocation": "Staking Rewards",
+      "allocation": "Partnerships & Liquidity",
       "amount": 10000000,
       "percent": 10,
-      "schedule": "Programmatic staking emissions"
+      "schedule": "2% unlocked at TGE, remainder vests linearly over 24 months"
     },
     {
-      "allocation": "Liquidity Provision",
-      "amount": 5000000,
-      "percent": 5,
-      "schedule": "TON DEX and CEX liquidity support"
+      "allocation": "Treasury & Emergency",
+      "amount": 10000000,
+      "percent": 10,
+      "schedule": "60-month linear release with governance-controlled pause rights"
     }
   ],
   "emissionNotes": [
-    "Emission events are orchestrated via audited TON smart contracts.",
+    "Ecosystem & staking emissions distribute 40,000,000 DCT across five years in front-loaded annual buckets of 12M, 10M, 8M, 6M, and 4M (with monthly slices).",
+    "10% of subscription spend is automatically burned and treasury buybacks execute quarterly, starting at 250,000 DCT per quarter with 20% year-over-year growth.",
     "Treasury-controlled mint functions are time-locked and require multi-signature authorization to protect against supply shocks."
   ],
   "saleRounds": {
-    "intro": "Token distribution campaigns translate the long-term supply map into milestone-based raises that fund growth while protecting circulating float.",
+    "intro": "Token distribution campaigns translate the long-term supply map into milestone-based raises that fund growth while protecting circulating float. The launch plan delivers 13,000,000 DCT at TGE across community, liquidity, and partnership channels, while long-dated allocations vest via governed cliffs.",
     "rounds": [
       {
-        "name": "Private Sale (Seed Investors)",
-        "allocation": 10000000,
-        "price": 0.02,
-        "priceDenom": "USD",
-        "vesting": "20% at TGE, remaining 80% vests linearly over six months.",
-        "notes": "Anchors early strategic capital with an 18-month participation covenant for network support."
+        "name": "Community Launch (TGE)",
+        "allocation": 3000000,
+        "price": 0.12,
+        "priceDenom": "TON (auction clearing)",
+        "vesting": "Unlocked at TGE with optional 90-day staking boosters.",
+        "notes": "Represents 3% of total supply dedicated to ecosystem activation quests and referrals."
       },
       {
-        "name": "Liquidity Bootstrap",
+        "name": "Liquidity Bootstrap Pools",
         "allocation": 5000000,
         "price": 0.1,
         "priceDenom": "Treasury cost basis USD",
-        "vesting": "Locked in DEX pools.",
-        "notes": "Matches the STON.fi and DeDust deployment plan to guarantee two-sided quotes."
+        "vesting": "Seeded into STON.fi and DeDust pools at TGE.",
+        "notes": "Accounts for 5% of supply and underwrites initial market depth across TON pairs."
       },
       {
-        "name": "Community Sale",
-        "allocation": 15000000,
-        "price": 0.12,
-        "priceDenom": "TON",
-        "vesting": "Immediate delivery with staking bonus multipliers for 90-day lockups.",
-        "notes": "Aligns with quest campaigns and referral programs to expand on-chain membership."
+        "name": "Strategic Partnerships Unlock",
+        "allocation": 2000000,
+        "price": 0.0,
+        "priceDenom": "N/A",
+        "vesting": "2% unlocked at TGE with remaining partnership grants vesting over 24 months.",
+        "notes": "Supports integrations, custodians, and key ecosystem collaborators.",
+        "tge": true
+      },
+      {
+        "name": "Investor Pool / Fund Operations",
+        "allocation": 25000000,
+        "price": 0.08,
+        "priceDenom": "USD",
+        "vesting": "6-month cliff followed by 24-month linear vesting.",
+        "notes": "Aligns strategic capital with fund operation milestones and quarterly reporting covenants."
       }
     ]
   },

--- a/docs/dct-jetton-starter-kit.md
+++ b/docs/dct-jetton-starter-kit.md
@@ -25,13 +25,13 @@ and a TypeScript Edge Function that automates the subscription → buyback → b
 
 - [ ] Genesis transactions mint the following fixed amounts to controlled
       wallets:
-  | Allocation                | Amount (DCT) | Notes                                |
-  | ------------------------- | ------------ | ------------------------------------ |
-  | Community & Rewards       | 50,000,000   | Streamed via emissions controller    |
-  | Treasury / Operations     | 20,000,000   | Liquidity, partnerships, incentives  |
-  | Team & Advisors (Vested)  | 15,000,000   | 12-month cliff, 36-month linear vest |
-  | Liquidity & Market Making | 10,000,000   | Initial DEX & market making          |
-  | Ecosystem Grants          | 5,000,000    | Grants and ecosystem growth          |
+  | Allocation                 | Amount (DCT) | Notes                                                                                |
+  | -------------------------- | ------------ | ------------------------------------------------------------------------------------ |
+  | Ecosystem & Staking        | 40,000,000   | 5-year emissions (12M → 4M buckets); seeds the 3% community drop + staking bootstrap |
+  | Investor Pool / Fund Ops   | 25,000,000   | 6-month cliff, then 24-month linear vesting under fund governance                    |
+  | Founders & Team (Vested)   | 15,000,000   | 12-month cliff, then 36-month linear vesting                                         |
+  | Partnerships & Liquidity   | 10,000,000   | 5% liquidity buffer and 2% partner unlock at TGE; 24-month vest on remainder         |
+  | Treasury & Emergency Guard | 10,000,000   | 60-month linear release with emergency pause controls                                |
 - [ ] After genesis, no account (including multisig) can mint additional tokens.
 
 ### Governance & Safety Controls
@@ -85,8 +85,8 @@ Key tables:
   output, and burn metrics per subscription cycle.
 - `dct_stakes` — tracks off-chain staking balances with lock windows, weights,
   and status transitions.
-- `dct_emissions` — ledger for epoch rewards distributed from the Community &
-  Rewards allocation.
+- `dct_emissions` — ledger for epoch rewards streamed from the Ecosystem &
+  Staking allocation.
 
 Each table enforces referential integrity and retains operational metadata
 (created/updated timestamps, webhook trace IDs, etc.). Numeric columns use

--- a/docs/dynamic-capital-ton-whitepaper.md
+++ b/docs/dynamic-capital-ton-whitepaper.md
@@ -129,17 +129,31 @@ stability concerns arise.
 
 ## Token Supply & Emissions
 
-| Allocation          | Amount (DCT) | Percent of Supply | Vesting / Unlock Schedule                 |
-| ------------------- | ------------ | ----------------- | ----------------------------------------- |
-| Public Circulation  | 50,000,000   | 50%               | Sales, airdrops, and ecosystem incentives |
-| Treasury            | 20,000,000   | 20%               | Governance-gated deployments              |
-| Team & Advisors     | 15,000,000   | 15%               | 12-month cliff, 36-month vesting          |
-| Staking Rewards     | 10,000,000   | 10%               | Programmatic staking emissions            |
-| Liquidity Provision | 5,000,000    | 5%                | TON DEX and CEX liquidity support         |
+| Allocation               | Amount (DCT) | Percent of Supply | Vesting / Unlock Schedule                                         |
+| ------------------------ | ------------ | ----------------- | ----------------------------------------------------------------- |
+| Ecosystem & Staking      | 40,000,000   | 40%               | Five-year emissions with decaying buckets (12M, 10M, 8M, 6M, 4M)  |
+| Investor Pool / Fund Ops | 25,000,000   | 25%               | 6-month cliff, then 24-month linear vesting                       |
+| Founders & Team          | 15,000,000   | 15%               | 12-month cliff, then 36-month linear vesting                      |
+| Partnerships & Liquidity | 10,000,000   | 10%               | 2% unlocked at TGE, remainder vests over 24 months                |
+| Treasury & Emergency     | 10,000,000   | 10%               | 60-month linear release with governance-controlled pause features |
 
-- Emission events are orchestrated via audited TON smart contracts.
-- Treasury-controlled mint functions are time-locked and require multi-signature
-  authorization to protect against supply shocks.
+- 10% of total supply (13,000,000 DCT) unlocks at TGE, split 3% to community
+  distribution, 5% to liquidity bootstrap pools, and 2% to strategic
+  partnerships.
+- Ecosystem & Staking emissions distribute 40,000,000 DCT across five years in
+  front-loaded annual buckets of 12M, 10M, 8M, 6M, and 4M, streamed monthly to
+  active validators and strategy vaults.
+- Investor Pool / Fund Ops tokens follow a six-month cliff with a 24-month
+  linear vest, aligning capital commitments with fund performance milestones.
+- Founders & Team allocations unlock linearly over 36 months following a
+  12-month cliff to ensure long-term execution incentives.
+- Partnerships & Liquidity grants vest over 24 months after the initial 2%
+  unlock, coordinating with exchange integrations and ecosystem campaigns.
+- Treasury & Emergency reserves stream out over 60 months, with governance
+  controls capable of pausing releases during market stress.
+- 10% of subscription spend is automatically burned, and quarterly buybacks
+  start at 250,000 DCT per quarter with 20% year-over-year growth to reinforce
+  long-run scarcity.
 
 ## Token Valuation Framework
 

--- a/docs/tonstarter/tokenomics-tables.md
+++ b/docs/tonstarter/tokenomics-tables.md
@@ -6,24 +6,25 @@ hosted in the diligence data room.
 
 ## Allocation Summary
 
-| Bucket              | Amount (DCT) | Percent of Supply | Unlock & Vesting Notes                                                         |
-| ------------------- | ------------ | ----------------- | ------------------------------------------------------------------------------ |
-| Public Circulation  | 50,000,000   | 50%               | IDO, airdrops, and ecosystem incentives unlocked at TGE.                       |
-| Treasury            | 20,000,000   | 20%               | Governance-gated deployments; emissions require multisig + timelock approvals. |
-| Team & Advisors     | 15,000,000   | 15%               | 12-month cliff followed by 36-month linear vesting.                            |
-| Staking Rewards     | 10,000,000   | 10%               | Programmatic staking emissions streamed weekly.                                |
-| Liquidity Provision | 5,000,000    | 5%                | STON.fi / DeDust liquidity inventory with treasury oversight.                  |
+| Bucket                   | Amount (DCT) | Percent of Supply | Unlock & Vesting Notes                                                                                           |
+| ------------------------ | ------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Ecosystem & Staking      | 40,000,000   | 40%               | Five-year emissions with decaying buckets (12M → 4M); 6M seeded across the TGE drop and initial staking tranche. |
+| Investor Pool / Fund Ops | 25,000,000   | 25%               | 6-month cliff followed by 24-month linear vesting.                                                               |
+| Founders & Team          | 15,000,000   | 15%               | 12-month cliff followed by 36-month linear vesting.                                                              |
+| Partnerships & Liquidity | 10,000,000   | 10%               | 5% liquidity buffer and 2% partner grants unlocked at TGE; 3% vests over 24 months.                              |
+| Treasury & Emergency     | 10,000,000   | 10%               | 60-month linear release with governance pause controls.                                                          |
 
 _Source:
 [`docs/dynamic-capital-ton-whitepaper.md`](../dynamic-capital-ton-whitepaper.md)_
 
 ## Sale Round Breakdown
 
-| Round                         | Allocation (DCT) | Price (USD)               | Unlock Schedule                                          | Notes                                                                                                                  |
-| ----------------------------- | ---------------- | ------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Private Sale (Seed Investors) | 10,000,000       | $0.020                    | 20% at TGE, remaining 80% vests linearly over six months | Aligns with the "Private Sale (Seed Investors)" plan in the whitepaper.                                                |
-| Public Sale (Tonstarter IDO)  | 15,000,000       | $0.050                    | 100% at TGE                                              | Tonstarter community sale; no lock-up to accelerate circulation.                                                       |
-| Liquidity Bootstrap           | 5,000,000        | Treasury cost basis $0.10 | Locked in DEX pools                                      | Matches the STON.fi / DeDust plan in [`docs/dynamic-capital-ton-whitepaper.md`](../dynamic-capital-ton-whitepaper.md). |
+| Round                           | Allocation (DCT) | Price / Basis              | Unlock Schedule                                    | Notes                                                                                      |
+| ------------------------------- | ---------------- | -------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Community Launch (TGE)          | 3,000,000        | ≈0.12 TON (Dutch auction)  | 100% at TGE with optional 90-day staking boosters  | Fuels quests and referral campaigns; represents the 3% community unlock.                   |
+| Liquidity Bootstrap Pools       | 5,000,000        | Treasury basis ≈$0.10      | 100% at TGE, deployed to STON.fi and DeDust pools  | Seeds two-sided liquidity across TON pairs and remains treasury-supervised.                |
+| Strategic Partnerships Unlock   | 2,000,000        | N/A                        | 2% unlocked at TGE; remainder vests over 24 months | Supports integrations, custodians, and exchange collaborations tied to milestone delivery. |
+| Investor Pool / Fund Operations | 25,000,000       | $0.08 (funding agreements) | 6-month cliff followed by 24-month linear vesting  | Aligns strategic capital with fund performance reviews and quarterly reporting covenants.  |
 
 The pricing ladder and unlock schedules align with the projections generated by
 the Tonstarter sale planner (`algorithms/python/dct_tonstarter_sale.py`) and
@@ -33,12 +34,13 @@ satisfy Tonstarter’s requirement for reproducible math within the repository.
 
 ```
 Total Supply: 100,000,000 DCT
-Less: Treasury (20,000,000 DCT) — locked behind multisig + timelock
-Less: Team & Advisors (15,000,000 DCT) — subject to cliff/vesting contract
-Less: Staking Rewards (un-emitted portion) — gated by emission scheduler
-Less: Liquidity Provision (5,000,000 DCT) — pooled with TON/USDT, accounted for separately
+Less: Ecosystem & Staking (34,000,000 DCT) — remainder after seeding 3,000,000 DCT to the community drop and 3,000,000 DCT to the initial staking tranche at TGE
+Less: Investor Pool / Fund Ops (25,000,000 DCT) — 6-month cliff + 24-month linear vesting
+Less: Founders & Team (15,000,000 DCT) — 12-month cliff + 36-month linear vesting
+Less: Treasury & Emergency (10,000,000 DCT) — 60-month linear release with governance pause rights
+Less: Partnerships & Liquidity locked remainder (3,000,000 DCT) — balance that vests over 24 months after the 5% liquidity and 2% partnership TGE unlocks
 -------------------------------------------
-Projected Circulating Supply at TGE: 60,000,000 DCT
+Projected Circulating Supply at TGE: 13,000,000 DCT
 ```
 
 The calculations above match the figures shared with Tonstarter reviewers. Any


### PR DESCRIPTION
## Summary
- align `content/whitepapers/dct.json` with the revised 40/25/15/10/10 token allocation, updated vesting cliffs, front-loaded emission buckets, and refreshed sale round descriptions
- sync `docs/dynamic-capital-ton-whitepaper.md` and `docs/tonstarter/tokenomics-tables.md` with the new TGE breakdown, quarterly buyback cadence, and 13,000,000 DCT circulating supply snapshot
- update `docs/dct-jetton-starter-kit.md` genesis mint table and emissions notes so deployers mint the new category balances and terminology

## Testing
- npx deno fmt content/whitepapers/dct.json docs/dynamic-capital-ton-whitepaper.md docs/tonstarter/tokenomics-tables.md docs/dct-jetton-starter-kit.md

------
https://chatgpt.com/codex/tasks/task_e_68d857bcc604832283f4f91f4913f565