### PR TITLE
Add structured version metadata with timestamps

### DIFF
--- a/docs/open_source_dictionary_apis.md
+++ b/docs/open_source_dictionary_apis.md
@@ -1,17 +1,30 @@
 # Open-Source Dictionary APIs
 
-This guide highlights several open-source dictionary APIs that are useful for building language-aware applications. Each section includes data sources, notable features, and practical usage tips to help you choose the right service for your project.
+This guide highlights several open-source dictionary APIs that are useful for
+building language-aware applications. Each section includes data sources,
+notable features, and practical usage tips to help you choose the right service
+for your project.
 
 ## Quickstart Tasks
-1. **Verify connectivity:** Issue the sample `curl` command provided for the API you plan to use and confirm you receive a `200 OK` JSON response.
-2. **Map response fields:** Run the parsing snippet (Python or shell) to extract definitions, phonetics, and example sentences from the payload.
-3. **Normalize for Dynamic AGI:** Convert the parsed data into a compact dictionary and feed it into `DynamicAGIModel.evaluate()` following the example below.
-4. **Record findings:** Capture any anomalies (missing fields, rate-limit headers, latency spikes) in your integration notes so the evaluation loop can address them.
-5. **Re-run with cached inputs:** Repeat the request using your application cache or proxy to confirm deterministic results before promoting the workflow.
+
+1. **Verify connectivity:** Issue the sample `curl` command provided for the API
+   you plan to use and confirm you receive a `200 OK` JSON response.
+2. **Map response fields:** Run the parsing snippet (Python or shell) to extract
+   definitions, phonetics, and example sentences from the payload.
+3. **Normalize for Dynamic AGI:** Convert the parsed data into a compact
+   dictionary and feed it into `DynamicAGIModel.evaluate()` following the
+   example below.
+4. **Record findings:** Capture any anomalies (missing fields, rate-limit
+   headers, latency spikes) in your integration notes so the evaluation loop can
+   address them.
+5. **Re-run with cached inputs:** Repeat the request using your application
+   cache or proxy to confirm deterministic results before promoting the
+   workflow.
 
 ### Runbook
 
-Execute the following commands locally (or in CI) to exercise each checklist item end-to-end:
+Execute the following commands locally (or in CI) to exercise each checklist
+item end-to-end:
 
 1. **Hit the API and confirm transport health.**
 
@@ -20,7 +33,8 @@ Execute the following commands locally (or in CI) to exercise each checklist ite
    curl -i "https://api.dictionaryapi.dev/api/v2/entries/en/liquidity" | head -n 5
    ```
 
-2. **Project key lexical fields.** Use `jq` for shell-based parsing or the Python helper below for richer validation.
+2. **Project key lexical fields.** Use `jq` for shell-based parsing or the
+   Python helper below for richer validation.
 
    ```bash
    curl -s "https://api.dictionaryapi.dev/api/v2/entries/en/liquidity" \
@@ -56,14 +70,22 @@ Execute the following commands locally (or in CI) to exercise each checklist ite
    print(json.dumps(lexical_projection, indent=2))
    ```
 
-3. **Normalize and send to Dynamic AGI.** Combine the projected fields with any upstream signals (market data, experiment metadata) before invoking the evaluation model as shown later in this guide.
+3. **Normalize and send to Dynamic AGI.** Combine the projected fields with any
+   upstream signals (market data, experiment metadata) before invoking the
+   evaluation model as shown later in this guide.
 
-4. **Document anomalies.** Append structured notes—status codes, missing fields, throttling headers—to your run log or issue tracker so the evaluation feedback loop has concrete observations to address.
+4. **Document anomalies.** Append structured notes—status codes, missing fields,
+   throttling headers—to your run log or issue tracker so the evaluation
+   feedback loop has concrete observations to address.
 
-5. **Repeat against cache or proxy.** Re-run the exact request through your caching tier and diff the payload. A zero-diff result validates deterministic semantics for the scenario you just exercised.
+5. **Repeat against cache or proxy.** Re-run the exact request through your
+   caching tier and diff the payload. A zero-diff result validates deterministic
+   semantics for the scenario you just exercised.
 
 ## 1. Free Dictionary API
-This popular and straightforward service is ideal when you need to wire up dictionary functionality quickly.
+
+This popular and straightforward service is ideal when you need to wire up
+dictionary functionality quickly.
 
 - **Data source:** English Wiktionary.
 - **Key features:** Definitions, phonetics, pronunciations, parts of speech,
@@ -78,6 +100,7 @@ curl -s "https://api.dictionaryapi.dev/api/v2/entries/en/liquidity" | jq '.[0].m
 ```
 
 ## 2. Wiktionary API
+
 As the source that powers Free Dictionary, the Wiktionary API provides direct
 access to the collaborative, multilingual corpus.
 
@@ -92,11 +115,12 @@ curl -s "https://en.wiktionary.org/w/api.php?action=query&prop=extracts&format=j
 ```
 
 ## 3. Wordnik API
+
 Wordnik aggregates multiple commercial and open dictionary sources into a
 single, developer-friendly interface.
 
-- **Data source:** Wiktionary, American Heritage Dictionary, Century
-  Dictionary, WordNet, and additional partners.
+- **Data source:** Wiktionary, American Heritage Dictionary, Century Dictionary,
+  WordNet, and additional partners.
 - **Key features:** Definitions, synonyms, antonyms, example sentences, audio
   pronunciations, and a word-of-the-day feed.
 - **Usage:** Offers a dedicated developer portal. An API key is required for
@@ -110,6 +134,7 @@ curl -s "https://api.wordnik.com/v4/word.json/liquidity/definitions?limit=1&incl
 ```
 
 ## 4. Datamuse API
+
 While not a traditional dictionary, Datamuse excels at semantic and phonetic
 relationships that complement definition-based lookups.
 
@@ -124,6 +149,7 @@ curl -s "https://api.datamuse.com/words?ml=liquidity&max=5" | jq '.[].word'
 ```
 
 ## Selection Considerations
+
 - **Licensing:** Check that the license aligns with your distribution plans,
   particularly for commercial products.
 - **Data quality and scope:** Evaluate language coverage, update cadence, and
@@ -132,23 +158,32 @@ curl -s "https://api.datamuse.com/words?ml=liquidity&max=5" | jq '.[].word'
   and responsive support channels.
 
 ## Complete Tasks
-1. [ ] Identify the dictionary API that best fits your language and licensing requirements.
-2. [ ] Issue a sample request (e.g., `curl` or `requests`) to confirm the endpoint and payload format.
-3. [ ] Normalise the response into definitions, synonyms, and usage examples required by your workflow.
-4. [ ] Feed the processed payload into `DynamicAGIModel.evaluate()` via the `research` argument.
-5. [ ] Capture reviewer notes or user feedback in `feedback_notes` to guide iterative improvements.
-6. [ ] Re-run the evaluation to verify the updated context resolves any outstanding lexical gaps.
-7. [ ] Log latency, error rates, and rate-limit headers in your monitoring stack to catch regressions early.
-8. [ ] Schedule recurring validation (e.g., weekly) to ensure upstream API schema or licensing changes are surfaced quickly.
+
+1. [ ] Identify the dictionary API that best fits your language and licensing
+       requirements.
+2. [ ] Issue a sample request (e.g., `curl` or `requests`) to confirm the
+       endpoint and payload format.
+3. [ ] Normalise the response into definitions, synonyms, and usage examples
+       required by your workflow.
+4. [ ] Feed the processed payload into `DynamicAGIModel.evaluate()` via the
+       `research` argument.
+5. [ ] Capture reviewer notes or user feedback in `feedback_notes` to guide
+       iterative improvements.
+6. [ ] Re-run the evaluation to verify the updated context resolves any
+       outstanding lexical gaps.
+7. [ ] Log latency, error rates, and rate-limit headers in your monitoring stack
+       to catch regressions early.
+8. [ ] Schedule recurring validation (e.g., weekly) to ensure upstream API
+       schema or licensing changes are surfaced quickly.
 
 ## Connect with Dynamic AGI
-The `dynamic_agi` package can ingest dictionary outputs as part of a broader
-knowledge or research pipeline. Use dictionary entries to enrich the
-`research` payload that accompanies a market or product evaluation.
 
-1. Normalise the API response into lightweight fields (definitions,
-   synonyms, usage examples) so the AGI layer can digest it alongside other
-   telemetry.
+The `dynamic_agi` package can ingest dictionary outputs as part of a broader
+knowledge or research pipeline. Use dictionary entries to enrich the `research`
+payload that accompanies a market or product evaluation.
+
+1. Normalise the API response into lightweight fields (definitions, synonyms,
+   usage examples) so the AGI layer can digest it alongside other telemetry.
 2. Thread the processed payload into `DynamicAGIModel.evaluate()` via the
    `research` argument, keeping contextual tags (e.g., language, domain) that
    matter for downstream analysis.
@@ -179,9 +214,13 @@ agi_output = model.evaluate(
     ],
 )
 
-print(agi_output.to_dict()["research"]["lexical_insights"])
+metadata = agi_output.to_dict()
+print(metadata["version"])  # Dynamic AGI-00.01
+print(metadata["version_info"]["number"]["formatted"])  # 00.01
+print(metadata["generated_at"])  # 2024-06-05T13:25:42.901823+00:00
 ```
 
-This pattern keeps dictionary intelligence aligned with broader market
-context, enabling Dynamic AGI to fold linguistic nuance into its decisioning
-loop.
+This pattern keeps dictionary intelligence aligned with broader market context,
+enabling Dynamic AGI to fold linguistic nuance into its decisioning loop. Each
+evaluation now returns a `generated_at` timestamp alongside structured version
+metadata, simplifying chronological log reviews and cross-model comparisons.

--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -1,6 +1,12 @@
 """Dynamic AGI package exposing orchestrator utilities."""
 
-from .model import AGIDiagnostics, AGIOutput, DynamicAGIModel
+from .model import (
+    AGIDiagnostics,
+    AGIOutput,
+    DynamicAGIModel,
+    MODEL_VERSION,
+    MODEL_VERSION_INFO,
+)
 from .self_improvement import (
     DynamicSelfImprovement,
     ImprovementPlan,
@@ -12,6 +18,8 @@ __all__ = [
     "AGIDiagnostics",
     "AGIOutput",
     "DynamicAGIModel",
+    "MODEL_VERSION",
+    "MODEL_VERSION_INFO",
     "DynamicSelfImprovement",
     "ImprovementPlan",
     "ImprovementSignal",

--- a/dynamic_algo/__init__.py
+++ b/dynamic_algo/__init__.py
@@ -1,6 +1,8 @@
 """Trading algorithm utilities for orchestrating MT5/Exness execution."""
 
 from .trading_core import (
+    ALGO_VERSION,
+    ALGO_VERSION_INFO,
     ORDER_ACTION_BUY,
     ORDER_ACTION_SELL,
     SUCCESS_RETCODE,
@@ -109,6 +111,8 @@ from .dynamic_problem_solving import (
 )
 
 __all__ = [
+    "ALGO_VERSION",
+    "ALGO_VERSION_INFO",
     "ORDER_ACTION_BUY",
     "ORDER_ACTION_SELL",
     "SUCCESS_RETCODE",

--- a/dynamic_metadata/__init__.py
+++ b/dynamic_metadata/__init__.py
@@ -1,0 +1,5 @@
+"""Shared metadata helpers for Dynamic Capital models."""
+
+from .versioning import ModelVersion, VersionNumber
+
+__all__ = ["ModelVersion", "VersionNumber"]

--- a/dynamic_metadata/versioning.py
+++ b/dynamic_metadata/versioning.py
@@ -1,0 +1,86 @@
+"""Utilities for synchronising model version numbers and metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+def _utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp without relying on global state."""
+
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True, frozen=True)
+class VersionNumber:
+    """Structured representation of a model version number."""
+
+    major: int = 0
+    minor: int = 0
+    patch: int = 0
+    width: int = 2
+
+    def __post_init__(self) -> None:
+        for value, label in ((self.major, "major"), (self.minor, "minor"), (self.patch, "patch")):
+            if value < 0:
+                raise ValueError(f"{label} version component cannot be negative")
+        if self.width < 1:
+            raise ValueError("width must be at least 1")
+
+    def format(self) -> str:
+        """Render the version number as a zero-padded string."""
+
+        components = [f"{self.major:0{self.width}d}", f"{self.minor:0{self.width}d}"]
+        if self.patch:
+            components.append(f"{self.patch:0{self.width}d}")
+        return ".".join(components)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "major": self.major,
+            "minor": self.minor,
+            "patch": self.patch,
+            "width": self.width,
+            "formatted": self.format(),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ModelVersion:
+    """Wrapper containing naming, numbering, and timestamp metadata."""
+
+    name: str
+    number: VersionNumber = field(default_factory=VersionNumber)
+    build_timestamp: datetime = field(default_factory=_utcnow)
+    source: str = "registry"
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name must not be empty")
+        if self.build_timestamp.tzinfo is None:
+            object.__setattr__(self, "build_timestamp", self.build_timestamp.replace(tzinfo=timezone.utc))
+        else:
+            object.__setattr__(self, "build_timestamp", self.build_timestamp.astimezone(timezone.utc))
+
+    @property
+    def tag(self) -> str:
+        return f"{self.name}-{self.number.format()}"
+
+    def with_source(self, source: str) -> "ModelVersion":
+        return ModelVersion(
+            name=self.name,
+            number=self.number,
+            build_timestamp=self.build_timestamp,
+            source=source,
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "version": self.tag,
+            "number": self.number.to_dict(),
+            "build_timestamp": self.build_timestamp.isoformat(),
+            "source": self.source,
+        }


### PR DESCRIPTION
## Summary
- add shared versioning utilities to standardise model version labels across packages
- extend Dynamic AGI outputs and trading execution results with version metadata accessors and generated timestamps
- update documentation to showcase the new version information exposed by the evaluation API

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d898633bac8322bfba507b609de7da