### PR TITLE
feat: add space agent persona

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -26,6 +26,8 @@ __all__ = [
     "ResearchAgentResult",
     "RiskAgent",
     "RiskAgentResult",
+    "SpaceAgent",
+    "SpaceAgentResult",
     "run_dynamic_agent_cycle",
 ]
 
@@ -41,6 +43,8 @@ _AGENT_EXPORTS = {
     "ResearchAgentResult",
     "RiskAgent",
     "RiskAgentResult",
+    "SpaceAgent",
+    "SpaceAgentResult",
 }
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
@@ -57,6 +61,8 @@ if TYPE_CHECKING:  # pragma: no cover - import-time only
         ResearchAgentResult,
         RiskAgent,
         RiskAgentResult,
+        SpaceAgent,
+        SpaceAgentResult,
     )
 
 

--- a/dynamic_agents/space.py
+++ b/dynamic_agents/space.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing the space persona lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["SpaceAgent", "SpaceAgentResult"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import SpaceAgent, SpaceAgentResult
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.space' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -12,6 +12,8 @@ from .agents import (
     ResearchAgentResult,
     RiskAgent,
     RiskAgentResult,
+    SpaceAgent,
+    SpaceAgentResult,
 )
 from .core import AISignal, DynamicFusionAlgo
 from .dolphin_adapter import (
@@ -89,6 +91,8 @@ __all__ = [
     "RiskParameters",
     "RiskAgent",
     "RiskAgentResult",
+    "SpaceAgent",
+    "SpaceAgentResult",
     "AccountState",
     "DynamicHedgePolicy",
     "ExposurePosition",

--- a/tests/test_dynamic_space_agent.py
+++ b/tests/test_dynamic_space_agent.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dynamic_agents import SpaceAgent, SpaceAgentResult
+from dynamic_agents.space import SpaceAgent as ShimSpaceAgent
+from dynamic_space import (
+    BodyKind,
+    CelestialBody,
+    DynamicSpace,
+    OrbitalRoute,
+    SpaceEventSeverity,
+    SpaceSector,
+)
+
+
+def _build_sector() -> SpaceSector:
+    terra = CelestialBody(
+        name="Terra",
+        kind=BodyKind.PLANET,
+        mass_kg=5.97e24,
+        velocity_kms=29.78,
+        resource_index=0.82,
+        habitability=0.94,
+    )
+    station = CelestialBody(
+        name="Astra Station",
+        kind=BodyKind.STATION,
+        mass_kg=2.5e8,
+        velocity_kms=7.66,
+        resource_index=0.55,
+        habitability=0.4,
+        tags=("logistics", "hub"),
+    )
+    routes = (
+        OrbitalRoute(
+            identifier="terra-orbit",
+            origin="Terra",
+            destination="Astra Station",
+            delta_v_kms=9.1,
+            congestion=0.72,
+            stability=0.65,
+        ),
+        OrbitalRoute(
+            identifier="station-transfer",
+            origin="Astra Station",
+            destination="Terra",
+            delta_v_kms=9.1,
+            congestion=0.68,
+            stability=0.62,
+        ),
+    )
+    return SpaceSector(
+        name="L4 Corridor",
+        bodies=(terra, station),
+        routes=routes,
+        hazard_index=0.32,
+        supply_level=0.74,
+        energy_output_gw=18.5,
+    )
+
+
+def test_space_agent_generates_snapshot_and_recommendations() -> None:
+    manager = DynamicSpace()
+    agent = SpaceAgent(manager)
+
+    sector = _build_sector()
+    payload = {
+        "sectors": [sector],
+        "events": [
+            {
+                "sector_name": sector.name,
+                "description": "micrometeorite shower",
+                "impact_score": 0.6,
+                "severity": SpaceEventSeverity.ALERT,
+            },
+            {
+                "sector_name": sector.name,
+                "description": "routing congestion",
+                "impact_score": 0.4,
+                "severity": SpaceEventSeverity.ADVISORY,
+            },
+        ],
+        "sector": sector.name,
+        "rebalance": True,
+        "congestion_threshold": 0.65,
+        "horizon": 3,
+    }
+
+    result = agent.run(payload)
+    assert isinstance(result, SpaceAgentResult)
+    assert result.sector == sector.name
+    assert result.snapshot.sector_name == sector.name
+    assert result.recommendations
+    assert result.events
+    assert result.snapshot.recent_events[-1].description == "routing congestion"
+
+    payload_dict = result.to_dict()
+    assert payload_dict["sector"] == sector.name
+    assert payload_dict["snapshot"]["sector_name"] == sector.name
+    assert payload_dict["events"] == payload_dict["snapshot"]["recent_events"]
+    assert all(isinstance(rec, str) and rec for rec in payload_dict["recommendations"])
+
+
+def test_space_agent_shim_matches_direct_import() -> None:
+    direct = SpaceAgent()
+    via_shim = ShimSpaceAgent()
+
+    sector = _build_sector()
+    result_direct = direct.run({"sectors": [sector], "sector": sector.name})
+    result_shim = via_shim.run({"sectors": [sector], "sector": sector.name})
+
+    assert result_direct.snapshot.sector_name == result_shim.snapshot.sector_name
+    assert result_direct.to_dict()["snapshot"]["sector_name"] == result_shim.to_dict()["snapshot"]["sector_name"]


### PR DESCRIPTION
## Summary
- add a Dynamic Space persona with snapshot serialization helpers and governance heuristics
- expose the new persona through the dynamic_agents compatibility namespace
- cover the space agent with unit tests and verify shim parity

## Testing
- npm run format
- npm run lint
- npm run typecheck
- pytest tests/test_dynamic_space_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d85bc18da08322981b4fb32f9df587