### PR TITLE
Add trading persona to dynamic agents

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -26,6 +26,8 @@ __all__ = [
     "ResearchAgentResult",
     "RiskAgent",
     "RiskAgentResult",
+    "TradingAgent",
+    "TradingAgentResult",
     "SpaceAgent",
     "SpaceAgentResult",
     "run_dynamic_agent_cycle",
@@ -43,6 +45,8 @@ _AGENT_EXPORTS = {
     "ResearchAgentResult",
     "RiskAgent",
     "RiskAgentResult",
+    "TradingAgent",
+    "TradingAgentResult",
     "SpaceAgent",
     "SpaceAgentResult",
 }

--- a/dynamic_agents/trading.py
+++ b/dynamic_agents/trading.py
@@ -1,0 +1,22 @@
+"""Compatibility shim exposing the trading persona lazily."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = ["TradingAgent", "TradingAgentResult"]
+
+if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_ai.agents import TradingAgent, TradingAgentResult
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("dynamic_ai.agents")
+        return getattr(module, name)
+    raise AttributeError(f"module 'dynamic_agents.trading' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(set(globals()) | set(__all__))

--- a/dynamic_ai/__init__.py
+++ b/dynamic_ai/__init__.py
@@ -12,6 +12,8 @@ from .agents import (
     ResearchAgentResult,
     RiskAgent,
     RiskAgentResult,
+    TradingAgent,
+    TradingAgentResult,
     SpaceAgent,
     SpaceAgentResult,
 )
@@ -91,6 +93,8 @@ __all__ = [
     "RiskParameters",
     "RiskAgent",
     "RiskAgentResult",
+    "TradingAgent",
+    "TradingAgentResult",
     "SpaceAgent",
     "SpaceAgentResult",
     "AccountState",

--- a/tests/test_dynamic_trading_agent.py
+++ b/tests/test_dynamic_trading_agent.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from dynamic_ai.agents import TradingAgent, TradingAgentResult
+from dynamic_algo.trading_core import SUCCESS_RETCODE, TradeExecutionResult
+
+
+class StubTrader:
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict[str, str], float, str]] = []
+
+    def execute_trade(self, signal: dict[str, str], *, lot: float, symbol: str) -> TradeExecutionResult:
+        self.calls.append((dict(signal), lot, symbol))
+        return TradeExecutionResult(
+            retcode=SUCCESS_RETCODE,
+            message="filled",
+            profit=12.5,
+            ticket=9876,
+            symbol=symbol,
+            lot=lot,
+            price=1.2345,
+        )
+
+
+@pytest.fixture()
+def agent_cycle() -> dict[str, object]:
+    return {
+        "agents": {
+            "research": {"agent": "research", "rationale": "stub", "confidence": 0.5, "analysis": {}},
+            "execution": {
+                "agent": "execution",
+                "rationale": "stub",
+                "confidence": 0.8,
+                "signal": {"action": "BUY", "confidence": 0.8},
+            },
+            "risk": {
+                "agent": "risk",
+                "rationale": "risk stable",
+                "confidence": 0.7,
+                "adjusted_signal": {"action": "BUY", "confidence": 0.7, "risk_notes": ["stable"]},
+                "hedge_decisions": (),
+                "escalations": (),
+            },
+        },
+        "decision": {"action": "BUY", "confidence": 0.7, "rationale": "alignment"},
+    }
+
+
+def test_trading_agent_uses_payload_cycle(agent_cycle: dict[str, object]) -> None:
+    trader = StubTrader()
+    agent = TradingAgent()
+
+    result = agent.run({"symbol": "ETHUSD", "lot": 0.4, "agent_cycle": agent_cycle, "trader": trader})
+
+    assert isinstance(result, TradingAgentResult)
+    assert trader.calls and trader.calls[0][2] == "ETHUSD"
+    assert result.trade["symbol"] == "ETHUSD"
+    assert result.decision["action"] == "BUY"
+    assert result.rationale == "alignment"
+    assert pytest.approx(result.confidence, rel=1e-6) == 0.7
+
+
+def test_trading_agent_respects_default_trader(agent_cycle: dict[str, object]) -> None:
+    trader = StubTrader()
+    agent = TradingAgent(trader=trader)
+
+    result = agent.run({"symbol": "XAUUSD", "lot": 0.2, "agent_cycle": agent_cycle})
+
+    assert trader.calls and trader.calls[0][2] == "XAUUSD"
+    assert result.trade["status"] == "executed"
+    assert result.trade["ticket"] == 9876
+    assert result.optimisation["status"] == "executed"


### PR DESCRIPTION
## Summary
- introduce a TradingAgent persona that wraps the Dynamic Trading Algo alignment flow and returns structured TradingAgentResult payloads
- expose the new trading persona through the dynamic_agents shim for backwards-compatible imports
- add targeted tests covering trading agent orchestration and default trader injection behaviour

## Testing
- pytest tests/test_dynamic_trading_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d85fd806fc83229a79987a34c1bb63