### PR TITLE
Add dynamic task manager engine

### DIFF
--- a/dynamic_task_manager/__init__.py
+++ b/dynamic_task_manager/__init__.py
@@ -1,0 +1,23 @@
+"""Dynamic task manager utilities."""
+
+from .manager import (
+    BlockedTask,
+    DeferredTask,
+    DynamicTaskManager,
+    Task,
+    TaskContext,
+    TaskSchedule,
+    TaskSlot,
+    TaskStatus,
+)
+
+__all__ = [
+    "BlockedTask",
+    "DeferredTask",
+    "DynamicTaskManager",
+    "Task",
+    "TaskContext",
+    "TaskSchedule",
+    "TaskSlot",
+    "TaskStatus",
+]

--- a/dynamic_task_manager/manager.py
+++ b/dynamic_task_manager/manager.py
@@ -1,0 +1,447 @@
+"""Dynamic task management engine for prioritising and scheduling work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from enum import Enum
+from typing import Dict, Iterable, List, MutableMapping, Sequence, Set, Tuple
+
+__all__ = [
+    "TaskStatus",
+    "Task",
+    "TaskContext",
+    "TaskSlot",
+    "DeferredTask",
+    "BlockedTask",
+    "TaskSchedule",
+    "DynamicTaskManager",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    """Clamp ``value`` to the inclusive ``[lower, upper]`` range."""
+
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str, *, fallback: str | None = None) -> str:
+    """Return normalised text or ``fallback`` when the string is empty."""
+
+    cleaned = value.strip()
+    if cleaned:
+        return cleaned
+    if fallback is not None:
+        return fallback
+    raise ValueError("text value must not be empty")
+
+
+def _to_date(value: date | datetime | str | None) -> date | None:
+    """Coerce a value into a :class:`datetime.date` when possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"invalid ISO date string: {value!r}") from exc
+    raise TypeError("due_date must be a date, datetime, ISO string, or None")
+
+
+# ---------------------------------------------------------------------------
+# domain model
+
+
+class TaskStatus(str, Enum):
+    """Represents the lifecycle state of a task."""
+
+    TODO = "todo"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    DONE = "done"
+
+
+@dataclass(slots=True)
+class Task:
+    """Single unit of work tracked by :class:`DynamicTaskManager`."""
+
+    name: str
+    description: str = ""
+    priority: float = 0.5
+    effort_hours: float = 1.0
+    due_date: date | None = None
+    status: TaskStatus = TaskStatus.TODO
+    progress: float = 0.0
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.description = self.description.strip()
+        self.priority = _clamp(float(self.priority))
+        self.effort_hours = max(float(self.effort_hours), 0.0)
+        self.due_date = _to_date(self.due_date)
+        if not isinstance(self.status, TaskStatus):
+            self.status = TaskStatus(str(self.status))
+        self.progress = _clamp(float(self.progress))
+        normalised_tags: List[str] = []
+        for tag in self.tags:
+            if not tag:
+                continue
+            cleaned = _normalise_text(tag, fallback="").strip()
+            if not cleaned:
+                continue
+            normalised_tags.append(cleaned.lower())
+        self.tags = tuple(normalised_tags)
+
+    @property
+    def remaining_hours(self) -> float:
+        """Return the estimated hours still required to finish the task."""
+
+        return max(self.effort_hours * (1.0 - self.progress), 0.0)
+
+    def mark_done(self) -> None:
+        """Convenience helper to mark a task as complete."""
+
+        self.status = TaskStatus.DONE
+        self.progress = 1.0
+
+
+@dataclass(slots=True)
+class TaskContext:
+    """Context for producing a schedule."""
+
+    mission: str
+    reporting_period: str
+    available_hours: float
+    current_date: date | datetime | str
+    focus_bias: float = 0.5
+    risk_tolerance: float = 0.5
+    planning_window_days: int = 14
+    focus_tags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.mission = _normalise_text(self.mission)
+        self.reporting_period = _normalise_text(self.reporting_period)
+        self.available_hours = max(float(self.available_hours), 0.0)
+        self.current_date = _to_date(self.current_date) or date.today()
+        self.focus_bias = _clamp(float(self.focus_bias))
+        self.risk_tolerance = _clamp(float(self.risk_tolerance))
+        self.planning_window_days = max(int(self.planning_window_days), 1)
+        normalised_focus: List[str] = []
+        for tag in self.focus_tags:
+            if not tag:
+                continue
+            cleaned = _normalise_text(tag, fallback="").strip()
+            if not cleaned:
+                continue
+            normalised_focus.append(cleaned.lower())
+        self.focus_tags = tuple(normalised_focus)
+
+
+@dataclass(slots=True)
+class TaskSlot:
+    """Represents a scheduled block of time for a task."""
+
+    name: str
+    allocated_hours: float
+    remaining_hours: float
+    status: TaskStatus
+    notes: str = ""
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "allocated_hours": self.allocated_hours,
+            "remaining_hours": self.remaining_hours,
+            "status": self.status.value,
+            "notes": self.notes,
+        }
+
+
+@dataclass(slots=True)
+class DeferredTask:
+    """Task that could not be scheduled or finished."""
+
+    name: str
+    reason: str
+    status: TaskStatus
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "reason": self.reason,
+            "status": self.status.value,
+        }
+
+
+@dataclass(slots=True)
+class BlockedTask:
+    """Task blocked by outstanding dependencies."""
+
+    name: str
+    missing_dependencies: Tuple[str, ...]
+    status: TaskStatus
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "missing_dependencies": list(self.missing_dependencies),
+            "status": self.status.value,
+        }
+
+
+@dataclass(slots=True)
+class TaskSchedule:
+    """Full schedule generated by :class:`DynamicTaskManager`."""
+
+    slots: Tuple[TaskSlot, ...]
+    deferred: Tuple[DeferredTask, ...]
+    blocked: Tuple[BlockedTask, ...]
+    summary: str
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "slots": [slot.as_dict() for slot in self.slots],
+            "deferred": [item.as_dict() for item in self.deferred],
+            "blocked": [item.as_dict() for item in self.blocked],
+            "summary": self.summary,
+        }
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicTaskManager:
+    """Prioritise and schedule tasks based on urgency, focus, and capacity."""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, Task] = {}
+        self._dependencies: Dict[str, Set[str]] = {}
+
+    # ------------------------------------------------------------- task intake
+    def add(self, task: Task) -> None:
+        """Register a new task for future scheduling cycles."""
+
+        if not isinstance(task, Task):  # pragma: no cover - defensive guard
+            raise TypeError("task must be a Task instance")
+        if task.name in self._tasks:
+            raise ValueError(f"task with name {task.name!r} already registered")
+        self._tasks[task.name] = task
+        self._dependencies.setdefault(task.name, set())
+
+    def extend(self, tasks: Iterable[Task]) -> None:
+        for task in tasks:
+            self.add(task)
+
+    def clear(self) -> None:
+        self._tasks.clear()
+        self._dependencies.clear()
+
+    # -------------------------------------------------------- dependency API
+    def add_dependency(self, task_name: str, depends_on: str) -> None:
+        """Declare that ``task_name`` depends on ``depends_on`` being complete."""
+
+        task_name = _normalise_text(task_name)
+        depends_on = _normalise_text(depends_on)
+        if task_name == depends_on:
+            raise ValueError("tasks cannot depend on themselves")
+        if task_name not in self._tasks:
+            raise KeyError(f"unknown task: {task_name!r}")
+        if depends_on not in self._tasks:
+            raise KeyError(f"unknown dependency: {depends_on!r}")
+
+        deps = self._dependencies.setdefault(task_name, set())
+        if depends_on in deps:
+            return
+
+        # prevent introducing dependency cycles
+        if self._creates_cycle(task_name, depends_on):
+            raise ValueError(
+                f"adding dependency {task_name!r} -> {depends_on!r} would create a cycle"
+            )
+        deps.add(depends_on)
+
+    def _creates_cycle(self, task_name: str, depends_on: str) -> bool:
+        """Check whether linking ``task_name`` to ``depends_on`` forms a cycle."""
+
+        stack = [depends_on]
+        visited: Set[str] = set()
+        while stack:
+            current = stack.pop()
+            if current == task_name:
+                return True
+            if current in visited:
+                continue
+            visited.add(current)
+            stack.extend(self._dependencies.get(current, ()))
+        return False
+
+    # ----------------------------------------------------------- state API
+    def update_status(self, task_name: str, status: TaskStatus) -> None:
+        task = self._tasks.get(task_name)
+        if task is None:
+            raise KeyError(f"unknown task: {task_name!r}")
+        task.status = status
+        if status is TaskStatus.DONE:
+            task.progress = 1.0
+
+    def get(self, task_name: str) -> Task:
+        task = self._tasks.get(task_name)
+        if task is None:
+            raise KeyError(f"unknown task: {task_name!r}")
+        return task
+
+    # -------------------------------------------------------------- reporting
+    def backlog_snapshot(self, *, include_completed: bool = False) -> Tuple[Task, ...]:
+        """Return tasks sorted by scheduling priority."""
+
+        if not self._tasks:
+            return tuple()
+        context = TaskContext(
+            mission="backlog",
+            reporting_period="snapshot",
+            available_hours=1.0,
+            current_date=date.today(),
+        )
+        ranked = sorted(
+            (
+                task
+                for task in self._tasks.values()
+                if include_completed or task.status is not TaskStatus.DONE
+            ),
+            key=lambda task: self._score(task, context),
+            reverse=True,
+        )
+        return tuple(ranked)
+
+    # ------------------------------------------------------------- scheduling
+    def plan(self, context: TaskContext) -> TaskSchedule:
+        if not self._tasks:
+            raise RuntimeError("no tasks have been registered")
+
+        ready: List[Task] = []
+        blocked: List[BlockedTask] = []
+
+        for task in self._tasks.values():
+            if task.status is TaskStatus.DONE or task.remaining_hours <= 0.0:
+                continue
+            deps = self._dependencies.get(task.name, set())
+            missing = tuple(sorted(dep for dep in deps if self._tasks[dep].status is not TaskStatus.DONE))
+            if missing:
+                blocked.append(BlockedTask(task.name, missing, task.status))
+                continue
+            ready.append(task)
+
+        if not ready and not blocked:
+            return TaskSchedule(tuple(), tuple(), tuple(), "no tasks require scheduling")
+
+        ranked_ready = sorted(ready, key=lambda task: self._score(task, context), reverse=True)
+
+        slots: List[TaskSlot] = []
+        deferred: List[DeferredTask] = []
+        remaining_capacity = context.available_hours
+
+        for task in ranked_ready:
+            required = task.remaining_hours
+            if required <= 0.0:
+                continue
+            if remaining_capacity <= 0.0:
+                deferred.append(
+                    DeferredTask(task.name, "insufficient capacity this cycle", task.status)
+                )
+                continue
+
+            allocation = min(required, remaining_capacity)
+            remaining_capacity -= allocation
+            spillover = max(required - allocation, 0.0)
+
+            notes: List[str] = []
+            if task.status is TaskStatus.TODO:
+                notes.append("kick-off scheduled")
+            if spillover > 0.0:
+                notes.append("additional sessions required")
+                deferred.append(
+                    DeferredTask(task.name, "requires additional capacity", task.status)
+                )
+
+            projected_status = TaskStatus.IN_PROGRESS
+            if task.status is TaskStatus.IN_PROGRESS and spillover <= 0.0:
+                projected_status = TaskStatus.IN_PROGRESS
+            elif spillover <= 0.0 and required <= allocation:
+                projected_status = TaskStatus.DONE if task.progress >= 1.0 else TaskStatus.IN_PROGRESS
+
+            slots.append(
+                TaskSlot(
+                    name=task.name,
+                    allocated_hours=allocation,
+                    remaining_hours=spillover,
+                    status=projected_status,
+                    notes="; ".join(notes),
+                )
+            )
+
+        summary = self._summarise(slots, deferred, blocked, remaining_capacity)
+
+        return TaskSchedule(tuple(slots), tuple(deferred), tuple(blocked), summary)
+
+    # ----------------------------------------------------------- scoring utils
+    def _score(self, task: Task, context: TaskContext) -> float:
+        priority = task.priority
+        urgency = self._urgency(task, context)
+        focus = self._focus_alignment(task, context)
+        momentum = 0.15 if task.status is TaskStatus.IN_PROGRESS else 0.0
+        effort_balance = 1.0 - _clamp(task.remaining_hours / (context.available_hours + 1e-9))
+
+        weighted = (
+            priority * 0.45
+            + urgency * 0.3
+            + focus * context.focus_bias * 0.15
+            + momentum
+            + effort_balance * 0.1
+        )
+        return _clamp(weighted, lower=0.0, upper=1.5)
+
+    def _urgency(self, task: Task, context: TaskContext) -> float:
+        if task.due_date is None:
+            return 0.3 + (context.risk_tolerance * 0.3)
+
+        delta_days = (task.due_date - context.current_date).days
+        if delta_days <= 0:
+            return 1.0
+        window = float(context.planning_window_days)
+        return _clamp(1.0 - (delta_days / window), lower=0.0, upper=1.0)
+
+    def _focus_alignment(self, task: Task, context: TaskContext) -> float:
+        if not context.focus_tags or not task.tags:
+            return 0.0
+        focus_set = set(context.focus_tags)
+        overlap = focus_set.intersection(task.tags)
+        if not overlap:
+            return 0.0
+        return _clamp(len(overlap) / max(len(focus_set), 1), lower=0.0, upper=1.0)
+
+    def _summarise(
+        self,
+        slots: Sequence[TaskSlot],
+        deferred: Sequence[DeferredTask],
+        blocked: Sequence[BlockedTask],
+        remaining_capacity: float,
+    ) -> str:
+        parts = [
+            f"scheduled {len(slots)} task(s)",
+            f"blocked {len(blocked)}",
+            f"deferred {len(deferred)}",
+        ]
+        if remaining_capacity > 0.0:
+            parts.append(f"{remaining_capacity:.1f}h capacity remaining")
+        return ", ".join(parts)

--- a/tests_python/test_dynamic_task_manager.py
+++ b/tests_python/test_dynamic_task_manager.py
@@ -1,0 +1,113 @@
+"""Tests for the dynamic task manager module."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date, timedelta
+
+from dynamic_task_manager import (
+    DynamicTaskManager,
+    Task,
+    TaskContext,
+    TaskSchedule,
+    TaskSlot,
+    TaskStatus,
+)
+
+
+class TaskSchedulingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.today = date(2024, 1, 1)
+        self.manager = DynamicTaskManager()
+
+    def _base_context(self, *, hours: float) -> TaskContext:
+        return TaskContext(
+            mission="Quarterly OKRs",
+            reporting_period="weekly",
+            available_hours=hours,
+            current_date=self.today,
+            focus_bias=0.6,
+            risk_tolerance=0.4,
+            planning_window_days=10,
+            focus_tags=("growth", "experimentation"),
+        )
+
+    def test_urgent_tasks_are_prioritised(self) -> None:
+        urgent = Task(
+            name="Publish customer report",
+            priority=0.6,
+            effort_hours=3.0,
+            due_date=self.today + timedelta(days=1),
+            tags=("growth",),
+        )
+        deep_work = Task(
+            name="Refactor analytics pipeline",
+            priority=0.9,
+            effort_hours=4.0,
+            due_date=self.today + timedelta(days=9),
+            tags=("architecture",),
+        )
+        blocked = Task(
+            name="Launch experiment",
+            priority=0.8,
+            effort_hours=2.0,
+            due_date=self.today + timedelta(days=2),
+            tags=("experimentation",),
+        )
+
+        self.manager.extend([urgent, deep_work, blocked])
+        self.manager.add_dependency("Launch experiment", "Publish customer report")
+
+        schedule = self.manager.plan(self._base_context(hours=5.0))
+
+        self.assertIsInstance(schedule, TaskSchedule)
+        self.assertEqual(len(schedule.slots), 2)
+        self.assertEqual(schedule.slots[0].name, "Publish customer report")
+        self.assertLessEqual(schedule.slots[0].allocated_hours, 3.0)
+        self.assertTrue(any(item.name == "Launch experiment" for item in schedule.blocked))
+
+    def test_partial_allocation_records_deferred_item(self) -> None:
+        task = Task(
+            name="Migrate billing system",
+            priority=0.9,
+            effort_hours=5.0,
+            tags=("platform",),
+        )
+        self.manager.add(task)
+
+        schedule = self.manager.plan(self._base_context(hours=2.0))
+
+        self.assertEqual(len(schedule.slots), 1)
+        slot = schedule.slots[0]
+        self.assertIsInstance(slot, TaskSlot)
+        self.assertAlmostEqual(slot.allocated_hours, 2.0)
+        self.assertGreater(slot.remaining_hours, 0.0)
+        self.assertTrue(any(item.name == task.name for item in schedule.deferred))
+
+    def test_cycle_detection_prevents_invalid_dependencies(self) -> None:
+        first = Task(name="Draft strategy", priority=0.8)
+        second = Task(name="Review strategy", priority=0.7)
+
+        self.manager.extend([first, second])
+        self.manager.add_dependency("Review strategy", "Draft strategy")
+
+        with self.assertRaises(ValueError):
+            self.manager.add_dependency("Draft strategy", "Review strategy")
+
+    def test_backlog_snapshot_orders_by_priority(self) -> None:
+        a = Task(name="Document architecture", priority=0.5)
+        b = Task(name="Ship onboarding", priority=0.9, due_date=self.today)
+        c = Task(name="Add telemetry", priority=0.6, status=TaskStatus.IN_PROGRESS, progress=0.3)
+        d = Task(name="Archive legacy system", priority=0.4, status=TaskStatus.DONE)
+
+        self.manager.extend([a, b, c, d])
+
+        snapshot = self.manager.backlog_snapshot()
+
+        self.assertEqual(snapshot[0].name, "Ship onboarding")
+        self.assertNotIn(d, snapshot)
+        self.assertLess(snapshot.index(c), snapshot.index(a))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dynamic_task_manager package with scheduling, prioritisation, and dependency modelling primitives
- expose the new engine via package exports and add focused pytest coverage for planning, blocking, and backlog ordering

## Testing
- npm run format
- npm run lint
- npm run typecheck
- python -m pytest tests_python/test_dynamic_task_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d88f03f9dc83229a19e7c04d85a20c