### PR TITLE
feat: add dynamic benchmark toolkit

### DIFF
--- a/dynamic_benchmark/__init__.py
+++ b/dynamic_benchmark/__init__.py
@@ -1,0 +1,19 @@
+"""Dynamic benchmark orchestration toolkit."""
+
+from .engine import (
+    BenchmarkMetric,
+    BenchmarkScenario,
+    BenchmarkRun,
+    MetricAssessment,
+    BenchmarkReport,
+    DynamicBenchmark,
+)
+
+__all__ = [
+    "BenchmarkMetric",
+    "BenchmarkScenario",
+    "BenchmarkRun",
+    "MetricAssessment",
+    "BenchmarkReport",
+    "DynamicBenchmark",
+]

--- a/dynamic_benchmark/engine.py
+++ b/dynamic_benchmark/engine.py
@@ -1,0 +1,377 @@
+"""Benchmark synthesis primitives for Dynamic Capital."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from statistics import mean
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "BenchmarkMetric",
+    "BenchmarkScenario",
+    "BenchmarkRun",
+    "MetricAssessment",
+    "BenchmarkReport",
+    "DynamicBenchmark",
+]
+
+
+# ---------------------------------------------------------------------------
+# normalisation helpers
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_name(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+def _coerce_numeric(value: float | int) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+        raise TypeError("value must be numeric") from exc
+    return numeric
+
+
+# ---------------------------------------------------------------------------
+# dataclasses
+
+
+@dataclass(slots=True)
+class BenchmarkMetric:
+    """Definition for a metric tracked within a benchmark scenario."""
+
+    name: str
+    target: float
+    weight: float = 1.0
+    higher_is_better: bool = True
+    tolerance: float = 0.05
+    description: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_name(self.name)
+        self.target = _coerce_numeric(self.target)
+        if self.weight <= 0:
+            raise ValueError("weight must be positive")
+        self.weight = float(self.weight)
+        self.higher_is_better = bool(self.higher_is_better)
+        self.tolerance = max(float(self.tolerance), 0.0)
+        self.description = _normalise_optional_text(self.description)
+        self.metadata = _coerce_mapping(self.metadata)
+
+
+@dataclass(slots=True)
+class BenchmarkScenario:
+    """Container describing a benchmark configuration."""
+
+    name: str
+    cadence: str
+    owner: str
+    metrics: Sequence[BenchmarkMetric]
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_name(self.name)
+        self.cadence = _normalise_name(self.cadence)
+        self.owner = _normalise_name(self.owner)
+        if not self.metrics:
+            raise ValueError("scenario must define at least one metric")
+        deduped: dict[str, BenchmarkMetric] = {}
+        for metric in self.metrics:
+            if metric.name in deduped:
+                raise ValueError(f"duplicate metric name: {metric.name}")
+            deduped[metric.name] = metric
+        self.metrics = tuple(deduped.values())
+        self.description = _normalise_optional_text(self.description)
+
+    @property
+    def metric_names(self) -> tuple[str, ...]:
+        return tuple(metric.name for metric in self.metrics)
+
+    def get_metric(self, name: str) -> BenchmarkMetric:
+        normalised = _normalise_name(name)
+        for metric in self.metrics:
+            if metric.name == normalised:
+                return metric
+        raise KeyError(f"metric '{name}' not found in scenario '{self.name}'")
+
+
+@dataclass(slots=True)
+class BenchmarkRun:
+    """Single execution of a benchmark with collected metric values."""
+
+    run_id: str
+    metrics: Mapping[str, float]
+    timestamp: datetime = field(default_factory=_utcnow)
+    notes: str | None = None
+    inputs: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.run_id = _normalise_name(self.run_id)
+        normalised: dict[str, float] = {}
+        for key, value in self.metrics.items():
+            key = _normalise_name(key)
+            numeric = _coerce_numeric(value)
+            normalised[key] = numeric
+        self.metrics = normalised
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.notes = _normalise_optional_text(self.notes)
+        self.inputs = _coerce_mapping(self.inputs)
+
+
+@dataclass(slots=True)
+class MetricAssessment:
+    """Scorecard for a single metric within a benchmark run."""
+
+    name: str
+    value: float
+    target: float
+    score: float
+    delta: float
+    status: str
+    weight: float
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "value": self.value,
+            "target": self.target,
+            "score": self.score,
+            "delta": self.delta,
+            "status": self.status,
+            "weight": self.weight,
+            "narrative": self.narrative,
+        }
+
+
+@dataclass(slots=True)
+class BenchmarkReport:
+    """Aggregated benchmark results for a run."""
+
+    scenario: str
+    run_id: str
+    timestamp: datetime
+    overall_score: float
+    status: str
+    metric_assessments: tuple[MetricAssessment, ...]
+    recommendations: tuple[str, ...]
+    inputs: Mapping[str, object] | None = None
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "scenario": self.scenario,
+            "run_id": self.run_id,
+            "timestamp": self.timestamp.isoformat(),
+            "overall_score": self.overall_score,
+            "status": self.status,
+            "metric_assessments": [assessment.as_dict() for assessment in self.metric_assessments],
+            "recommendations": list(self.recommendations),
+            "inputs": dict(self.inputs) if self.inputs is not None else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# benchmark engine
+
+
+class DynamicBenchmark:
+    """Evaluate benchmark runs and synthesise trend-aware guidance."""
+
+    def __init__(
+        self,
+        scenario: BenchmarkScenario,
+        *,
+        history: Iterable[BenchmarkRun] | None = None,
+        history_limit: int = 12,
+    ) -> None:
+        self.scenario = scenario
+        self._history: Deque[BenchmarkRun] = deque(maxlen=max(history_limit, 1))
+        if history:
+            for run in history:
+                self._history.append(run)
+
+    @property
+    def history(self) -> tuple[BenchmarkRun, ...]:
+        return tuple(self._history)
+
+    def record(self, run: BenchmarkRun) -> BenchmarkReport:
+        """Record and evaluate a new benchmark run."""
+
+        report = self.evaluate(run)
+        self._history.append(run)
+        return report
+
+    def evaluate(self, run: BenchmarkRun) -> BenchmarkReport:
+        """Evaluate a run without mutating history."""
+
+        metric_assessments = self._evaluate_metrics(run)
+        overall_score = self._aggregate_score(metric_assessments)
+        status = self._classify_status(overall_score)
+        recommendations = self._recommendations(metric_assessments, status)
+        return BenchmarkReport(
+            scenario=self.scenario.name,
+            run_id=run.run_id,
+            timestamp=run.timestamp,
+            overall_score=overall_score,
+            status=status,
+            metric_assessments=metric_assessments,
+            recommendations=recommendations,
+            inputs=run.inputs,
+        )
+
+    # ------------------------------------------------------------------
+    # evaluation helpers
+
+    def _evaluate_metrics(self, run: BenchmarkRun) -> tuple[MetricAssessment, ...]:
+        assessments: list[MetricAssessment] = []
+        for metric in self.scenario.metrics:
+            value = run.metrics.get(metric.name)
+            if value is None:
+                raise KeyError(
+                    f"run '{run.run_id}' missing metric '{metric.name}' for scenario '{self.scenario.name}'"
+                )
+            score, delta, status = self._score_metric(metric, value)
+            narrative = self._metric_narrative(metric, value, delta, status)
+            assessments.append(
+                MetricAssessment(
+                    name=metric.name,
+                    value=value,
+                    target=metric.target,
+                    score=score,
+                    delta=delta,
+                    status=status,
+                    weight=metric.weight,
+                    narrative=narrative,
+                )
+            )
+        return tuple(assessments)
+
+    def _score_metric(self, metric: BenchmarkMetric, value: float) -> tuple[float, float, str]:
+        target = metric.target
+        if target == 0:
+            baseline_ratio = 1.0 if value == 0 else 2.0
+        else:
+            if metric.higher_is_better:
+                baseline_ratio = value / target
+            else:
+                # smaller values are better, so invert the ratio
+                baseline_ratio = target / value if value != 0 else 2.0
+        ratio = max(baseline_ratio, 0.0)
+        score = _clamp(ratio)
+        delta = value - target if metric.higher_is_better else target - value
+        tolerance = metric.tolerance * target if target != 0 else metric.tolerance
+        if ratio >= 1.05:
+            status = "exceeds"
+        elif ratio >= 1.0 - (tolerance / target if target != 0 else metric.tolerance):
+            status = "meets"
+        else:
+            status = "lags"
+        return score, delta, status
+
+    def _metric_narrative(
+        self,
+        metric: BenchmarkMetric,
+        value: float,
+        delta: float,
+        status: str,
+    ) -> str:
+        direction = "higher" if metric.higher_is_better else "lower"
+        if status == "exceeds":
+            return (
+                f"{metric.name} outperforms the target by {delta:+.2f}. Maintain the inputs driving this "
+                f"{direction} result."
+            )
+        if status == "meets":
+            return (
+                f"{metric.name} is on target with {value:.2f}. Continue monitoring {direction} pressures to "
+                "sustain performance."
+            )
+        adjustment = "increase" if metric.higher_is_better else "reduce"
+        return (
+            f"{metric.name} trails the benchmark by {abs(delta):.2f}. Prioritise initiatives that {adjustment} "
+            f"the metric within the next cycle."
+        )
+
+    def _aggregate_score(self, assessments: Sequence[MetricAssessment]) -> float:
+        total_weight = sum(assessment.weight for assessment in assessments)
+        if total_weight <= 0:
+            return 0.0
+        weighted = sum(assessment.score * assessment.weight for assessment in assessments)
+        return _clamp(weighted / total_weight)
+
+    def _classify_status(self, overall_score: float) -> str:
+        if overall_score >= 1.05:
+            return "surpassing"
+        if overall_score >= 0.95:
+            return "on-track"
+        return "at-risk"
+
+    def _recommendations(
+        self,
+        assessments: Sequence[MetricAssessment],
+        overall_status: str,
+    ) -> tuple[str, ...]:
+        recommendations: list[str] = []
+        if overall_status == "at-risk":
+            lagging = [a for a in assessments if a.status == "lags"]
+            if lagging:
+                worst = min(lagging, key=lambda a: a.score)
+                recommendations.append(
+                    f"Escalate recovery plan for '{worst.name}' with focus on {worst.narrative.lower()}"
+                )
+        exceeding = [a for a in assessments if a.status == "exceeds"]
+        if exceeding:
+            trend = self._trend_commentary(exceeding)
+            recommendations.append(trend)
+        if not recommendations:
+            recommendations.append(
+                "Maintain current execution cadence and validate signals against leading indicators."
+            )
+        return tuple(recommendations)
+
+    def _trend_commentary(self, assessments: Sequence[MetricAssessment]) -> str:
+        metric_names = {assessment.name for assessment in assessments}
+        historical_scores: list[float] = []
+        for run in self._history:
+            for name in metric_names:
+                if name in run.metrics:
+                    historical_scores.append(_coerce_numeric(run.metrics[name]))
+        if len(historical_scores) >= 2:
+            avg_score = mean(historical_scores)
+            return (
+                "Sustain outperforming metrics by codifying playbooks; "
+                f"historical average sits at {avg_score:.2f}."
+            )
+        return "Track outperforming metrics for durability across future cycles."


### PR DESCRIPTION
## Summary
- add a dedicated `dynamic_benchmark` package that exposes benchmark metric, scenario, and run primitives
- implement a dynamic benchmarking engine that scores runs, generates recommendations, and tracks history

## Testing
- python -m compileall dynamic_benchmark

------
https://chatgpt.com/codex/tasks/task_e_68d85c2ea3208322bfb4a924143ebe28