### PR TITLE
Refactor dynamic_agents lazy loading

### DIFF
--- a/dynamic_agents/_lazy.py
+++ b/dynamic_agents/_lazy.py
@@ -1,0 +1,63 @@
+"""Utilities for building lightweight compatibility shims.
+
+The :mod:`dynamic_agents` package largely re-exports the concrete
+implementations that now live in :mod:`dynamic_ai`.  Historically each
+module implemented its own ``__getattr__`` to defer importing those heavy
+modules until they were actually needed.  That approach worked but it also
+meant a fair amount of duplicated boilerplate scattered across every
+persona specific shim.
+
+To keep the individual modules focused on the public API we centralise the
+lazy-loading mechanics here.  Modules only need to declare the names they
+expose and optionally provide per-symbol overrides when the source module
+differs from the default.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Iterable, Mapping
+
+
+class LazyNamespace:
+    """Resolve attributes on demand while keeping module code minimal."""
+
+    __slots__ = ("_default_module", "_exports", "_export_set", "_overrides")
+
+    def __init__(
+        self,
+        default_module: str,
+        exports: Iterable[str],
+        overrides: Mapping[str, str] | None = None,
+    ) -> None:
+        self._default_module = default_module
+        self._exports = tuple(exports)
+        self._export_set = frozenset(self._exports)
+        self._overrides = dict(overrides or {})
+
+    def resolve(self, name: str, namespace: dict[str, Any]) -> Any:
+        """Return the attribute from the backing module lazily.
+
+        The resolved object is cached on ``namespace`` (typically the module's
+        ``globals()``) so subsequent lookups avoid the import machinery.
+        """
+
+        if name not in self._export_set:
+            module_name = namespace.get("__name__", "module")
+            raise AttributeError(f"module '{module_name}' has no attribute {name!r}")
+
+        target_module = self._overrides.get(name, self._default_module)
+        value = getattr(import_module(target_module), name)
+        namespace[name] = value
+        return value
+
+    def dir(self, namespace: Mapping[str, Any]) -> list[str]:
+        """Expose exported attributes alongside the existing namespace."""
+
+        return sorted(set(namespace) | self._export_set)
+
+    @property
+    def exports(self) -> tuple[str, ...]:
+        """Return the ordered exports for convenience."""
+
+        return self._exports

--- a/dynamic_agents/base.py
+++ b/dynamic_agents/base.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["Agent", "AgentResult"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import Agent, AgentResult
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.base' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/chat.py
+++ b/dynamic_agents/chat.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["ChatAgentResult", "ChatTurn", "DynamicChatAgent"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import ChatAgentResult, ChatTurn, DynamicChatAgent
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.chat' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/cycle.py
+++ b/dynamic_agents/cycle.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["run_dynamic_agent_cycle"]
+
+_LAZY = LazyNamespace("algorithms.python.dynamic_ai_sync", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
 
 
 def __getattr__(name: str) -> Any:
-    if name == "run_dynamic_agent_cycle":
-        module = import_module("algorithms.python.dynamic_ai_sync")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.cycle' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/execution.py
+++ b/dynamic_agents/execution.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["ExecutionAgent", "ExecutionAgentResult"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import ExecutionAgent, ExecutionAgentResult
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.execution' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/research.py
+++ b/dynamic_agents/research.py
@@ -9,21 +9,21 @@ accessed.
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["ResearchAgent", "ResearchAgentResult"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import ResearchAgent, ResearchAgentResult
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.research' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/risk.py
+++ b/dynamic_agents/risk.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["RiskAgent", "RiskAgentResult"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import RiskAgent, RiskAgentResult
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.risk' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/space.py
+++ b/dynamic_agents/space.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["SpaceAgent", "SpaceAgentResult"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import SpaceAgent, SpaceAgentResult
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.space' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())

--- a/dynamic_agents/trading.py
+++ b/dynamic_agents/trading.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+from ._lazy import LazyNamespace
+
 __all__ = ["TradingAgent", "TradingAgentResult"]
+
+_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import TradingAgent, TradingAgentResult
 
 
 def __getattr__(name: str) -> Any:
-    if name in __all__:
-        module = import_module("dynamic_ai.agents")
-        return getattr(module, name)
-    raise AttributeError(f"module 'dynamic_agents.trading' has no attribute {name!r}")
+    return _LAZY.resolve(name, globals())
 
 
 def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return sorted(set(globals()) | set(__all__))
+    return _LAZY.dir(globals())


### PR DESCRIPTION
## Summary
- add a shared `LazyNamespace` helper to centralize dynamic agent lazy loading
- refactor all dynamic agent shims to use the helper and keep compatibility focused

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d86607d948832299acde95225da001