### PR TITLE
Simplify dynamic planning engines

### DIFF
--- a/dynamic_review/__init__.py
+++ b/dynamic_review/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic review synthesis primitives."""
+
+from .engine import (
+    DynamicReviewEngine,
+    ReviewContext,
+    ReviewInput,
+    ReviewReport,
+    ReviewSection,
+)
+
+__all__ = [
+    "DynamicReviewEngine",
+    "ReviewContext",
+    "ReviewInput",
+    "ReviewReport",
+    "ReviewSection",
+]

--- a/dynamic_review/engine.py
+++ b/dynamic_review/engine.py
@@ -1,0 +1,186 @@
+"""Compact review synthesis helpers for Dynamic Capital rituals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Dict, Iterable, List, MutableMapping, Sequence
+
+__all__ = [
+    "ReviewInput",
+    "ReviewContext",
+    "ReviewSection",
+    "ReviewReport",
+    "DynamicReviewEngine",
+]
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+@dataclass(slots=True)
+class ReviewInput:
+    """Observation captured for a review."""
+
+    area: str
+    headline: str
+    impact: float = 0.5
+    urgency: float = 0.5
+    confidence: float = 0.5
+    sentiment: float = 0.5
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.area = _normalise_text(self.area)
+        self.headline = _normalise_text(self.headline)
+        self.impact = _clamp(self.impact)
+        self.urgency = _clamp(self.urgency)
+        self.confidence = _clamp(self.confidence)
+        self.sentiment = _clamp(self.sentiment)
+        self.weight = max(float(self.weight), 0.0)
+
+
+@dataclass(slots=True)
+class ReviewContext:
+    """Guiding parameters for assembling the review."""
+
+    mission: str
+    cadence: str
+    attention_minutes: int
+    risk_tolerance: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.cadence = _normalise_text(self.cadence)
+        self.attention_minutes = max(int(self.attention_minutes), 0)
+        self.risk_tolerance = _clamp(self.risk_tolerance)
+
+
+@dataclass(slots=True)
+class ReviewSection:
+    title: str
+    talking_points: tuple[str, ...]
+    priority: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "title": self.title,
+            "talking_points": list(self.talking_points),
+            "priority": self.priority,
+        }
+
+
+@dataclass(slots=True)
+class ReviewReport:
+    health_score: float
+    agenda: tuple[ReviewSection, ...]
+    risks: tuple[str, ...]
+    decisions: tuple[str, ...]
+    follow_ups: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "health_score": self.health_score,
+            "agenda": [section.as_dict() for section in self.agenda],
+            "risks": list(self.risks),
+            "decisions": list(self.decisions),
+            "follow_ups": list(self.follow_ups),
+            "narrative": self.narrative,
+        }
+
+
+class DynamicReviewEngine:
+    """Group observations into a compact review deck."""
+
+    def __init__(self) -> None:
+        self._inputs: List[ReviewInput] = []
+
+    def add(self, observation: ReviewInput) -> None:
+        if not isinstance(observation, ReviewInput):  # pragma: no cover - guard
+            raise TypeError("observation must be a ReviewInput instance")
+        self._inputs.append(observation)
+
+    def extend(self, observations: Iterable[ReviewInput]) -> None:
+        for observation in observations:
+            self.add(observation)
+
+    def clear(self) -> None:
+        self._inputs.clear()
+
+    def compile(self, context: ReviewContext) -> ReviewReport:
+        if not self._inputs:
+            raise RuntimeError("no review inputs available")
+
+        ranked = sorted(self._inputs, key=lambda item: self._score(item), reverse=True)
+
+        grouped: Dict[str, List[ReviewInput]] = {}
+        for item in ranked:
+            grouped.setdefault(item.area, []).append(item)
+
+        agenda = [self._section(area, items) for area, items in grouped.items()]
+        agenda.sort(key=lambda section: self._priority_rank(section.priority))
+
+        risks = tuple(
+            f"{item.area}: {item.headline}"
+            for item in ranked
+            if item.sentiment <= 0.4 and item.urgency >= 0.6
+        )
+        decisions = tuple(
+            f"Confirm path for {item.area}: {item.headline}"
+            for item in ranked
+            if item.confidence >= 0.7 and item.impact >= 0.6
+        )
+        follow_ups = tuple(
+            f"Assign owner for {item.area}: {item.headline}"
+            for item in ranked
+            if item.confidence < 0.5
+        )
+
+        health_score = round(
+            fmean(item.sentiment for item in ranked if item.weight > 0) * 100
+        ) / 100
+
+        narrative = (
+            f"Mission {context.mission} ({context.cadence}). "
+            f"Reviewing {len(self._inputs)} signals across {len(grouped)} areas "
+            f"with {context.attention_minutes} minutes of attention."
+        )
+
+        return ReviewReport(
+            health_score=health_score,
+            agenda=tuple(agenda),
+            risks=risks,
+            decisions=decisions,
+            follow_ups=follow_ups,
+            narrative=narrative,
+        )
+
+    # ------------------------------------------------------------------ utils
+    def _score(self, item: ReviewInput) -> float:
+        return item.weight * (item.impact * 0.6 + item.urgency * 0.4)
+
+    def _section(self, area: str, items: Sequence[ReviewInput]) -> ReviewSection:
+        talking_points = tuple(entry.headline for entry in items[:3])
+        avg_impact = fmean(entry.impact for entry in items)
+        avg_sentiment = fmean(entry.sentiment for entry in items)
+        if avg_sentiment < 0.45:
+            priority = "Critical"
+        elif avg_impact >= 0.6:
+            priority = "Focus"
+        else:
+            priority = "Monitor"
+        return ReviewSection(title=area, talking_points=talking_points, priority=priority)
+
+    def _priority_rank(self, priority: str) -> int:
+        order = {"Critical": 0, "Focus": 1, "Monitor": 2}
+        return order.get(priority, 99)
+

--- a/dynamic_routine/__init__.py
+++ b/dynamic_routine/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic routine planning primitives."""
+
+from .engine import (
+    DynamicRoutineEngine,
+    RoutineActivity,
+    RoutineBlock,
+    RoutineContext,
+    RoutinePlan,
+)
+
+__all__ = [
+    "DynamicRoutineEngine",
+    "RoutineActivity",
+    "RoutineBlock",
+    "RoutineContext",
+    "RoutinePlan",
+]

--- a/dynamic_routine/engine.py
+++ b/dynamic_routine/engine.py
@@ -1,0 +1,257 @@
+"""Lightweight routine planning helpers used across Dynamic Capital."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, MutableMapping, Sequence
+
+__all__ = [
+    "RoutineActivity",
+    "RoutineContext",
+    "RoutineBlock",
+    "RoutinePlan",
+    "DynamicRoutineEngine",
+]
+
+
+# ---------------------------------------------------------------------------
+# normalisation helpers
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    """Clamp ``value`` to the inclusive ``[lower, upper]`` range."""
+
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str, *, fallback: str | None = None) -> str:
+    """Normalise textual fields and optionally fall back to ``fallback``."""
+
+    cleaned = value.strip()
+    if cleaned:
+        return cleaned
+    if fallback is not None:
+        return fallback
+    raise ValueError("text value must not be empty")
+
+
+# ---------------------------------------------------------------------------
+# data structures
+
+
+@dataclass(slots=True)
+class RoutineActivity:
+    """Single activity considered for a daily or weekly routine."""
+
+    name: str
+    category: str = "general"
+    importance: float = 0.5
+    duration_minutes: int = 25
+    energy: float = 0.5
+    focus: float = 0.5
+    recovery: float = 0.0
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.category = _normalise_text(self.category, fallback="general")
+        self.importance = _clamp(float(self.importance))
+        self.duration_minutes = max(int(self.duration_minutes), 0)
+        self.energy = _clamp(float(self.energy))
+        self.focus = _clamp(float(self.focus))
+        self.recovery = _clamp(float(self.recovery))
+        self.weight = max(float(self.weight), 0.0)
+
+
+@dataclass(slots=True)
+class RoutineContext:
+    """Context describing the available capacity for the routine."""
+
+    mission: str
+    cadence: str
+    available_minutes: int
+    energy: float
+    focus: float
+    recovery_bias: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.cadence = _normalise_text(self.cadence, fallback="unspecified")
+        self.available_minutes = max(int(self.available_minutes), 0)
+        self.energy = _clamp(float(self.energy))
+        self.focus = _clamp(float(self.focus))
+        self.recovery_bias = _clamp(float(self.recovery_bias))
+
+
+@dataclass(slots=True)
+class RoutineBlock:
+    """Concrete block of time in the final routine plan."""
+
+    name: str
+    minutes: int
+    intent: str
+    intensity: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "minutes": self.minutes,
+            "intent": self.intent,
+            "intensity": self.intensity,
+        }
+
+
+@dataclass(slots=True)
+class RoutinePlan:
+    """Full output returned by :class:`DynamicRoutineEngine`."""
+
+    primary: tuple[RoutineBlock, ...]
+    overflow: tuple[RoutineBlock, ...]
+    recovery_actions: tuple[str, ...]
+    automation_candidates: tuple[str, ...]
+    summary: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "primary": [block.as_dict() for block in self.primary],
+            "overflow": [block.as_dict() for block in self.overflow],
+            "recovery_actions": list(self.recovery_actions),
+            "automation_candidates": list(self.automation_candidates),
+            "summary": self.summary,
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicRoutineEngine:
+    """Plan routines by allocating weighted activities into a time window."""
+
+    def __init__(self) -> None:
+        self._activities: List[RoutineActivity] = []
+
+    # -------------------------------------------------------------- intake API
+    def add(self, activity: RoutineActivity) -> None:
+        """Register a new activity for the next planning cycle."""
+
+        if not isinstance(activity, RoutineActivity):  # pragma: no cover - guard
+            raise TypeError("activity must be a RoutineActivity instance")
+        self._activities.append(activity)
+
+    def extend(self, activities: Iterable[RoutineActivity]) -> None:
+        for activity in activities:
+            self.add(activity)
+
+    def clear(self) -> None:
+        self._activities.clear()
+
+    # ----------------------------------------------------------- core planner
+    def design(self, context: RoutineContext) -> RoutinePlan:
+        if not self._activities:
+            raise RuntimeError("no activities registered")
+
+        ranked = sorted(self._activities, key=lambda item: self._score(item, context), reverse=True)
+
+        primary: list[RoutineBlock] = []
+        overflow: list[RoutineBlock] = []
+        remaining = context.available_minutes
+
+        for activity in ranked:
+            if activity.duration_minutes == 0 or activity.weight == 0:
+                continue
+
+            minutes = activity.duration_minutes
+            block = RoutineBlock(
+                name=activity.name,
+                minutes=min(minutes, max(remaining, 0)),
+                intent=self._intent(activity),
+                intensity=self._intensity(activity, context),
+            )
+
+            if remaining > 0:
+                allocated = min(minutes, remaining)
+                block.minutes = allocated
+                primary.append(block)
+                remaining -= allocated
+                if minutes > allocated:
+                    overflow.append(
+                        RoutineBlock(
+                            name=f"{activity.name} (defer)",
+                            minutes=minutes - allocated,
+                            intent=block.intent,
+                            intensity=block.intensity,
+                        )
+                    )
+            else:
+                overflow.append(block)
+
+        recovery_actions = self._recovery_actions(context, ranked)
+        automation_candidates = self._automation_candidates(ranked)
+        summary = self._summary(context, primary, recovery_actions)
+
+        return RoutinePlan(
+            primary=tuple(primary),
+            overflow=tuple(overflow),
+            recovery_actions=recovery_actions,
+            automation_candidates=automation_candidates,
+            summary=summary,
+        )
+
+    # ------------------------------------------------------------- heuristics
+    def _score(self, activity: RoutineActivity, context: RoutineContext) -> float:
+        priority = activity.weight * activity.importance
+        energy_alignment = 1.0 - abs(activity.energy - context.energy)
+        focus_alignment = 1.0 - abs(activity.focus - context.focus)
+        recovery_alignment = activity.recovery * context.recovery_bias
+        return priority * 0.6 + energy_alignment * 0.2 + focus_alignment * 0.15 + recovery_alignment * 0.05
+
+    def _intent(self, activity: RoutineActivity) -> str:
+        return f"Advance {activity.category} work"
+
+    def _intensity(self, activity: RoutineActivity, context: RoutineContext) -> str:
+        energy_delta = activity.energy - context.energy
+        focus_delta = activity.focus - context.focus
+        if energy_delta >= 0.25 or focus_delta >= 0.25:
+            return "High"
+        if energy_delta <= -0.4 and activity.recovery > 0.4:
+            return "Restorative"
+        if abs(energy_delta) <= 0.15 and abs(focus_delta) <= 0.15:
+            return "Steady"
+        return "Moderate"
+
+    def _recovery_actions(
+        self, context: RoutineContext, activities: Sequence[RoutineActivity]
+    ) -> tuple[str, ...]:
+        actions: list[str] = []
+        avg_recovery = sum(item.recovery for item in activities) / len(activities)
+        if context.recovery_bias >= 0.6 and avg_recovery < 0.3:
+            actions.append("Reserve 15 minutes for deliberate recovery")
+        if context.energy < 0.4:
+            actions.append("Add short break after the most demanding block")
+        if not actions:
+            actions.append("Log qualitative energy notes for tomorrow")
+        return tuple(actions)
+
+    def _automation_candidates(self, activities: Sequence[RoutineActivity]) -> tuple[str, ...]:
+        candidates: list[str] = []
+        for activity in activities:
+            if activity.importance <= 0.3 and activity.duration_minutes >= 40:
+                candidates.append(f"Delegate or automate: {activity.name}")
+        return tuple(dict.fromkeys(candidates))
+
+    def _summary(
+        self,
+        context: RoutineContext,
+        primary: Sequence[RoutineBlock],
+        recovery_actions: Sequence[str],
+    ) -> str:
+        booked = sum(block.minutes for block in primary)
+        utilisation = 0 if context.available_minutes == 0 else round((booked / context.available_minutes) * 100)
+        headline = primary[0].name if primary else "No focus blocks"
+        recovery = recovery_actions[0] if recovery_actions else "Document energy signals"
+        return (
+            f"Mission {context.mission} ({context.cadence}). Utilisation {utilisation}% with focus on "
+            f"{headline}. {recovery}."
+        )
+

--- a/dynamic_skills/__init__.py
+++ b/dynamic_skills/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic skills orchestration primitives."""
+
+from .engine import (
+    DynamicSkillsEngine,
+    SkillContext,
+    SkillFocus,
+    SkillPlan,
+    SkillSignal,
+)
+
+__all__ = [
+    "DynamicSkillsEngine",
+    "SkillContext",
+    "SkillFocus",
+    "SkillPlan",
+    "SkillSignal",
+]

--- a/dynamic_skills/engine.py
+++ b/dynamic_skills/engine.py
@@ -1,0 +1,175 @@
+"""Concise skill development planning primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, MutableMapping
+
+__all__ = [
+    "SkillSignal",
+    "SkillContext",
+    "SkillFocus",
+    "SkillPlan",
+    "DynamicSkillsEngine",
+]
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+@dataclass(slots=True)
+class SkillSignal:
+    """Observed evidence for a specific skill."""
+
+    skill: str
+    observation: str
+    proficiency: float = 0.5
+    demand: float = 0.5
+    momentum: float = 0.5
+    confidence: float = 0.5
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.skill = _normalise_text(self.skill)
+        self.observation = _normalise_text(self.observation)
+        self.proficiency = _clamp(self.proficiency)
+        self.demand = _clamp(self.demand)
+        self.momentum = _clamp(self.momentum)
+        self.confidence = _clamp(self.confidence)
+        self.weight = max(float(self.weight), 0.0)
+
+
+@dataclass(slots=True)
+class SkillContext:
+    """Context window for prioritising development work."""
+
+    mission: str
+    horizon_weeks: int
+    bandwidth: float
+    strategic_weight: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.horizon_weeks = max(int(self.horizon_weeks), 0)
+        self.bandwidth = _clamp(self.bandwidth)
+        self.strategic_weight = _clamp(self.strategic_weight)
+
+
+@dataclass(slots=True)
+class SkillFocus:
+    skill: str
+    priority: str
+    actions: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "skill": self.skill,
+            "priority": self.priority,
+            "actions": list(self.actions),
+        }
+
+
+@dataclass(slots=True)
+class SkillPlan:
+    accelerate: tuple[SkillFocus, ...]
+    sustain: tuple[SkillFocus, ...]
+    watch: tuple[SkillFocus, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "accelerate": [focus.as_dict() for focus in self.accelerate],
+            "sustain": [focus.as_dict() for focus in self.sustain],
+            "watch": [focus.as_dict() for focus in self.watch],
+            "narrative": self.narrative,
+        }
+
+
+class DynamicSkillsEngine:
+    """Rank skill signals and generate a pragmatic improvement plan."""
+
+    def __init__(self) -> None:
+        self._signals: List[SkillSignal] = []
+
+    def add(self, signal: SkillSignal) -> None:
+        if not isinstance(signal, SkillSignal):  # pragma: no cover - guard
+            raise TypeError("signal must be a SkillSignal instance")
+        self._signals.append(signal)
+
+    def extend(self, signals: Iterable[SkillSignal]) -> None:
+        for signal in signals:
+            self.add(signal)
+
+    def clear(self) -> None:
+        self._signals.clear()
+
+    def plan(self, context: SkillContext) -> SkillPlan:
+        if not self._signals:
+            raise RuntimeError("no skill signals available")
+
+        ranked = sorted(self._signals, key=self._score, reverse=True)
+
+        accelerate: list[SkillFocus] = []
+        sustain: list[SkillFocus] = []
+        watch: list[SkillFocus] = []
+
+        for signal in ranked:
+            category, actions = self._categorise(signal, context)
+            focus = SkillFocus(skill=signal.skill, priority=category, actions=actions)
+            if category == "Accelerate":
+                accelerate.append(focus)
+            elif category == "Sustain":
+                sustain.append(focus)
+            else:
+                watch.append(focus)
+
+        narrative = (
+            f"Mission {context.mission}. {len(accelerate)} acceleration targets over "
+            f"{context.horizon_weeks}-week horizon with bandwidth {context.bandwidth:.2f}."
+        )
+
+        return SkillPlan(
+            accelerate=tuple(accelerate),
+            sustain=tuple(sustain),
+            watch=tuple(watch),
+            narrative=narrative,
+        )
+
+    # ------------------------------------------------------------------ utils
+    def _score(self, signal: SkillSignal) -> float:
+        demand_gap = max(signal.demand - signal.proficiency, 0.0)
+        return signal.weight * (demand_gap * 0.6 + (1.0 - signal.confidence) * 0.4)
+
+    def _categorise(self, signal: SkillSignal, context: SkillContext) -> tuple[str, tuple[str, ...]]:
+        demand_gap = max(signal.demand - signal.proficiency, 0.0)
+        stretch = demand_gap * context.strategic_weight
+        if stretch >= 0.4 and context.bandwidth >= 0.3:
+            category = "Accelerate"
+            actions = (
+                f"Schedule deliberate practice for {signal.skill}",
+                "Pair with mentor for weekly feedback",
+            )
+        elif stretch >= 0.2:
+            category = "Sustain"
+            actions = (
+                f"Ship small project using {signal.skill}",
+                "Review learning backlog bi-weekly",
+            )
+        else:
+            category = "Watch"
+            actions = (
+                f"Monitor market signals for {signal.skill}",
+                "Log lightweight reps monthly",
+            )
+        if signal.momentum < 0.4:
+            actions += ("Boost momentum with quick-win task",)
+        return category, actions
+

--- a/dynamic_teaching/__init__.py
+++ b/dynamic_teaching/__init__.py
@@ -1,0 +1,17 @@
+"""Dynamic teaching orchestration primitives."""
+
+from .engine import (
+    DynamicTeachingEngine,
+    TeachingContext,
+    TeachingLoop,
+    TeachingMoment,
+    TeachingPlan,
+)
+
+__all__ = [
+    "DynamicTeachingEngine",
+    "TeachingContext",
+    "TeachingLoop",
+    "TeachingMoment",
+    "TeachingPlan",
+]

--- a/dynamic_teaching/engine.py
+++ b/dynamic_teaching/engine.py
@@ -1,0 +1,187 @@
+"""Helpers for quickly assembling a Dynamic Capital teaching loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, MutableMapping, Sequence
+
+__all__ = [
+    "TeachingMoment",
+    "TeachingContext",
+    "TeachingLoop",
+    "TeachingPlan",
+    "DynamicTeachingEngine",
+]
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+@dataclass(slots=True)
+class TeachingMoment:
+    """Captured learning moment used to inform future sessions."""
+
+    topic: str
+    audience: str
+    clarity: float = 0.5
+    engagement: float = 0.5
+    retention: float = 0.5
+    confidence: float = 0.5
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.topic = _normalise_text(self.topic)
+        self.audience = _normalise_text(self.audience)
+        self.clarity = _clamp(self.clarity)
+        self.engagement = _clamp(self.engagement)
+        self.retention = _clamp(self.retention)
+        self.confidence = _clamp(self.confidence)
+        self.weight = max(float(self.weight), 0.0)
+
+
+@dataclass(slots=True)
+class TeachingContext:
+    """Parameters describing the upcoming teaching need."""
+
+    mission: str
+    audience_profile: str
+    duration_minutes: int
+    format: str
+    reinforcement_bias: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.audience_profile = _normalise_text(self.audience_profile)
+        self.duration_minutes = max(int(self.duration_minutes), 0)
+        self.format = _normalise_text(self.format)
+        self.reinforcement_bias = _clamp(self.reinforcement_bias)
+
+
+@dataclass(slots=True)
+class TeachingLoop:
+    title: str
+    duration: int
+    objectives: tuple[str, ...]
+    reinforcement: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "title": self.title,
+            "duration": self.duration,
+            "objectives": list(self.objectives),
+            "reinforcement": list(self.reinforcement),
+        }
+
+
+@dataclass(slots=True)
+class TeachingPlan:
+    loops: tuple[TeachingLoop, ...]
+    reinforcement: tuple[str, ...]
+    next_steps: tuple[str, ...]
+    narrative: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "loops": [loop.as_dict() for loop in self.loops],
+            "reinforcement": list(self.reinforcement),
+            "next_steps": list(self.next_steps),
+            "narrative": self.narrative,
+        }
+
+
+class DynamicTeachingEngine:
+    """Translate captured teaching moments into a structured agenda."""
+
+    def __init__(self) -> None:
+        self._moments: List[TeachingMoment] = []
+
+    def add(self, moment: TeachingMoment) -> None:
+        if not isinstance(moment, TeachingMoment):  # pragma: no cover - guard
+            raise TypeError("moment must be a TeachingMoment instance")
+        self._moments.append(moment)
+
+    def extend(self, moments: Iterable[TeachingMoment]) -> None:
+        for moment in moments:
+            self.add(moment)
+
+    def clear(self) -> None:
+        self._moments.clear()
+
+    def design(self, context: TeachingContext) -> TeachingPlan:
+        if not self._moments:
+            raise RuntimeError("no teaching moments recorded")
+
+        ranked = sorted(self._moments, key=self._score, reverse=True)
+
+        loops = self._assemble_loops(context, ranked)
+        reinforcement = self._reinforcement_actions(context, ranked)
+        next_steps = self._next_steps(ranked)
+        narrative = (
+            f"Mission {context.mission} for {context.audience_profile}. "
+            f"{len(loops)} loop(s) across {context.duration_minutes} minutes in {context.format} format."
+        )
+
+        return TeachingPlan(
+            loops=tuple(loops),
+            reinforcement=tuple(reinforcement),
+            next_steps=tuple(next_steps),
+            narrative=narrative,
+        )
+
+    # ------------------------------------------------------------------ utils
+    def _score(self, moment: TeachingMoment) -> float:
+        return moment.weight * (moment.clarity * 0.4 + moment.engagement * 0.3 + moment.retention * 0.3)
+
+    def _assemble_loops(
+        self, context: TeachingContext, moments: Sequence[TeachingMoment]
+    ) -> List[TeachingLoop]:
+        total_minutes = max(context.duration_minutes, 1)
+        segment = max(total_minutes // 3, 5)
+        topics = [moment.topic for moment in moments[:3]]
+        loops: list[TeachingLoop] = []
+        stages = ("Prime", "Practice", "Reinforce")
+        for index, title in enumerate(stages):
+            topic = topics[index] if index < len(topics) else topics[-1]
+            objectives = (
+                f"Clarify key concept: {topic}",
+                "Capture audience reflections",
+            )
+            reinforcement = (
+                "Share concise summary afterward",
+                "Log open questions in knowledge base",
+            )
+            loops.append(
+                TeachingLoop(
+                    title=f"{title}: {topic}",
+                    duration=segment,
+                    objectives=objectives,
+                    reinforcement=reinforcement,
+                )
+            )
+        return loops
+
+    def _reinforcement_actions(
+        self, context: TeachingContext, moments: Sequence[TeachingMoment]
+    ) -> List[str]:
+        actions = ["Send recap with key visuals"]
+        if context.reinforcement_bias >= 0.6:
+            actions.append("Schedule follow-up clinic in 1 week")
+        if any(moment.confidence < 0.5 for moment in moments[:3]):
+            actions.append("Pair attendees for peer teaching reps")
+        return actions
+
+    def _next_steps(self, moments: Sequence[TeachingMoment]) -> List[str]:
+        hottest_topic = moments[0].topic
+        return [
+            f"Gather qualitative feedback on {hottest_topic}",
+            "Update canonical playbook with new insights",
+        ]
+


### PR DESCRIPTION
## Summary
- streamline the routine planner to focus on lightweight activity scoring, recovery nudges, and concise output
- rebuild the review synthesiser around compact agenda generation, risk triage, and narrative messaging
- simplify the skills and teaching engines with minimal dataclasses and heuristics for categorising priorities

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d888572a148322852f1593aa8c0901