### PR TITLE
feat: add dynamic space engine orchestrator

### DIFF
--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -80,6 +80,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_reference": ("DynamicReference",),
     "dynamic_self_awareness": ("DynamicSelfAwareness",),
     "dynamic_skeleton": ("DynamicGovernanceAlgo", "DynamicComplianceAlgo"),
+    "dynamic_space.engine": ("DynamicSpaceEngine",),
     "dynamic_states": ("DynamicStateEngine",),
     "dynamic_stem_cell": ("DynamicStemCell",),
     "dynamic_syncronization": ("DynamicSyncronizationOrchestrator",),

--- a/dynamic_space/__init__.py
+++ b/dynamic_space/__init__.py
@@ -1,5 +1,6 @@
 """Dynamic space governance and exploration models."""
 
+from .engine import DynamicSpaceEngine, SpaceNetworkOverview
 from .space import (
     BodyKind,
     CelestialBody,
@@ -20,4 +21,6 @@ __all__ = [
     "SpaceEvent",
     "SpaceSnapshot",
     "DynamicSpace",
+    "SpaceNetworkOverview",
+    "DynamicSpaceEngine",
 ]

--- a/dynamic_space/engine.py
+++ b/dynamic_space/engine.py
@@ -1,0 +1,162 @@
+"""High-level orchestration utilities for :mod:`dynamic_space`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from .space import (
+    DynamicSpace,
+    SpaceEvent,
+    SpaceSector,
+    SpaceSnapshot,
+)
+
+__all__ = ["SpaceNetworkOverview", "DynamicSpaceEngine"]
+
+
+def _clamp_threshold(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    numeric = float(value)
+    if numeric < lower:
+        return lower
+    if numeric > upper:
+        return upper
+    return numeric
+
+
+def _coerce_sector(value: SpaceSector | Mapping[str, object]) -> SpaceSector:
+    if isinstance(value, SpaceSector):
+        return value
+    if isinstance(value, Mapping):
+        return SpaceSector(**value)
+    raise TypeError("sector must be a SpaceSector instance or a mapping")
+
+
+def _coerce_event(value: SpaceEvent | Mapping[str, object]) -> SpaceEvent:
+    if isinstance(value, SpaceEvent):
+        return value
+    if isinstance(value, Mapping):
+        return SpaceEvent(**value)
+    raise TypeError("event must be a SpaceEvent instance or a mapping")
+
+
+@dataclass(frozen=True, slots=True)
+class SpaceNetworkOverview:
+    """Aggregated perspective of the current space network posture."""
+
+    average_stability: float
+    total_energy_output_gw: float
+    sectors_requiring_attention: tuple[str, ...]
+    snapshots: Mapping[str, SpaceSnapshot]
+
+
+class DynamicSpaceEngine:
+    """Co-ordinate space sectors, events and interventions across a network."""
+
+    def __init__(
+        self,
+        sectors: Sequence[SpaceSector | Mapping[str, object]] | None = None,
+        *,
+        max_events: int = 256,
+        intervention_threshold: float = 0.5,
+    ) -> None:
+        self._space = DynamicSpace(sectors or (), max_events=max_events)
+        self._intervention_threshold = _clamp_threshold(intervention_threshold)
+
+    # --------------------------------------------------------------------- basic
+    @property
+    def space(self) -> DynamicSpace:
+        """Expose the underlying :class:`DynamicSpace` instance."""
+
+        return self._space
+
+    @property
+    def sectors(self) -> tuple[SpaceSector, ...]:
+        return self._space.sectors
+
+    @property
+    def intervention_threshold(self) -> float:
+        return self._intervention_threshold
+
+    def configure_intervention_threshold(self, value: float) -> None:
+        self._intervention_threshold = _clamp_threshold(value)
+
+    # ------------------------------------------------------------------ register
+    def upsert_sector(self, sector: SpaceSector | Mapping[str, object]) -> SpaceSector:
+        resolved = _coerce_sector(sector)
+        self._space.register_sector(resolved)
+        return resolved
+
+    # ------------------------------------------------------------------- dynamics
+    def record_event(self, event: SpaceEvent | Mapping[str, object]) -> SpaceEvent:
+        return self._space.record_event(_coerce_event(event))
+
+    def ingest_events(self, events: Iterable[SpaceEvent | Mapping[str, object]]) -> list[SpaceEvent]:
+        resolved = [_coerce_event(event) for event in events]
+        return self._space.ingest_events(resolved)
+
+    def stabilise(
+        self,
+        sector_name: str,
+        *,
+        congestion_threshold: float = 0.65,
+        damping_factor: float = 0.85,
+    ) -> SpaceSector:
+        return self._space.rebalance_routes(
+            sector_name,
+            congestion_threshold=congestion_threshold,
+            damping_factor=damping_factor,
+        )
+
+    # ---------------------------------------------------------------- snapshots
+    def snapshot(self, sector_name: str, *, horizon: int = 5) -> SpaceSnapshot:
+        return self._space.snapshot(sector_name, horizon=horizon)
+
+    def prioritise_interventions(
+        self,
+        *,
+        limit: int = 3,
+        horizon: int = 5,
+    ) -> tuple[SpaceSnapshot, ...]:
+        if limit <= 0:
+            return ()
+        overview = self.network_overview(horizon=horizon)
+        ordered = sorted(
+            overview.snapshots.values(),
+            key=lambda snapshot: (snapshot.stability_score, snapshot.sector_name.lower()),
+        )
+        return tuple(ordered[:limit])
+
+    def network_overview(self, *, horizon: int = 5) -> SpaceNetworkOverview:
+        sectors = self._space.sectors
+        snapshots: MutableMapping[str, SpaceSnapshot] = {}
+        for sector in sectors:
+            snapshots[sector.name] = self._space.snapshot(sector.name, horizon=horizon)
+        if snapshots:
+            average_stability = sum(snapshot.stability_score for snapshot in snapshots.values()) / len(snapshots)
+        else:
+            average_stability = 0.0
+        total_energy_output = sum(sector.energy_output_gw for sector in sectors)
+        attention = tuple(
+            name
+            for name, snapshot in sorted(
+                snapshots.items(),
+                key=lambda item: (item[1].stability_score, item[0].lower()),
+            )
+            if snapshot.stability_score < self._intervention_threshold
+        )
+        return SpaceNetworkOverview(
+            average_stability=average_stability,
+            total_energy_output_gw=total_energy_output,
+            sectors_requiring_attention=attention,
+            snapshots=snapshots,
+        )
+
+    def export_state(self, *, horizon: int = 5) -> dict[str, object]:
+        overview = self.network_overview(horizon=horizon)
+        return {
+            "average_stability": overview.average_stability,
+            "total_energy_output_gw": overview.total_energy_output_gw,
+            "sectors_requiring_attention": overview.sectors_requiring_attention,
+            "snapshots": {name: snapshot.as_dict() for name, snapshot in overview.snapshots.items()},
+        }

--- a/tests/test_dynamic_space_engine.py
+++ b/tests/test_dynamic_space_engine.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dynamic_space import (
+    BodyKind,
+    CelestialBody,
+    OrbitalRoute,
+    SpaceEvent,
+    SpaceEventSeverity,
+    SpaceSector,
+)
+from dynamic_space.engine import DynamicSpaceEngine, SpaceNetworkOverview
+
+
+def _build_corridor() -> SpaceSector:
+    terra = CelestialBody(
+        name="Terra",
+        kind=BodyKind.PLANET,
+        mass_kg=5.97e24,
+        velocity_kms=29.78,
+        resource_index=0.82,
+        habitability=0.94,
+    )
+    station = CelestialBody(
+        name="Astra Station",
+        kind=BodyKind.STATION,
+        mass_kg=2.5e8,
+        velocity_kms=7.66,
+        resource_index=0.55,
+        habitability=0.4,
+        tags=("logistics", "hub"),
+    )
+    routes = (
+        OrbitalRoute(
+            identifier="terra-orbit",
+            origin="Terra",
+            destination="Astra Station",
+            delta_v_kms=9.1,
+            congestion=0.72,
+            stability=0.65,
+        ),
+        OrbitalRoute(
+            identifier="station-transfer",
+            origin="Astra Station",
+            destination="Terra",
+            delta_v_kms=9.1,
+            congestion=0.68,
+            stability=0.62,
+        ),
+    )
+    return SpaceSector(
+        name="L4 Corridor",
+        bodies=(terra, station),
+        routes=routes,
+        hazard_index=0.32,
+        supply_level=0.74,
+        energy_output_gw=18.5,
+    )
+
+
+def _build_outer_belt() -> SpaceSector:
+    ceres = CelestialBody(
+        name="Ceres",
+        kind=BodyKind.ASTEROID,
+        mass_kg=9.39e20,
+        velocity_kms=17.9,
+        resource_index=0.45,
+        habitability=0.1,
+    )
+    refinery = CelestialBody(
+        name="Belt Refinery",
+        kind=BodyKind.STATION,
+        mass_kg=4.1e9,
+        velocity_kms=12.4,
+        resource_index=0.48,
+        habitability=0.2,
+        tags=("mining", "processing"),
+    )
+    routes = (
+        OrbitalRoute(
+            identifier="belt-haul",
+            origin="Ceres",
+            destination="Belt Refinery",
+            delta_v_kms=6.7,
+            congestion=0.58,
+            stability=0.52,
+        ),
+    )
+    return SpaceSector(
+        name="Outer Belt",
+        bodies=(ceres, refinery),
+        routes=routes,
+        hazard_index=0.58,
+        supply_level=0.42,
+        energy_output_gw=4.2,
+    )
+
+
+def test_network_overview_and_priorities() -> None:
+    engine = DynamicSpaceEngine([_build_corridor(), _build_outer_belt()])
+    overview = engine.network_overview(horizon=4)
+
+    assert isinstance(overview, SpaceNetworkOverview)
+    assert set(overview.snapshots.keys()) == {"L4 Corridor", "Outer Belt"}
+    assert overview.total_energy_output_gw == 22.7
+
+    average = sum(snapshot.stability_score for snapshot in overview.snapshots.values()) / 2
+    assert overview.average_stability == average
+
+    # degrade the Outer Belt sector with critical events
+    engine.record_event(
+        SpaceEvent(
+            sector_name="Outer Belt",
+            description="micro-meteor swarm",
+            impact_score=0.8,
+            severity=SpaceEventSeverity.CRITICAL,
+        )
+    )
+    engine.record_event(
+        {
+            "sector_name": "Outer Belt",
+            "description": "radiation surge",
+            "impact_score": 0.6,
+            "severity": SpaceEventSeverity.ALERT,
+        }
+    )
+
+    priorities = engine.prioritise_interventions(limit=2, horizon=3)
+    assert len(priorities) == 2
+    assert priorities[0].sector_name == "Outer Belt"
+    assert priorities[0].stability_score <= priorities[1].stability_score
+
+    engine.configure_intervention_threshold(0.65)
+    updated_overview = engine.network_overview(horizon=3)
+    assert "Outer Belt" in updated_overview.sectors_requiring_attention
+    assert updated_overview.snapshots["Outer Belt"].stability_score == priorities[0].stability_score
+
+    # verify state export mirrors snapshot values
+    exported = engine.export_state(horizon=3)
+    assert exported["average_stability"] == updated_overview.average_stability
+    assert exported["total_energy_output_gw"] == updated_overview.total_energy_output_gw
+    assert exported["sectors_requiring_attention"] == updated_overview.sectors_requiring_attention
+    assert exported["snapshots"]["Outer Belt"]["stability_score"] == priorities[0].stability_score
+
+
+def test_stabilise_updates_routes_and_hazard() -> None:
+    engine = DynamicSpaceEngine([_build_corridor()])
+    before = engine.space.get_sector("L4 Corridor")
+
+    after = engine.stabilise("L4 Corridor", congestion_threshold=0.65)
+    assert after.hazard_index <= before.hazard_index
+    assert any(new.congestion <= old.congestion for new, old in zip(after.routes, before.routes))
+
+    # upsert a new sector using mapping payload
+    payload = {
+        "name": "Deep Relay",
+        "bodies": (
+            {
+                "name": "Relay Alpha",
+                "kind": BodyKind.STATION,
+                "mass_kg": 6.5e9,
+                "velocity_kms": 10.2,
+                "resource_index": 0.5,
+                "habitability": 0.3,
+            },
+        ),
+        "routes": (
+            {
+                "identifier": "relay-hop",
+                "origin": "Relay Alpha",
+                "destination": "Terra",
+                "delta_v_kms": 11.4,
+                "congestion": 0.48,
+                "stability": 0.57,
+            },
+        ),
+        "hazard_index": 0.2,
+        "supply_level": 0.66,
+        "energy_output_gw": 6.4,
+    }
+    sector = engine.upsert_sector(payload)
+    assert sector.name == "Deep Relay"
+    assert any(sector.name == "Deep Relay" for sector in engine.sectors)


### PR DESCRIPTION
## Summary
- add a DynamicSpaceEngine orchestrator that surfaces network overviews, intervention prioritisation, and export helpers
- re-export the engine through the dynamic_space package and dynamic_engines compatibility layer
- cover the engine behaviour with dedicated pytest cases

## Testing
- npm run lint
- npm run typecheck
- pytest tests/test_dynamic_space_engine.py tests/test_dynamic_space.py

------
https://chatgpt.com/codex/tasks/task_e_68d85b9542dc83228746fca8a50c95cd