### PR TITLE
Fix Nasdaq 100 market mover symbol

### DIFF
--- a/algorithms/python/jobs/market_movers_job.py
+++ b/algorithms/python/jobs/market_movers_job.py
@@ -23,7 +23,7 @@ DEFAULT_SYMBOLS: Mapping[str, str] = {
     "SI=F": "Silver futures",
     "CL=F": "WTI crude",
     "^GSPC": "S&P 500",
-    "^IXIC": "Nasdaq 100",
+    "^NDX": "Nasdaq 100",
     "^RUT": "Russell 2000",
     "BTC-USD": "Bitcoin",
     "ETH-USD": "Ethereum",


### PR DESCRIPTION
## Summary
- correct the Yahoo Finance symbol for the Nasdaq 100 market mover feed to use ^NDX instead of the composite index

## Testing
- pytest algorithms/python/tests/test_market_movers_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d87678aa18832298b2b313b2c57d81