### PR TITLE
Remove PDF distribution from conduct guide

### DIFF
--- a/docs/dynamic-capital-conduct-engineers-architects.md
+++ b/docs/dynamic-capital-conduct-engineers-architects.md
@@ -1,0 +1,87 @@
+# Code of Professional Conduct – Engineers & Architects
+
+## Table of Contents
+1. [Introduction](#1-introduction)
+2. [Core Principles](#2-core-principles)
+3. [Professional Responsibilities](#3-professional-responsibilities)
+4. [Duty to Public & Environment](#4-duty-to-public--environment)
+5. [Ethical Conduct](#5-ethical-conduct)
+6. [Compliance & Standards](#6-compliance--standards)
+7. [Collaboration & Communication](#7-collaboration--communication)
+8. [Lifelong Development](#8-lifelong-development)
+9. [Enforcement](#9-enforcement)
+10. [Closing Statement](#10-closing-statement)
+11. [Branding & Design Specifications](#branding--design-specifications)
+
+## 1. Introduction
+This Code of Professional Conduct establishes the ethical principles, professional duties, and responsibilities expected of engineers and architects. It ensures integrity, accountability, and excellence in protecting public safety, fostering innovation, and upholding sustainable development.
+
+## 2. Core Principles
+1. **Integrity** – Uphold honesty, transparency, and fairness.
+2. **Accountability** – Accept responsibility for all professional actions.
+3. **Competence** – Work only within areas of expertise.
+4. **Respect** – Treat clients, colleagues, and communities with dignity.
+5. **Sustainability** – Prioritize environmentally responsible design and engineering solutions.
+
+## 3. Professional Responsibilities
+### Engineers
+- Ensure technical accuracy, safety, and reliability in all systems and structures.
+- Apply science and mathematics responsibly to protect human life.
+- Document and report all findings truthfully.
+
+### Architects
+- Design with creativity balanced by safety, function, and sustainability.
+- Respect cultural, historical, and environmental contexts in design.
+- Promote accessibility, inclusivity, and wellness in the spaces created.
+
+## 4. Duty to Public & Environment
+- Place public health, safety, and welfare above all personal interests.
+- Minimize environmental impact through innovative and sustainable practices.
+- Consider long-term consequences of all projects.
+
+## 5. Ethical Conduct
+- **No Conflict of Interest** – Disclose financial or personal interests that may affect judgment.
+- **No Corruption** – Reject bribery, unfair favors, or unethical practices.
+- **Fair Practice** – Ensure equity and non-discrimination in professional dealings.
+
+## 6. Compliance & Standards
+- Follow all applicable building codes, laws, and safety regulations.
+- Respect intellectual property and acknowledge contributions.
+- Maintain professional records, drawings, and approvals transparently.
+
+## 7. Collaboration & Communication
+- Work with clarity across multidisciplinary teams.
+- Provide information to clients and the public in understandable terms.
+- Promote teamwork and shared responsibility.
+
+## 8. Lifelong Development
+- Commit to continuous education and innovation.
+- Mentor future generations of engineers and architects.
+- Contribute research, knowledge, and service to society.
+
+## 9. Enforcement
+Violations of this Code may result in disciplinary actions, loss of professional license, or legal consequences under governing regulations.
+
+## 10. Closing Statement
+Engineers and architects are not only creators of infrastructure and spaces but also custodians of public trust. By adhering to these principles, we ensure a legacy of safety, sustainability, and excellence.
+
+## Branding & Design Specifications
+- **Cover & Layout**
+  - Title: “Code of Professional Conduct – Engineers & Architects”.
+  - Minimalistic cover with geometric lines, blueprint grid background, and architectural sketch accents.
+  - Logo positioned in the top-left corner of every page with a consistent header reading “Dynamic Capital”.
+  - Footer includes the page number and the tagline “Code of Professional Conduct”.
+- **Color Palette**
+  - Professional blues (#0E2F5A, #1F4E79) contrasted with warm neutrals (#F4F5F7, #D4C5B9).
+  - Accent color (#00A8E8) for icons and emphasized rules.
+- **Typography**
+  - Headers: Bold sans-serif styling inspired by Montserrat or Helvetica.
+  - Body: Readable serif styling inspired by Lora or Times New Roman.
+- **Iconography**
+  - ⚖️ Ethics and fairness.
+  - 🌍 Sustainability and environmental stewardship.
+  - 🏛️ Compliance and governance.
+- **Format & Accessibility**
+  - Maintain clearly numbered sections and a linked index in all shared formats.
+  - Incorporate blueprint line art in the background to reinforce the architectural theme while maintaining legibility.
+  - Emphasize clarity, succinct bullet points, and inclusive language for global audiences across print and digital layouts.


### PR DESCRIPTION
## Summary
- remove the generated PDF for the engineers and architects conduct guide
- update the markdown guide to drop the PDF download link and keep formatting guidance format-agnostic

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d88d756ee08322a657e037d9021541