### PR TITLE
Add lazy exports for dynamic keepers and helpers

### DIFF
--- a/dynamic_keepers/__init__.py
+++ b/dynamic_keepers/__init__.py
@@ -1,42 +1,76 @@
-"""Dynamic Keepers orchestration surface.
+"""Compatibility shims for legacy ``dynamic_keepers`` imports.
 
-The keeper algorithms live under :mod:`algorithms.python` and provide
-structured sync reports for different surfaces (API, backend, frontend,
-channels, groups, and routing) along with the master time keeper.  This
-package exposes a stable import path that mirrors other ``dynamic_*``
-modules in the repository.
+Historically a single ``dynamic_keepers`` namespace re-exported the keeper
+algorithms and the data contracts they returned.  The canonical
+implementations now live under :mod:`algorithms.python.*_keeper`, but a
+number of callers – especially orchestration scripts – still import from the
+legacy path.  To keep those integrations working we lazily forward attribute
+access to the modern modules.  This mirrors the approach used by
+``dynamic_engines`` and avoids importing heavy dependencies until a symbol is
+first accessed.
 """
 
-from algorithms.python import (
-    ApiKeeperSyncResult,
-    BackendKeeperSyncResult,
-    ChannelKeeperSyncResult,
-    DynamicAPIKeeperAlgorithm,
-    DynamicBackendKeeperAlgorithm,
-    DynamicChannelKeeperAlgorithm,
-    DynamicFrontendKeeperAlgorithm,
-    DynamicGroupKeeperAlgorithm,
-    DynamicRouteKeeperAlgorithm,
-    DynamicTimeKeeperAlgorithm,
-    FrontendKeeperSyncResult,
-    GroupKeeperSyncResult,
-    RouteKeeperSyncResult,
-    TimeKeeperSyncResult,
-)
+from __future__ import annotations
 
-__all__ = [
-    "ApiKeeperSyncResult",
-    "BackendKeeperSyncResult",
-    "ChannelKeeperSyncResult",
-    "DynamicAPIKeeperAlgorithm",
-    "DynamicBackendKeeperAlgorithm",
-    "DynamicChannelKeeperAlgorithm",
-    "DynamicFrontendKeeperAlgorithm",
-    "DynamicGroupKeeperAlgorithm",
-    "DynamicRouteKeeperAlgorithm",
-    "DynamicTimeKeeperAlgorithm",
-    "FrontendKeeperSyncResult",
-    "GroupKeeperSyncResult",
-    "RouteKeeperSyncResult",
-    "TimeKeeperSyncResult",
-]
+from importlib import import_module
+from typing import Dict, Iterable, Tuple
+
+_KEEPER_EXPORTS: Dict[str, Tuple[str, ...]] = {
+    "algorithms.python.api_keeper": (
+        "ApiEndpoint",
+        "ApiKeeperSyncResult",
+        "DynamicAPIKeeperAlgorithm",
+    ),
+    "algorithms.python.backend_keeper": (
+        "BackendService",
+        "BackendKeeperSyncResult",
+        "DynamicBackendKeeperAlgorithm",
+    ),
+    "algorithms.python.channel_keeper": (
+        "BroadcastChannel",
+        "ChannelKeeperSyncResult",
+        "DynamicChannelKeeperAlgorithm",
+    ),
+    "algorithms.python.frontend_keeper": (
+        "FrontendSurface",
+        "FrontendKeeperSyncResult",
+        "DynamicFrontendKeeperAlgorithm",
+    ),
+    "algorithms.python.group_keeper": (
+        "CommunityGroup",
+        "GroupKeeperSyncResult",
+        "DynamicGroupKeeperAlgorithm",
+    ),
+    "algorithms.python.route_keeper": (
+        "Route",
+        "RouteKeeperSyncResult",
+        "DynamicRouteKeeperAlgorithm",
+    ),
+    "algorithms.python.time_keeper": (
+        "MVT_TIMEZONE",
+        "TradingSession",
+        "KillZone",
+        "TimeKeeperSyncResult",
+        "DynamicTimeKeeperAlgorithm",
+    ),
+}
+
+__all__ = sorted({symbol for symbols in _KEEPER_EXPORTS.values() for symbol in symbols})
+
+
+def _load_symbol(module_name: str, symbol: str) -> object:
+    module = import_module(module_name)
+    value = getattr(module, symbol)
+    globals()[symbol] = value
+    return value
+
+
+def __getattr__(name: str) -> object:
+    for module_name, symbols in _KEEPER_EXPORTS.items():
+        if name in symbols:
+            return _load_symbol(module_name, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> Iterable[str]:
+    return sorted(__all__)

--- a/tests/dynamic_helpers/test_dynamic_helpers_exports.py
+++ b/tests/dynamic_helpers/test_dynamic_helpers_exports.py
@@ -1,0 +1,53 @@
+"""Tests for the ``dynamic_helpers`` lazy export surface."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_dynamic_helpers_exports_reference_canonical_symbols() -> None:
+    dynamic_helpers = importlib.import_module("dynamic_helpers")
+
+    agents_module = importlib.import_module("dynamic_agents")
+    ai_module = importlib.import_module("dynamic_ai")
+    algo_module = importlib.import_module("dynamic_algo")
+    bridge_module = importlib.import_module("dynamic_bridge")
+
+    assert (
+        dynamic_helpers.run_dynamic_agent_cycle
+        is agents_module.run_dynamic_agent_cycle
+    )
+
+    assert (
+        dynamic_helpers.calibrate_lorentzian_lobe
+        is ai_module.calibrate_lorentzian_lobe
+    )
+    assert (
+        dynamic_helpers.load_lorentzian_model is ai_module.load_lorentzian_model
+    )
+
+    assert dynamic_helpers.normalise_symbol is algo_module.normalise_symbol
+    assert dynamic_helpers.ORDER_ACTION_BUY == algo_module.ORDER_ACTION_BUY
+    assert dynamic_helpers.ORDER_ACTION_SELL == algo_module.ORDER_ACTION_SELL
+    assert dynamic_helpers.SUCCESS_RETCODE == algo_module.SUCCESS_RETCODE
+
+    assert (
+        dynamic_helpers.create_dynamic_mt5_bridge
+        is bridge_module.create_dynamic_mt5_bridge
+    )
+
+
+def test_dynamic_helpers_dir_reports_all_exports() -> None:
+    dynamic_helpers = importlib.import_module("dynamic_helpers")
+
+    for symbol in (
+        "run_dynamic_agent_cycle",
+        "calibrate_lorentzian_lobe",
+        "load_lorentzian_model",
+        "normalise_symbol",
+        "ORDER_ACTION_BUY",
+        "ORDER_ACTION_SELL",
+        "SUCCESS_RETCODE",
+        "create_dynamic_mt5_bridge",
+    ):
+        assert symbol in dir(dynamic_helpers)

--- a/tests/dynamic_keepers/test_dynamic_keepers_exports.py
+++ b/tests/dynamic_keepers/test_dynamic_keepers_exports.py
@@ -1,0 +1,94 @@
+"""Tests for the legacy ``dynamic_keepers`` compatibility shims."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_dynamic_keepers_exports_reference_canonical_modules() -> None:
+    dynamic_keepers = importlib.import_module("dynamic_keepers")
+
+    api_module = importlib.import_module("algorithms.python.api_keeper")
+    backend_module = importlib.import_module("algorithms.python.backend_keeper")
+    channel_module = importlib.import_module("algorithms.python.channel_keeper")
+    frontend_module = importlib.import_module("algorithms.python.frontend_keeper")
+    group_module = importlib.import_module("algorithms.python.group_keeper")
+    route_module = importlib.import_module("algorithms.python.route_keeper")
+    time_module = importlib.import_module("algorithms.python.time_keeper")
+
+    assert dynamic_keepers.ApiEndpoint is api_module.ApiEndpoint
+    assert dynamic_keepers.DynamicAPIKeeperAlgorithm is api_module.DynamicAPIKeeperAlgorithm
+    assert dynamic_keepers.ApiKeeperSyncResult is api_module.ApiKeeperSyncResult
+
+    assert dynamic_keepers.BackendService is backend_module.BackendService
+    assert (
+        dynamic_keepers.DynamicBackendKeeperAlgorithm
+        is backend_module.DynamicBackendKeeperAlgorithm
+    )
+    assert (
+        dynamic_keepers.BackendKeeperSyncResult is backend_module.BackendKeeperSyncResult
+    )
+
+    assert dynamic_keepers.BroadcastChannel is channel_module.BroadcastChannel
+    assert (
+        dynamic_keepers.DynamicChannelKeeperAlgorithm
+        is channel_module.DynamicChannelKeeperAlgorithm
+    )
+    assert (
+        dynamic_keepers.ChannelKeeperSyncResult
+        is channel_module.ChannelKeeperSyncResult
+    )
+
+    assert dynamic_keepers.FrontendSurface is frontend_module.FrontendSurface
+    assert (
+        dynamic_keepers.DynamicFrontendKeeperAlgorithm
+        is frontend_module.DynamicFrontendKeeperAlgorithm
+    )
+    assert (
+        dynamic_keepers.FrontendKeeperSyncResult
+        is frontend_module.FrontendKeeperSyncResult
+    )
+
+    assert dynamic_keepers.CommunityGroup is group_module.CommunityGroup
+    assert (
+        dynamic_keepers.DynamicGroupKeeperAlgorithm
+        is group_module.DynamicGroupKeeperAlgorithm
+    )
+    assert (
+        dynamic_keepers.GroupKeeperSyncResult is group_module.GroupKeeperSyncResult
+    )
+
+    assert dynamic_keepers.Route is route_module.Route
+    assert (
+        dynamic_keepers.DynamicRouteKeeperAlgorithm
+        is route_module.DynamicRouteKeeperAlgorithm
+    )
+    assert (
+        dynamic_keepers.RouteKeeperSyncResult is route_module.RouteKeeperSyncResult
+    )
+
+    assert dynamic_keepers.MVT_TIMEZONE is time_module.MVT_TIMEZONE
+    assert dynamic_keepers.TradingSession is time_module.TradingSession
+    assert dynamic_keepers.KillZone is time_module.KillZone
+    assert (
+        dynamic_keepers.DynamicTimeKeeperAlgorithm
+        is time_module.DynamicTimeKeeperAlgorithm
+    )
+    assert dynamic_keepers.TimeKeeperSyncResult is time_module.TimeKeeperSyncResult
+
+
+def test_dynamic_keepers_dir_reports_all_exports() -> None:
+    dynamic_keepers = importlib.import_module("dynamic_keepers")
+
+    for symbol in (
+        "ApiEndpoint",
+        "BackendService",
+        "BroadcastChannel",
+        "FrontendSurface",
+        "CommunityGroup",
+        "Route",
+        "MVT_TIMEZONE",
+        "TradingSession",
+        "KillZone",
+    ):
+        assert symbol in dir(dynamic_keepers)


### PR DESCRIPTION
## Summary
- replace eager imports in `dynamic_keepers` with a lazy export shim that mirrors other dynamic compatibility modules
- cover the legacy `dynamic_keepers` namespace with focused tests to ensure all keeper symbols resolve to the canonical algorithms
- add regression tests for the `dynamic_helpers` lazy export surface

## Testing
- pytest tests/dynamic_keepers tests/dynamic_helpers

------
https://chatgpt.com/codex/tasks/task_e_68d85f23735c8322ad5b128714c06b86