### PR TITLE
Refine token metadata sourcing

### DIFF
--- a/apps/web/app/token/page.tsx
+++ b/apps/web/app/token/page.tsx
@@ -1,80 +1,41 @@
-import { Column, Heading, Icon, Row, Tag, Text } from "@/components/dynamic-ui-system";
+import {
+  Column,
+  Heading,
+  Icon,
+  Meta,
+  Row,
+  Schema,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+import {
+  baseURL as siteBaseURL,
+  tokenContent,
+  tokenDescriptor,
+} from "@/resources";
 
-const TOKEN_NAME = "Dynamic Capital Token";
-const TOKEN_SYMBOL = "DCT";
-const TOKEN_DECIMALS = 9;
-const TOKEN_MAX_SUPPLY = 100_000_000;
+const normalizeBaseURL = (value: string) =>
+  value.endsWith("/") ? value.slice(0, -1) : value;
 
-const SUPPLY_SPLITS = [
-  {
-    label: "Operations",
-    value: "60%",
-    description: "Fuel day-to-day desk execution, analytics, and mentor coverage.",
-    icon: "sparkles" as const,
-  },
-  {
-    label: "Auto-invest pool",
-    value: "30%",
-    description: "Deploy liquidity into strategies the desk validates each epoch.",
-    icon: "rocket" as const,
-  },
-  {
-    label: "Buyback & burn",
-    value: "10%",
-    description: "Stabilize the treasury with scheduled market operations and burns.",
-    icon: "repeat" as const,
-  },
-] as const;
+const tokenBaseURL = tokenDescriptor.externalUrl?.length
+  ? tokenDescriptor.externalUrl
+  : siteBaseURL;
+const normalizedBaseURL = normalizeBaseURL(tokenBaseURL);
+const tokenCanonicalUrl = `${normalizedBaseURL}${tokenContent.path}`;
+const schemaSameAs = Array.from(
+  new Set([tokenCanonicalUrl, ...tokenContent.sameAs]),
+);
 
-const LOCK_TIERS = [
-  {
-    tier: "Bronze",
-    duration: "3 months",
-    multiplier: "1.2×",
-    description: "Starter tier that unlocks curated market briefs and limited drops.",
-  },
-  {
-    tier: "Silver",
-    duration: "6 months",
-    multiplier: "1.5×",
-    description: "Enhance reward flow with priority access to automation templates.",
-  },
-  {
-    tier: "Gold",
-    duration: "12 months",
-    multiplier: "2.0×",
-    description: "Max utility with VIP desk passes, mentor escalations, and beta slots.",
-  },
-] as const;
-
-const TOKEN_UTILITIES = [
-  "Redeem on-chain for VIP membership credits and automation boosts.",
-  "Stake into the auto-invest pool to participate in weekly performance.",
-  "Vote on treasury moves through the 48-hour guarded governance window.",
-] as const;
-
-const DEX_POOLS = [
-  {
-    dex: "STON.fi",
-    pair: "DCT/USDT",
-    url: "https://app.ston.fi/swap?from=USDT&to=DCT",
-    description:
-      "Anchor the treasury's USD peg with a stablecoin pool that supports fiat settlements and OTC conversions.",
-  },
-  {
-    dex: "DeDust",
-    pair: "DCT/TON",
-    url: "https://dedust.io/swap/TON-DCT",
-    description:
-      "Route native TON liquidity for buybacks, burns, and member swaps directly against the treasury's base asset.",
-  },
-] as const;
-
-export const metadata = {
-  title: "Dynamic Capital Token (DCT)",
-  description:
-    "Explore the Dynamic Capital Token utility, distribution, and staking tiers powering the trading desk ecosystem.",
-};
+export function generateMetadata() {
+  return Meta.generate({
+    title: tokenContent.title,
+    description: tokenContent.description,
+    baseURL: normalizedBaseURL,
+    path: tokenContent.path,
+    image: tokenContent.ogImage,
+    canonical: tokenCanonicalUrl,
+  });
+}
 
 const formatNumber = (value: number) => value.toLocaleString("en-US");
 
@@ -88,16 +49,28 @@ export default function TokenPage() {
       horizontal="center"
       fillWidth
     >
+      <Schema
+        as="webPage"
+        baseURL={normalizedBaseURL}
+        title={tokenContent.title}
+        description={tokenContent.description}
+        path={tokenContent.path}
+        image={tokenContent.ogImage}
+        sameAs={schemaSameAs}
+      />
       <Column maxWidth={32} gap="12" align="center" horizontal="center">
         <Tag size="s" background="brand-alpha-weak" prefixIcon="shield">
           Treasury utility
         </Tag>
         <Heading variant="display-strong-s" align="center">
-          {TOKEN_NAME} ({TOKEN_SYMBOL})
+          {tokenContent.title}
         </Heading>
-        <Text variant="body-default-m" onBackground="neutral-weak" align="center">
-          The membership currency that powers Dynamic Capital automations, treasury
-          governance, and community rewards.
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          {tokenContent.intro}
         </Text>
         <Row gap="16" wrap horizontal="center">
           <Row
@@ -109,7 +82,9 @@ export default function TokenPage() {
             vertical="center"
           >
             <Icon name="infinity" onBackground="brand-medium" />
-            <Text variant="label-strong-s">Max supply {formatNumber(TOKEN_MAX_SUPPLY)}</Text>
+            <Text variant="label-strong-s">
+              Max supply {formatNumber(tokenDescriptor.maxSupply)}
+            </Text>
           </Row>
           <Row
             gap="8"
@@ -120,7 +95,9 @@ export default function TokenPage() {
             vertical="center"
           >
             <Icon name="sparkles" onBackground="brand-medium" />
-            <Text variant="label-strong-s">Decimals {TOKEN_DECIMALS}</Text>
+            <Text variant="label-strong-s">
+              Decimals {tokenDescriptor.decimals}
+            </Text>
           </Row>
         </Row>
       </Column>
@@ -128,7 +105,7 @@ export default function TokenPage() {
       <Column gap="24" maxWidth={40} fillWidth>
         <Heading variant="heading-strong-l">Utility in motion</Heading>
         <Column gap="16" as="ul">
-          {TOKEN_UTILITIES.map((utility) => (
+          {tokenContent.utilities.map((utility) => (
             <Row
               key={utility}
               gap="12"
@@ -151,7 +128,7 @@ export default function TokenPage() {
       <Column gap="24" maxWidth={40} fillWidth>
         <Heading variant="heading-strong-l">Supply allocation</Heading>
         <Column gap="16">
-          {SUPPLY_SPLITS.map((split) => (
+          {tokenContent.supplySplits.map((split) => (
             <Row
               key={split.label}
               gap="16"
@@ -179,7 +156,7 @@ export default function TokenPage() {
       <Column gap="24" maxWidth={40} fillWidth>
         <Heading variant="heading-strong-l">Lock tiers & multipliers</Heading>
         <Column gap="16">
-          {LOCK_TIERS.map((tier) => (
+          {tokenContent.lockTiers.map((tier) => (
             <Row
               key={tier.tier}
               background="surface"
@@ -212,7 +189,7 @@ export default function TokenPage() {
       <Column gap="24" maxWidth={40} fillWidth>
         <Heading variant="heading-strong-l">Active DEX pools</Heading>
         <Column gap="16">
-          {DEX_POOLS.map((pool) => (
+          {tokenContent.dexPools.map((pool) => (
             <Row
               key={pool.pair}
               gap="16"

--- a/apps/web/resources/index.ts
+++ b/apps/web/resources/index.ts
@@ -40,3 +40,5 @@ export {
 } from "./assets";
 
 export { getRouteDefinitions, isRouteEnabled } from "./routes";
+
+export { tokenContent, tokenDescriptor } from "./token";

--- a/apps/web/resources/token.ts
+++ b/apps/web/resources/token.ts
@@ -1,0 +1,150 @@
+import jettonMetadata from "../../../dynamic-capital-ton/contracts/jetton/metadata.json" assert {
+  type: "json",
+};
+import type { IconName } from "./icons";
+
+type DexPool = {
+  dex: string;
+  pair: string;
+  url: string;
+  description: string;
+};
+
+type SupplySplit = {
+  label: string;
+  value: string;
+  description: string;
+  icon: IconName;
+};
+
+type LockTier = {
+  tier: string;
+  duration: string;
+  multiplier: string;
+  description: string;
+};
+
+type TokenContent = {
+  path: string;
+  title: string;
+  description: string;
+  intro: string;
+  ogImage: string;
+  utilities: readonly string[];
+  supplySplits: readonly SupplySplit[];
+  lockTiers: readonly LockTier[];
+  dexPools: readonly DexPool[];
+  sameAs: readonly string[];
+};
+
+type TokenDescriptor = {
+  name: string;
+  symbol: string;
+  description: string;
+  decimals: number;
+  maxSupply: number;
+  externalUrl?: string;
+};
+
+const tokenDescriptor: TokenDescriptor = {
+  name: jettonMetadata.name,
+  symbol: jettonMetadata.symbol,
+  description: jettonMetadata.description,
+  decimals: jettonMetadata.decimals,
+  maxSupply: 100_000_000,
+  externalUrl: jettonMetadata.external_url,
+};
+
+const tokenPath = "/token" as const;
+const tokenTitle = `${tokenDescriptor.name} (${tokenDescriptor.symbol})`;
+const tokenIntro =
+  "The membership currency that powers Dynamic Capital automations, treasury governance, and community rewards.";
+const tokenOgImage = `/api/og/generate?title=${encodeURIComponent(tokenTitle)}`;
+
+const tokenUtilities = [
+  "Redeem on-chain for VIP membership credits and automation boosts.",
+  "Stake into the auto-invest pool to participate in weekly performance.",
+  "Vote on treasury moves through the 48-hour guarded governance window.",
+] as const;
+
+const tokenSupplySplits = [
+  {
+    label: "Operations",
+    value: "60%",
+    description:
+      "Fuel day-to-day desk execution, analytics, and mentor coverage.",
+    icon: "sparkles",
+  },
+  {
+    label: "Auto-invest pool",
+    value: "30%",
+    description:
+      "Deploy liquidity into strategies the desk validates each epoch.",
+    icon: "rocket",
+  },
+  {
+    label: "Buyback & burn",
+    value: "10%",
+    description:
+      "Stabilize the treasury with scheduled market operations and burns.",
+    icon: "repeat",
+  },
+] as const satisfies readonly SupplySplit[];
+
+const tokenLockTiers = [
+  {
+    tier: "Bronze",
+    duration: "3 months",
+    multiplier: "1.2×",
+    description:
+      "Starter tier that unlocks curated market briefs and limited drops.",
+  },
+  {
+    tier: "Silver",
+    duration: "6 months",
+    multiplier: "1.5×",
+    description:
+      "Enhance reward flow with priority access to automation templates.",
+  },
+  {
+    tier: "Gold",
+    duration: "12 months",
+    multiplier: "2.0×",
+    description:
+      "Max utility with VIP desk passes, mentor escalations, and beta slots.",
+  },
+] as const satisfies readonly LockTier[];
+
+const tokenDexPools = [
+  {
+    dex: "STON.fi",
+    pair: "DCT/USDT",
+    url: "https://app.ston.fi/swap?from=USDT&to=DCT",
+    description:
+      "Anchor the treasury's USD peg with a stablecoin pool that supports fiat settlements and OTC conversions.",
+  },
+  {
+    dex: "DeDust",
+    pair: "DCT/TON",
+    url: "https://dedust.io/swap/TON-DCT",
+    description:
+      "Route native TON liquidity for buybacks, burns, and member swaps directly against the treasury's base asset.",
+  },
+] as const satisfies readonly DexPool[];
+
+const tokenSameAs = tokenDexPools.map((pool) => pool.url) as readonly string[];
+
+const tokenContent: TokenContent = {
+  path: tokenPath,
+  title: tokenTitle,
+  description: tokenDescriptor.description,
+  intro: tokenIntro,
+  ogImage: tokenOgImage,
+  utilities: tokenUtilities,
+  supplySplits: tokenSupplySplits,
+  lockTiers: tokenLockTiers,
+  dexPools: tokenDexPools,
+  sameAs: tokenSameAs,
+};
+
+export { tokenContent, tokenDescriptor };


### PR DESCRIPTION
## Summary
- centralize the token page content in a shared resource backed by the jetton metadata file
- update the token route to consume the shared descriptor, normalize canonical URLs, and reuse the new schema links
- expose the token resource through the resources index for reuse across the web app

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d89b5ee2908322b487625b9b784100