### PR TITLE
Add dynamic routine, review, skills, and teaching engines

### DIFF
--- a/dynamic_review/__init__.py
+++ b/dynamic_review/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic review synthesis primitives."""
+
+from .engine import (
+    DynamicReviewEngine,
+    ReviewContext,
+    ReviewInput,
+    ReviewReport,
+    ReviewSection,
+)
+
+__all__ = [
+    "DynamicReviewEngine",
+    "ReviewContext",
+    "ReviewInput",
+    "ReviewReport",
+    "ReviewSection",
+]

--- a/dynamic_review/engine.py
+++ b/dynamic_review/engine.py
@@ -1,0 +1,343 @@
+"""Review synthesis engine for Dynamic Capital's execution loops."""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "ReviewInput",
+    "ReviewContext",
+    "ReviewSection",
+    "ReviewReport",
+    "DynamicReviewEngine",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+# ---------------------------------------------------------------------------
+# dataclasses
+
+
+@dataclass(slots=True)
+class ReviewInput:
+    """Single observation considered in a review session."""
+
+    area: str
+    headline: str
+    impact: float = 0.5
+    confidence: float = 0.5
+    urgency: float = 0.5
+    sentiment: float = 0.5
+    trend: float = 0.5
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_utcnow)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    owner: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.area = _normalise_text(self.area)
+        self.headline = _normalise_text(self.headline)
+        self.impact = _clamp(float(self.impact))
+        self.confidence = _clamp(float(self.confidence))
+        self.urgency = _clamp(float(self.urgency))
+        self.sentiment = _clamp(float(self.sentiment))
+        self.trend = _clamp(float(self.trend))
+        self.weight = max(float(self.weight), 0.0)
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.tags = _normalise_tags(self.tags)
+        self.owner = _normalise_optional(self.owner)
+        self.metadata = _coerce_mapping(self.metadata)
+
+
+@dataclass(slots=True)
+class ReviewContext:
+    """Parameters guiding the review cadence and expectations."""
+
+    mission: str
+    cadence: str
+    audience: str
+    timebox_minutes: int
+    risk_appetite: float
+    alignment_pressure: float
+    morale: float
+    focus_areas: tuple[str, ...] = field(default_factory=tuple)
+    prior_commitments: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.cadence = _normalise_text(self.cadence)
+        self.audience = _normalise_text(self.audience)
+        self.timebox_minutes = max(int(self.timebox_minutes), 0)
+        self.risk_appetite = _clamp(float(self.risk_appetite))
+        self.alignment_pressure = _clamp(float(self.alignment_pressure))
+        self.morale = _clamp(float(self.morale))
+        self.focus_areas = tuple(_normalise_text(item) for item in self.focus_areas if item.strip())
+        self.prior_commitments = tuple(_normalise_text(item) for item in self.prior_commitments if item.strip())
+
+    @property
+    def is_high_pressure(self) -> bool:
+        return self.alignment_pressure >= 0.7
+
+    @property
+    def is_low_morale(self) -> bool:
+        return self.morale <= 0.4
+
+
+@dataclass(slots=True)
+class ReviewSection:
+    """Segment in the review agenda."""
+
+    title: str
+    talking_points: tuple[str, ...]
+    priority: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "title": self.title,
+            "talking_points": list(self.talking_points),
+            "priority": self.priority,
+        }
+
+
+@dataclass(slots=True)
+class ReviewReport:
+    """Structured output of the review engine."""
+
+    health_score: float
+    momentum: float
+    headline: str
+    sections: tuple[ReviewSection, ...]
+    risks: tuple[str, ...]
+    decisions: tuple[str, ...]
+    follow_ups: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "health_score": self.health_score,
+            "momentum": self.momentum,
+            "headline": self.headline,
+            "sections": [section.as_dict() for section in self.sections],
+            "risks": list(self.risks),
+            "decisions": list(self.decisions),
+            "follow_ups": list(self.follow_ups),
+            "narrative": self.narrative,
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicReviewEngine:
+    """Aggregate review inputs and synthesise an agenda with decisions."""
+
+    def __init__(self, *, history: int = 120) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._inputs: Deque[ReviewInput] = deque(maxlen=history)
+
+    # -------------------------------------------------------------- intake
+    def capture(self, item: ReviewInput | Mapping[str, object]) -> ReviewInput:
+        resolved = self._coerce_input(item)
+        self._inputs.append(resolved)
+        return resolved
+
+    def extend(self, items: Iterable[ReviewInput | Mapping[str, object]]) -> None:
+        for item in items:
+            self.capture(item)
+
+    def reset(self) -> None:
+        self._inputs.clear()
+
+    def _coerce_input(self, item: ReviewInput | Mapping[str, object]) -> ReviewInput:
+        if isinstance(item, ReviewInput):
+            return item
+        if isinstance(item, Mapping):
+            payload: MutableMapping[str, object] = dict(item)
+            if "timestamp" not in payload:
+                payload["timestamp"] = _utcnow()
+            return ReviewInput(**payload)  # type: ignore[arg-type]
+        raise TypeError("item must be ReviewInput or mapping")
+
+    # ----------------------------------------------------------- computation
+    def compile_report(self, context: ReviewContext) -> ReviewReport:
+        if not self._inputs:
+            raise RuntimeError("no review inputs captured")
+
+        weighted_total = sum(item.weight for item in self._inputs if item.weight > 0)
+        if weighted_total <= 0:
+            raise RuntimeError("review inputs have zero weight")
+
+        health_score = self._weighted_metric(lambda item: (item.sentiment + item.confidence) / 2)
+        momentum = self._weighted_metric(lambda item: (item.trend + item.impact) / 2)
+
+        sections = self._build_sections()
+        risks = self._collect_risks(context)
+        decisions = self._collect_decisions(context)
+        follow_ups = self._collect_follow_ups(context)
+        headline = self._headline(context, health_score, momentum)
+        narrative = self._narrative(context, health_score, momentum, sections, risks)
+
+        return ReviewReport(
+            health_score=round(health_score, 3),
+            momentum=round(momentum, 3),
+            headline=headline,
+            sections=sections,
+            risks=risks,
+            decisions=decisions,
+            follow_ups=follow_ups,
+            narrative=narrative,
+        )
+
+    def _weighted_metric(self, selector: Callable[[ReviewInput], float]) -> float:
+        total_weight = sum(item.weight for item in self._inputs if item.weight > 0)
+        if total_weight <= 0:
+            return 0.0
+        aggregate = sum(selector(item) * item.weight for item in self._inputs if item.weight > 0)
+        return _clamp(aggregate / total_weight)
+
+    def _build_sections(self) -> tuple[ReviewSection, ...]:
+        grouped: dict[str, list[ReviewInput]] = {}
+        for item in self._inputs:
+            grouped.setdefault(item.area, []).append(item)
+
+        sections: list[ReviewSection] = []
+        for area, items in grouped.items():
+            priority = self._section_priority(items)
+            talking_points = tuple(self._section_points(items))
+            sections.append(
+                ReviewSection(
+                    title=area,
+                    talking_points=talking_points,
+                    priority=priority,
+                )
+            )
+
+        sections.sort(key=lambda section: ("High" != section.priority, section.title))
+        return tuple(sections)
+
+    def _section_priority(self, items: Sequence[ReviewInput]) -> str:
+        avg_urgency = sum(item.urgency for item in items) / len(items)
+        avg_impact = sum(item.impact for item in items) / len(items)
+        if avg_urgency >= 0.65 or avg_impact >= 0.7:
+            return "High"
+        if avg_urgency >= 0.45:
+            return "Medium"
+        return "Low"
+
+    def _section_points(self, items: Sequence[ReviewInput]) -> Sequence[str]:
+        ordered = sorted(items, key=lambda item: (-item.impact, -item.urgency, item.headline))
+        points = [item.headline for item in ordered[:3]]
+        if len(items) > 3:
+            points.append(f"+ {len(items) - 3} additional updates")
+        return points
+
+    def _collect_risks(self, context: ReviewContext) -> tuple[str, ...]:
+        risks: list[str] = []
+        for item in self._inputs:
+            if item.impact >= 0.7 and item.urgency >= 0.6:
+                owner = f" (owner: {item.owner})" if item.owner else ""
+                risks.append(f"{item.area}: {item.headline}{owner}")
+        if context.is_low_morale:
+            risks.append("Morale below target: plan recognition loop")
+        if context.is_high_pressure:
+            risks.append("Alignment pressure high: pre-wire decisions before session")
+        return tuple(dict.fromkeys(risks))
+
+    def _collect_decisions(self, context: ReviewContext) -> tuple[str, ...]:
+        decisions: list[str] = []
+        hotspots = Counter(item.area for item in self._inputs if item.impact >= 0.6)
+        for area, count in hotspots.most_common(3):
+            decisions.append(f"Decide go/no-go for {area} initiatives ({count} blockers)")
+        if context.prior_commitments:
+            decisions.append("Re-affirm prior commitments: " + ", ".join(context.prior_commitments))
+        if not decisions:
+            decisions.append("Confirm status quo and close the session early")
+        return tuple(decisions)
+
+    def _collect_follow_ups(self, context: ReviewContext) -> tuple[str, ...]:
+        follow_ups: list[str] = []
+        for item in self._inputs:
+            if item.trend <= 0.4 and item.sentiment <= 0.5:
+                follow_ups.append(f"Stabilise {item.area}: assign support and define 48h actions")
+        if context.focus_areas:
+            follow_ups.append("Send async memo covering: " + ", ".join(context.focus_areas))
+        if not follow_ups:
+            follow_ups.append("Log review notes and publish decisions within 30 minutes")
+        return tuple(dict.fromkeys(follow_ups))
+
+    def _headline(self, context: ReviewContext, health: float, momentum: float) -> str:
+        direction = "accelerating" if momentum >= 0.6 else "stabilising" if momentum >= 0.45 else "at risk"
+        return (
+            f"{context.cadence.title()} review: {direction} trajectory with health {int(round(health * 100))}%"
+        )
+
+    def _narrative(
+        self,
+        context: ReviewContext,
+        health: float,
+        momentum: float,
+        sections: Sequence[ReviewSection],
+        risks: Sequence[str],
+    ) -> str:
+        top_section = sections[0].title if sections else "General"
+        risk_note = risks[0] if risks else "No critical risks flagged"
+        morale_note = "Morale steady" if not context.is_low_morale else "Morale requires intervention"
+        return (
+            f"Mission: {context.mission}. Momentum {int(round(momentum * 100))}% with top focus on {top_section}. "
+            f"{risk_note}. {morale_note}."
+        )

--- a/dynamic_routine/__init__.py
+++ b/dynamic_routine/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic routine planning primitives."""
+
+from .engine import (
+    DynamicRoutineEngine,
+    RoutineActivity,
+    RoutineBlock,
+    RoutineContext,
+    RoutinePlan,
+)
+
+__all__ = [
+    "DynamicRoutineEngine",
+    "RoutineActivity",
+    "RoutineBlock",
+    "RoutineContext",
+    "RoutinePlan",
+]

--- a/dynamic_routine/engine.py
+++ b/dynamic_routine/engine.py
@@ -1,0 +1,330 @@
+"""Ritual planning engine for Dynamic Capital's operating routines."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "RoutineActivity",
+    "RoutineContext",
+    "RoutineBlock",
+    "RoutinePlan",
+    "DynamicRoutineEngine",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_lower(value: str, *, default: str = "") -> str:
+    cleaned = value.strip().lower()
+    return cleaned or default
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+# ---------------------------------------------------------------------------
+# dataclasses
+
+
+@dataclass(slots=True)
+class RoutineActivity:
+    """Single task or ritual considered for the routine design."""
+
+    name: str
+    category: str
+    importance: float = 0.5
+    duration_minutes: int = 30
+    energy_cost: float = 0.5
+    focus_demand: float = 0.5
+    renewal_value: float = 0.5
+    cadence: str = "daily"
+    weight: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.category = _normalise_lower(self.category, default="general")
+        self.importance = _clamp(float(self.importance))
+        self.duration_minutes = max(int(self.duration_minutes), 0)
+        self.energy_cost = _clamp(float(self.energy_cost))
+        self.focus_demand = _clamp(float(self.focus_demand))
+        self.renewal_value = _clamp(float(self.renewal_value))
+        self.cadence = _normalise_lower(self.cadence, default="unspecified")
+        self.weight = max(float(self.weight), 0.0)
+        self.tags = _normalise_tags(self.tags)
+        self.metadata = _coerce_mapping(self.metadata)
+
+
+@dataclass(slots=True)
+class RoutineContext:
+    """Ambient constraints and goals for a routine cycle."""
+
+    mission: str
+    cadence: str
+    available_minutes: int
+    energy: float
+    focus: float
+    load: float
+    recovery_priority: float
+    constraints: tuple[str, ...] = field(default_factory=tuple)
+    guardrails: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.cadence = _normalise_lower(self.cadence, default="unspecified")
+        self.available_minutes = max(int(self.available_minutes), 0)
+        self.energy = _clamp(float(self.energy))
+        self.focus = _clamp(float(self.focus))
+        self.load = _clamp(float(self.load))
+        self.recovery_priority = _clamp(float(self.recovery_priority))
+        self.constraints = tuple(_normalise_text(item) for item in self.constraints if item.strip())
+        self.guardrails = tuple(_normalise_text(item) for item in self.guardrails if item.strip())
+
+    @property
+    def is_energy_constrained(self) -> bool:
+        return self.energy <= 0.4
+
+    @property
+    def is_overloaded(self) -> bool:
+        return self.load >= 0.7
+
+
+@dataclass(slots=True)
+class RoutineBlock:
+    """Structured block inside the resulting routine."""
+
+    name: str
+    minutes: int
+    intent: str
+    intensity: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "minutes": self.minutes,
+            "intent": self.intent,
+            "intensity": self.intensity,
+        }
+
+
+@dataclass(slots=True)
+class RoutinePlan:
+    """Full routine output with prioritised blocks and supporting actions."""
+
+    primary_blocks: tuple[RoutineBlock, ...]
+    secondary_blocks: tuple[RoutineBlock, ...]
+    recovery_actions: tuple[str, ...]
+    automation_candidates: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "primary_blocks": [block.as_dict() for block in self.primary_blocks],
+            "secondary_blocks": [block.as_dict() for block in self.secondary_blocks],
+            "recovery_actions": list(self.recovery_actions),
+            "automation_candidates": list(self.automation_candidates),
+            "narrative": self.narrative,
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicRoutineEngine:
+    """Aggregate activities and compose a resilient routine."""
+
+    def __init__(self, *, history: int = 90) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._activities: Deque[RoutineActivity] = deque(maxlen=history)
+
+    # -------------------------------------------------------------- intake
+    def add(self, activity: RoutineActivity | Mapping[str, object]) -> RoutineActivity:
+        resolved = self._coerce_activity(activity)
+        self._activities.append(resolved)
+        return resolved
+
+    def extend(self, activities: Iterable[RoutineActivity | Mapping[str, object]]) -> None:
+        for activity in activities:
+            self.add(activity)
+
+    def reset(self) -> None:
+        self._activities.clear()
+
+    def _coerce_activity(self, activity: RoutineActivity | Mapping[str, object]) -> RoutineActivity:
+        if isinstance(activity, RoutineActivity):
+            return activity
+        if isinstance(activity, Mapping):
+            payload: MutableMapping[str, object] = dict(activity)
+            return RoutineActivity(**payload)  # type: ignore[arg-type]
+        raise TypeError("activity must be RoutineActivity or mapping")
+
+    # ----------------------------------------------------------- computation
+    def design(self, context: RoutineContext) -> RoutinePlan:
+        if not self._activities:
+            raise RuntimeError("no routine activities captured")
+
+        scored = [
+            (self._score_activity(activity, context), activity)
+            for activity in self._activities
+            if activity.weight > 0
+        ]
+        if not scored:
+            raise RuntimeError("routine activities have zero weight")
+
+        scored.sort(key=lambda item: (-item[0], item[1].importance, -item[1].duration_minutes))
+
+        primary: list[RoutineBlock] = []
+        secondary: list[RoutineBlock] = []
+        time_remaining = context.available_minutes
+        partial_flag = False
+
+        for score, activity in scored:
+            block_minutes = min(activity.duration_minutes, context.available_minutes or activity.duration_minutes)
+            intent = self._intent_summary(activity)
+            intensity = self._intensity_label(activity, context)
+            if time_remaining > 0 and block_minutes > 0:
+                allocation = min(block_minutes, time_remaining)
+                block = RoutineBlock(
+                    name=activity.name,
+                    minutes=allocation,
+                    intent=intent,
+                    intensity=intensity,
+                )
+                primary.append(block)
+                time_remaining -= allocation
+                if allocation < block_minutes:
+                    secondary.append(
+                        RoutineBlock(
+                            name=f"{activity.name} (deferred)",
+                            minutes=block_minutes - allocation,
+                            intent=intent,
+                            intensity=intensity,
+                        )
+                    )
+                    partial_flag = True
+            else:
+                secondary.append(
+                    RoutineBlock(
+                        name=activity.name,
+                        minutes=block_minutes,
+                        intent=intent,
+                        intensity=intensity,
+                    )
+                )
+
+        recovery_actions = self._recovery_actions(context)
+        automation_candidates = self._automation_candidates(scored)
+        narrative = self._narrative(context, primary, recovery_actions, partial_flag)
+
+        return RoutinePlan(
+            primary_blocks=tuple(primary),
+            secondary_blocks=tuple(secondary),
+            recovery_actions=recovery_actions,
+            automation_candidates=automation_candidates,
+            narrative=narrative,
+        )
+
+    def _score_activity(self, activity: RoutineActivity, context: RoutineContext) -> float:
+        if activity.duration_minutes <= 0:
+            return 0.0
+        base = activity.importance * activity.weight
+        energy_alignment = 1.0 - abs(activity.energy_cost - context.energy)
+        focus_alignment = 1.0 - abs(activity.focus_demand - context.focus)
+        renewal = activity.renewal_value * max(context.recovery_priority, 0.2)
+        overload_penalty = 0.1 if context.is_overloaded and activity.focus_demand >= 0.7 else 0.0
+        energy_penalty = 0.15 if context.is_energy_constrained and activity.energy_cost >= 0.7 else 0.0
+        score = base * 0.55 + energy_alignment * 0.2 + focus_alignment * 0.15 + renewal * 0.1
+        score -= overload_penalty + energy_penalty
+        return _clamp(score)
+
+    def _intent_summary(self, activity: RoutineActivity) -> str:
+        cadence = activity.cadence.replace("_", " ")
+        return f"Stabilise {activity.category} systems ({cadence})"
+
+    def _intensity_label(self, activity: RoutineActivity, context: RoutineContext) -> str:
+        if activity.focus_demand >= 0.75 or activity.energy_cost >= 0.75:
+            return "High"
+        if activity.focus_demand >= 0.5 or activity.energy_cost >= 0.5:
+            return "Moderate"
+        if context.is_energy_constrained:
+            return "Restorative"
+        return "Light"
+
+    def _recovery_actions(self, context: RoutineContext) -> tuple[str, ...]:
+        actions: list[str] = []
+        if context.recovery_priority >= 0.6:
+            actions.append("Block 20 minutes for recovery ritual")
+        if context.is_energy_constrained:
+            actions.append("Schedule active recovery: hydration, light movement, sunlight")
+        if context.is_overloaded:
+            actions.append("Audit commitments and renegotiate at least one obligation")
+        if not actions:
+            actions.append("Log energy trendline and micro-adjust routine tomorrow")
+        return tuple(actions)
+
+    def _automation_candidates(self, scored: list[tuple[float, RoutineActivity]]) -> tuple[str, ...]:
+        candidates: list[str] = []
+        for score, activity in scored:
+            if activity.duration_minutes >= 45 and activity.importance <= 0.4:
+                candidates.append(f"Automate or delegate: {activity.name}")
+            elif activity.importance <= 0.3 and score <= 0.4:
+                candidates.append(f"Batch {activity.name} later in the week")
+        return tuple(dict.fromkeys(candidates))
+
+    def _narrative(
+        self,
+        context: RoutineContext,
+        primary: Sequence[RoutineBlock],
+        recovery_actions: Sequence[str],
+        partial_flag: bool,
+    ) -> str:
+        primary_minutes = sum(block.minutes for block in primary)
+        utilisation = 0 if context.available_minutes == 0 else int(round((primary_minutes / max(context.available_minutes, 1)) * 100))
+        recovery_note = recovery_actions[0] if recovery_actions else "Document micro-recovery"
+        partial_note = " Some items were partially allocated." if partial_flag else ""
+        return (
+            f"Mission: {context.mission}. Utilisation at {utilisation}% of available capacity. "
+            f"Leading block: {primary[0].name if primary else 'None'}. {recovery_note}.{partial_note}"
+        )

--- a/dynamic_skills/__init__.py
+++ b/dynamic_skills/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic skills orchestration primitives."""
+
+from .engine import (
+    DynamicSkillsEngine,
+    SkillContext,
+    SkillFocus,
+    SkillPlan,
+    SkillSignal,
+)
+
+__all__ = [
+    "DynamicSkillsEngine",
+    "SkillContext",
+    "SkillFocus",
+    "SkillPlan",
+    "SkillSignal",
+]

--- a/dynamic_skills/engine.py
+++ b/dynamic_skills/engine.py
@@ -1,0 +1,329 @@
+"""Skill orchestration engine for Dynamic Capital's talent systems."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "SkillSignal",
+    "SkillContext",
+    "SkillFocus",
+    "SkillPlan",
+    "DynamicSkillsEngine",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+# ---------------------------------------------------------------------------
+# dataclasses
+
+
+@dataclass(slots=True)
+class SkillSignal:
+    """Observed evidence about a particular skill."""
+
+    skill: str
+    evidence: str
+    proficiency: float = 0.5
+    momentum: float = 0.5
+    confidence: float = 0.5
+    risk: float = 0.0
+    leverage: float = 0.5
+    time_invested_hours: float = 0.0
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_utcnow)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    coach: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.skill = _normalise_text(self.skill)
+        self.evidence = _normalise_text(self.evidence)
+        self.proficiency = _clamp(float(self.proficiency))
+        self.momentum = _clamp(float(self.momentum))
+        self.confidence = _clamp(float(self.confidence))
+        self.risk = _clamp(float(self.risk))
+        self.leverage = _clamp(float(self.leverage))
+        self.time_invested_hours = max(float(self.time_invested_hours), 0.0)
+        self.weight = max(float(self.weight), 0.0)
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.tags = _normalise_tags(self.tags)
+        self.coach = _normalise_optional(self.coach)
+        self.metadata = _coerce_mapping(self.metadata)
+
+
+@dataclass(slots=True)
+class SkillContext:
+    """Context for evaluating skill development priorities."""
+
+    mission: str
+    role: str
+    focus_window_weeks: int
+    bandwidth: float
+    strategic_weight: float
+    stretch_pressure: float
+    constraints: tuple[str, ...] = field(default_factory=tuple)
+    support_assets: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.role = _normalise_text(self.role)
+        self.focus_window_weeks = max(int(self.focus_window_weeks), 0)
+        self.bandwidth = _clamp(float(self.bandwidth))
+        self.strategic_weight = _clamp(float(self.strategic_weight))
+        self.stretch_pressure = _clamp(float(self.stretch_pressure))
+        self.constraints = tuple(_normalise_text(item) for item in self.constraints if item.strip())
+        self.support_assets = tuple(_normalise_text(item) for item in self.support_assets if item.strip())
+
+    @property
+    def is_bandwidth_constrained(self) -> bool:
+        return self.bandwidth <= 0.4
+
+    @property
+    def is_high_stretch(self) -> bool:
+        return self.stretch_pressure >= 0.6
+
+
+@dataclass(slots=True)
+class SkillFocus:
+    """Single focus area for the skill plan."""
+
+    skill: str
+    priority: str
+    actions: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "skill": self.skill,
+            "priority": self.priority,
+            "actions": list(self.actions),
+        }
+
+
+@dataclass(slots=True)
+class SkillPlan:
+    """Structured plan for upskilling and maintenance."""
+
+    accelerators: tuple[SkillFocus, ...]
+    maintenance: tuple[SkillFocus, ...]
+    experiments: tuple[str, ...]
+    coaching_requests: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "accelerators": [focus.as_dict() for focus in self.accelerators],
+            "maintenance": [focus.as_dict() for focus in self.maintenance],
+            "experiments": list(self.experiments),
+            "coaching_requests": list(self.coaching_requests),
+            "narrative": self.narrative,
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicSkillsEngine:
+    """Aggregate skill signals and produce a targeted development plan."""
+
+    def __init__(self, *, history: int = 150) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._signals: Deque[SkillSignal] = deque(maxlen=history)
+
+    # -------------------------------------------------------------- intake
+    def capture(self, signal: SkillSignal | Mapping[str, object]) -> SkillSignal:
+        resolved = self._coerce_signal(signal)
+        self._signals.append(resolved)
+        return resolved
+
+    def extend(self, signals: Iterable[SkillSignal | Mapping[str, object]]) -> None:
+        for signal in signals:
+            self.capture(signal)
+
+    def reset(self) -> None:
+        self._signals.clear()
+
+    def _coerce_signal(self, signal: SkillSignal | Mapping[str, object]) -> SkillSignal:
+        if isinstance(signal, SkillSignal):
+            return signal
+        if isinstance(signal, Mapping):
+            payload: MutableMapping[str, object] = dict(signal)
+            if "timestamp" not in payload:
+                payload["timestamp"] = _utcnow()
+            return SkillSignal(**payload)  # type: ignore[arg-type]
+        raise TypeError("signal must be SkillSignal or mapping")
+
+    # ----------------------------------------------------------- computation
+    def build_plan(self, context: SkillContext) -> SkillPlan:
+        if not self._signals:
+            raise RuntimeError("no skill signals captured")
+
+        weighted_total = sum(signal.weight for signal in self._signals if signal.weight > 0)
+        if weighted_total <= 0:
+            raise RuntimeError("skill signals have zero weight")
+
+        accelerators = self._accelerators(context)
+        maintenance = self._maintenance(context)
+        experiments = self._experiments(context)
+        coaching_requests = self._coaching_requests(context)
+        narrative = self._narrative(context, accelerators, maintenance)
+
+        return SkillPlan(
+            accelerators=accelerators,
+            maintenance=maintenance,
+            experiments=experiments,
+            coaching_requests=coaching_requests,
+            narrative=narrative,
+        )
+
+    def _accelerators(self, context: SkillContext) -> tuple[SkillFocus, ...]:
+        high_leverage = [
+            signal
+            for signal in self._signals
+            if signal.leverage >= 0.6 and signal.momentum >= 0.5 and signal.weight > 0
+        ]
+        high_leverage.sort(key=lambda s: (-s.leverage, -s.momentum, -s.proficiency, s.skill))
+
+        focuses: list[SkillFocus] = []
+        for signal in high_leverage[:4]:
+            priority = "High" if signal.proficiency < 0.75 else "Medium"
+            actions = [
+                f"Design deliberate practice block for {signal.skill}",
+                f"Ship artefact proving {signal.skill} within {context.focus_window_weeks} weeks",
+            ]
+            if context.is_high_stretch:
+                actions.append("Pair with stretch project to accelerate feedback loops")
+            focuses.append(
+                SkillFocus(
+                    skill=signal.skill,
+                    priority=priority,
+                    actions=tuple(actions),
+                )
+            )
+        if not focuses:
+            focuses.append(
+                SkillFocus(
+                    skill="Meta-Learning",
+                    priority="High",
+                    actions=("Run weekly reflection on learning velocity", "Increase exposure to new domains"),
+                )
+            )
+        return tuple(focuses)
+
+    def _maintenance(self, context: SkillContext) -> tuple[SkillFocus, ...]:
+        maintenance_targets = [
+            signal
+            for signal in self._signals
+            if signal.proficiency >= 0.7 and signal.momentum <= 0.55 and signal.weight > 0
+        ]
+        maintenance_targets.sort(key=lambda s: (s.momentum, -s.proficiency, s.skill))
+
+        focuses: list[SkillFocus] = []
+        for signal in maintenance_targets[:3]:
+            actions = [
+                f"Set monthly mastery checkpoint for {signal.skill}",
+                "Document playbook updates from recent reps",
+            ]
+            if context.is_bandwidth_constrained:
+                actions.append("Automate or templatise routine reps to save bandwidth")
+            focuses.append(
+                SkillFocus(
+                    skill=signal.skill,
+                    priority="Maintenance",
+                    actions=tuple(actions),
+                )
+            )
+        return tuple(focuses)
+
+    def _experiments(self, context: SkillContext) -> tuple[str, ...]:
+        experiments: list[str] = []
+        for signal in self._signals:
+            if signal.momentum <= 0.45 and signal.risk >= 0.4:
+                experiments.append(f"Prototype new training loop for {signal.skill}")
+        if not experiments:
+            experiments.append("Shadow adjacent expert and extract transferable heuristics")
+        if context.support_assets:
+            experiments.append("Leverage assets: " + ", ".join(context.support_assets))
+        return tuple(dict.fromkeys(experiments))
+
+    def _coaching_requests(self, context: SkillContext) -> tuple[str, ...]:
+        requests: list[str] = []
+        for signal in self._signals:
+            if signal.coach and signal.confidence <= 0.5:
+                requests.append(f"Book calibration session with {signal.coach} on {signal.skill}")
+        if context.is_high_stretch:
+            requests.append("Secure monthly executive mentor for strategic navigation")
+        if context.is_bandwidth_constrained:
+            requests.append("Request operations support to shield learning time")
+        return tuple(dict.fromkeys(requests))
+
+    def _narrative(
+        self,
+        context: SkillContext,
+        accelerators: Sequence[SkillFocus],
+        maintenance: Sequence[SkillFocus],
+    ) -> str:
+        lead_skill = accelerators[0].skill if accelerators else "Meta-Learning"
+        maintenance_note = (
+            f"Maintenance covers {', '.join(focus.skill for focus in maintenance)}"
+            if maintenance
+            else "No maintenance tracks scheduled"
+        )
+        stretch_note = "Stretch window high" if context.is_high_stretch else "Stretch window manageable"
+        return (
+            f"Mission: {context.mission}. Lead skill: {lead_skill}. {maintenance_note}. {stretch_note}."
+        )

--- a/dynamic_teaching/__init__.py
+++ b/dynamic_teaching/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic teaching orchestration primitives."""
+
+from .engine import (
+    DynamicTeachingEngine,
+    TeachingContext,
+    TeachingLoop,
+    TeachingMoment,
+    TeachingPlan,
+)
+
+__all__ = [
+    "DynamicTeachingEngine",
+    "TeachingContext",
+    "TeachingLoop",
+    "TeachingMoment",
+    "TeachingPlan",
+]

--- a/dynamic_teaching/engine.py
+++ b/dynamic_teaching/engine.py
@@ -1,0 +1,332 @@
+"""Teaching design engine for Dynamic Capital's knowledge loops."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "TeachingMoment",
+    "TeachingContext",
+    "TeachingLoop",
+    "TeachingPlan",
+    "DynamicTeachingEngine",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        cleaned = tag.strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+# ---------------------------------------------------------------------------
+# dataclasses
+
+
+@dataclass(slots=True)
+class TeachingMoment:
+    """Single captured teaching moment or lesson insight."""
+
+    topic: str
+    audience: str
+    clarity: float = 0.5
+    engagement: float = 0.5
+    retention: float = 0.5
+    confidence: float = 0.5
+    impact: float = 0.5
+    weight: float = 1.0
+    timestamp: datetime = field(default_factory=_utcnow)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    feedback: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.topic = _normalise_text(self.topic)
+        self.audience = _normalise_text(self.audience)
+        self.clarity = _clamp(float(self.clarity))
+        self.engagement = _clamp(float(self.engagement))
+        self.retention = _clamp(float(self.retention))
+        self.confidence = _clamp(float(self.confidence))
+        self.impact = _clamp(float(self.impact))
+        self.weight = max(float(self.weight), 0.0)
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.tags = _normalise_tags(self.tags)
+        self.feedback = _normalise_optional(self.feedback)
+        self.metadata = _coerce_mapping(self.metadata)
+
+
+@dataclass(slots=True)
+class TeachingContext:
+    """Parameters describing the upcoming teaching session."""
+
+    mission: str
+    audience_profile: str
+    timebox_minutes: int
+    format: str
+    interactivity: float
+    rigor: float
+    follow_up_pressure: float
+    constraints: tuple[str, ...] = field(default_factory=tuple)
+    reinforcement_channels: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.audience_profile = _normalise_text(self.audience_profile)
+        self.timebox_minutes = max(int(self.timebox_minutes), 0)
+        self.format = _normalise_text(self.format)
+        self.interactivity = _clamp(float(self.interactivity))
+        self.rigor = _clamp(float(self.rigor))
+        self.follow_up_pressure = _clamp(float(self.follow_up_pressure))
+        self.constraints = tuple(_normalise_text(item) for item in self.constraints if item.strip())
+        self.reinforcement_channels = tuple(
+            _normalise_text(item) for item in self.reinforcement_channels if item.strip()
+        )
+
+    @property
+    def is_time_constrained(self) -> bool:
+        return self.timebox_minutes <= 30
+
+    @property
+    def needs_reinforcement(self) -> bool:
+        return self.follow_up_pressure >= 0.6
+
+
+@dataclass(slots=True)
+class TeachingLoop:
+    """Single teaching loop segment in the final plan."""
+
+    title: str
+    duration: int
+    objectives: tuple[str, ...]
+    reinforcement: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "title": self.title,
+            "duration": self.duration,
+            "objectives": list(self.objectives),
+            "reinforcement": list(self.reinforcement),
+        }
+
+
+@dataclass(slots=True)
+class TeachingPlan:
+    """Aggregated teaching plan with loops and follow-ups."""
+
+    loops: tuple[TeachingLoop, ...]
+    engagement_strategies: tuple[str, ...]
+    reinforcement_actions: tuple[str, ...]
+    risks: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "loops": [loop.as_dict() for loop in self.loops],
+            "engagement_strategies": list(self.engagement_strategies),
+            "reinforcement_actions": list(self.reinforcement_actions),
+            "risks": list(self.risks),
+            "narrative": self.narrative,
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicTeachingEngine:
+    """Aggregate teaching moments and design an upcoming lesson."""
+
+    def __init__(self, *, history: int = 100) -> None:
+        if history <= 0:
+            raise ValueError("history must be positive")
+        self._moments: Deque[TeachingMoment] = deque(maxlen=history)
+
+    # -------------------------------------------------------------- intake
+    def capture(self, moment: TeachingMoment | Mapping[str, object]) -> TeachingMoment:
+        resolved = self._coerce_moment(moment)
+        self._moments.append(resolved)
+        return resolved
+
+    def extend(self, moments: Iterable[TeachingMoment | Mapping[str, object]]) -> None:
+        for moment in moments:
+            self.capture(moment)
+
+    def reset(self) -> None:
+        self._moments.clear()
+
+    def _coerce_moment(self, moment: TeachingMoment | Mapping[str, object]) -> TeachingMoment:
+        if isinstance(moment, TeachingMoment):
+            return moment
+        if isinstance(moment, Mapping):
+            payload: MutableMapping[str, object] = dict(moment)
+            if "timestamp" not in payload:
+                payload["timestamp"] = _utcnow()
+            return TeachingMoment(**payload)  # type: ignore[arg-type]
+        raise TypeError("moment must be TeachingMoment or mapping")
+
+    # ----------------------------------------------------------- computation
+    def build_plan(self, context: TeachingContext) -> TeachingPlan:
+        if not self._moments:
+            raise RuntimeError("no teaching moments captured")
+
+        weighted_total = sum(moment.weight for moment in self._moments if moment.weight > 0)
+        if weighted_total <= 0:
+            raise RuntimeError("teaching moments have zero weight")
+
+        loops = self._build_loops(context)
+        engagement_strategies = self._engagement_strategies(context)
+        reinforcement_actions = self._reinforcement_actions(context)
+        risks = self._risks(context)
+        narrative = self._narrative(context, loops, risks)
+
+        return TeachingPlan(
+            loops=loops,
+            engagement_strategies=engagement_strategies,
+            reinforcement_actions=reinforcement_actions,
+            risks=risks,
+            narrative=narrative,
+        )
+
+    def _build_loops(self, context: TeachingContext) -> tuple[TeachingLoop, ...]:
+        ordered = sorted(
+            (moment for moment in self._moments if moment.weight > 0),
+            key=lambda moment: (-moment.impact, -moment.engagement, moment.topic),
+        )
+        time_remaining = context.timebox_minutes or sum(moment.weight for moment in ordered)
+        loops: list[TeachingLoop] = []
+        for moment in ordered[:5]:
+            duration = max(int(round((moment.weight / max(1.0, ordered[0].weight)) * 10)), 5)
+            if context.timebox_minutes:
+                duration = min(duration, time_remaining)
+            objectives = (
+                f"Deliver clarity on {moment.topic}",
+                "Probe for retention via scenarios",
+            )
+            reinforcement = self._loop_reinforcement(moment, context)
+            loops.append(
+                TeachingLoop(
+                    title=moment.topic,
+                    duration=duration,
+                    objectives=objectives,
+                    reinforcement=reinforcement,
+                )
+            )
+            time_remaining = max(time_remaining - duration, 0)
+            if time_remaining <= 0:
+                break
+        if not loops:
+            loops.append(
+                TeachingLoop(
+                    title="Foundational principles",
+                    duration=context.timebox_minutes or 20,
+                    objectives=("Frame mission context", "Surface known blind spots"),
+                    reinforcement=("Send summary memo",),
+                )
+            )
+        return tuple(loops)
+
+    def _loop_reinforcement(self, moment: TeachingMoment, context: TeachingContext) -> tuple[str, ...]:
+        reinforcement: list[str] = []
+        if context.reinforcement_channels:
+            reinforcement.append("Channel follow-up: " + ", ".join(context.reinforcement_channels))
+        if moment.retention <= 0.5:
+            reinforcement.append("Schedule retention check-in within 72h")
+        if moment.feedback:
+            reinforcement.append(f"Address feedback: {moment.feedback}")
+        if not reinforcement:
+            reinforcement.append("Capture Q&A transcript and publish highlight reel")
+        return tuple(dict.fromkeys(reinforcement))
+
+    def _engagement_strategies(self, context: TeachingContext) -> tuple[str, ...]:
+        strategies: list[str] = []
+        if context.interactivity >= 0.6:
+            strategies.append("Run live problem solving pods")
+        else:
+            strategies.append("Embed micro-polls every 5 minutes")
+        if context.is_time_constrained:
+            strategies.append("Pre-ship primer so synchronous time stays high-fidelity")
+        if context.rigor >= 0.7:
+            strategies.append("Introduce graded challenge to reinforce rigor")
+        return tuple(dict.fromkeys(strategies))
+
+    def _reinforcement_actions(self, context: TeachingContext) -> tuple[str, ...]:
+        actions: list[str] = []
+        if context.needs_reinforcement:
+            actions.append("Schedule follow-up lab within one week")
+        if context.reinforcement_channels:
+            actions.append("Automate drip reminders via " + ", ".join(context.reinforcement_channels))
+        actions.append("Publish teaching artefacts within 24h")
+        return tuple(dict.fromkeys(actions))
+
+    def _risks(self, context: TeachingContext) -> tuple[str, ...]:
+        risks: list[str] = []
+        for moment in self._moments:
+            if moment.clarity <= 0.45:
+                risks.append(f"Clarity gap on {moment.topic}: upgrade visuals")
+            if moment.engagement <= 0.4:
+                risks.append(f"Low engagement on {moment.topic}: assign facilitator")
+        if context.is_time_constrained:
+            risks.append("Tight timebox: enforce agenda transitions")
+        return tuple(dict.fromkeys(risks))
+
+    def _narrative(
+        self,
+        context: TeachingContext,
+        loops: Sequence[TeachingLoop],
+        risks: Sequence[str],
+    ) -> str:
+        lead_loop = loops[0].title if loops else "Foundations"
+        risk_note = risks[0] if risks else "No critical teaching risks"
+        reinforcement_note = (
+            "Reinforcement plan active" if context.needs_reinforcement else "Reinforcement optional"
+        )
+        return (
+            f"Mission: {context.mission}. Lead loop: {lead_loop}. {risk_note}. {reinforcement_note}."
+        )


### PR DESCRIPTION
## Summary
- add a dynamic routine engine to turn weighted activities and context into a prioritised routine plan
- introduce a dynamic review synthesiser that groups observations into agenda sections, risks, decisions, and follow-ups
- provide dynamic skills and teaching engines to orchestrate development roadmaps and lesson plans with reinforcement loops

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d888572a148322852f1593aa8c0901