### PR TITLE
Enhance DCT sync with Dynamic AI guidance

### DIFF
--- a/algorithms/python/dct_token_sync.py
+++ b/algorithms/python/dct_token_sync.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import math
 import textwrap
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence
 
 from .multi_llm import LLMConfig, LLMRun, parse_json_response, serialise_runs
 from .supabase_sync import SupabaseTableWriter
@@ -36,6 +37,16 @@ def _safe_divide(numerator: float, denominator: float) -> float:
     if denominator == 0:
         return 0.0
     return numerator / denominator
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(numeric):
+        return default
+    return numeric
 
 
 @dataclass(slots=True)
@@ -155,6 +166,32 @@ class DCTProductionPlan:
             "cap": self.cap,
             "cap_applied": self.cap_applied,
         }
+
+    def scale(self, factor: float) -> "DCTProductionPlan":
+        """Return a copy of the plan with mint amounts scaled by ``factor``."""
+
+        factor = max(0.0, float(factor))
+        if factor == 1.0:
+            return self
+
+        target = self.target_mint * factor
+        buffered = self.buffered_mint * factor
+        smoothed = self.smoothed_mint * factor
+
+        cap = self.cap
+        final = smoothed
+        if cap:
+            final = min(final, cap)
+        cap_applied = final < smoothed
+
+        return DCTProductionPlan(
+            target_mint=target,
+            buffered_mint=buffered,
+            smoothed_mint=smoothed,
+            final_mint=final,
+            cap=cap,
+            cap_applied=cap_applied,
+        )
 
 
 @dataclass(slots=True)
@@ -357,6 +394,9 @@ class DCTLLMOptimisationResult:
     runs: Sequence[LLMRun] = field(default_factory=tuple)
     recommendations: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
     notes: Sequence[str] = field(default_factory=tuple)
+    agent_cycle: Mapping[str, Any] | None = None
+    agent_summary: Mapping[str, Any] | None = None
+    agent_production_scale: float = 1.0
 
     def serialised_runs(self, *, include_prompt: bool = False) -> Optional[str]:
         return serialise_runs(self.runs, include_prompt=include_prompt)
@@ -370,6 +410,12 @@ class DCTLLMOptimisationResult:
         runs = self.serialised_runs()
         if runs:
             payload["runs"] = runs
+        if self.agent_cycle:
+            payload["agent_cycle"] = dict(self.agent_cycle)
+        if self.agent_summary:
+            payload["agent_summary"] = dict(self.agent_summary)
+        if self.agent_production_scale != 1.0:
+            payload["agent_production_scale"] = round(self.agent_production_scale, 6)
         return payload
 
 
@@ -385,6 +431,8 @@ class DCTMultiLLMOptimiser:
     multiplier_lower_bound: float = 0.5
     multiplier_upper_bound: float = 1.5
     extra_instructions: str = ""
+    agent_runner: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None
+    enable_agents: bool = True
 
     def optimise(
         self,
@@ -399,6 +447,9 @@ class DCTMultiLLMOptimiser:
         adjustments: list[DCTLLMAdjustment] = []
         recommendations: list[Mapping[str, Any]] = []
         notes: list[str] = []
+        agent_cycle: Mapping[str, Any] | None = None
+        agent_summary: Mapping[str, Any] | None = None
+        agent_scale = 1.0
 
         for config in self.models:
             run = config.run(prompt)
@@ -413,11 +464,39 @@ class DCTMultiLLMOptimiser:
             notes.extend(self._extract_notes(parsed))
 
         aggregate = self._aggregate_adjustments(adjustments)
+
+        if self.enable_agents:
+            agent_runner = self.agent_runner
+            if agent_runner is None:
+                try:
+                    from .dynamic_ai_sync import run_dynamic_agent_cycle as default_runner
+                except Exception:
+                    agent_runner = None
+                else:
+                    object.__setattr__(self, "agent_runner", default_runner)
+                    agent_runner = default_runner
+            if agent_runner is not None:
+                adjusted, cycle, agent_note = self._apply_agent_guidance(
+                    snapshot, aggregate, agent_runner
+                )
+                if adjusted is not None:
+                    aggregate = adjusted
+                if cycle:
+                    agent_cycle = cycle
+                    agent_summary, agent_scale = self._summarise_agent_cycle(
+                        aggregate, cycle
+                    )
+                if agent_note:
+                    notes.append(agent_note)
+
         return DCTLLMOptimisationResult(
             adjustment=aggregate,
             runs=runs,
             recommendations=recommendations,
             notes=tuple(notes),
+            agent_cycle=agent_cycle,
+            agent_summary=agent_summary,
+            agent_production_scale=agent_scale,
         )
 
     def _empty_result(self) -> DCTLLMOptimisationResult:
@@ -664,6 +743,653 @@ class DCTMultiLLMOptimiser:
                     notes.append(text)
         return notes
 
+    def _apply_agent_guidance(
+        self,
+        snapshot: "DCTMarketSnapshot",
+        adjustment: DCTLLMAdjustment,
+        runner: Callable[[Mapping[str, Any]], Mapping[str, Any]],
+    ) -> tuple[DCTLLMAdjustment | None, Mapping[str, Any] | None, str | None]:
+        try:
+            context = self._build_agent_context(snapshot, adjustment)
+        except Exception:
+            return adjustment, None, None
+
+        try:
+            cycle = runner(context)
+        except Exception:
+            return adjustment, None, None
+        if not isinstance(cycle, Mapping):
+            return adjustment, None, None
+
+        refined = self._modulate_adjustment(adjustment, cycle)
+
+        decision = cycle.get("decision") if isinstance(cycle, Mapping) else None
+        note = None
+        if isinstance(decision, Mapping):
+            action = decision.get("action")
+            confidence_value = decision.get("confidence")
+            if action:
+                confidence_note = None
+                if confidence_value is not None:
+                    confidence_note = _coerce_float(confidence_value, default=math.nan)
+                    if math.isnan(confidence_note):
+                        confidence_note = None
+                if confidence_note is not None:
+                    note = f"Agent decision {action} (confidence {confidence_note:.2f})"
+                else:
+                    note = f"Agent decision {action}"
+
+        return refined, dict(cycle), note
+
+    def _summarise_agent_cycle(
+        self, adjustment: DCTLLMAdjustment, agent_cycle: Mapping[str, Any]
+    ) -> tuple[Mapping[str, Any] | None, float]:
+        if not isinstance(agent_cycle, Mapping):
+            return None, 1.0
+
+        decision_payload = agent_cycle.get("decision")
+        action = "HOLD"
+        confidence = 0.0
+        rationale: str | None = None
+        decision_notes: tuple[str, ...] = ()
+        if isinstance(decision_payload, Mapping):
+            action = str(decision_payload.get("action", "HOLD")).upper() or "HOLD"
+            confidence = _coerce_float(decision_payload.get("confidence"), default=0.0)
+            rationale_candidate = decision_payload.get("rationale") or decision_payload.get("reasoning")
+            if rationale_candidate:
+                rationale = str(rationale_candidate)
+            decision_notes = self._collect_strings(decision_payload.get("notes"))
+
+        agents_section = agent_cycle.get("agents") if isinstance(agent_cycle, Mapping) else None
+        risk_section = agents_section.get("risk") if isinstance(agents_section, Mapping) else None
+
+        risk_confidence: float | None = None
+        escalations: tuple[str, ...] = ()
+        hedge_count = 0
+        hedge_symbols: tuple[str, ...] = ()
+        adjusted_action: str | None = None
+        adjusted_confidence: float | None = None
+        risk_notes: tuple[str, ...] = ()
+        sizing_map: Mapping[str, Any] = {}
+        risk_rationale: str | None = None
+
+        if isinstance(risk_section, Mapping):
+            risk_rationale_candidate = risk_section.get("rationale")
+            if risk_rationale_candidate:
+                risk_rationale = str(risk_rationale_candidate)
+            risk_conf_value = self._coerce_float(risk_section.get("confidence"), default=math.nan)
+            if not math.isnan(risk_conf_value):
+                risk_confidence = max(0.0, min(1.0, risk_conf_value))
+            escalations = self._normalise_escalations(risk_section.get("escalations"))
+            sizing_map = self._normalise_sizing(risk_section.get("sizing"))
+            hedge_count, hedge_symbols = self._summarise_hedges(risk_section.get("hedge_decisions"))
+
+            adjusted_payload = risk_section.get("adjusted_signal")
+            if isinstance(adjusted_payload, Mapping):
+                adjusted_action_candidate = adjusted_payload.get("action")
+                if adjusted_action_candidate:
+                    adjusted_action = str(adjusted_action_candidate).upper()
+                adjusted_conf_value = self._coerce_float(
+                    adjusted_payload.get("confidence"), default=math.nan
+                )
+                if not math.isnan(adjusted_conf_value):
+                    adjusted_confidence = max(0.0, min(1.0, adjusted_conf_value))
+                risk_notes = self._collect_strings(adjusted_payload.get("risk_notes"))
+
+        summary: Dict[str, Any] = {
+            "decision": {
+                "action": action,
+                "confidence": round(confidence, 4),
+            },
+            "confidence_scale": round(self._confidence_scale(confidence), 4),
+        }
+        if rationale:
+            summary["decision"]["rationale"] = rationale
+        if decision_notes:
+            summary["decision"]["notes"] = decision_notes
+
+        risk_summary: Dict[str, Any] = {}
+        if risk_rationale:
+            risk_summary["rationale"] = risk_rationale
+        if risk_confidence is not None:
+            risk_summary["confidence"] = round(risk_confidence, 4)
+        if escalations:
+            risk_summary["escalations"] = escalations
+        if hedge_count:
+            risk_summary["hedges_recommended"] = hedge_count
+        if hedge_symbols:
+            risk_summary["hedge_symbols"] = hedge_symbols
+        if sizing_map:
+            risk_summary["sizing"] = sizing_map
+        if adjusted_action:
+            risk_summary["adjusted_action"] = adjusted_action
+        if adjusted_confidence is not None:
+            risk_summary["adjusted_confidence"] = round(adjusted_confidence, 4)
+        if risk_notes:
+            risk_summary["notes"] = risk_notes
+        if risk_summary:
+            summary["risk"] = risk_summary
+
+        allocation_bias = {
+            label: round(multiplier, 4)
+            for label, multiplier in adjustment.allocation_multipliers.items()
+            if abs(multiplier - 1.0) > 1e-6
+        }
+        if allocation_bias:
+            summary["allocation_bias"] = allocation_bias
+        if adjustment.policy_adjustment_delta:
+            summary["policy_delta"] = round(adjustment.policy_adjustment_delta, 4)
+
+        production_scale = self._compute_production_scale(
+            action,
+            confidence,
+            risk_confidence=risk_confidence,
+            escalations=escalations,
+            hedge_count=hedge_count,
+            adjusted_action=adjusted_action,
+            sizing=sizing_map,
+            sizing_notes=risk_section.get("sizing") if isinstance(risk_section, Mapping) else None,
+        )
+
+        summary["production_scale"] = round(production_scale, 4)
+
+        return summary, production_scale
+
+    def _normalise_escalations(self, payload: Any) -> tuple[str, ...]:
+        if payload is None:
+            return ()
+        if isinstance(payload, Mapping):
+            items = payload.keys()
+        elif isinstance(payload, Iterable) and not isinstance(payload, (str, bytes)):
+            items = payload
+        else:
+            items = (payload,)
+        normalised = []
+        for item in items:
+            text = str(item).strip()
+            if text:
+                normalised.append(text)
+        seen: Dict[str, None] = {}
+        for item in normalised:
+            seen.setdefault(item, None)
+        return tuple(seen.keys())
+
+    def _summarise_hedges(self, payload: Any) -> tuple[int, tuple[str, ...]]:
+        if payload is None:
+            return 0, ()
+        if isinstance(payload, Mapping):
+            items = payload.values()
+        elif isinstance(payload, Iterable) and not isinstance(payload, (str, bytes)):
+            items = payload
+        else:
+            items = ()
+        count = 0
+        symbols: list[str] = []
+        for entry in items:
+            count += 1
+            symbol = None
+            if isinstance(entry, Mapping):
+                symbol = entry.get("symbol") or entry.get("hedge_symbol")
+            else:
+                symbol = getattr(entry, "symbol", None) or getattr(entry, "hedge_symbol", None)
+            if symbol:
+                text = str(symbol).strip()
+                if text:
+                    symbols.append(text)
+        seen: Dict[str, None] = {}
+        for text in symbols:
+            seen.setdefault(text, None)
+        return count, tuple(seen.keys())
+
+    def _normalise_sizing(self, payload: Any) -> Mapping[str, Any]:
+        if payload is None:
+            return {}
+        if isinstance(payload, Mapping):
+            candidate = dict(payload)
+            notional = self._coerce_float(candidate.get("notional"), default=math.nan)
+            leverage = self._coerce_float(candidate.get("leverage"), default=math.nan)
+            notes = candidate.get("notes")
+        else:
+            notional = self._coerce_float(getattr(payload, "notional", None), default=math.nan)
+            leverage = self._coerce_float(getattr(payload, "leverage", None), default=math.nan)
+            notes = getattr(payload, "notes", None)
+
+        result: Dict[str, Any] = {}
+        if not math.isnan(notional):
+            result["notional"] = round(notional, 4)
+        if not math.isnan(leverage):
+            result["leverage"] = round(leverage, 4)
+        if notes:
+            text = str(notes).strip()
+            if text:
+                result["notes"] = text
+        return result
+
+    def _collect_strings(self, payload: Any) -> tuple[str, ...]:
+        if payload is None:
+            return ()
+        if isinstance(payload, str):
+            text = payload.strip()
+            return (text,) if text else ()
+        if isinstance(payload, Mapping):
+            results: list[str] = []
+            for value in payload.values():
+                results.extend(self._collect_strings(value))
+            return tuple(results)
+        if isinstance(payload, Iterable) and not isinstance(payload, (str, bytes)):
+            results: list[str] = []
+            for item in payload:
+                results.extend(self._collect_strings(item))
+            return tuple(results)
+        text = str(payload).strip()
+        return (text,) if text else ()
+
+    def _compute_production_scale(
+        self,
+        action: str,
+        confidence: float,
+        *,
+        risk_confidence: float | None,
+        escalations: Sequence[str],
+        hedge_count: int,
+        adjusted_action: str | None,
+        sizing: Mapping[str, Any],
+        sizing_notes: Any,
+    ) -> float:
+        bounded_conf = max(0.0, min(1.0, confidence))
+        shift = 0.0
+
+        action_upper = action.upper()
+        if action_upper == "BUY":
+            shift += 0.1 + 0.25 * bounded_conf
+        elif action_upper == "SELL":
+            shift -= 0.25 + 0.35 * bounded_conf
+        elif action_upper == "HOLD":
+            shift -= 0.1 * bounded_conf
+        else:
+            shift -= 0.08 * bounded_conf
+
+        if risk_confidence is not None:
+            bounded_risk = max(0.0, min(1.0, risk_confidence))
+            if bounded_risk < bounded_conf:
+                shift -= (bounded_conf - bounded_risk) * 0.25
+            else:
+                shift += (bounded_risk - bounded_conf) * 0.1
+
+        escalation_set = {item.lower() for item in escalations}
+        if escalation_set:
+            shift -= min(0.35, 0.12 * len(escalation_set))
+            if "treasury_utilisation" in escalation_set:
+                shift -= 0.1
+            if "daily_drawdown" in escalation_set:
+                shift -= 0.1
+
+        if hedge_count:
+            shift -= min(0.2, hedge_count * 0.05)
+
+        if adjusted_action:
+            adjusted_upper = adjusted_action.upper()
+            if adjusted_upper == "NEUTRAL":
+                shift -= 0.15
+            elif adjusted_upper == "SELL":
+                shift -= 0.1
+            elif adjusted_upper == "BUY":
+                shift += 0.04
+
+        notional = self._coerce_float(sizing.get("notional") if sizing else None, default=math.nan)
+        if not math.isnan(notional):
+            if notional < 0.2:
+                shift -= 0.08
+            elif notional > 1.0:
+                shift += 0.06
+            elif notional > 0.5:
+                shift += 0.03
+
+        leverage = self._coerce_float(sizing.get("leverage") if sizing else None, default=math.nan)
+        if not math.isnan(leverage):
+            if leverage < 1.0:
+                shift -= 0.05
+            elif leverage > 2.0:
+                shift += 0.04
+
+        if sizing_notes:
+            notes = self._collect_strings(sizing_notes)
+            for note in notes:
+                lowered = note.lower()
+                if "reduce" in lowered or "conservative" in lowered or "trim" in lowered:
+                    shift -= 0.04
+                elif "increase" in lowered or "aggressive" in lowered or "expand" in lowered:
+                    shift += 0.03
+
+        return _clamp(1.0 + shift, lower=0.4, upper=1.15)
+
+    def _build_agent_context(
+        self, snapshot: "DCTMarketSnapshot", adjustment: DCTLLMAdjustment
+    ) -> Dict[str, Any]:
+        base_inputs = snapshot.price_inputs()
+        adjusted_inputs = adjustment.apply_to_price_inputs(base_inputs)
+
+        ton_price = adjusted_inputs.ton_price_usd
+        trailing = max(adjusted_inputs.trailing_ton_price_usd, 1e-6)
+        price_delta = _safe_divide(ton_price - trailing, trailing)
+
+        demand = _clamp(adjusted_inputs.demand_index, lower=self.index_lower_bound, upper=self.index_upper_bound)
+        performance = _clamp(
+            adjusted_inputs.performance_index,
+            lower=self.index_lower_bound,
+            upper=self.index_upper_bound,
+        )
+        volatility = max(0.0, adjusted_inputs.volatility_index)
+        policy = _clamp(
+            adjusted_inputs.policy_adjustment,
+            lower=self.policy_lower_bound,
+            upper=self.policy_upper_bound,
+        )
+
+        demand_bias = demand - 0.5
+        performance_bias = performance - 0.5
+        buffer_ratio = max(0.0, snapshot.buffer_ratio)
+        reward_budget_ratio = _safe_divide(
+            snapshot.usd_reward_budget,
+            max(snapshot.circulating_supply, 1.0),
+        )
+
+        trend = "neutral"
+        if demand_bias >= 0.05 or performance_bias >= 0.05:
+            trend = "bullish"
+        elif demand_bias <= -0.05 or performance_bias <= -0.05:
+            trend = "bearish"
+
+        momentum = _clamp(performance_bias * 2.0, lower=-1.0, upper=1.0)
+        support_strength = _clamp((buffer_ratio - 0.05) * 6.0, lower=-1.0, upper=1.0)
+        resistance_pressure = _clamp((0.05 - buffer_ratio) * 6.0, lower=-1.0, upper=1.0)
+
+        growth_score = _clamp(demand_bias * 2.0, lower=-1.0, upper=1.0)
+        profitability = _clamp(performance_bias * 2.0, lower=-1.0, upper=1.0)
+        valuation_score = _clamp(abs(policy) * 0.5, lower=0.0, upper=1.0)
+        debt_ratio = _clamp(1.0 - buffer_ratio * 4.0, lower=0.0, upper=1.5)
+        cash_flow_trend = _clamp(reward_budget_ratio * 10.0, lower=-1.0, upper=1.0)
+        sample_size = max(100.0, snapshot.circulating_supply / 100.0)
+
+        social_score = _clamp(demand_bias * 1.5, lower=-1.0, upper=1.0)
+        news_bias = _clamp(-policy, lower=-1.0, upper=1.0)
+
+        if demand_bias > 0 and volatility < 0.4:
+            macro_regime = "risk-on"
+        elif demand_bias < 0 and volatility >= 0.45:
+            macro_regime = "risk-off"
+        else:
+            macro_regime = "neutral"
+        inflation_trend = _clamp(volatility - 0.3, lower=-1.0, upper=1.0)
+        growth_outlook = _clamp(performance_bias * 2.0, lower=-1.0, upper=1.0)
+        policy_support = _clamp(-policy, lower=-1.0, upper=1.0)
+        liquidity = _clamp(buffer_ratio * 4.0 + reward_budget_ratio * 8.0, lower=-1.0, upper=1.0)
+
+        treasury_utilisation = _clamp(0.5 + policy, lower=0.0, upper=1.0)
+        stress_index = _clamp(volatility, lower=0.0, upper=1.0)
+        drawdown = -_clamp(volatility - 0.25, lower=-1.0, upper=1.0)
+        halt = policy > 0.9
+
+        risk_context = {
+            "daily_drawdown": drawdown * 0.5,
+            "treasury_utilisation": treasury_utilisation,
+            "treasury_health": _clamp(1.0 - max(0.0, policy), lower=0.0, upper=1.5),
+            "volatility": volatility,
+        }
+
+        market_state = {
+            "volatility": {
+                "DCT": max(0.0, volatility),
+                "TON": abs(price_delta),
+            },
+            "correlations": (
+                {
+                    "symbol": "TON",
+                    "coefficient": _clamp(0.2 + demand_bias, lower=-1.0, upper=1.0),
+                },
+            ),
+            "news": (
+                {
+                    "headline": "DCT demand momentum",
+                    "severity": "high"
+                    if abs(demand_bias) > 0.15
+                    else "medium"
+                    if abs(demand_bias) > 0.05
+                    else "low",
+                    "impact": _clamp(demand_bias, lower=-1.0, upper=1.0),
+                },
+            ),
+        }
+
+        account_state = {
+            "mode": "hedging",
+            "exposures": (
+                {
+                    "symbol": "DCT",
+                    "side": "LONG",
+                    "quantity": max(1.0, snapshot.circulating_supply * 0.001),
+                    "beta": 1.0,
+                },
+            ),
+            "hedges": (
+                {
+                    "id": "TON_HEDGE",
+                    "symbol": "DCT",
+                    "hedge_symbol": "TON",
+                    "side": "SHORT_HEDGE",
+                    "qty": max(0.1, snapshot.circulating_supply * 0.0005),
+                    "reason": "volatility",
+                },
+            ),
+            "drawdown_r": drawdown,
+            "risk_capital": max(0.0, snapshot.usd_reward_budget),
+            "max_basket_risk": 1.5,
+        }
+
+        research_payload = {
+            "technical": {
+                "trend": trend,
+                "momentum": momentum,
+                "volatility": 1.0 + volatility,
+                "support_strength": support_strength,
+                "resistance_pressure": resistance_pressure,
+                "moving_average_alignment": ["bullish" if price_delta >= 0 else "bearish"],
+            },
+            "fundamental": {
+                "growth_score": growth_score,
+                "valuation_score": valuation_score,
+                "profitability": profitability,
+                "debt_ratio": debt_ratio,
+                "cash_flow_trend": cash_flow_trend,
+                "sample_size": sample_size,
+            },
+            "sentiment": {
+                "feeds": [
+                    {
+                        "score": growth_score,
+                        "confidence": 0.6 + max(0.0, demand_bias) * 0.3,
+                        "summary": "demand momentum strengthening"
+                        if demand_bias >= 0
+                        else "demand momentum cooling",
+                    },
+                    {
+                        "score": profitability,
+                        "confidence": 0.55 + max(0.0, performance_bias) * 0.25,
+                        "summary": "performance uptick"
+                        if performance_bias >= 0
+                        else "performance pressure",
+                    },
+                ],
+                "social_score": social_score,
+                "news_bias": news_bias,
+            },
+            "macro": {
+                "regime": macro_regime,
+                "inflation_trend": inflation_trend,
+                "growth_outlook": growth_outlook,
+                "policy_support": policy_support,
+                "liquidity": liquidity,
+            },
+            "risk": {
+                "drawdown": drawdown,
+                "treasury_utilisation": treasury_utilisation,
+                "stress_index": stress_index,
+                "halt": halt,
+            },
+        }
+
+        market_payload = {
+            "price": ton_price,
+            "reference_price": trailing,
+            "dispersion": abs(ton_price - trailing),
+            "trend": trend,
+            "momentum": momentum,
+            "volatility": max(0.05, volatility),
+            "session": "global",
+            "sentiment": {"bias": growth_score},
+            "treasury": {
+                "balance": snapshot.usd_reward_budget,
+                "liabilities": max(snapshot.circulating_supply, 1.0),
+                "utilisation": treasury_utilisation,
+            },
+            "composite_scores": [
+                growth_score,
+                profitability,
+                1.0 - stress_index,
+            ],
+        }
+
+        risk_parameters = {
+            "max_daily_drawdown": 0.08,
+            "treasury_utilisation_cap": 0.65,
+            "circuit_breaker_drawdown": 0.12,
+        }
+
+        return {
+            "symbol": "DCT/TON",
+            "market_symbol": "DCT/TON",
+            "research_payload": research_payload,
+            "market_payload": market_payload,
+            "risk_payload": {
+                "risk_context": risk_context,
+                "market_state": market_state,
+                "account_state": account_state,
+                "risk_parameters": risk_parameters,
+            },
+            "risk_context": risk_context,
+            "market_state": market_state,
+            "account_state": account_state,
+            "risk_parameters": risk_parameters,
+            "order_size": max(0.0, snapshot.previous_epoch_mint),
+        }
+
+    def _modulate_adjustment(
+        self, adjustment: DCTLLMAdjustment, agent_cycle: Mapping[str, Any]
+    ) -> DCTLLMAdjustment:
+        decision = agent_cycle.get("decision")
+        action = "HOLD"
+        confidence = 0.0
+        if isinstance(decision, Mapping):
+            action = str(decision.get("action", "HOLD")).upper() or "HOLD"
+            confidence = _coerce_float(decision.get("confidence"), default=0.0)
+
+        scale = self._confidence_scale(confidence)
+        if action == "HOLD":
+            scale *= 0.75
+        elif action == "SELL":
+            scale *= 0.65
+        elif action == "BUY":
+            scale *= 1.05
+
+        agents_section = agent_cycle.get("agents") if isinstance(agent_cycle, Mapping) else None
+        risk_section = agents_section.get("risk") if isinstance(agents_section, Mapping) else None
+        if isinstance(risk_section, Mapping):
+            risk_confidence = _coerce_float(risk_section.get("confidence"), default=confidence)
+            scale = min(scale, self._confidence_scale(risk_confidence))
+
+            escalations = risk_section.get("escalations")
+            escalation_set: set[str] = set()
+            if isinstance(escalations, Mapping):
+                escalation_set = {str(key) for key in escalations.keys()}
+            elif isinstance(escalations, Iterable) and not isinstance(escalations, (str, bytes)):
+                escalation_set = {str(item) for item in escalations}
+            elif escalations:
+                escalation_set = {str(escalations)}
+            if "treasury_utilisation" in escalation_set:
+                scale *= 0.7
+                action = "SELL"
+            if "daily_drawdown" in escalation_set:
+                scale *= 0.7
+
+            adjusted_signal = risk_section.get("adjusted_signal")
+            if isinstance(adjusted_signal, Mapping):
+                risk_action = str(adjusted_signal.get("action", "")).upper()
+                if risk_action == "HOLD":
+                    scale = min(scale, 0.75)
+                risk_confidence = _coerce_float(
+                    adjusted_signal.get("confidence"), default=risk_confidence
+                )
+                scale = min(scale, self._confidence_scale(risk_confidence))
+
+        scale = _clamp(scale, lower=0.2, upper=1.2)
+
+        policy_delta = adjustment.policy_adjustment_delta * scale
+        if action == "SELL":
+            policy_delta = min(policy_delta, 0.0)
+        elif action == "HOLD":
+            policy_delta *= 0.5
+        elif action == "BUY":
+            policy_delta = max(policy_delta, adjustment.policy_adjustment_delta)
+        policy_delta = _clamp(
+            policy_delta,
+            lower=adjustment.policy_lower_bound,
+            upper=adjustment.policy_upper_bound,
+        )
+
+        demand_multiplier = self._scale_multiplier_value(
+            adjustment.demand_index_multiplier, scale, action, lower=self.multiplier_lower_bound
+        )
+        performance_multiplier = self._scale_multiplier_value(
+            adjustment.performance_index_multiplier,
+            scale,
+            action,
+            lower=self.multiplier_lower_bound,
+        )
+        volatility_multiplier = self._scale_multiplier_value(
+            adjustment.volatility_index_multiplier,
+            scale,
+            action,
+            lower=self.multiplier_lower_bound,
+        )
+
+        allocation_multipliers = {
+            label: self._scale_multiplier_value(value, scale, action, lower=0.0)
+            for label, value in adjustment.allocation_multipliers.items()
+        }
+
+        return replace(
+            adjustment,
+            policy_adjustment_delta=policy_delta,
+            demand_index_multiplier=demand_multiplier,
+            performance_index_multiplier=performance_multiplier,
+            volatility_index_multiplier=volatility_multiplier,
+            allocation_multipliers=allocation_multipliers,
+        )
+
+    def _confidence_scale(self, confidence: float) -> float:
+        bounded = max(0.0, min(1.0, confidence))
+        return 0.4 + bounded * 0.6
+
+    def _scale_multiplier_value(
+        self, value: float, scale: float, action: str, *, lower: float
+    ) -> float:
+        scaled = 1.0 + (value - 1.0) * scale
+        if action == "SELL":
+            scaled = min(scaled, 1.0)
+        elif action == "HOLD":
+            scaled = 1.0 + (scaled - 1.0) * 0.5
+        return _clamp(scaled, lower=lower, upper=self.multiplier_upper_bound)
+
 
 @dataclass(slots=True)
 class DCTMarketSnapshot:
@@ -726,6 +1452,10 @@ class DCTSyncJob:
 
         breakdown = self.price_calculator.compute(price_inputs)
         plan = self.production_planner.plan(snapshot.production_inputs(), breakdown.final_price)
+
+        if optimisation is not None and optimisation.agent_production_scale != 1.0:
+            plan = plan.scale(optimisation.agent_production_scale)
+
         allocations = allocation_engine.distribute(plan.final_mint)
 
         payload: Dict[str, object] = {
@@ -747,5 +1477,13 @@ class DCTSyncJob:
                 payload["llm_recommendations"] = [
                     dict(rec) for rec in optimisation.recommendations
                 ]
+            if optimisation.agent_cycle:
+                payload["llm_agent_cycle"] = dict(optimisation.agent_cycle)
+            if optimisation.agent_summary:
+                payload["llm_agent_summary"] = dict(optimisation.agent_summary)
+            if optimisation.agent_production_scale != 1.0:
+                payload["llm_agent_production_scale"] = round(
+                    optimisation.agent_production_scale, 6
+                )
 
         return self.writer.upsert([payload])

--- a/algorithms/python/tests/test_dct_token_sync.py
+++ b/algorithms/python/tests/test_dct_token_sync.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, Sequence, Tuple
+from typing import Any, Dict, Mapping, Sequence, Tuple
 
 import pytest
 
@@ -13,6 +13,7 @@ from algorithms.python.dct_token_sync import (
     DCTPriceCalculator,
     DCTPriceInputs,
     DCTProductionInputs,
+    DCTProductionPlan,
     DCTProductionPlanner,
     DCTLLMAdjustment,
     DCTLLMOptimisationResult,
@@ -104,6 +105,29 @@ def test_production_planner_applies_smoothing_and_caps() -> None:
     assert pytest.approx(plan.buffered_mint, rel=1e-4) == 110000
     assert plan.final_mint <= plan.cap
     assert plan.cap_applied
+
+
+def test_production_plan_scale_respects_cap_and_factor() -> None:
+    plan = DCTProductionPlan(
+        target_mint=100_000,
+        buffered_mint=110_000,
+        smoothed_mint=95_000,
+        final_mint=90_000,
+        cap=92_000,
+        cap_applied=True,
+    )
+
+    scaled_down = plan.scale(0.5)
+    assert pytest.approx(scaled_down.target_mint, rel=1e-6) == 50_000
+    assert pytest.approx(scaled_down.smoothed_mint, rel=1e-6) == 47_500
+    assert pytest.approx(scaled_down.final_mint, rel=1e-6) == 47_500
+    assert not scaled_down.cap_applied
+
+    scaled_up = plan.scale(1.2)
+    assert pytest.approx(scaled_up.target_mint, rel=1e-6) == 120_000
+    assert pytest.approx(scaled_up.smoothed_mint, rel=1e-6) == 114_000
+    assert pytest.approx(scaled_up.final_mint, rel=1e-6) == plan.cap
+    assert scaled_up.cap_applied
 
 
 def test_allocation_engine_respects_weights_and_multipliers() -> None:
@@ -211,7 +235,9 @@ def test_multi_llm_optimiser_aggregates_responses() -> None:
     config_one = LLMConfig(name="treasury", client=client_one, temperature=0.2, nucleus_p=0.9, max_tokens=256)
     config_two = LLMConfig(name="growth", client=client_two, temperature=0.25, nucleus_p=0.85, max_tokens=256)
 
-    optimiser = DCTMultiLLMOptimiser(models=[config_one, config_two], multiplier_upper_bound=1.4)
+    optimiser = DCTMultiLLMOptimiser(
+        models=[config_one, config_two], multiplier_upper_bound=1.4, enable_agents=False
+    )
     result = optimiser.optimise(snapshot, rules)
 
     assert isinstance(result, DCTLLMOptimisationResult)
@@ -226,6 +252,77 @@ def test_multi_llm_optimiser_aggregates_responses() -> None:
     assert result.adjustment.allocation_multipliers["Treasury"] == pytest.approx(0.9, rel=1e-6)
     assert set(result.notes) == {"Boost VIP rewards", "Reduce treasury drift"}
     assert result.serialised_runs() is not None
+
+
+def test_multi_llm_optimiser_applies_agent_guidance() -> None:
+    snapshot = DCTMarketSnapshot(
+        as_of=datetime(2024, 6, 15, 9, 0, tzinfo=timezone.utc),
+        ton_price_usd=2.5,
+        trailing_ton_price_usd=2.3,
+        demand_index=0.68,
+        performance_index=0.6,
+        volatility_index=0.35,
+        policy_adjustment=0.2,
+        usd_reward_budget=90_000,
+        previous_epoch_mint=25_000,
+        circulating_supply=1_250_000,
+        buffer_ratio=0.07,
+        max_emission=None,
+    )
+    rules = [
+        DCTAllocationRule("VIP", weight=3, multiplier=1.2, member_count=40),
+        DCTAllocationRule("Treasury", weight=2, multiplier=1.0),
+    ]
+
+    response = json.dumps(
+        {
+            "policy_adjustment_delta": 0.3,
+            "demand_multiplier": 1.2,
+            "performance_multiplier": 1.1,
+            "volatility_multiplier": 0.85,
+            "allocation_overrides": {"VIP": 1.3},
+        }
+    )
+
+    agent_calls: list[Mapping[str, Any]] = []
+
+    def agent_runner(context: Mapping[str, Any]) -> Mapping[str, Any]:
+        agent_calls.append(context)
+        return {
+            "decision": {"action": "SELL", "confidence": 0.35},
+            "agents": {
+                "risk": {
+                    "confidence": 0.25,
+                    "escalations": ["treasury_utilisation"],
+                }
+            },
+        }
+
+    client = _StubLLMClient([response])
+    config = LLMConfig(name="policy", client=client, temperature=0.2, nucleus_p=0.85, max_tokens=256)
+
+    optimiser = DCTMultiLLMOptimiser(models=[config], agent_runner=agent_runner)
+    result = optimiser.optimise(snapshot, rules)
+
+    assert agent_calls, "Agent runner should receive context"
+    context = agent_calls[0]
+    assert "research_payload" in context
+    assert "market_payload" in context
+    assert "risk_payload" in context
+
+    assert isinstance(result.agent_cycle, Mapping)
+    assert result.agent_cycle["decision"]["action"] == "SELL"
+    assert result.adjustment.policy_adjustment_delta <= 0.0
+    assert result.adjustment.demand_index_multiplier <= 1.0
+    assert result.adjustment.allocation_multipliers["VIP"] <= 1.0
+    assert any(note.startswith("Agent decision") for note in result.notes)
+    assert result.agent_production_scale < 1.0
+    assert result.agent_summary is not None
+    assert pytest.approx(
+        result.agent_summary["production_scale"], rel=1e-6
+    ) == result.agent_production_scale
+    risk_summary = result.agent_summary.get("risk", {})  # type: ignore[index]
+    assert "escalations" in risk_summary
 
 
 def test_sync_job_includes_llm_adjustments() -> None:
@@ -265,6 +362,12 @@ def test_sync_job_includes_llm_adjustments() -> None:
                 runs=(),
                 recommendations=({"notes": ["Boost VIP rewards"]},),
                 notes=("Boost VIP rewards",),
+                agent_cycle={"decision": {"action": "HOLD", "confidence": 0.5}},
+                agent_summary={
+                    "decision": {"action": "HOLD", "confidence": 0.5},
+                    "production_scale": 0.75,
+                },
+                agent_production_scale=0.75,
             )
 
     optimiser = _StubOptimiser()
@@ -290,6 +393,23 @@ def test_sync_job_includes_llm_adjustments() -> None:
     assert optimiser.calls
 
     payload = writer.rows[0]
+    expected_adjustment = DCTLLMAdjustment(
+        policy_adjustment_delta=0.2,
+        demand_index_multiplier=1.1,
+        performance_index_multiplier=1.0,
+        volatility_index_multiplier=0.9,
+        allocation_multipliers={"VIP": 1.25},
+        index_lower_bound=0.0,
+        index_upper_bound=1.5,
+        policy_lower_bound=-1.0,
+        policy_upper_bound=1.0,
+    )
+    adjusted_inputs = expected_adjustment.apply_to_price_inputs(snapshot.price_inputs())
+    adjusted_breakdown = calculator.compute(adjusted_inputs)
+    expected_plan = planner.plan(snapshot.production_inputs(), adjusted_breakdown.final_price)
+    expected_smoothed = expected_plan.smoothed_mint * 0.75
+    expected_final = min(expected_smoothed, expected_plan.cap)
+
     assert "llm_adjustment" in payload
     assert payload["llm_adjustment"]["allocation_multipliers"]["VIP"] == pytest.approx(1.25, rel=1e-6)
     allocations = payload["allocations"]  # type: ignore[index]
@@ -298,3 +418,8 @@ def test_sync_job_includes_llm_adjustments() -> None:
     assert "llm_notes" in payload
     assert payload["llm_notes"][0] == "Boost VIP rewards"
     assert payload["llm_recommendations"][0]["notes"][0] == "Boost VIP rewards"
+    assert payload["llm_agent_cycle"]["decision"]["action"] == "HOLD"
+    assert payload["llm_agent_summary"]["production_scale"] == pytest.approx(0.75, rel=1e-6)
+    assert payload["llm_agent_production_scale"] == pytest.approx(0.75, rel=1e-6)
+    assert payload["production_plan"]["smoothed_mint"] == pytest.approx(expected_smoothed, rel=1e-6)
+    assert payload["production_plan"]["final_mint"] == pytest.approx(expected_final, rel=1e-6)


### PR DESCRIPTION
## Summary
- add production plan scaling and agent summary metadata derived from the Dynamic AI persona cycle
- expose agent insights and production scaling in the DCT sync payload alongside existing LLM telemetry
- extend DCT sync tests to cover plan scaling, agent summaries, and production adjustments driven by Dynamic AI

## Testing
- pytest algorithms/python/tests/test_dct_token_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d86edb6c0c8322952d75a0dff7ce60