### PR TITLE
Enhance dynamic spheres engine with collaborative roles

### DIFF
--- a/dynamic_spheres/__init__.py
+++ b/dynamic_spheres/__init__.py
@@ -5,7 +5,12 @@ from .engine import (
     SpherePulse,
     SphereSnapshot,
     SphereNetworkState,
+    SphereCollaborator,
     DynamicSpheresEngine,
+    create_sphere_agent,
+    create_sphere_keeper,
+    create_sphere_bot,
+    create_sphere_helper,
 )
 
 __all__ = [
@@ -13,5 +18,10 @@ __all__ = [
     "SpherePulse",
     "SphereSnapshot",
     "SphereNetworkState",
+    "SphereCollaborator",
     "DynamicSpheresEngine",
+    "create_sphere_agent",
+    "create_sphere_keeper",
+    "create_sphere_bot",
+    "create_sphere_helper",
 ]


### PR DESCRIPTION
## Summary
- introduce a SphereCollaborator data model plus factories for sphere agents, keepers, bots, and helpers
- extend DynamicSpheresEngine to manage collaborative roles and compute consciousness resilience metrics when building network state
- expose the new collaborator helpers through the dynamic_spheres package for downstream orchestration

## Testing
- npm run format
- python -m compileall dynamic_spheres

------
https://chatgpt.com/codex/tasks/task_e_68d8a0a4947c8322a82aa52456a7b0eb