### PR TITLE
Refresh mini app GUI styling and copy

### DIFF
--- a/apps/web/app/tools/dynamic-ui-optimizer/page.tsx
+++ b/apps/web/app/tools/dynamic-ui-optimizer/page.tsx
@@ -9,7 +9,7 @@ export default function DynamicUiOptimizerPage() {
     <Column gap="40" paddingY="40" align="center" horizontal="center" fillWidth>
       <Column maxWidth={36} gap="12" align="center" horizontal="center">
         <Heading variant="display-strong-s" align="center">
-          Dynamic UI optimizer
+          Dynamic GUI optimizer
         </Heading>
         <Text
           variant="body-default-m"
@@ -17,8 +17,8 @@ export default function DynamicUiOptimizerPage() {
           align="center"
         >
           Visualize readiness velocity, automation pipeline conversion, and
-          channel performance so you can prioritize the next rollout for the
-          desk.
+          channel performance so you can prioritize the next Dynamic GUI rollout
+          for the desk.
         </Text>
       </Column>
       <DynamicUiOptimizer />

--- a/apps/web/components/admin/AdminDashboard.tsx
+++ b/apps/web/components/admin/AdminDashboard.tsx
@@ -397,7 +397,7 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
               <div className="space-y-2 text-left">
                 <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/80 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-muted-foreground">
                   <Shield className="h-4 w-4 text-primary" />
-                  Dynamic UI admin cockpit
+                  Dynamic GUI admin cockpit
                 </span>
                 <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
                   Dynamic Capital operations
@@ -405,7 +405,7 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
                 <p className="text-sm text-muted-foreground">
                   Welcome back,{" "}
                   {adminName}. Review deposits, broadcast updates, and inspect
-                  bot health without leaving the Dynamic UI workspace.
+                  bot health without leaving the Dynamic GUI workspace.
                 </p>
               </div>
               <div className="flex flex-col items-start gap-2 sm:items-end">
@@ -465,7 +465,7 @@ export const AdminDashboard = ({ telegramData }: AdminDashboardProps) => {
                 <div className="flex flex-col gap-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
                   <p>
                     Monitor realtime metrics across the Dynamic Capital stack
-                    with Dynamic UI automation.
+                    with Dynamic GUI automation.
                   </p>
                   <Badge
                     variant="outline"

--- a/apps/web/components/miniapp/BottomNav.tsx
+++ b/apps/web/components/miniapp/BottomNav.tsx
@@ -14,8 +14,8 @@ export function BottomNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="sticky bottom-0 left-0 right-0 z-40">
-      <div className="border-t border-white/10 bg-background/80 px-4 pb-[calc(env(safe-area-inset-bottom)+12px)] pt-3 backdrop-blur-xl shadow-[0_-20px_60px_rgba(0,0,0,0.35)]">
+    <nav className="sticky bottom-0 left-0 right-0 z-40 px-4 pb-[calc(env(safe-area-inset-bottom)+12px)] pt-3">
+      <div className="miniapp-bottom-card px-4 py-3">
         <div className="grid grid-cols-4 gap-2">
           {MINIAPP_TABS.map(({ href, label, Icon, analyticsEvent }) => {
             const active = pathname?.startsWith(href);
@@ -25,9 +25,8 @@ export function BottomNav() {
                 key={href}
                 href={href}
                 className={cn(
-                  "relative flex flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-muted-foreground/80 transition",
-                  "hover:text-foreground",
-                  active && "text-primary",
+                  "miniapp-bottom-tab",
+                  active && "miniapp-bottom-tab--active",
                 )}
                 aria-current={active ? "page" : undefined}
                 onClick={() => {
@@ -35,25 +34,21 @@ export function BottomNav() {
                   void track(analyticsEvent);
                 }}
               >
-                <span className="relative flex h-10 w-full items-center justify-center">
-                  {active && (
-                    <motion.span
-                      layoutId="bottom-nav-active"
-                      className="absolute inset-y-0 w-full rounded-xl bg-primary/10"
-                      transition={{
-                        type: "spring",
-                        stiffness: 220,
-                        damping: 24,
-                      }}
-                    />
-                  )}
-                  <Icon
-                    size={20}
-                    strokeWidth={active ? 2.4 : 2}
-                    className="relative z-10"
+                {active && (
+                  <motion.span
+                    layoutId="bottom-nav-active"
+                    className="miniapp-bottom-tab__indicator"
+                    transition={{
+                      type: "spring",
+                      stiffness: 220,
+                      damping: 24,
+                    }}
                   />
+                )}
+                <span className="miniapp-bottom-tab__icon">
+                  <Icon size={20} strokeWidth={active ? 2.4 : 2} />
                 </span>
-                <span className="relative z-10">{label}</span>
+                <span className="miniapp-bottom-tab__label">{label}</span>
               </Link>
             );
           })}

--- a/apps/web/components/miniapp/HomeLanding.tsx
+++ b/apps/web/components/miniapp/HomeLanding.tsx
@@ -278,10 +278,9 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, ease: "easeOut" }}
-        className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/15 via-background to-background px-5 py-6 text-left shadow-[0_20px_60px_rgba(0,0,0,0.25)]"
+        className="miniapp-hero px-5 py-6 text-left"
       >
-        <div className="absolute inset-y-0 right-0 w-1/2 translate-x-1/4 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_55%)]" />
-        <div className="space-y-4 relative z-10">
+        <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
             <Badge variant="outline" className="bg-primary/15 text-primary">
               <Sparkles className="mr-1 h-3 w-3" /> Live trading desk
@@ -305,7 +304,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
           </div>
 
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-2xl border border-border/40 bg-background/70 p-4 backdrop-blur">
+            <div className="miniapp-panel p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-wide text-primary">
@@ -319,7 +318,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
               </div>
             </div>
 
-            <div className="rounded-2xl border border-border/40 bg-background/70 p-4 backdrop-blur">
+            <div className="miniapp-panel p-4">
               <p className="text-xs font-semibold uppercase tracking-wide text-primary">
                 Core services
               </p>
@@ -335,7 +334,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
           </div>
 
           {activePromo && (
-            <Card className="border-primary/20 bg-primary/10">
+            <Card className="glass-motion-card border border-primary/25">
               <CardHeader className="pb-2">
                 <CardTitle className="flex items-center gap-2 text-sm text-primary">
                   <Gift className="h-4 w-4" /> Limited-time offer
@@ -378,7 +377,7 @@ export default function HomeLanding({ telegramData }: HomeLandingProps) {
 
       <PlanSection />
 
-      <Card className="border-border/40 bg-background/70">
+      <Card className="glass-motion-card">
         <CardHeader>
           <CardTitle className="text-lg font-semibold text-foreground">
             What you get with VIP access

--- a/apps/web/components/miniapp/MiniAppMetricsSliders.tsx
+++ b/apps/web/components/miniapp/MiniAppMetricsSliders.tsx
@@ -58,7 +58,7 @@ const MiniAppMetricsSlidersComponent = ({
   }, [insights]);
 
   return (
-    <Card className="bg-gradient-to-br from-background/60 via-background to-muted/50 border-primary/10">
+    <Card className="glass-motion-card">
       <CardHeader>
         <div className="flex flex-wrap items-center gap-2 justify-between">
           <CardTitle className="text-subheading font-semibold">
@@ -141,7 +141,7 @@ const MiniAppMetricsSlidersComponent = ({
                 <li
                   key={insight.key}
                   className={cn(
-                    "flex items-start gap-2 rounded-md bg-background/60 p-2 border border-border/30",
+                    "miniapp-panel flex items-start gap-2 p-3 text-xs",
                     insight.emphasis === "marketing" &&
                       "border-amber-500/30 bg-amber-500/5",
                     insight.emphasis === "popularity" &&

--- a/apps/web/components/miniapp/NavigationHeader.tsx
+++ b/apps/web/components/miniapp/NavigationHeader.tsx
@@ -23,20 +23,20 @@ export function NavigationHeader() {
   }, [pathname]);
 
   return (
-    <header className="sticky top-0 z-40">
-      <div className="border-b border-white/10 bg-background/80 px-4 pb-4 pt-[calc(env(safe-area-inset-top)+12px)] backdrop-blur-xl">
+    <header className="sticky top-0 z-40 px-4 pt-[calc(env(safe-area-inset-top)+12px)] pb-3">
+      <div className="miniapp-hero px-4 pb-4">
         <div className="flex items-start gap-3">
           <motion.div
             layout
             initial={reduceMotion ? false : { scale: 0.85, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ duration: reduceMotion ? 0 : 0.25, ease: "easeOut" }}
-            className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-primary shadow-inner"
+            className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/20 text-primary shadow-inner"
           >
             <activeTab.Icon size={20} strokeWidth={2.2} />
           </motion.div>
           <div className="flex-1 space-y-1">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/80">
               You're viewing
             </p>
             <AnimatePresence mode="wait" initial={false}>
@@ -59,44 +59,46 @@ export function NavigationHeader() {
             </p>
           </div>
         </div>
-      </div>
-      <div className="border-b border-white/10 bg-background/80 px-4 pb-3 backdrop-blur-xl">
-        <nav
-          className="flex gap-2 overflow-x-auto"
-          aria-label="Mini app sections"
-        >
-          {MINIAPP_TABS.map((tab) => {
-            const isActive = tab.id === activeTab.id;
+        <div className="mt-4 border-t border-[hsl(var(--primary)/0.2)] pt-3">
+          <nav
+            className="flex gap-2 overflow-x-auto pb-1"
+            aria-label="Mini app sections"
+          >
+            {MINIAPP_TABS.map((tab) => {
+              const isActive = tab.id === activeTab.id;
 
-            return (
-              <Link
-                key={tab.id}
-                href={tab.href}
-                className={cn(
-                  "relative flex items-center gap-2 rounded-full border border-transparent px-3 py-2 text-xs font-semibold text-muted-foreground/80 transition",
-                  "hover:border-primary/20 hover:text-foreground",
-                  isActive &&
-                    "border-primary/30 bg-primary/10 text-primary shadow-[0_10px_30px_rgba(59,130,246,0.25)]",
-                )}
-                aria-current={isActive ? "page" : undefined}
-                onClick={() => {
-                  haptic(isActive ? "light" : "medium");
-                  void track(tab.analyticsEvent);
-                }}
-              >
-                <tab.Icon size={16} strokeWidth={isActive ? 2.4 : 2} />
-                <span>{tab.label}</span>
-                {isActive && (
-                  <motion.span
-                    layoutId="nav-chip-indicator"
-                    className="absolute inset-0 rounded-full border border-primary/40"
-                    transition={{ type: "spring", stiffness: 220, damping: 24 }}
-                  />
-                )}
-              </Link>
-            );
-          })}
-        </nav>
+              return (
+                <Link
+                  key={tab.id}
+                  href={tab.href}
+                  className={cn(
+                    "miniapp-chip",
+                    isActive && "miniapp-chip--active",
+                  )}
+                  aria-current={isActive ? "page" : undefined}
+                  onClick={() => {
+                    haptic(isActive ? "light" : "medium");
+                    void track(tab.analyticsEvent);
+                  }}
+                >
+                  <tab.Icon size={16} strokeWidth={isActive ? 2.4 : 2} />
+                  <span>{tab.label}</span>
+                  {isActive && (
+                    <motion.span
+                      layoutId="nav-chip-indicator"
+                      className="miniapp-chip__indicator"
+                      transition={{
+                        type: "spring",
+                        stiffness: 220,
+                        damping: 24,
+                      }}
+                    />
+                  )}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
       </div>
     </header>
   );

--- a/apps/web/components/navigation/SiteFooter.tsx
+++ b/apps/web/components/navigation/SiteFooter.tsx
@@ -11,7 +11,7 @@ import { schema, social } from "@/resources";
 import NAV_ITEMS from "./nav-items";
 
 const QUICK_LINKS = [
-  { label: "Dynamic UI optimizer", href: "/tools/dynamic-ui-optimizer" },
+  { label: "Dynamic GUI optimizer", href: "/tools/dynamic-ui-optimizer" },
   { label: "Dynamic market review", href: "/tools/dynamic-market-review" },
   { label: "Dynamic visual systems", href: "/tools/dynamic-visual" },
   { label: "Multi-LLM studio", href: "/tools/multi-llm" },

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -104,13 +104,13 @@ const extraNavItems: NavItem[] = [
   {
     id: "ui-optimizer",
     step: `Step ${firstExtraStep + 3}`,
-    label: "Dynamic UI optimizer",
+    label: "Dynamic GUI optimizer",
     description: "Optimize readiness workflows and activation channels.",
     icon: Gauge,
     path: "/tools/dynamic-ui-optimizer",
     ariaLabel: `Step ${
       firstExtraStep + 3
-    }: Dynamic UI optimizer. Optimize readiness workflows and activation channels.`,
+    }: Dynamic GUI optimizer. Optimize readiness workflows and activation channels.`,
     showOnMobile: true,
   },
   {

--- a/apps/web/components/tools/DynamicUiOptimizer.tsx
+++ b/apps/web/components/tools/DynamicUiOptimizer.tsx
@@ -203,7 +203,7 @@ export function DynamicUiOptimizer() {
     <Column gap="40" fillWidth>
       <Column gap="16" align="start" maxWidth={48}>
         <Tag size="s" background="brand-alpha-weak" prefixIcon="activity">
-          Dynamic UI activation
+          Dynamic GUI activation
         </Tag>
         <Heading variant="display-strong-xs">
           Optimize onboarding and automation coverage in one dashboard

--- a/apps/web/resources/content.tsx
+++ b/apps/web/resources/content.tsx
@@ -108,7 +108,7 @@ const home: Home = {
           onBackground="brand-strong"
           className="ml-4 font-semibold tracking-tight"
         >
-          Launch update: Dynamic UI optimizer
+          Launch update: Dynamic GUI optimizer
         </Text>
         <Line background="brand-alpha-strong" vert height="20" />
         <Text marginRight="4" onBackground="brand-medium">

--- a/apps/web/styles/theme.css
+++ b/apps/web/styles/theme.css
@@ -1,10 +1,10 @@
 :root {
-  /* Brand tokens – replace values to match marketing site */
-  --brand-bg: #0b0d12;
-  --brand-surface: #11141a;
-  --brand-text: #f7f9fc;
-  --brand-muted: #a6b0c3;
-  --brand-accent: #30c2f2; /* update to your brand */
+  /* Brand tokens – mirror the marketing snapshot */
+  --brand-bg: hsl(var(--background));
+  --brand-surface: hsl(var(--card));
+  --brand-text: hsl(var(--foreground));
+  --brand-muted: hsl(var(--muted-foreground));
+  --brand-accent: hsl(var(--accent));
   --radius: 16px;
   --shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
 
@@ -20,11 +20,12 @@
   --tap: 44px; /* min target */
 
   /* Telegram theme vars (set dynamically via TelegramProvider) */
-  --tg-bg: var(--brand-bg);
+  --tg-bg: var(--gradient-motion-bg);
   --tg-text: var(--brand-text);
   --tg-muted: var(--brand-muted);
-  --tg-accent: var(--brand-accent);
-  --tg-button: var(--brand-accent);
+  --tg-accent: hsl(var(--accent));
+  --tg-button: hsl(var(--primary));
+  --miniapp-grid-color: hsl(var(--primary) / 0.12);
 }
 
 html, body {
@@ -37,19 +38,63 @@ html, body {
 }
 
 .app-shell {
+  position: relative;
   min-height: 100dvh;
   display: grid;
   grid-template-rows: 1fr auto;
   background: var(--tg-bg);
+  color: var(--brand-text);
+  overflow: hidden;
+}
+
+.app-shell::before {
+  content: "";
+  position: absolute;
+  inset: -20% -30% 0;
+  background:
+    radial-gradient(
+      circle at 15% 20%,
+      hsl(var(--primary) / 0.2),
+      transparent 65%
+    ),
+    radial-gradient(
+    circle at 85% 5%,
+    hsl(var(--dc-secondary) / 0.18),
+    transparent 60%
+  ),
+    radial-gradient(
+    circle at 50% 100%,
+    hsl(var(--accent) / 0.12),
+    transparent 65%
+  );
+  filter: blur(40px);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.app-shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(90deg, var(--miniapp-grid-color) 1px, transparent 1px),
+    linear-gradient(0deg, var(--miniapp-grid-color) 1px, transparent 1px);
+  background-size: 140px 140px;
+  opacity: 0.12;
+  pointer-events: none;
 }
 
 .app-shell-body {
+  position: relative;
+  z-index: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
 .app-shell-main {
+  position: relative;
+  z-index: 1;
   flex: 1;
   width: 100%;
 }
@@ -317,4 +362,241 @@ html, body {
   100% {
     opacity: 0.6;
   }
+}
+
+.miniapp-hero {
+  position: relative;
+  border: 1px solid hsl(var(--glass-motion-border));
+  border-radius: 24px;
+  background:
+    radial-gradient(
+      circle at 16% 18%,
+      hsl(var(--primary) / 0.28),
+      transparent 58%
+    ),
+    radial-gradient(
+      circle at 82% 12%,
+      hsl(var(--dc-secondary) / 0.24),
+      transparent 60%
+    ),
+    linear-gradient(
+      135deg,
+      hsl(var(--card) / 0.92),
+      hsl(var(--background) / 0.78)
+    );
+  box-shadow: 0 28px 72px hsl(var(--dc-brand-dark) / 0.45);
+  backdrop-filter: var(--glass-motion-blur);
+  overflow: hidden;
+}
+
+.miniapp-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    160deg,
+    hsl(var(--dc-secondary) / 0.18),
+    transparent 55%
+  );
+  opacity: 0.65;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.miniapp-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.miniapp-panel {
+  position: relative;
+  border-radius: 20px;
+  border: 1px solid hsl(var(--glass-motion-border));
+  background: linear-gradient(
+    135deg,
+    hsl(var(--card) / 0.88),
+    hsl(var(--background) / 0.72)
+  );
+  box-shadow: inset 0 1px 0 hsl(var(--foreground) / 0.08);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+
+.miniapp-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle at top,
+    hsl(var(--primary) / 0.12),
+    transparent 65%
+  );
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.miniapp-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.miniapp-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: hsl(var(--muted-foreground) / 0.85);
+  border: 1px solid hsl(var(--glass-motion-border));
+  background: linear-gradient(
+    135deg,
+    hsl(var(--card) / 0.88),
+    hsl(var(--background) / 0.7)
+  );
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.miniapp-chip:hover {
+  color: hsl(var(--foreground));
+  border-color: hsl(var(--primary) / 0.45);
+  background: linear-gradient(
+    135deg,
+    hsl(var(--card) / 0.95),
+    hsl(var(--background) / 0.75)
+  );
+  transform: translateY(-1px);
+}
+
+.miniapp-chip--active {
+  color: hsl(var(--primary-foreground));
+  border-color: hsl(var(--primary) / 0.6);
+  background: linear-gradient(
+    135deg,
+    hsl(var(--primary) / 0.32),
+    hsl(var(--dc-secondary) / 0.26)
+  );
+  box-shadow: 0 18px 42px hsl(var(--primary) / 0.35);
+}
+
+.miniapp-chip__indicator {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid hsl(var(--primary) / 0.5);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.miniapp-bottom-card {
+  position: relative;
+  border-radius: 28px;
+  border: 1px solid hsl(var(--glass-motion-border));
+  background: linear-gradient(
+    160deg,
+    hsl(var(--card) / 0.85),
+    hsl(var(--background) / 0.7)
+  );
+  box-shadow: 0 -18px 50px hsl(var(--dc-brand-dark) / 0.45);
+  backdrop-filter: var(--glass-motion-blur);
+  overflow: hidden;
+}
+
+.miniapp-bottom-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    45deg,
+    hsl(var(--dc-secondary) / 0.2),
+    transparent 55%
+  );
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.miniapp-bottom-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.miniapp-bottom-tab {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 0.4rem;
+  border-radius: 18px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground) / 0.85);
+  overflow: hidden;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.miniapp-bottom-tab:hover {
+  color: hsl(var(--foreground));
+  transform: translateY(-2px);
+}
+
+.miniapp-bottom-tab--active {
+  color: hsl(var(--primary-foreground));
+}
+
+.miniapp-bottom-tab__indicator {
+  position: absolute;
+  inset: 0.25rem;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    hsl(var(--primary) / 0.25),
+    hsl(var(--dc-secondary) / 0.2)
+  );
+  box-shadow: 0 18px 42px hsl(var(--primary) / 0.35);
+  opacity: 0.95;
+  pointer-events: none;
+}
+
+.miniapp-bottom-tab__icon {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(
+    135deg,
+    hsl(var(--card) / 0.85),
+    hsl(var(--background) / 0.7)
+  );
+  color: inherit;
+}
+
+.miniapp-bottom-tab--active .miniapp-bottom-tab__icon {
+  background: linear-gradient(
+    135deg,
+    hsl(var(--primary) / 0.35),
+    hsl(var(--dc-secondary) / 0.3)
+  );
+}
+
+.miniapp-bottom-tab__label {
+  position: relative;
+  z-index: 1;
 }


### PR DESCRIPTION
## Summary
- retheme the mini app shell to mirror the marketing snapshot with glass panels, hero gradients, and unified bottom navigation
- rework mini app navigation components to use the new glass/gradient tokens and animated indicators
- rename user-facing "Dynamic UI" references to "Dynamic GUI" across navigation, optimizer, and admin copy

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d87b1527248322ab636519aa8e9095