### PR TITLE
Add celebrity star agents roster

### DIFF
--- a/docs/celebrity-stars-overview.md
+++ b/docs/celebrity-stars-overview.md
@@ -1,0 +1,107 @@
+# Celebrity Stars Overview
+
+## The Sun: Our Life-Giving Star
+
+- Distance: Approximately 150 million kilometers (1 astronomical unit) from
+  Earth.
+- Role: Supplies the light, heat, and energy necessary to sustain life on Earth.
+
+## Celebrity Star Agents
+
+The dynamic star engine now ships with hand-crafted `StarAgent` records for each
+celebrity listed below. Import them with:
+
+```python
+from dynamic_star_engine import get_celebrity_agents
+
+for agent in get_celebrity_agents():
+    print(agent.designation, agent.roles)
+```
+
+Each agent includes approximate spectral classifications, absolute magnitudes,
+and distances in light-years so they can slot directly into simulations alongside
+procedurally generated stars.
+
+## Brightest Stars in the Night Sky
+
+1. **Sirius (Alpha Canis Majoris)** – The brightest star in the night sky, known
+   as the "Dog Star."
+2. **Canopus (Alpha Carinae)** – The second-brightest star, prominent in the
+   Southern Hemisphere.
+3. **Rigil Kentaurus / Alpha Centauri** – The closest star system to Earth after
+   the Sun and home to Proxima Centauri.
+4. **Arcturus (Alpha Boötis)** – An orange giant that shines brightly in the
+   Northern Hemisphere.
+5. **Vega (Alpha Lyrae)** – Among the most studied stars and a key vertex of the
+   Summer Triangle.
+6. **Capella (Alpha Aurigae)** – A bright yellow star system that appears
+   similar to the Sun.
+7. **Rigel (Beta Orionis)** – A blue supergiant located in the constellation
+   Orion.
+8. **Procyon (Alpha Canis Minoris)** – A bright, nearby star that forms part of
+   the Winter Triangle.
+9. **Achernar (Alpha Eridani)** – A very hot, bright star visible in southern
+   skies.
+10. **Betelgeuse (Alpha Orionis)** – A well-known red supergiant in Orion that
+    is expected to eventually explode as a supernova.
+
+## Famous Stars by Role
+
+- **Polaris (North Star)** – Almost directly above Earth's north pole, making it
+  crucial for navigation.
+- **Aldebaran (Alpha Tauri)** – A red giant marking the "eye of the bull" in
+  Taurus.
+- **Spica (Alpha Virginis)** – A bright blue star that anchors the constellation
+  Virgo.
+- **Antares (Alpha Scorpii)** – A red supergiant that represents the "heart of
+  the scorpion."
+- **Altair (Alpha Aquilae)** – Forms part of the Summer Triangle along with Vega
+  and Deneb.
+- **Deneb (Alpha Cygni)** – A luminous blue-white supergiant and another vertex
+  of the Summer Triangle.
+
+## Nearby Stars of Scientific Interest
+
+- **Proxima Centauri** – The closest known star to Earth at about 4.24
+  light-years away; part of the Alpha Centauri system.
+- **Barnard's Star** – One of the nearest stars, frequently studied in the
+  search for exoplanets.
+- **Wolf 359** – A faint red dwarf star notable in both astronomy and science
+  fiction lore.
+
+## Generate Dynamic Star Names
+
+Use the `dynamic_star_names` toolkit to synthesize new, on-brand star names for
+fictional catalogs, games, or concept demos:
+
+```ts
+import { generateStarNames } from "../dynamic_star_names/generator.ts";
+// ↑ Adjust the relative path if you place this snippet outside the docs folder.
+
+const showcase = generateStarNames(5, {
+  seed: "nebulae",
+  style: "hybrid",
+  includeSpectralClass: true,
+  includeDesignation: true,
+});
+
+console.log(showcase.join("\n"));
+```
+
+Sample output (deterministic for the seed provided):
+
+```
+Empyreal Crown of Delta Aquilae (F0) B
+Nebular Paradox of Tau Centauri (G6) A
+Obsidian Voyager of Sigma Persei (B7) D
+Prismatic Nomad of Omicron Boötis (F2) B
+Luminous Helix of Rho Lyrae (A5) E
+```
+
+## Astronomical Perspective
+
+Astronomers have cataloged billions of stars, yet the objects listed above stand
+out as "celebrity stars"—they are bright, scientifically significant, and
+frequently referenced in both research and popular culture. The dynamic name
+builder lets you extend that list with bespoke entries while staying grounded in
+astronomical conventions.

--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -81,6 +81,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_self_awareness": ("DynamicSelfAwareness",),
     "dynamic_skeleton": ("DynamicGovernanceAlgo", "DynamicComplianceAlgo"),
     "dynamic_states": ("DynamicStateEngine",),
+    "dynamic_star_engine": ("DynamicStarEngine", "StarAgent"),
     "dynamic_stem_cell": ("DynamicStemCell",),
     "dynamic_syncronization": ("DynamicSyncronizationOrchestrator",),
     "dynamic_text": ("DynamicTextEngine",),

--- a/dynamic_star_engine/__init__.py
+++ b/dynamic_star_engine/__init__.py
@@ -1,0 +1,13 @@
+"""Dynamic star agent orchestration utilities."""
+
+from .agents import StarAgent
+from .celebrity import CELEBRITY_STAR_AGENTS, get_celebrity_agents
+from .engine import DynamicStarEngine, StarAgentSeed
+
+__all__ = [
+    "StarAgent",
+    "DynamicStarEngine",
+    "StarAgentSeed",
+    "CELEBRITY_STAR_AGENTS",
+    "get_celebrity_agents",
+]

--- a/dynamic_star_engine/agents.py
+++ b/dynamic_star_engine/agents.py
@@ -1,0 +1,81 @@
+"""Data structures describing synthetic star agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, MutableMapping, Sequence
+
+__all__ = ["StarAgent"]
+
+
+@dataclass(slots=True)
+class StarAgent:
+    """Container describing a synthetic star persona."""
+
+    identifier: str
+    designation: str
+    spectral_type: str
+    absolute_magnitude: float
+    distance_ly: float
+    roles: tuple[str, ...] = field(default_factory=tuple)
+    temperament: Mapping[str, float] = field(default_factory=dict)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        """Serialise the agent to a JSON-friendly mapping."""
+
+        return {
+            "identifier": self.identifier,
+            "designation": self.designation,
+            "spectral_type": self.spectral_type,
+            "absolute_magnitude": self.absolute_magnitude,
+            "distance_ly": self.distance_ly,
+            "roles": list(self.roles),
+            "temperament": dict(self.temperament),
+            "tags": list(self.tags),
+            "metadata": dict(self.metadata) if self.metadata is not None else None,
+        }
+
+    def with_roles(self, *roles: str) -> "StarAgent":
+        """Return a copy with the provided roles merged in."""
+
+        merged_roles = _merge_unique((*self.roles, *roles))
+        return StarAgent(
+            identifier=self.identifier,
+            designation=self.designation,
+            spectral_type=self.spectral_type,
+            absolute_magnitude=self.absolute_magnitude,
+            distance_ly=self.distance_ly,
+            roles=merged_roles,
+            temperament=self.temperament,
+            tags=self.tags,
+            metadata=self.metadata,
+        )
+
+    def with_tags(self, *tags: str) -> "StarAgent":
+        """Return a copy with the provided tags merged in."""
+
+        merged_tags = _merge_unique((*self.tags, *tags))
+        return StarAgent(
+            identifier=self.identifier,
+            designation=self.designation,
+            spectral_type=self.spectral_type,
+            absolute_magnitude=self.absolute_magnitude,
+            distance_ly=self.distance_ly,
+            roles=self.roles,
+            temperament=self.temperament,
+            tags=merged_tags,
+            metadata=self.metadata,
+        )
+
+
+def _merge_unique(values: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    merged: list[str] = []
+    for value in values:
+        cleaned = value.strip()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            merged.append(cleaned)
+    return tuple(merged)

--- a/dynamic_star_engine/celebrity.py
+++ b/dynamic_star_engine/celebrity.py
@@ -1,0 +1,266 @@
+"""Predefined agents representing well-known real-world stars."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+from .agents import StarAgent
+
+__all__ = ["CELEBRITY_STAR_AGENTS", "get_celebrity_agents"]
+
+
+def _slugify(name: str) -> str:
+    slug: list[str] = []
+    last_dash = False
+    for char in name.lower():
+        if char.isalnum():
+            slug.append(char)
+            last_dash = False
+        elif char in {" ", "-"}:
+            if not last_dash and slug:
+                slug.append("-")
+                last_dash = True
+        else:
+            last_dash = False
+            continue
+    return "".join(slug).strip("-")
+
+
+def _build_agent(
+    *,
+    name: str,
+    designation: str,
+    spectral_type: str,
+    absolute_magnitude: float,
+    distance_ly: float,
+    roles: Sequence[str],
+    tags: Sequence[str],
+    metadata: Mapping[str, object],
+) -> StarAgent:
+    identifier = _slugify(name)
+    return StarAgent(
+        identifier=identifier,
+        designation=designation,
+        spectral_type=spectral_type,
+        absolute_magnitude=absolute_magnitude,
+        distance_ly=distance_ly,
+        roles=tuple(roles),
+        tags=tuple(tags),
+        metadata=dict(metadata),
+    )
+
+
+def _agents() -> Iterable[StarAgent]:
+    yield _build_agent(
+        name="The Sun",
+        designation="The Sun",
+        spectral_type="G2V",
+        absolute_magnitude=4.83,
+        distance_ly=1.5813e-5,
+        roles=["Life-Giving Star"],
+        tags=["sol", "celebrity"],
+        metadata={
+            "distance_km": 150_000_000,
+            "description": "Our home star providing the light and heat required for life on Earth.",
+        },
+    )
+    yield _build_agent(
+        name="Sirius",
+        designation="Sirius (Alpha Canis Majoris)",
+        spectral_type="A1V",
+        absolute_magnitude=1.42,
+        distance_ly=8.6,
+        roles=["Brightest Night Sky Star"],
+        tags=["brightest", "dog-star"],
+        metadata={"notable_for": "Brightest star visible from Earth."},
+    )
+    yield _build_agent(
+        name="Canopus",
+        designation="Canopus (Alpha Carinae)",
+        spectral_type="A9II",
+        absolute_magnitude=-5.53,
+        distance_ly=310.0,
+        roles=["Brightest Night Sky Star"],
+        tags=["southern", "navigation"],
+        metadata={"notable_for": "Second-brightest star, dominant in the southern sky."},
+    )
+    yield _build_agent(
+        name="Rigil Kentaurus",
+        designation="Rigil Kentaurus (Alpha Centauri)",
+        spectral_type="G2V + K1V",
+        absolute_magnitude=4.38,
+        distance_ly=4.37,
+        roles=["Brightest Night Sky Star", "Nearby System"],
+        tags=["alpha-centauri", "binary"],
+        metadata={"notable_for": "Closest star system to Earth after the Sun."},
+    )
+    yield _build_agent(
+        name="Arcturus",
+        designation="Arcturus (Alpha Boötis)",
+        spectral_type="K1.5III",
+        absolute_magnitude=-0.30,
+        distance_ly=36.7,
+        roles=["Brightest Night Sky Star"],
+        tags=["northern", "orange-giant"],
+        metadata={"notable_for": "Luminous orange giant visible in the northern hemisphere."},
+    )
+    yield _build_agent(
+        name="Vega",
+        designation="Vega (Alpha Lyrae)",
+        spectral_type="A0V",
+        absolute_magnitude=0.58,
+        distance_ly=25.0,
+        roles=["Brightest Night Sky Star", "Summer Triangle"],
+        tags=["lyra", "benchmark"],
+        metadata={"notable_for": "Well-studied reference star and part of the Summer Triangle."},
+    )
+    yield _build_agent(
+        name="Capella",
+        designation="Capella (Alpha Aurigae)",
+        spectral_type="G5III + G0III",
+        absolute_magnitude=0.37,
+        distance_ly=42.9,
+        roles=["Brightest Night Sky Star"],
+        tags=["binary", "northern"],
+        metadata={"notable_for": "Yellow giant pair resembling a brighter version of the Sun."},
+    )
+    yield _build_agent(
+        name="Rigel",
+        designation="Rigel (Beta Orionis)",
+        spectral_type="B8Ia",
+        absolute_magnitude=-6.69,
+        distance_ly=860.0,
+        roles=["Brightest Night Sky Star"],
+        tags=["blue-supergiant", "orion"],
+        metadata={"notable_for": "Blue supergiant anchoring the constellation Orion."},
+    )
+    yield _build_agent(
+        name="Procyon",
+        designation="Procyon (Alpha Canis Minoris)",
+        spectral_type="F5IV-V",
+        absolute_magnitude=2.66,
+        distance_ly=11.46,
+        roles=["Brightest Night Sky Star"],
+        tags=["nearby", "winter-triangle"],
+        metadata={"notable_for": "Bright nearby star forming the Winter Triangle."},
+    )
+    yield _build_agent(
+        name="Achernar",
+        designation="Achernar (Alpha Eridani)",
+        spectral_type="B6Vep",
+        absolute_magnitude=-2.77,
+        distance_ly=139.0,
+        roles=["Brightest Night Sky Star"],
+        tags=["southern", "rapid-rotator"],
+        metadata={"notable_for": "Rapidly rotating, extremely hot star in the southern sky."},
+    )
+    yield _build_agent(
+        name="Betelgeuse",
+        designation="Betelgeuse (Alpha Orionis)",
+        spectral_type="M1-2Ia-Iab",
+        absolute_magnitude=-5.85,
+        distance_ly=548.0,
+        roles=["Brightest Night Sky Star", "Supernova Progenitor"],
+        tags=["red-supergiant", "variable"],
+        metadata={"notable_for": "Variable red supergiant expected to end in a supernova."},
+    )
+    yield _build_agent(
+        name="Polaris",
+        designation="Polaris (Alpha Ursae Minoris)",
+        spectral_type="F7Ib",
+        absolute_magnitude=-3.64,
+        distance_ly=433.0,
+        roles=["Navigational Star"],
+        tags=["north-star", "cepheid"],
+        metadata={"notable_for": "North Star positioned nearly above Earth's north pole."},
+    )
+    yield _build_agent(
+        name="Aldebaran",
+        designation="Aldebaran (Alpha Tauri)",
+        spectral_type="K5III",
+        absolute_magnitude=-0.63,
+        distance_ly=65.3,
+        roles=["Navigational Star"],
+        tags=["taurus", "red-giant"],
+        metadata={"notable_for": "Marks the eye of Taurus in the night sky."},
+    )
+    yield _build_agent(
+        name="Spica",
+        designation="Spica (Alpha Virginis)",
+        spectral_type="B1III-IV",
+        absolute_magnitude=-3.55,
+        distance_ly=250.0,
+        roles=["Navigational Star"],
+        tags=["virgo", "binary"],
+        metadata={"notable_for": "Blue double star forming the anchor of Virgo."},
+    )
+    yield _build_agent(
+        name="Antares",
+        designation="Antares (Alpha Scorpii)",
+        spectral_type="M1.5Iab-Ib",
+        absolute_magnitude=-5.28,
+        distance_ly=554.0,
+        roles=["Navigational Star", "Supernova Progenitor"],
+        tags=["red-supergiant", "scorpius"],
+        metadata={"notable_for": "Red supergiant forming the heart of Scorpius."},
+    )
+    yield _build_agent(
+        name="Altair",
+        designation="Altair (Alpha Aquilae)",
+        spectral_type="A7V",
+        absolute_magnitude=2.21,
+        distance_ly=16.7,
+        roles=["Navigational Star", "Summer Triangle"],
+        tags=["aquila", "rapid-rotator"],
+        metadata={"notable_for": "Forms the Summer Triangle with Vega and Deneb."},
+    )
+    yield _build_agent(
+        name="Deneb",
+        designation="Deneb (Alpha Cygni)",
+        spectral_type="A2Ia",
+        absolute_magnitude=-7.20,
+        distance_ly=2615.0,
+        roles=["Navigational Star", "Summer Triangle"],
+        tags=["cygnus", "blue-supergiant"],
+        metadata={"notable_for": "Luminous blue-white supergiant completing the Summer Triangle."},
+    )
+    yield _build_agent(
+        name="Proxima Centauri",
+        designation="Proxima Centauri",
+        spectral_type="M5.5Ve",
+        absolute_magnitude=15.53,
+        distance_ly=4.24,
+        roles=["Nearby System"],
+        tags=["alpha-centauri", "red-dwarf"],
+        metadata={"notable_for": "Closest star to the Sun and a prime exoplanet target."},
+    )
+    yield _build_agent(
+        name="Barnard's Star",
+        designation="Barnard's Star",
+        spectral_type="M4Ve",
+        absolute_magnitude=13.24,
+        distance_ly=5.96,
+        roles=["Nearby System"],
+        tags=["red-dwarf", "high-proper-motion"],
+        metadata={"notable_for": "Nearby red dwarf famed for its high proper motion."},
+    )
+    yield _build_agent(
+        name="Wolf 359",
+        designation="Wolf 359",
+        spectral_type="M6Ve",
+        absolute_magnitude=16.65,
+        distance_ly=7.86,
+        roles=["Nearby System"],
+        tags=["red-dwarf", "faint"],
+        metadata={"notable_for": "Dim red dwarf of interest to astronomers and science fiction."},
+    )
+
+
+CELEBRITY_STAR_AGENTS: tuple[StarAgent, ...] = tuple(_agents())
+
+
+def get_celebrity_agents() -> tuple[StarAgent, ...]:
+    """Return the immutable roster of celebrity star agents."""
+
+    return CELEBRITY_STAR_AGENTS
+

--- a/dynamic_star_engine/engine.py
+++ b/dynamic_star_engine/engine.py
@@ -1,0 +1,495 @@
+"""Procedural generation utilities for dynamic star agents."""
+
+from __future__ import annotations
+
+import math
+import random
+import unicodedata
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Dict, Mapping, Sequence
+from typing import Literal, cast
+
+from .agents import StarAgent
+
+__all__ = ["DynamicStarEngine", "StarAgentSeed"]
+
+# Styles supported by both the Python engine and the TypeScript star name
+# generator.  Using ``Literal`` keeps the public API type-safe and allows us to
+# validate caller input before attempting to build names.
+StarStyle = Literal["classical", "mythic", "catalog", "hybrid"]
+
+
+DEFAULT_VOCABULARY: Mapping[str, Sequence[str]] = {
+    "greek_letters": (
+        "Alpha",
+        "Beta",
+        "Gamma",
+        "Delta",
+        "Epsilon",
+        "Zeta",
+        "Eta",
+        "Theta",
+        "Iota",
+        "Kappa",
+        "Lambda",
+        "Mu",
+        "Nu",
+        "Xi",
+        "Omicron",
+        "Pi",
+        "Rho",
+        "Sigma",
+        "Tau",
+        "Upsilon",
+        "Phi",
+        "Chi",
+        "Psi",
+        "Omega",
+    ),
+    "constellations": (
+        "Andromedae",
+        "Aquilae",
+        "Aurigae",
+        "Boötis",
+        "Canis Majoris",
+        "Carinae",
+        "Cassiopeiae",
+        "Centauri",
+        "Cygni",
+        "Draconis",
+        "Eridani",
+        "Geminorum",
+        "Leonis",
+        "Lyrae",
+        "Orionis",
+        "Pegasi",
+        "Persei",
+        "Sagittarii",
+        "Scorpii",
+        "Tauri",
+        "Ursae Majoris",
+        "Ursae Minoris",
+        "Virginis",
+    ),
+    "mythic_descriptors": (
+        "Luminous",
+        "Radiant",
+        "Arcane",
+        "Celestial",
+        "Wandering",
+        "Eternal",
+        "Glacial",
+        "Solar",
+        "Nebular",
+        "Verdant",
+        "Harmonic",
+        "Resonant",
+        "Empyreal",
+        "Obsidian",
+        "Auroral",
+        "Chrono",
+        "Stellar",
+        "Prismatic",
+        "Vanguard",
+        "Aether",
+    ),
+    "mythic_cores": (
+        "Phoenix",
+        "Drake",
+        "Oracle",
+        "Nomad",
+        "Sentinel",
+        "Aegis",
+        "Lyric",
+        "Crown",
+        "Harbinger",
+        "Grove",
+        "Lattice",
+        "Paradox",
+        "Spire",
+        "Monolith",
+        "Echo",
+        "Harmony",
+        "Pulse",
+        "Voyager",
+        "Helix",
+        "Beacon",
+    ),
+    "catalog_prefixes": ("HD", "HR", "HIP", "BD", "SAO", "TYC", "Gaia"),
+    "spectral_classes": ("O", "B", "A", "F", "G", "K", "M"),
+    "designations": ("A", "B", "C", "D", "E"),
+    "luminosity_classes": ("Ia", "Ib", "II", "III", "IV", "V"),
+}
+
+
+@dataclass(frozen=True)
+class StarAgentSeed:
+    """Parameters controlling how agents are generated."""
+
+    style: StarStyle = "hybrid"
+    include_spectral_class: bool = True
+    include_designation: bool = False
+    vocabulary: Mapping[str, Sequence[str]] | None = None
+
+
+@dataclass(frozen=True)
+class _ResolvedSeed:
+    """Immutable configuration used for a single generation step."""
+
+    style: StarStyle
+    include_spectral_class: bool
+    include_designation: bool
+    vocabulary: Mapping[str, Sequence[str]]
+
+
+class DynamicStarEngine:
+    """Create deterministic star agents suitable for simulations."""
+
+    def __init__(
+        self,
+        *,
+        seed: int | str | None = None,
+        defaults: StarAgentSeed | None = None,
+    ) -> None:
+        self._seed = seed
+        self._defaults = defaults or StarAgentSeed()
+        self._invocation_index = 0
+
+    def spawn_agent(
+        self,
+        *,
+        role: str | None = None,
+        tags: Sequence[str] | None = None,
+        metadata: Mapping[str, object] | None = None,
+        style: str | None = None,
+        include_spectral_class: bool | None = None,
+        include_designation: bool | None = None,
+        vocabulary: Mapping[str, Sequence[str]] | None = None,
+    ) -> StarAgent:
+        """Generate a deterministic agent from the configured seed."""
+
+        config = self._resolve_config(
+            style=style,
+            include_spectral_class=include_spectral_class,
+            include_designation=include_designation,
+            vocabulary=vocabulary,
+        )
+        tags_tuple = _normalise_sequence(tags or ())
+        agent = self._spawn_agent_at(
+            self._invocation_index,
+            config,
+            role=role,
+            tags=tags_tuple,
+            metadata=metadata,
+        )
+        self._invocation_index += 1
+        return agent
+
+    def spawn_roster(
+        self,
+        count: int,
+        *,
+        roles: Sequence[str] | None = None,
+        tags: Sequence[str] | None = None,
+        style: str | None = None,
+        include_spectral_class: bool | None = None,
+        include_designation: bool | None = None,
+        vocabulary: Mapping[str, Sequence[str]] | None = None,
+    ) -> list[StarAgent]:
+        """Generate a roster of star agents with deterministic ordering."""
+
+        if count <= 0 or not math.isfinite(count):
+            raise ValueError("count must be a positive finite number")
+
+        resolved = self._resolve_config(
+            style=style,
+            include_spectral_class=include_spectral_class,
+            include_designation=include_designation,
+            vocabulary=vocabulary,
+        )
+        tags_tuple = _normalise_sequence(tags or ())
+        role_cycle = list(roles or ())
+
+        roster: list[StarAgent] = []
+        for index in range(int(count)):
+            role = role_cycle[index % len(role_cycle)] if role_cycle else None
+            roster.append(
+                self._spawn_agent_at(
+                    self._invocation_index,
+                    resolved,
+                    role=role,
+                    tags=tags_tuple,
+                    metadata=None,
+                )
+            )
+            self._invocation_index += 1
+        return roster
+
+    def preview(
+        self,
+        count: int,
+        *,
+        style: str | None = None,
+        include_spectral_class: bool | None = None,
+        include_designation: bool | None = None,
+        vocabulary: Mapping[str, Sequence[str]] | None = None,
+    ) -> list[str]:
+        """Return a quick-look list of generated designations."""
+
+        if count <= 0 or not math.isfinite(count):
+            raise ValueError("count must be a positive finite number")
+
+        resolved = self._resolve_config(
+            style=style,
+            include_spectral_class=include_spectral_class,
+            include_designation=include_designation,
+            vocabulary=vocabulary,
+        )
+        return [
+            self._spawn_agent_at(
+                self._invocation_index + index,
+                resolved,
+                role=None,
+                tags=(),
+                metadata=None,
+            ).designation
+            for index in range(int(count))
+        ]
+
+    def all_designations(
+        self,
+        *,
+        style: str | None = None,
+        vocabulary: Mapping[str, Sequence[str]] | None = None,
+    ) -> list[str]:
+        """Enumerate every designation available for deterministic styles."""
+
+        resolved = self._resolve_config(
+            style=style,
+            include_spectral_class=None,
+            include_designation=None,
+            vocabulary=vocabulary,
+        )
+        return list(_enumerate_designations(resolved.style, resolved.vocabulary))
+
+    def _build_rng(self, offset: int) -> random.Random:
+        seed = self._seed
+        if seed is None:
+            return random.Random()
+        chained = f"{seed}:{offset}" if offset else str(seed)
+        return random.Random(chained)
+
+    def _resolve_config(
+        self,
+        *,
+        style: str | None,
+        include_spectral_class: bool | None,
+        include_designation: bool | None,
+        vocabulary: Mapping[str, Sequence[str]] | None,
+    ) -> _ResolvedSeed:
+        defaults = self._defaults
+        style_value = style or defaults.style
+        if style_value not in {"classical", "mythic", "catalog", "hybrid"}:
+            raise ValueError(f"unknown star style: {style_value!r}")
+
+        include_spectral = (
+            include_spectral_class
+            if include_spectral_class is not None
+            else defaults.include_spectral_class
+        )
+        include_designation_value = (
+            include_designation
+            if include_designation is not None
+            else defaults.include_designation
+        )
+
+        vocab_source = vocabulary or defaults.vocabulary
+        vocabulary_value = _normalise_vocabulary(vocab_source)
+
+        resolved_style = cast(StarStyle, style_value)
+        return _ResolvedSeed(
+            style=resolved_style,
+            include_spectral_class=include_spectral,
+            include_designation=include_designation_value,
+            vocabulary=vocabulary_value,
+        )
+
+    def _generate_name(self, rng: random.Random, config: _ResolvedSeed) -> str:
+        vocab = config.vocabulary
+        style = config.style
+        if style == "classical":
+            name = _classical_name(rng, vocab)
+        elif style == "mythic":
+            name = _mythic_name(rng, vocab)
+        elif style == "catalog":
+            name = _catalog_name(rng, vocab)
+        else:
+            name = _hybrid_name(rng, vocab)
+
+        segments = [name]
+        if config.include_spectral_class:
+            spectral = rng.choice(vocab["spectral_classes"])
+            subclass = rng.randrange(10)
+            segments.append(f"({spectral}{subclass})")
+        if config.include_designation:
+            segments.append(rng.choice(vocab["designations"]))
+        return " ".join(segments)
+
+    def _generate_spectral_type(
+        self,
+        rng: random.Random,
+        config: _ResolvedSeed,
+        name: str,
+    ) -> str:
+        vocab = config.vocabulary
+        spectral = rng.choice(vocab["spectral_classes"])
+        subclass = rng.randrange(10)
+        luminosity = rng.choice(vocab["luminosity_classes"])
+        checksum = sum(ord(char) for char in name) % 3
+        variability = ("var", "pec", "std")[checksum]
+        return f"{spectral}{subclass} {luminosity} {variability}"
+
+    def _spawn_agent_at(
+        self,
+        offset: int,
+        config: _ResolvedSeed,
+        *,
+        role: str | None,
+        tags: tuple[str, ...],
+        metadata: Mapping[str, object] | None,
+    ) -> StarAgent:
+        rng = self._build_rng(offset)
+        name = self._generate_name(rng, config)
+        spectral_type = self._generate_spectral_type(rng, config, name)
+        magnitude = _round(rng.uniform(-5.5, 14.0), 3)
+        distance = _round(rng.uniform(3.2, 1500.0), 3)
+        temperament = _build_temperament(rng)
+        role_tuple = _normalise_sequence((role,) if role else ())
+        identifier = _slugify(name)
+
+        return StarAgent(
+            identifier=identifier,
+            designation=name,
+            spectral_type=spectral_type,
+            absolute_magnitude=magnitude,
+            distance_ly=distance,
+            roles=role_tuple,
+            temperament=temperament,
+            tags=tags,
+            metadata=dict(metadata) if metadata is not None else None,
+        )
+
+
+def _normalise_vocabulary(
+    overrides: Mapping[str, Sequence[str]] | None,
+) -> Mapping[str, Sequence[str]]:
+    if overrides is None:
+        return DEFAULT_VOCABULARY
+
+    merged: Dict[str, Sequence[str]] = {
+        key: tuple(values) for key, values in DEFAULT_VOCABULARY.items()
+    }
+    for key, values in overrides.items():
+        normalised = tuple(values)
+        if not normalised:
+            raise ValueError(f"vocabulary[{key!r}] must not be empty")
+        merged[key] = normalised
+    return MappingProxyType(merged)
+
+
+def _classical_name(rng: random.Random, vocab: Mapping[str, Sequence[str]]) -> str:
+    return f"{rng.choice(vocab['greek_letters'])} {rng.choice(vocab['constellations'])}"
+
+
+def _mythic_name(rng: random.Random, vocab: Mapping[str, Sequence[str]]) -> str:
+    return f"{rng.choice(vocab['mythic_descriptors'])} {rng.choice(vocab['mythic_cores'])}"
+
+
+def _catalog_name(rng: random.Random, vocab: Mapping[str, Sequence[str]]) -> str:
+    prefix = rng.choice(vocab["catalog_prefixes"])
+    digits = rng.randrange(1000, 9999)
+    suffix = rng.randrange(100)
+    return f"{prefix} {digits}{suffix:02d}"
+
+
+def _hybrid_name(rng: random.Random, vocab: Mapping[str, Sequence[str]]) -> str:
+    return f"{_mythic_name(rng, vocab)} of {_classical_name(rng, vocab)}"
+
+
+def _enumerate_designations(
+    style: StarStyle,
+    vocabulary: Mapping[str, Sequence[str]],
+) -> Sequence[str]:
+    if style == "classical":
+        return _enumerate_classical(vocabulary)
+    if style == "mythic":
+        return _enumerate_mythic(vocabulary)
+    if style == "hybrid":
+        return _enumerate_hybrid(vocabulary)
+    # Catalog designations rely on pseudo-random numeric components and would
+    # explode combinatorially if enumerated. Callers should instead request the
+    # specific amount they need via ``preview`` or ``spawn_roster``.
+    raise ValueError("catalog designations cannot be enumerated exhaustively")
+
+
+def _enumerate_classical(
+    vocabulary: Mapping[str, Sequence[str]],
+) -> Sequence[str]:
+    letters = vocabulary["greek_letters"]
+    constellations = vocabulary["constellations"]
+    return [
+        f"{letter} {constellation}"
+        for letter in letters
+        for constellation in constellations
+    ]
+
+
+def _enumerate_mythic(
+    vocabulary: Mapping[str, Sequence[str]],
+) -> Sequence[str]:
+    descriptors = vocabulary["mythic_descriptors"]
+    cores = vocabulary["mythic_cores"]
+    return [f"{descriptor} {core}" for descriptor in descriptors for core in cores]
+
+
+def _enumerate_hybrid(
+    vocabulary: Mapping[str, Sequence[str]],
+) -> Sequence[str]:
+    mythic_names = _enumerate_mythic(vocabulary)
+    classical_names = _enumerate_classical(vocabulary)
+    return [f"{mythic} of {classical}" for mythic in mythic_names for classical in classical_names]
+
+
+def _build_temperament(rng: random.Random) -> Mapping[str, float]:
+    traits = {
+        "stability": rng.uniform(0.2, 0.95),
+        "curiosity": rng.uniform(0.3, 0.99),
+        "ingenuity": rng.uniform(0.25, 0.98),
+        "influence": rng.uniform(0.1, 0.9),
+    }
+    return {key: _round(value, 3) for key, value in traits.items()}
+
+
+def _normalise_sequence(values: Sequence[str]) -> tuple[str, ...]:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        stripped = value.strip()
+        if stripped and stripped not in seen:
+            cleaned.append(stripped)
+            seen.add(stripped)
+    return tuple(cleaned)
+
+
+def _slugify(value: str) -> str:
+    normalised = unicodedata.normalize("NFKD", value)
+    ascii_value = normalised.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_value.lower()
+    slug = "".join(char if char.isalnum() else "-" for char in lowered)
+    slug = "-".join(filter(None, slug.split("-")))
+    return slug or "star-agent"
+
+
+def _round(value: float, precision: int) -> float:
+    return round(value, precision)

--- a/dynamic_star_names/generator.test.ts
+++ b/dynamic_star_names/generator.test.ts
@@ -1,0 +1,105 @@
+import {
+  assertEquals,
+  assertMatch,
+  assertThrows,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  generateAllStarNames,
+  generateStarName,
+  generateStarNames,
+} from "./generator.ts";
+
+Deno.test("deterministic output for seeded generator", () => {
+  const first = generateStarName({
+    seed: "mentor",
+    includeSpectralClass: true,
+    includeDesignation: true,
+  });
+  const second = generateStarName({
+    seed: "mentor",
+    includeSpectralClass: true,
+    includeDesignation: true,
+  });
+  assertEquals(first, second);
+  assertMatch(first, /\(.*\) [A-E]$/);
+});
+
+Deno.test("bulk generation produces unique-looking catalogue", () => {
+  const names = generateStarNames(5, {
+    seed: 42,
+    style: "hybrid",
+    includeSpectralClass: true,
+  });
+  assertEquals(names, [
+    "Resonant Sentinel of Beta Sagittarii (B2)",
+    "Chrono Nomad of Iota Carinae (G5)",
+    "Auroral Lattice of Eta Centauri (O7)",
+    "Empyreal Crown of Gamma Cygni (K6)",
+    "Solar Pulse of Mu Aquilae (G6)",
+  ]);
+});
+
+Deno.test("custom vocabulary overrides default lexicon", () => {
+  const names = generateStarNames(3, {
+    seed: "custom",
+    vocabulary: {
+      mythicDescriptors: ["Crimson"],
+      mythicCores: ["Hydra", "Hydra"],
+      constellations: ["Hydrae"],
+      greekLetters: ["Zeta"],
+    },
+  });
+
+  names.forEach((name) => {
+    assertMatch(name, /Crimson Hydra/);
+    assertMatch(name, /Hydrae/);
+  });
+});
+
+Deno.test("empty vocabulary overrides raise", () => {
+  assertThrows(
+    () =>
+      generateStarName({
+        seed: 99,
+        vocabulary: {
+          greekLetters: [] as string[],
+        },
+      }),
+    Error,
+    "vocabulary.greekLetters must not be empty",
+  );
+});
+
+Deno.test("enumerating classical names returns full catalog", () => {
+  const names = generateAllStarNames({ style: "classical" });
+  assertEquals(names.length, 24 * 23);
+  assertEquals(names[0], "Alpha Andromedae");
+  assertEquals(names.at(-1), "Omega Virginis");
+});
+
+Deno.test("hybrid enumeration respects custom vocabulary", () => {
+  const names = generateAllStarNames({
+    style: "hybrid",
+    vocabulary: {
+      mythicDescriptors: ["Radiant"],
+      mythicCores: ["Oracle", "Monolith"],
+      greekLetters: ["Alpha", "Beta"],
+      constellations: ["Lyrae"],
+    },
+  });
+
+  assertEquals(names, [
+    "Radiant Oracle of Alpha Lyrae",
+    "Radiant Oracle of Beta Lyrae",
+    "Radiant Monolith of Alpha Lyrae",
+    "Radiant Monolith of Beta Lyrae",
+  ]);
+});
+
+Deno.test("catalog enumeration rejects request", () => {
+  assertThrows(
+    () => generateAllStarNames({ style: "catalog" }),
+    Error,
+    "catalog designations cannot be enumerated exhaustively",
+  );
+});

--- a/dynamic_star_names/generator.ts
+++ b/dynamic_star_names/generator.ts
@@ -1,0 +1,350 @@
+export type StarNameStyle = "classical" | "mythic" | "catalog" | "hybrid";
+
+export interface StarNameOptions {
+  /**
+   * Seed to deterministically generate a sequence of names. Accepts numbers or
+   * strings so calling code can derive a seed from user input. When omitted the
+   * generator falls back to a time-based seed for additional entropy.
+   */
+  seed?: number | string;
+  /**
+   * Strategy used to construct the base star designation.
+   */
+  style?: StarNameStyle;
+  /**
+   * Append a spectral class code (e.g. `G2`) to the generated name.
+   */
+  includeSpectralClass?: boolean;
+  /**
+   * Append a simple companion designation (A, B, C) to illustrate multi-star systems.
+   */
+  includeDesignation?: boolean;
+  /**
+   * Override the stock vocabularies with custom arrays.
+   */
+  vocabulary?: Partial<typeof DEFAULT_VOCABULARY>;
+}
+
+const DEFAULT_VOCABULARY = {
+  greekLetters: [
+    "Alpha",
+    "Beta",
+    "Gamma",
+    "Delta",
+    "Epsilon",
+    "Zeta",
+    "Eta",
+    "Theta",
+    "Iota",
+    "Kappa",
+    "Lambda",
+    "Mu",
+    "Nu",
+    "Xi",
+    "Omicron",
+    "Pi",
+    "Rho",
+    "Sigma",
+    "Tau",
+    "Upsilon",
+    "Phi",
+    "Chi",
+    "Psi",
+    "Omega",
+  ],
+  constellations: [
+    "Andromedae",
+    "Aquilae",
+    "Aurigae",
+    "Boötis",
+    "Canis Majoris",
+    "Carinae",
+    "Cassiopeiae",
+    "Centauri",
+    "Cygni",
+    "Draconis",
+    "Eridani",
+    "Geminorum",
+    "Leonis",
+    "Lyrae",
+    "Orionis",
+    "Pegasi",
+    "Persei",
+    "Sagittarii",
+    "Scorpii",
+    "Tauri",
+    "Ursae Majoris",
+    "Ursae Minoris",
+    "Virginis",
+  ],
+  mythicDescriptors: [
+    "Luminous",
+    "Radiant",
+    "Arcane",
+    "Celestial",
+    "Wandering",
+    "Eternal",
+    "Glacial",
+    "Solar",
+    "Nebular",
+    "Verdant",
+    "Harmonic",
+    "Resonant",
+    "Empyreal",
+    "Obsidian",
+    "Auroral",
+    "Chrono",
+    "Stellar",
+    "Prismatic",
+    "Vanguard",
+    "Aether",
+  ],
+  mythicCores: [
+    "Phoenix",
+    "Drake",
+    "Oracle",
+    "Nomad",
+    "Sentinel",
+    "Aegis",
+    "Lyric",
+    "Crown",
+    "Harbinger",
+    "Grove",
+    "Lattice",
+    "Paradox",
+    "Spire",
+    "Monolith",
+    "Echo",
+    "Harmony",
+    "Pulse",
+    "Voyager",
+    "Helix",
+    "Beacon",
+  ],
+  catalogPrefixes: ["HD", "HR", "HIP", "BD", "SAO", "TYC", "Gaia"],
+  spectralClasses: ["O", "B", "A", "F", "G", "K", "M"],
+  designations: ["A", "B", "C", "D", "E"],
+};
+
+export function generateStarName(options: StarNameOptions = {}): string {
+  const {
+    seed,
+    style = "hybrid",
+    includeSpectralClass = false,
+    includeDesignation = false,
+    vocabulary,
+  } = options;
+
+  const vocab = mergeVocabulary(vocabulary);
+  const rng = createRng(seed);
+
+  const baseName = style === "classical"
+    ? createClassicalName(rng, vocab)
+    : style === "mythic"
+    ? createMythicName(rng, vocab)
+    : style === "catalog"
+    ? createCatalogName(rng, vocab)
+    : createHybridName(rng, vocab);
+
+  const segments = [baseName];
+
+  if (includeSpectralClass) {
+    const spectral = pick(vocab.spectralClasses, rng);
+    const subclass = Math.floor(rng() * 10);
+    segments.push(`(${spectral}${subclass})`);
+  }
+
+  if (includeDesignation) {
+    segments.push(pick(vocab.designations, rng));
+  }
+
+  return segments.join(" ");
+}
+
+export function generateStarNames(
+  count: number,
+  options: StarNameOptions = {},
+): string[] {
+  if (!Number.isFinite(count) || count <= 0) {
+    throw new RangeError("count must be a positive finite number");
+  }
+
+  const names: string[] = [];
+  // Chain the seed to produce distinct names without requiring callers to
+  // manage offsets manually.
+  for (let index = 0; index < Math.floor(count); index += 1) {
+    const chainedSeed = options.seed != null
+      ? `${options.seed}:${index}`
+      : undefined;
+    names.push(
+      generateStarName({
+        ...options,
+        seed: chainedSeed,
+      }),
+    );
+  }
+
+  return names;
+}
+
+export function generateAllStarNames(
+  options: Pick<StarNameOptions, "style" | "vocabulary"> = {},
+): string[] {
+  const { style = "hybrid", vocabulary } = options;
+  const vocab = mergeVocabulary(vocabulary);
+
+  if (style === "classical") {
+    return enumerateClassical(vocab);
+  }
+
+  if (style === "mythic") {
+    return enumerateMythic(vocab);
+  }
+
+  if (style === "hybrid") {
+    return enumerateHybrid(vocab);
+  }
+
+  throw new Error("catalog designations cannot be enumerated exhaustively");
+}
+
+function mergeVocabulary(
+  overrides: Partial<typeof DEFAULT_VOCABULARY> | undefined,
+) {
+  if (!overrides || Object.keys(overrides).length === 0) {
+    return DEFAULT_VOCABULARY;
+  }
+
+  const merged: typeof DEFAULT_VOCABULARY = {
+    greekLetters: [...DEFAULT_VOCABULARY.greekLetters],
+    constellations: [...DEFAULT_VOCABULARY.constellations],
+    mythicDescriptors: [...DEFAULT_VOCABULARY.mythicDescriptors],
+    mythicCores: [...DEFAULT_VOCABULARY.mythicCores],
+    catalogPrefixes: [...DEFAULT_VOCABULARY.catalogPrefixes],
+    spectralClasses: [...DEFAULT_VOCABULARY.spectralClasses],
+    designations: [...DEFAULT_VOCABULARY.designations],
+  };
+
+  for (
+    const [key, values] of Object.entries(overrides) as Array<[
+      keyof typeof DEFAULT_VOCABULARY,
+      string[] | undefined,
+    ]>
+  ) {
+    if (!values || values.length === 0) {
+      throw new Error(`vocabulary.${key} must not be empty`);
+    }
+    merged[key] = [...values];
+  }
+
+  return merged;
+}
+
+function createClassicalName(
+  rng: () => number,
+  vocab: typeof DEFAULT_VOCABULARY,
+): string {
+  const letter = pick(vocab.greekLetters, rng);
+  const constellation = pick(vocab.constellations, rng);
+  return `${letter} ${constellation}`;
+}
+
+function createMythicName(
+  rng: () => number,
+  vocab: typeof DEFAULT_VOCABULARY,
+): string {
+  const descriptor = pick(vocab.mythicDescriptors, rng);
+  const core = pick(vocab.mythicCores, rng);
+  return `${descriptor} ${core}`;
+}
+
+function createCatalogName(
+  rng: () => number,
+  vocab: typeof DEFAULT_VOCABULARY,
+): string {
+  const prefix = pick(vocab.catalogPrefixes, rng);
+  const digits = Math.floor(rng() * 9000) + 1000;
+  const suffix = Math.floor(rng() * 100);
+  return `${prefix} ${digits}${suffix.toString().padStart(2, "0")}`;
+}
+
+function createHybridName(
+  rng: () => number,
+  vocab: typeof DEFAULT_VOCABULARY,
+): string {
+  const classical = createClassicalName(rng, vocab);
+  const mythic = createMythicName(rng, vocab);
+  return `${mythic} of ${classical}`;
+}
+
+function enumerateClassical(vocab: typeof DEFAULT_VOCABULARY): string[] {
+  const names: string[] = [];
+  for (const letter of vocab.greekLetters) {
+    for (const constellation of vocab.constellations) {
+      names.push(`${letter} ${constellation}`);
+    }
+  }
+  return names;
+}
+
+function enumerateMythic(vocab: typeof DEFAULT_VOCABULARY): string[] {
+  const names: string[] = [];
+  for (const descriptor of vocab.mythicDescriptors) {
+    for (const core of vocab.mythicCores) {
+      names.push(`${descriptor} ${core}`);
+    }
+  }
+  return names;
+}
+
+function enumerateHybrid(vocab: typeof DEFAULT_VOCABULARY): string[] {
+  const mythic = enumerateMythic(vocab);
+  const classical = enumerateClassical(vocab);
+  const names: string[] = [];
+  for (const mythicName of mythic) {
+    for (const classicalName of classical) {
+      names.push(`${mythicName} of ${classicalName}`);
+    }
+  }
+  return names;
+}
+
+function pick<T>(list: readonly T[], rng: () => number): T {
+  if (list.length === 0) {
+    throw new Error("Cannot pick from an empty list");
+  }
+
+  const index = Math.floor(rng() * list.length) % list.length;
+  return list[index];
+}
+
+function createRng(seed?: number | string): () => number {
+  if (seed == null) {
+    const autoSeed = Math.floor(Math.random() * 2 ** 32);
+    return mulberry32(autoSeed);
+  }
+
+  const numericSeed = typeof seed === "number"
+    ? seed
+    : Math.abs(hashString(seed));
+  return mulberry32(numericSeed >>> 0);
+}
+
+function mulberry32(initial: number): () => number {
+  let a = initial >>> 0;
+  return function () {
+    a += 0x6D2B79F5;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}

--- a/tests/test_dynamic_star_engine.py
+++ b/tests/test_dynamic_star_engine.py
@@ -1,0 +1,139 @@
+"""Tests for the dynamic star agent engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from dynamic_star_engine import (
+    CELEBRITY_STAR_AGENTS,
+    DynamicStarEngine,
+    StarAgentSeed,
+    get_celebrity_agents,
+)
+
+
+@pytest.fixture
+def seeded_engine() -> DynamicStarEngine:
+    return DynamicStarEngine(seed="andromeda-core")
+
+
+def test_spawn_agent_is_deterministic(seeded_engine: DynamicStarEngine) -> None:
+    agent = seeded_engine.spawn_agent(role="Navigator")
+    assert agent.designation == "Nebular Crown of Alpha Pegasi (F8)"
+    assert agent.spectral_type == "B8 IV var"
+    assert agent.roles == ("Navigator",)
+    assert agent.identifier == "nebular-crown-of-alpha-pegasi-f8"
+    assert agent.temperament["stability"] == pytest.approx(0.762)
+
+
+def test_roster_cycles_roles(seeded_engine: DynamicStarEngine) -> None:
+    roster = seeded_engine.spawn_roster(3, roles=("Scout", "Guardian"))
+    assert [agent.roles for agent in roster] == [
+        ("Scout",),
+        ("Guardian",),
+        ("Scout",),
+    ]
+    assert roster[0].designation == "Nebular Crown of Alpha Pegasi (F8)"
+    assert roster[1].designation == "Celestial Sentinel of Alpha Canis Majoris (F3)"
+    assert roster[2].designation == "Vanguard Grove of Tau Cassiopeiae (K6)"
+
+
+def test_preview_does_not_advance_state(seeded_engine: DynamicStarEngine) -> None:
+    preview = seeded_engine.preview(2)
+    assert preview == [
+        "Nebular Crown of Alpha Pegasi (F8)",
+        "Celestial Sentinel of Alpha Canis Majoris (F3)",
+    ]
+    agent = seeded_engine.spawn_agent()
+    assert agent.designation == "Nebular Crown of Alpha Pegasi (F8)"
+
+
+def test_custom_vocabulary_overrides() -> None:
+    engine = DynamicStarEngine(
+        seed=7,
+        defaults=StarAgentSeed(
+            style="classical",
+            include_spectral_class=False,
+            vocabulary={
+                "greek_letters": ("Zeta",),
+                "constellations": ("Centauri",),
+            },
+        ),
+    )
+    agent = engine.spawn_agent()
+    assert agent.designation == "Zeta Centauri"
+    assert agent.spectral_type.startswith(tuple("OBAFGKM"))
+
+
+def test_empty_vocabulary_raises() -> None:
+    engine = DynamicStarEngine(seed=11)
+    with pytest.raises(ValueError):
+        engine.spawn_agent(vocabulary={"greek_letters": ()})
+
+
+def test_invalid_style_raises(seeded_engine: DynamicStarEngine) -> None:
+    with pytest.raises(ValueError):
+        seeded_engine.spawn_agent(style="quantum")
+
+
+def test_all_designations_classical(seeded_engine: DynamicStarEngine) -> None:
+    designations = seeded_engine.all_designations(style="classical")
+    assert len(designations) == 24 * 23
+    assert designations[0] == "Alpha Andromedae"
+    assert designations[-1] == "Omega Virginis"
+
+
+def test_all_designations_hybrid_custom_vocab() -> None:
+    engine = DynamicStarEngine()
+    designations = engine.all_designations(
+        style="hybrid",
+        vocabulary={
+            "mythic_descriptors": ("Radiant",),
+            "mythic_cores": ("Oracle", "Monolith"),
+            "greek_letters": ("Alpha", "Beta"),
+            "constellations": ("Lyrae",),
+        },
+    )
+    assert designations == [
+        "Radiant Oracle of Alpha Lyrae",
+        "Radiant Oracle of Beta Lyrae",
+        "Radiant Monolith of Alpha Lyrae",
+        "Radiant Monolith of Beta Lyrae",
+    ]
+
+
+def test_all_designations_catalog_rejected(seeded_engine: DynamicStarEngine) -> None:
+    with pytest.raises(ValueError):
+        seeded_engine.all_designations(style="catalog")
+
+
+def test_celebrity_agents_cover_all_requested_stars() -> None:
+    agents = get_celebrity_agents()
+    assert agents is CELEBRITY_STAR_AGENTS
+    assert len(agents) == 20
+    designations = {agent.designation for agent in agents}
+    expected = {
+        "The Sun",
+        "Sirius (Alpha Canis Majoris)",
+        "Canopus (Alpha Carinae)",
+        "Rigil Kentaurus (Alpha Centauri)",
+        "Arcturus (Alpha Boötis)",
+        "Vega (Alpha Lyrae)",
+        "Capella (Alpha Aurigae)",
+        "Rigel (Beta Orionis)",
+        "Procyon (Alpha Canis Minoris)",
+        "Achernar (Alpha Eridani)",
+        "Betelgeuse (Alpha Orionis)",
+        "Polaris (Alpha Ursae Minoris)",
+        "Aldebaran (Alpha Tauri)",
+        "Spica (Alpha Virginis)",
+        "Antares (Alpha Scorpii)",
+        "Altair (Alpha Aquilae)",
+        "Deneb (Alpha Cygni)",
+        "Proxima Centauri",
+        "Barnard's Star",
+        "Wolf 359",
+    }
+    assert designations == expected
+    assert all(agent.identifier for agent in agents)
+    assert len({agent.identifier for agent in agents}) == len(agents)


### PR DESCRIPTION
## Summary
- add a predefined `CELEBRITY_STAR_AGENTS` roster and accessor that model each highlighted real-world star as a `StarAgent`
- expose the celebrity roster through the package init and document how to import and inspect the agents
- extend pytest coverage to ensure every requested star is represented exactly once with unique identifiers

## Testing
- pytest tests/test_dynamic_star_engine.py
- npm run lint
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d85d11034c832287716f2e217c933c