### PR TITLE
Refactor lazy agent shims

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -11,9 +11,9 @@ only when they are first accessed.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = [
     "Agent",
@@ -40,7 +40,8 @@ __all__ = [
     "run_dynamic_agent_cycle",
 ]
 
-_LAZY = LazyNamespace(
+_LAZY = install_lazy_module(
+    globals(),
     "dynamic_ai",
     __all__,
     overrides={
@@ -71,13 +72,3 @@ if TYPE_CHECKING:  # pragma: no cover - import-time only
         WaveAgent,
         WaveAgentResult,
     )
-
-
-def __getattr__(name: str) -> Any:
-    """Lazily expose objects from the modern implementation modules."""
-
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/_lazy.py
+++ b/dynamic_agents/_lazy.py
@@ -61,3 +61,24 @@ class LazyNamespace:
         """Return the ordered exports for convenience."""
 
         return self._exports
+
+
+def install_lazy_module(
+    namespace: dict[str, Any],
+    default_module: str,
+    exports: Iterable[str],
+    overrides: Mapping[str, str] | None = None,
+) -> LazyNamespace:
+    """Attach lazy-loading hooks to ``namespace`` and return the shim."""
+
+    lazy_namespace = LazyNamespace(default_module, exports, overrides)
+
+    def __getattr__(name: str) -> Any:
+        return lazy_namespace.resolve(name, namespace)
+
+    def __dir__() -> list[str]:  # pragma: no cover - trivial
+        return lazy_namespace.dir(namespace)
+
+    namespace["__getattr__"] = __getattr__
+    namespace["__dir__"] = __dir__
+    return lazy_namespace

--- a/dynamic_agents/base.py
+++ b/dynamic_agents/base.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["Agent", "AgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import Agent, AgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/chat.py
+++ b/dynamic_agents/chat.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["ChatAgentResult", "ChatTurn", "DynamicChatAgent"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import ChatAgentResult, ChatTurn, DynamicChatAgent
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/cycle.py
+++ b/dynamic_agents/cycle.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["run_dynamic_agent_cycle"]
 
-_LAZY = LazyNamespace("algorithms.python.dynamic_ai_sync", __all__)
+_LAZY = install_lazy_module(
+    globals(), "algorithms.python.dynamic_ai_sync", __all__
+)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/execution.py
+++ b/dynamic_agents/execution.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["ExecutionAgent", "ExecutionAgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import ExecutionAgent, ExecutionAgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/research.py
+++ b/dynamic_agents/research.py
@@ -9,21 +9,13 @@ accessed.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["ResearchAgent", "ResearchAgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import ResearchAgent, ResearchAgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/risk.py
+++ b/dynamic_agents/risk.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["RiskAgent", "RiskAgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import RiskAgent, RiskAgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/space.py
+++ b/dynamic_agents/space.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["SpaceAgent", "SpaceAgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import SpaceAgent, SpaceAgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/trading.py
+++ b/dynamic_agents/trading.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["TradingAgent", "TradingAgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import TradingAgent, TradingAgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())

--- a/dynamic_agents/wave.py
+++ b/dynamic_agents/wave.py
@@ -2,21 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from ._lazy import LazyNamespace
+from ._lazy import install_lazy_module
 
 __all__ = ["WaveAgent", "WaveAgentResult"]
 
-_LAZY = LazyNamespace("dynamic_ai.agents", __all__)
+_LAZY = install_lazy_module(globals(), "dynamic_ai.agents", __all__)
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_ai.agents import WaveAgent, WaveAgentResult
-
-
-def __getattr__(name: str) -> Any:
-    return _LAZY.resolve(name, globals())
-
-
-def __dir__() -> list[str]:  # pragma: no cover - trivial
-    return _LAZY.dir(globals())


### PR DESCRIPTION
## Summary
- add a shared `install_lazy_module` helper so the compatibility shims attach lazy hooks consistently
- switch the `dynamic_agents` namespace modules to the shared helper and remove their duplicated `__getattr__`/`__dir__` definitions

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d894f386188322ae4e18bab361c358