### PR TITLE
Refine cosmic recycling lifecycle doc for project application

### DIFF
--- a/docs/cosmic-recycling-lifecycle.md
+++ b/docs/cosmic-recycling-lifecycle.md
@@ -1,0 +1,52 @@
+# Cosmic Recycling Lifecycle Playbook
+
+Cosmic recycling captures how star systems continuously forge, distribute, and reuse matter. Dynamic Capital taps the same rhythm to compound treasury strength, contributor knowledge, and shipping velocity. Treat each stellar stage as a blueprint for shipping loops, telemetry feedback, and governance upgrades that keep the platform cycling forward.
+
+## Stage-to-Platform Mapping
+
+| Cosmic Stage | Astrophysical Dynamics | Dynamic Capital Lens | Implementation Signals |
+| --- | --- | --- | --- |
+| **Primordial Gas (H, He)** | Cold molecular clouds collapse under gravity to form protostars. | Raw community energy, market inputs, and liquidity partners entering the funnel. | Capture inflow metrics in `dynamic_recycling` ingestion jobs and surface sentiment telemetry in `dynamic_cosmic` dashboards.
+| **Protostar → Main Sequence Star** | Accretion and ignition stabilize sustained fusion. | Core infrastructure (custody, risk, observability) reaching production maturity. | Promote features from staging only after `dynamic_validator` guardrails and alerting thresholds pass acceptance.
+| **Fusion Pathways** | Sequential fusion generates heavier elements up to iron. | Iterative feature growth: compliance modules, analytics layers, partner integrations. | Use release cadences governed by `dynamic_cycle` to avoid fusing "heavier" initiatives before the core metrics are stable.
+| **Stellar Winds & Supernovae** | Catastrophic events eject metals into the interstellar medium. | Major launches, audits, or incidents releasing learnings and capital back into the ecosystem. | Run post-event retrospectives via `dynamic_review` and pipe artifacts into contributor portals.
+| **Enriched ISM Collapse** | Metal-rich clouds birth the next generation of stars and planets. | Reinvested telemetry, treasury returns, and storytelling powering the next roadmap wave. | Feed insights into `dynamic_memory_reconsolidation` to update playbooks, OKRs, and liquidity strategy.
+
+## Fusion Stack Reference
+
+```
+H → He → C, O → … → Fe
+```
+
+- **Platform cue:** escalate experiments only when upstream stability (H → He) has persisted across two quality gates.
+- **Revenue cue:** heavier "metal" features should unlock new treasury or fee streams before proceeding to the next fusion layer.
+
+## Feedback Cycle Instrumentation
+
+1. **Inflow Sensing** — Use `dynamic_message_queue` pipelines to log partner deposits, user sentiment, and compliance flags as the "primordial" intake.
+2. **Core Stabilization** — Validate baseline KPIs (latency, custody availability, fraud detection) with `dynamic_engineer` scorecards before declaring a module main sequence ready.
+3. **Differentiation Builds** — Stage analytics, governance, or multi-LLM automation as the heavier-element tranche. Gate each build with scenario modeling in `dynamic_forecast` and `dynamic_energy` stress simulations.
+4. **Event Harvesting** — Capture audits, launches, or incidents as "supernova" events. Archive incident timelines in `dynamic_memory` and convert the outcomes into public-facing narratives within `dynamic_story` (marketing) tracks.
+5. **Reinvestment Loop** — Feed improved runbooks, liquidity strategies, and marketing playbooks back into growth sprints. The objective is higher "metallicity": more resilient contributors, diversified liquidity, and richer onboarding stories every cycle.
+
+## Operational Checklist
+
+- [ ] **Primordial Intake Ready:**
+  - [ ] Partner, community, and liquidity inflows instrumented with shared metrics definitions.
+  - [ ] Sentiment tags normalized so `dynamic_cosmic` visualizations can compare cycles.
+- [ ] **Core Fusion Stability:**
+  - [ ] Custody, compliance, and risk monitors hold steady for two consecutive sprints.
+  - [ ] Post-incident reviews within `dynamic_review` closed with action items assigned.
+- [ ] **Heavy Element Expansion:**
+  - [ ] Advanced modules (cross-chain, analytics, multi-LLM tooling) gated by measurable uplifts.
+  - [ ] Treasury council signs off on projected burn vs. return using `dynamic_budget` models.
+- [ ] **Supernova Learnings Captured:**
+  - [ ] Launch or incident summaries published internally within 48 hours.
+  - [ ] Key lessons seeded into onboarding and marketing collateral.
+- [ ] **Metallicity Growth Metrics:**
+  - [ ] Track contributor readiness, treasury diversification, and ecosystem partnerships to quantify enrichment.
+  - [ ] Compare current cycle KPIs against prior rotations to confirm compounding progress.
+
+## Key Takeaway
+
+Every Dynamic Capital sprint should leave the ecosystem richer—more telemetry, more resilient treasury flows, and better contributor fluency—just as each stellar generation increases universal metallicity. Treat the cosmic recycling loop as the operational north star guiding roadmap prioritization and storytelling.


### PR DESCRIPTION
## Summary
- reframe the cosmic recycling lifecycle as a Dynamic Capital operational playbook
- add platform-aligned mappings, instrumentation guidance, and an actionable checklist

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d89d642f7c8322a06144196ca4fe79