### PR TITLE
Execute hedge directives and apply risk sizing

### DIFF
--- a/tests/test_dynamic_trading_agent.py
+++ b/tests/test_dynamic_trading_agent.py
@@ -3,23 +3,56 @@ from __future__ import annotations
 import pytest
 
 from dynamic_ai.agents import TradingAgent, TradingAgentResult
-from dynamic_algo.trading_core import SUCCESS_RETCODE, TradeExecutionResult
+from dynamic_ai.risk import PositionSizing
+from dynamic_algo.trading_core import (
+    SUCCESS_RETCODE,
+    TradeExecutionResult,
+    DynamicTradingAlgo,
+)
 
 
 class StubTrader:
     def __init__(self) -> None:
         self.calls: list[tuple[dict[str, str], float, str]] = []
+        self.hedge_calls: list[tuple[str, float, str, bool]] = []
+        self._helper = DynamicTradingAlgo()
 
-    def execute_trade(self, signal: dict[str, str], *, lot: float, symbol: str) -> TradeExecutionResult:
-        self.calls.append((dict(signal), lot, symbol))
+    def _resolve_symbol(self, symbol: str) -> tuple[str, object]:
+        return self._helper._resolve_symbol(symbol)
+
+    def _clamp_lot(self, lot: float, profile: object) -> float:
+        return self._helper._clamp_lot(lot, profile)
+
+    def execute_trade(
+        self, signal: dict[str, str], *, lot: float, symbol: str
+    ) -> TradeExecutionResult:
+        resolved_symbol, profile = self._resolve_symbol(symbol)
+        adjusted_lot = self._clamp_lot(lot, profile)
+        self.calls.append((dict(signal), adjusted_lot, resolved_symbol))
         return TradeExecutionResult(
             retcode=SUCCESS_RETCODE,
             message="filled",
             profit=12.5,
             ticket=9876,
-            symbol=symbol,
-            lot=lot,
+            symbol=resolved_symbol,
+            lot=adjusted_lot,
             price=1.2345,
+        )
+
+    def execute_hedge(
+        self, *, symbol: str, lot: float, side: str, close: bool = False
+    ) -> TradeExecutionResult:
+        resolved_symbol, profile = self._resolve_symbol(symbol)
+        adjusted_lot = self._clamp_lot(lot, profile)
+        self.hedge_calls.append((resolved_symbol, adjusted_lot, side, close))
+        return TradeExecutionResult(
+            retcode=SUCCESS_RETCODE,
+            message="hedged",
+            profit=3.21,
+            ticket=5555,
+            symbol=resolved_symbol,
+            lot=adjusted_lot,
+            price=1.0,
         )
 
 
@@ -71,3 +104,74 @@ def test_trading_agent_respects_default_trader(agent_cycle: dict[str, object]) -
     assert result.trade["status"] == "executed"
     assert result.trade["ticket"] == 9876
     assert result.optimisation["status"] == "executed"
+
+
+def test_trading_agent_executes_hedge_decisions(agent_cycle: dict[str, object]) -> None:
+    trader = StubTrader()
+    agent = TradingAgent(trader=trader)
+
+    cycle = dict(agent_cycle)
+    decision = dict(cycle["decision"])
+    decision["hedge_decisions"] = [
+        {
+            "action": "OPEN",
+            "symbol": "BTCUSD",
+            "hedge_symbol": "ETHUSD",
+            "side": "SHORT_HEDGE",
+            "quantity": 0.25,
+            "reason": "VOLATILITY",
+            "score": 0.9,
+        },
+        {
+            "action": "CLOSE",
+            "symbol": "BTCUSD",
+            "hedge_symbol": "ETHUSD",
+            "side": "SHORT_HEDGE",
+            "quantity": 0.25,
+            "reason": "VOLATILITY",
+            "score": 0.4,
+        },
+    ]
+    cycle["decision"] = decision
+    agents = dict(cycle["agents"])
+    risk_agent = dict(agents["risk"])
+    risk_agent["hedge_decisions"] = tuple(decision["hedge_decisions"])
+    agents["risk"] = risk_agent
+    cycle["agents"] = agents
+
+    result = agent.run({"symbol": "ETHUSD", "lot": 0.1, "agent_cycle": cycle})
+
+    assert len(trader.hedge_calls) == 2
+    assert trader.hedge_calls[0][3] is False
+    assert trader.hedge_calls[1][3] is True
+    assert result.optimisation["hedges_recommended"] == 2
+    assert result.optimisation["hedges_executed"] == 2
+    assert result.trade["status"] == "executed"
+    assert "hedges" in result.trade
+
+
+def test_trading_agent_applies_risk_sizing(agent_cycle: dict[str, object]) -> None:
+    trader = StubTrader()
+    agent = TradingAgent(trader=trader)
+
+    cycle = dict(agent_cycle)
+    decision = dict(cycle["decision"])
+    decision["sizing"] = PositionSizing(notional=150.0, leverage=1.5, notes="risk guided")
+    cycle["decision"] = decision
+
+    result = agent.run({"symbol": "ETHUSD", "lot": 0.1, "agent_cycle": cycle})
+
+    assert trader.calls, "trade execution expected"
+    executed_signal, executed_lot, executed_symbol = trader.calls[0]
+    assert executed_symbol == "ETHUSD"
+
+    _, profile = trader._resolve_symbol("ETHUSD")
+    exposure = 150.0 * 1.5
+    expected_lot = trader._clamp_lot(exposure / profile.reference_price, profile)
+    assert pytest.approx(executed_lot, rel=1e-6) == expected_lot
+
+    applied_sizing = result.trade.get("applied_sizing")
+    assert applied_sizing is not None
+    assert pytest.approx(applied_sizing["lot"], rel=1e-6) == expected_lot
+    assert applied_sizing["notional"] == 150.0
+    assert applied_sizing["leverage"] == 1.5


### PR DESCRIPTION
## Summary
- apply risk manager sizing guidance when translating agent trades to execution lots
- execute hedge directives surfaced by the risk persona and capture their outcomes in the alignment payload
- extend trading agent tests with hedge and sizing coverage via an instrument-aware stub trader

## Testing
- pytest tests/test_dynamic_trading_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d86acd21b083228958b0dd8d954f1d