### PR TITLE
Make dynamic life cycle preset extensible

### DIFF
--- a/dynamic_cycle/__init__.py
+++ b/dynamic_cycle/__init__.py
@@ -1,15 +1,19 @@
 """Dynamic Cycle orchestration toolkit."""
 
 from .cycle import (
+    LIFE_CYCLE_BLUEPRINT,
     CycleEvent,
     CyclePhase,
     CycleSnapshot,
     DynamicCycleOrchestrator,
+    create_dynamic_life_cycle,
 )
 
 __all__ = [
+    "LIFE_CYCLE_BLUEPRINT",
     "CycleEvent",
     "CyclePhase",
     "CycleSnapshot",
     "DynamicCycleOrchestrator",
+    "create_dynamic_life_cycle",
 ]


### PR DESCRIPTION
## Summary
- expose the canonical LIFE_CYCLE_BLUEPRINT so projects can introspect or reuse the default life cycle definition
- extend create_dynamic_life_cycle with override and extension hooks to tailor phases without rewriting the factory
- add regression coverage ensuring overrides, additional phases, and alternate starting phases behave as expected

## Testing
- npm run format
- pytest tests/test_dynamic_cycle.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d89d7f428883228e2bbb3b557401c2