### PR TITLE
Optimize DynamicSelfImprovement metric aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ Explore the broader platform anatomy and contributor guides:
 - [Dynamic Capital ecosystem anatomy](docs/dynamic-capital-ecosystem-anatomy.md)
 - [Dynamic AI overview](docs/dynamic-ai-overview.md)
 
+### Dynamic AGI self-improvement loop
+
+`dynamic_agi.DynamicAGIModel` now accepts an optional
+`DynamicSelfImprovement` manager that records each evaluation and emits an
+iterative improvement plan. Provide realised performance telemetry or human
+feedback when calling `evaluate()` so the manager can accumulate session
+snapshots. The returned `AGIOutput` includes an `improvement` payload with
+ranked focus areas, aggregated metrics, and the latest introspection reports.
+See `tests/dynamic_agi/test_dynamic_self_improvement.py` for an end-to-end
+example.
+
 ## Dynamic Theme System
 
 The web console and Mini App share a synchronized theming pipeline so traders

--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -1,5 +1,19 @@
 """Dynamic AGI package exposing orchestrator utilities."""
 
 from .model import AGIDiagnostics, AGIOutput, DynamicAGIModel
+from .self_improvement import (
+    DynamicSelfImprovement,
+    ImprovementPlan,
+    ImprovementSignal,
+    LearningSnapshot,
+)
 
-__all__ = ["AGIDiagnostics", "AGIOutput", "DynamicAGIModel"]
+__all__ = [
+    "AGIDiagnostics",
+    "AGIOutput",
+    "DynamicAGIModel",
+    "DynamicSelfImprovement",
+    "ImprovementPlan",
+    "ImprovementSignal",
+    "LearningSnapshot",
+]

--- a/dynamic_agi/self_improvement.py
+++ b/dynamic_agi/self_improvement.py
@@ -1,0 +1,440 @@
+"""Self-improvement loop for the Dynamic AGI orchestrator."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from statistics import mean
+from typing import Any, Deque, Dict, Iterable, Mapping, Optional, Sequence
+
+from dynamic_self_awareness.engine import AwarenessContext, DynamicSelfAwareness
+from dynamic_metacognition.engine import DynamicMetacognition, ReflectionContext
+
+__all__ = [
+    "ImprovementSignal",
+    "LearningSnapshot",
+    "ImprovementPlan",
+    "DynamicSelfImprovement",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_mapping(payload: Mapping[str, Any] | None) -> Dict[str, Any]:
+    if payload is None:
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    return dict(payload)
+
+
+def _to_awareness_context(
+    context: AwarenessContext | Mapping[str, Any] | None,
+) -> AwarenessContext | None:
+    if context is None:
+        return None
+    if isinstance(context, AwarenessContext):
+        return context
+    if isinstance(context, Mapping):
+        return AwarenessContext(**dict(context))  # type: ignore[arg-type]
+    raise TypeError("awareness context must be AwarenessContext or mapping")
+
+
+def _to_reflection_context(
+    context: ReflectionContext | Mapping[str, Any] | None,
+) -> ReflectionContext | None:
+    if context is None:
+        return None
+    if isinstance(context, ReflectionContext):
+        return context
+    if isinstance(context, Mapping):
+        return ReflectionContext(**dict(context))  # type: ignore[arg-type]
+    raise TypeError("reflection context must be ReflectionContext or mapping")
+
+
+@dataclass(slots=True)
+class ImprovementSignal:
+    """Directional signal describing how the AGI should adapt."""
+
+    metric: str
+    value: float
+    direction: str = "neutral"
+    weight: float = 1.0
+    notes: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.metric = self.metric.strip() or "general"
+        self.value = float(self.value)
+        self.direction = (self.direction or "neutral").strip().lower()
+        if self.direction not in {"positive", "negative", "neutral"}:
+            raise ValueError("direction must be positive, negative, or neutral")
+        self.weight = max(float(self.weight), 0.0)
+        if self.notes is not None:
+            cleaned = self.notes.strip()
+            self.notes = cleaned if cleaned else None
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "metric": self.metric,
+            "value": self.value,
+            "direction": self.direction,
+            "weight": self.weight,
+        }
+        if self.notes is not None:
+            payload["notes"] = self.notes
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ImprovementSignal":
+        return cls(**dict(payload))  # type: ignore[arg-type]
+
+
+@dataclass(slots=True)
+class LearningSnapshot:
+    """Snapshot of an AGI evaluation cycle and its telemetry."""
+
+    output: Dict[str, Any]
+    performance: Dict[str, float]
+    feedback: tuple[str, ...]
+    signals: tuple[ImprovementSignal, ...]
+    awareness_report: Optional[Dict[str, Any]] = None
+    metacognition_report: Optional[Dict[str, Any]] = None
+    timestamp: datetime = field(default_factory=_utcnow)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "output": self.output,
+            "performance": self.performance,
+            "feedback": list(self.feedback),
+            "signals": [signal.to_dict() for signal in self.signals],
+            "timestamp": self.timestamp.isoformat(),
+        }
+        if self.awareness_report is not None:
+            payload["awareness_report"] = self.awareness_report
+        if self.metacognition_report is not None:
+            payload["metacognition_report"] = self.metacognition_report
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "LearningSnapshot":
+        output = dict(payload.get("output", {}))
+        performance = {
+            key: float(value)
+            for key, value in dict(payload.get("performance", {})).items()
+        }
+        feedback = tuple(str(item) for item in payload.get("feedback", []))
+        signals_payload = payload.get("signals", [])
+        signals = tuple(
+            signal
+            if isinstance(signal, ImprovementSignal)
+            else ImprovementSignal.from_dict(signal)
+            for signal in signals_payload
+        )
+        awareness_report = payload.get("awareness_report")
+        metacognition_report = payload.get("metacognition_report")
+        timestamp_raw = payload.get("timestamp")
+        if isinstance(timestamp_raw, str):
+            timestamp = datetime.fromisoformat(timestamp_raw)
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            else:
+                timestamp = timestamp.astimezone(timezone.utc)
+        else:
+            timestamp = _utcnow()
+        return cls(
+            output=output,
+            performance=performance,
+            feedback=feedback,
+            signals=signals,
+            awareness_report=awareness_report,
+            metacognition_report=metacognition_report,
+            timestamp=timestamp,
+        )
+
+
+@dataclass(slots=True)
+class ImprovementPlan:
+    """Synthesised strategy for improving the AGI across sessions."""
+
+    focus: tuple[str, ...]
+    metrics: Dict[str, float]
+    actions: tuple[str, ...]
+    feedback: tuple[str, ...]
+    introspection: Dict[str, Any]
+    summary: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "focus": list(self.focus),
+            "metrics": self.metrics,
+            "actions": list(self.actions),
+            "feedback": list(self.feedback),
+            "introspection": self.introspection,
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ImprovementPlan":
+        return cls(
+            focus=tuple(payload.get("focus", ())),
+            metrics=dict(payload.get("metrics", {})),
+            actions=tuple(payload.get("actions", ())),
+            feedback=tuple(payload.get("feedback", ())),
+            introspection=dict(payload.get("introspection", {})),
+            summary=dict(payload.get("summary", {})),
+        )
+
+
+class DynamicSelfImprovement:
+    """Collects run telemetry and formulates iterative improvement plans."""
+
+    def __init__(
+        self,
+        *,
+        history: int = 30,
+        self_awareness: Optional[DynamicSelfAwareness] = None,
+        metacognition: Optional[DynamicMetacognition] = None,
+    ) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._history: Deque[LearningSnapshot] = deque(maxlen=history)
+        self.self_awareness = self_awareness
+        self.metacognition = metacognition
+
+    def reset(self) -> None:
+        self._history.clear()
+
+    @property
+    def snapshot_count(self) -> int:
+        return len(self._history)
+
+    def record_session(
+        self,
+        *,
+        output: Mapping[str, Any] | Any,
+        performance: Optional[Mapping[str, Any]] = None,
+        feedback_notes: Optional[Iterable[str]] = None,
+        introspection_inputs: Optional[Mapping[str, Any]] = None,
+    ) -> LearningSnapshot:
+        output_payload = self._serialise_output(output)
+        performance_payload = {
+            key: float(value)
+            for key, value in _coerce_mapping(performance).items()
+            if _is_number(value)
+        }
+        feedback = tuple(note.strip() for note in feedback_notes or () if note.strip())
+        signals = self._derive_signals(performance_payload, feedback)
+
+        awareness_report: Optional[Dict[str, Any]] = None
+        metacog_report: Optional[Dict[str, Any]] = None
+
+        if introspection_inputs:
+            awareness_ctx = _to_awareness_context(introspection_inputs.get("awareness"))
+            reflection_ctx = _to_reflection_context(introspection_inputs.get("reflection"))
+
+            if awareness_ctx and self.self_awareness:
+                try:
+                    awareness_report = dict(
+                        self.self_awareness.generate_report(awareness_ctx).as_dict()
+                    )
+                except RuntimeError:
+                    awareness_report = None
+
+            if reflection_ctx and self.metacognition:
+                try:
+                    metacog_report = dict(
+                        self.metacognition.generate_report(reflection_ctx).as_dict()
+                    )
+                except RuntimeError:
+                    metacog_report = None
+
+        snapshot = LearningSnapshot(
+            output=output_payload,
+            performance=performance_payload,
+            feedback=feedback,
+            signals=signals,
+            awareness_report=awareness_report,
+            metacognition_report=metacog_report,
+        )
+        self._history.append(snapshot)
+        return snapshot
+
+    def generate_plan(
+        self,
+        *,
+        window: Optional[int] = None,
+    ) -> ImprovementPlan:
+        if not self._history:
+            raise RuntimeError("no sessions recorded")
+
+        snapshots = list(self._history)[-window:] if window else list(self._history)
+        aggregated_metrics = self._aggregate_metrics(snapshots)
+        focus = self._rank_focus(aggregated_metrics)
+        actions = self._actions_for_focus(focus, aggregated_metrics)
+        feedback = self._collate_feedback(snapshots)
+        introspection = self._latest_introspection(snapshots)
+
+        summary = {
+            "sessions_considered": len(snapshots),
+            "snapshot_range": [snapshots[0].timestamp.isoformat(), snapshots[-1].timestamp.isoformat()],
+            "average_metric_score": mean(aggregated_metrics.values()) if aggregated_metrics else 0.0,
+        }
+
+        return ImprovementPlan(
+            focus=focus,
+            metrics=aggregated_metrics,
+            actions=actions,
+            feedback=feedback,
+            introspection=introspection,
+            summary=summary,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "history": [snapshot.to_dict() for snapshot in self._history],
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        history: int = 30,
+        self_awareness: Optional[DynamicSelfAwareness] = None,
+        metacognition: Optional[DynamicMetacognition] = None,
+    ) -> "DynamicSelfImprovement":
+        manager = cls(
+            history=history,
+            self_awareness=self_awareness,
+            metacognition=metacognition,
+        )
+        for snapshot_payload in payload.get("history", []):
+            snapshot = (
+                snapshot_payload
+                if isinstance(snapshot_payload, LearningSnapshot)
+                else LearningSnapshot.from_dict(snapshot_payload)
+            )
+            manager._history.append(snapshot)
+        return manager
+
+    # ----------------------------------------------------------------- helpers
+    def _serialise_output(self, output: Mapping[str, Any] | Any) -> Dict[str, Any]:
+        if hasattr(output, "to_dict") and callable(output.to_dict):  # type: ignore[attr-defined]
+            resolved = output.to_dict()  # type: ignore[call-arg]
+            if isinstance(resolved, Mapping):
+                return dict(resolved)
+        if isinstance(output, Mapping):
+            return dict(output)
+        raise TypeError("output must be mapping-like or provide to_dict()")
+
+    def _derive_signals(
+        self,
+        performance: Mapping[str, float],
+        feedback: Sequence[str],
+    ) -> tuple[ImprovementSignal, ...]:
+        signals: list[ImprovementSignal] = []
+        for metric, value in performance.items():
+            direction = "positive" if value >= 0 else "negative"
+            notes = None
+            if direction == "negative":
+                notes = f"Performance under target for {metric}"
+            signals.append(
+                ImprovementSignal(
+                    metric=metric,
+                    value=value,
+                    direction=direction,
+                    weight=1.0 + abs(value) * 0.1,
+                    notes=notes,
+                )
+            )
+
+        if feedback:
+            signals.append(
+                ImprovementSignal(
+                    metric="feedback_sentiment",
+                    value=-1.0,
+                    direction="negative",
+                    weight=1.0 + 0.1 * len(feedback),
+                    notes="Human feedback suggests refinement",
+                )
+            )
+        return tuple(signals)
+
+    def _aggregate_metrics(
+        self, snapshots: Sequence[LearningSnapshot]
+    ) -> Dict[str, float]:
+        totals: Dict[str, float] = {}
+        counts: Dict[str, int] = {}
+        for snapshot in snapshots:
+            for signal in snapshot.signals:
+                metric = signal.metric
+                totals[metric] = totals.get(metric, 0.0) + signal.value
+                counts[metric] = counts.get(metric, 0) + 1
+        return {
+            metric: totals[metric] / counts[metric]
+            for metric in totals
+            if counts[metric]
+        }
+
+    def _rank_focus(self, metrics: Mapping[str, float]) -> tuple[str, ...]:
+        if not metrics:
+            return ()
+        sorted_metrics = sorted(metrics.items(), key=lambda item: item[1])
+        return tuple(metric for metric, _ in sorted_metrics[:3])
+
+    def _actions_for_focus(
+        self,
+        focus: Sequence[str],
+        metrics: Mapping[str, float],
+    ) -> tuple[str, ...]:
+        actions: list[str] = []
+        for metric in focus:
+            score = metrics.get(metric, 0.0)
+            if metric == "feedback_sentiment":
+                actions.append("Review human feedback and integrate adjustments into prompts")
+            elif score < 0:
+                actions.append(f"Investigate root cause for negative {metric} trend")
+            else:
+                actions.append(f"Amplify strategies driving positive {metric} results")
+        if not actions:
+            actions.append("Maintain current strategy while monitoring for drift")
+        return tuple(actions)
+
+    def _collate_feedback(
+        self, snapshots: Sequence[LearningSnapshot]
+    ) -> tuple[str, ...]:
+        notes: list[str] = []
+        for snapshot in snapshots:
+            notes.extend(snapshot.feedback)
+        return tuple(notes)
+
+    def _latest_introspection(
+        self, snapshots: Sequence[LearningSnapshot]
+    ) -> Dict[str, Any]:
+        awareness = None
+        metacognition = None
+        for snapshot in reversed(snapshots):
+            if awareness is None and snapshot.awareness_report is not None:
+                awareness = snapshot.awareness_report
+            if metacognition is None and snapshot.metacognition_report is not None:
+                metacognition = snapshot.metacognition_report
+            if awareness is not None and metacognition is not None:
+                break
+        payload: Dict[str, Any] = {}
+        if awareness is not None:
+            payload["self_awareness"] = awareness
+        if metacognition is not None:
+            payload["metacognition"] = metacognition
+        return payload
+
+
+def _is_number(value: Any) -> bool:
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return False
+    return True
+

--- a/tests/dynamic_agi/test_dynamic_self_improvement.py
+++ b/tests/dynamic_agi/test_dynamic_self_improvement.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import pytest
+
+from dynamic_agi import DynamicAGIModel, DynamicSelfImprovement
+from dynamic_ai.core import AISignal, PreparedMarketContext
+from dynamic_ai.risk import PositionSizing
+from dynamic_metacognition import DynamicMetacognition, MetaSignal, ReflectionContext
+from dynamic_self_awareness import AwarenessContext, DynamicSelfAwareness, SelfAwarenessSignal
+
+
+class _StubFusion:
+    def __init__(self, ctx: PreparedMarketContext) -> None:
+        self._context = ctx
+
+    def prepare_context(self, market_data):  # type: ignore[override]
+        return self._context
+
+    def composite_diagnostics(self, context):  # type: ignore[override]
+        return {"composite": 0.5}
+
+    def consensus_matrix(self, context):  # type: ignore[override]
+        return {"BUY": 0.7, "SELL": 0.3}
+
+    def generate_signal(self, market_data, *, context=None):  # type: ignore[override]
+        return AISignal(action="BUY", confidence=0.6, reasoning="stub")
+
+    def mm_parameters(self, market_payload, treasury_payload, inventory):  # type: ignore[override]
+        return {"skew": 0.1, "inventory": inventory}
+
+
+class _StubAnalysis:
+    def analyse(self, research):  # type: ignore[override]
+        payload = dict(research)
+        payload.setdefault("insight", "stubbed")
+        return payload
+
+
+class _StubRiskManager:
+    def enforce(self, signal, context):  # type: ignore[override]
+        payload = dict(signal)
+        payload.setdefault("confidence", 0.6)
+        payload.setdefault("notes", [])
+        return payload
+
+    def sizing(self, context, *, confidence, volatility):  # type: ignore[override]
+        return PositionSizing(notional=1.0, leverage=1.0, notes="stub sizing")
+
+
+def _prepared_context() -> PreparedMarketContext:
+    return PreparedMarketContext(
+        source_signal="ALERT",
+        resolved_signal="BUY",
+        momentum=0.4,
+        trend="up",
+        sentiment_value=0.2,
+        composite_scores=(0.2, 0.4, 0.1),
+        composite_trimmed_mean=0.3,
+        indicator_panel=(("rsi", 55.0), ("macd", 0.12)),
+        volatility=0.15,
+        news_topics=("macro",),
+        alignment=0.6,
+        data_quality=0.9,
+        risk_score=0.2,
+        drawdown=0.05,
+        base_confidence=0.55,
+        support_level=100.0,
+        resistance_level=110.0,
+        human_bias=None,
+        human_weight=None,
+        circuit_breaker=False,
+    )
+
+
+def test_evaluate_accumulates_improvement_plan() -> None:
+    context = _prepared_context()
+    manager = DynamicSelfImprovement(history=5)
+    model = DynamicAGIModel(
+        fusion=_StubFusion(context),
+        analysis=_StubAnalysis(),
+        risk_manager=_StubRiskManager(),
+        self_improvement=manager,
+    )
+
+    result_one = model.evaluate(
+        market_data={"price": 100.0},
+        performance={"pnl": -2.5},
+        feedback_notes=["Needs tighter risk controls"],
+    )
+    assert result_one.improvement is not None
+    assert result_one.improvement["summary"]["sessions_considered"] == 1
+
+    result_two = model.evaluate(
+        market_data={"price": 102.0},
+        performance={"pnl": 3.0},
+    )
+
+    assert result_two.improvement is not None
+    metrics = result_two.improvement["metrics"]
+    assert pytest.approx(metrics["pnl"], rel=1e-3) == 0.25
+    assert "feedback_sentiment" in metrics
+    assert result_two.improvement["summary"]["sessions_considered"] == 2
+    assert "pnl" in result_two.improvement["focus"]
+
+
+def test_self_improvement_introspection_reports_in_plan() -> None:
+    awareness = DynamicSelfAwareness()
+    awareness.capture(
+        SelfAwarenessSignal(
+            channel="thought",
+            observation="Monitoring execution cadence",
+            clarity=0.7,
+            alignment=0.6,
+            agitation=0.2,
+            action_bias=0.4,
+        )
+    )
+    metacognition = DynamicMetacognition()
+    metacognition.capture(
+        MetaSignal(
+            domain="learning",
+            insight="Need faster evaluation loop",
+            impact=0.6,
+            stability=0.5,
+            friction=0.3,
+        )
+    )
+
+    manager = DynamicSelfImprovement(
+        history=3,
+        self_awareness=awareness,
+        metacognition=metacognition,
+    )
+
+    snapshot = manager.record_session(
+        output={"signal": {"action": "BUY"}},
+        performance={"pnl": -1.0},
+        introspection_inputs={
+            "awareness": AwarenessContext(
+                situation="Executing strategy",
+                emotion_label="focused",
+                cognitive_noise=0.2,
+                bodily_tension=0.3,
+                readiness_for_action=0.8,
+                value_alignment_target=0.7,
+            ),
+            "reflection": ReflectionContext(
+                learning_goal="Improve trade review cadence",
+                time_available=0.5,
+                cognitive_load=0.3,
+                emotion_state="calm",
+                support_available=0.6,
+            ),
+        },
+    )
+
+    assert snapshot.awareness_report is not None
+    assert snapshot.metacognition_report is not None
+
+    plan = manager.generate_plan()
+    assert "self_awareness" in plan.introspection
+    assert "metacognition" in plan.introspection
+    assert plan.metrics["pnl"] == -1.0
+


### PR DESCRIPTION
## Summary
- replace the list-accumulation metric aggregation with running totals and counts for lower overhead

## Testing
- pytest tests/dynamic_agi/test_dynamic_self_improvement.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8847bea18832289c849c06d9d10ca