### PR TITLE
feat(web): add dynamic heatmap explorer

### DIFF
--- a/apps/web/app/tools/heatmap/page.tsx
+++ b/apps/web/app/tools/heatmap/page.tsx
@@ -1,11 +1,11 @@
 import { Column, Heading, Text } from "@/components/dynamic-ui-system";
 
-import { HeatmapTool } from "@/components/tools/HeatmapTool";
+import { HeatmapToolExplorer } from "@/components/tools/HeatmapToolExplorer";
 
 export const metadata = {
-  title: "Market Heatmap Tool – Dynamic Capital",
+  title: "Dynamic Heatmap Tool – Dynamic Capital",
   description:
-    "Explore Dynamic Capital's market heatmap with cross-asset momentum, volatility posture, and trend conviction insights.",
+    "Explore Dynamic Capital's dynamic heatmap with cross-asset momentum, volatility posture, and trend conviction insights across commodities, FX, indices, and crypto.",
 };
 
 export default function HeatmapToolPage() {
@@ -13,19 +13,20 @@ export default function HeatmapToolPage() {
     <Column gap="32" paddingY="40" align="center" horizontal="center" fillWidth>
       <Column maxWidth={32} gap="12" align="center" horizontal="center">
         <Heading variant="display-strong-s" align="center">
-          Market heatmap tool
+          Dynamic heatmap tool
         </Heading>
         <Text
           variant="body-default-m"
           onBackground="neutral-weak"
           align="center"
         >
-          Get the desk&apos;s multi-asset readout with commodity strength,
-          volatility posture, and global momentum in one consolidated heatmap.
+          Toggle between commodities, FX, indices, and crypto heatmaps to spot
+          cross-asset momentum, volatility posture, and leadership shifts in one
+          consolidated dashboard.
         </Text>
       </Column>
       <Column maxWidth={64} fillWidth>
-        <HeatmapTool assetClass="commodities" />
+        <HeatmapToolExplorer />
       </Column>
     </Column>
   );

--- a/apps/web/components/tools/HeatmapToolExplorer.tsx
+++ b/apps/web/components/tools/HeatmapToolExplorer.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  Column,
+  Row,
+  SegmentedControl,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+
+import { HeatmapTool } from "./HeatmapTool";
+import { HEATMAP_CONFIGS, type HeatmapAssetClass } from "./heatmapConfigs";
+
+const ASSET_CLASS_ORDER = [
+  "commodities",
+  "currencies",
+  "indices",
+  "crypto",
+] as const satisfies readonly HeatmapAssetClass[];
+
+const ASSET_CLASS_LABELS: Record<HeatmapAssetClass, string> = {
+  commodities: "Commodities",
+  currencies: "FX",
+  indices: "Indices",
+  crypto: "Crypto",
+};
+
+const isHeatmapAssetClass = (
+  value: string,
+): value is HeatmapAssetClass =>
+  ASSET_CLASS_ORDER.includes(value as HeatmapAssetClass);
+
+export function HeatmapToolExplorer() {
+  const [selectedAssetClass, setSelectedAssetClass] = useState<
+    HeatmapAssetClass
+  >(
+    ASSET_CLASS_ORDER[0],
+  );
+
+  const segmentedOptions = useMemo(
+    () =>
+      ASSET_CLASS_ORDER.map((assetClass) => ({
+        label: ASSET_CLASS_LABELS[assetClass],
+        value: assetClass,
+      })),
+    [],
+  );
+
+  const snapshotLabel = HEATMAP_CONFIGS[selectedAssetClass].snapshotLabel;
+
+  return (
+    <Column gap="24" fillWidth>
+      <Column gap="8" align="start" fillWidth>
+        <Text variant="label-default-s" onBackground="neutral-weak">
+          Select an asset complex
+        </Text>
+        <SegmentedControl
+          aria-label="Select asset class heatmap"
+          buttons={segmentedOptions}
+          fillWidth
+          onToggle={(value) => {
+            if (isHeatmapAssetClass(value)) {
+              setSelectedAssetClass(value);
+            }
+          }}
+          selected={selectedAssetClass}
+        />
+      </Column>
+
+      <Row gap="12" vertical="center" wrap>
+        <Tag background="brand-alpha-weak" size="s">
+          {ASSET_CLASS_LABELS[selectedAssetClass]}
+        </Tag>
+        <Text variant="label-default-s" onBackground="neutral-medium">
+          {snapshotLabel}
+        </Text>
+      </Row>
+
+      <HeatmapTool key={selectedAssetClass} assetClass={selectedAssetClass} />
+    </Column>
+  );
+}
+
+export default HeatmapToolExplorer;


### PR DESCRIPTION
## Summary
- add a HeatmapToolExplorer client wrapper that lets users toggle between the existing commodity, FX, index, and crypto heatmaps
- refresh the heatmap tool page metadata and intro copy to highlight the new cross-asset selector

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d879ff5a308322961ba98288d675b1