### PR TITLE
Add financial dynamic ocean agents and orchestration stack

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -27,6 +27,12 @@ __all__ = [
     "DynamicArchitectAgentResult",
     "DynamicEngineerAgent",
     "DynamicEngineerAgentResult",
+    "DynamicOceanLayerAgent",
+    "DynamicEpipelagicAgent",
+    "DynamicMesopelagicAgent",
+    "DynamicBathypelagicAgent",
+    "DynamicAbyssopelagicAgent",
+    "DynamicHadalpelagicAgent",
     "DynamicRecyclingAgent",
     "configure_dynamic_start_agents",
     "ExecutionAgent",
@@ -43,6 +49,7 @@ __all__ = [
     "reset_dynamic_start_agents",
     "RecyclingAgentConfig",
     "RecyclingAgentReport",
+    "OceanLayerAgentSummary",
     "SpaceAgent",
     "SpaceAgentResult",
     "TradingAgent",
@@ -64,6 +71,13 @@ _LAZY = LazyNamespace(
         "DynamicRecyclingAgent": "dynamic_agents.recycling",
         "RecyclingAgentConfig": "dynamic_agents.recycling",
         "RecyclingAgentReport": "dynamic_agents.recycling",
+        "DynamicOceanLayerAgent": "dynamic_agents.ocean",
+        "DynamicEpipelagicAgent": "dynamic_agents.ocean",
+        "DynamicMesopelagicAgent": "dynamic_agents.ocean",
+        "DynamicBathypelagicAgent": "dynamic_agents.ocean",
+        "DynamicAbyssopelagicAgent": "dynamic_agents.ocean",
+        "DynamicHadalpelagicAgent": "dynamic_agents.ocean",
+        "OceanLayerAgentSummary": "dynamic_agents.ocean",
     },
 )
 
@@ -99,6 +113,15 @@ if TYPE_CHECKING:  # pragma: no cover - import-time only
         DynamicRecyclingAgent,
         RecyclingAgentConfig,
         RecyclingAgentReport,
+    )
+    from dynamic_agents.ocean import (
+        DynamicOceanLayerAgent,
+        DynamicEpipelagicAgent,
+        DynamicMesopelagicAgent,
+        DynamicBathypelagicAgent,
+        DynamicAbyssopelagicAgent,
+        DynamicHadalpelagicAgent,
+        OceanLayerAgentSummary,
     )
 
 

--- a/dynamic_agents/ocean.py
+++ b/dynamic_agents/ocean.py
@@ -1,0 +1,189 @@
+"""Dynamic ocean agents specialised for financial data collection."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, Sequence
+
+from dynamic_ocean.finance import (
+    DEFAULT_FINANCIAL_PROFILES,
+    PelagicFinancialProfile,
+    PelagicMarketSignal,
+    build_financial_ocean,
+    derive_market_signal,
+    resolve_financial_profile,
+)
+from dynamic_ocean.ocean import DynamicOcean
+
+__all__ = [
+    "OceanLayerAgentSummary",
+    "DynamicOceanLayerAgent",
+    "DynamicEpipelagicAgent",
+    "DynamicMesopelagicAgent",
+    "DynamicBathypelagicAgent",
+    "DynamicAbyssopelagicAgent",
+    "DynamicHadalpelagicAgent",
+]
+
+
+@dataclass(slots=True)
+class OceanLayerAgentSummary:
+    """Aggregate statistics derived from a window of market signals."""
+
+    profile: PelagicFinancialProfile
+    generated_at: datetime
+    window: int
+    average_liquidity: float
+    average_momentum: float
+    average_volatility: float
+    average_systemic_risk: float
+    average_sentiment: float
+    recent_alerts: tuple[str, ...]
+    active_recommendations: tuple[str, ...]
+
+
+class DynamicOceanLayerAgent:
+    """Coordinate :class:`DynamicOcean` observations for a pelagic profile."""
+
+    def __init__(
+        self,
+        profile: PelagicFinancialProfile | str | None = None,
+        *,
+        engine: DynamicOcean | None = None,
+        history_limit: int = 96,
+    ) -> None:
+        if isinstance(profile, str):
+            resolved_profile = resolve_financial_profile(profile)
+        else:
+            resolved_profile = profile
+
+        if resolved_profile is None:
+            resolved_profile = next(iter(DEFAULT_FINANCIAL_PROFILES.values()))
+
+        self._profile = resolved_profile
+        self._engine = engine or build_financial_ocean()
+        if history_limit <= 0:
+            raise ValueError("history_limit must be positive")
+        self._signals: Deque[PelagicMarketSignal] = deque(maxlen=history_limit)
+
+    @property
+    def profile(self) -> PelagicFinancialProfile:
+        return self._profile
+
+    @property
+    def engine(self) -> DynamicOcean:
+        return self._engine
+
+    @property
+    def signals(self) -> tuple[PelagicMarketSignal, ...]:
+        return tuple(self._signals)
+
+    def capture_signal(
+        self,
+        *,
+        depth: float | None = None,
+        location: Sequence[float] | None = None,
+        timestamp: datetime | None = None,
+    ) -> PelagicMarketSignal:
+        target_depth = depth if depth is not None else self._profile.default_depth
+        target_location = location if location is not None else self._profile.default_location
+        snapshot = self._engine.observe(
+            depth=target_depth,
+            location=target_location,
+            timestamp=timestamp,
+            layer=self._profile.layer_name,
+        )
+        signal = derive_market_signal(snapshot, self._profile)
+        self._signals.append(signal)
+        return signal
+
+    def capture_signals(
+        self,
+        observations: Iterable[Mapping[str, object] | None],
+    ) -> list[PelagicMarketSignal]:
+        results: list[PelagicMarketSignal] = []
+        for overrides in observations:
+            overrides = overrides or {}
+            results.append(
+                self.capture_signal(
+                    depth=overrides.get("depth"),
+                    location=overrides.get("location"),
+                    timestamp=overrides.get("timestamp"),
+                )
+            )
+        return results
+
+    def summarise(self, *, window: int | None = None) -> OceanLayerAgentSummary:
+        if window is not None and window <= 0:
+            raise ValueError("window must be positive when provided")
+        buffer = list(self._signals)
+        if not buffer:
+            raise RuntimeError("no signals captured yet")
+        if window is not None:
+            buffer = buffer[-window:]
+        alerts: list[str] = []
+        recommendations: list[str] = []
+        for signal in buffer:
+            alerts.extend(signal.alerts)
+            recommendations.extend(signal.recommendations)
+        unique_alerts = tuple(dict.fromkeys(alerts))
+        unique_recommendations = tuple(dict.fromkeys(recommendations))
+        return OceanLayerAgentSummary(
+            profile=self._profile,
+            generated_at=datetime.now(timezone.utc),
+            window=len(buffer),
+            average_liquidity=sum(s.liquidity_score for s in buffer) / len(buffer),
+            average_momentum=sum(s.momentum_score for s in buffer) / len(buffer),
+            average_volatility=sum(s.volatility_score for s in buffer) / len(buffer),
+            average_systemic_risk=sum(s.systemic_risk_score for s in buffer) / len(buffer),
+            average_sentiment=sum(s.sentiment_score for s in buffer) / len(buffer),
+            recent_alerts=unique_alerts,
+            active_recommendations=unique_recommendations,
+        )
+
+
+class DynamicEpipelagicAgent(DynamicOceanLayerAgent):
+    def __init__(self, *, engine: DynamicOcean | None = None, history_limit: int = 96) -> None:
+        super().__init__(
+            resolve_financial_profile("Epipelagic"),
+            engine=engine,
+            history_limit=history_limit,
+        )
+
+
+class DynamicMesopelagicAgent(DynamicOceanLayerAgent):
+    def __init__(self, *, engine: DynamicOcean | None = None, history_limit: int = 96) -> None:
+        super().__init__(
+            resolve_financial_profile("Mesopelagic"),
+            engine=engine,
+            history_limit=history_limit,
+        )
+
+
+class DynamicBathypelagicAgent(DynamicOceanLayerAgent):
+    def __init__(self, *, engine: DynamicOcean | None = None, history_limit: int = 96) -> None:
+        super().__init__(
+            resolve_financial_profile("Bathypelagic"),
+            engine=engine,
+            history_limit=history_limit,
+        )
+
+
+class DynamicAbyssopelagicAgent(DynamicOceanLayerAgent):
+    def __init__(self, *, engine: DynamicOcean | None = None, history_limit: int = 96) -> None:
+        super().__init__(
+            resolve_financial_profile("Abyssopelagic"),
+            engine=engine,
+            history_limit=history_limit,
+        )
+
+
+class DynamicHadalpelagicAgent(DynamicOceanLayerAgent):
+    def __init__(self, *, engine: DynamicOcean | None = None, history_limit: int = 96) -> None:
+        super().__init__(
+            resolve_financial_profile("Hadalpelagic"),
+            engine=engine,
+            history_limit=history_limit,
+        )

--- a/dynamic_bots/__init__.py
+++ b/dynamic_bots/__init__.py
@@ -11,5 +11,22 @@ structure.
 from integrations.telegram_bot import DynamicTelegramBot
 
 from .recycling import DynamicRecyclingBot
+from .ocean import (
+    DynamicOceanLayerBot,
+    DynamicEpipelagicBot,
+    DynamicMesopelagicBot,
+    DynamicBathypelagicBot,
+    DynamicAbyssopelagicBot,
+    DynamicHadalpelagicBot,
+)
 
-__all__ = ["DynamicTelegramBot", "DynamicRecyclingBot"]
+__all__ = [
+    "DynamicTelegramBot",
+    "DynamicRecyclingBot",
+    "DynamicOceanLayerBot",
+    "DynamicEpipelagicBot",
+    "DynamicMesopelagicBot",
+    "DynamicBathypelagicBot",
+    "DynamicAbyssopelagicBot",
+    "DynamicHadalpelagicBot",
+]

--- a/dynamic_bots/ocean.py
+++ b/dynamic_bots/ocean.py
@@ -1,0 +1,77 @@
+"""Bot wrappers delivering financial dynamic ocean insights."""
+
+from __future__ import annotations
+
+from dynamic_agents.ocean import DynamicOceanLayerAgent
+from dynamic_helpers.ocean import DynamicOceanLayerHelper
+from dynamic_keepers.ocean import DynamicOceanLayerKeeper
+
+__all__ = [
+    "DynamicOceanLayerBot",
+    "DynamicEpipelagicBot",
+    "DynamicMesopelagicBot",
+    "DynamicBathypelagicBot",
+    "DynamicAbyssopelagicBot",
+    "DynamicHadalpelagicBot",
+]
+
+
+class DynamicOceanLayerBot:
+    """High-level interface that formats and dispatches layer insights."""
+
+    def __init__(
+        self,
+        *,
+        agent: DynamicOceanLayerAgent,
+        helper: DynamicOceanLayerHelper | None = None,
+        keeper: DynamicOceanLayerKeeper | None = None,
+    ) -> None:
+        self._agent = agent
+        self._helper = helper or DynamicOceanLayerHelper(agent.profile)
+        self._keeper = keeper or DynamicOceanLayerKeeper(agent.profile)
+
+    @property
+    def agent(self) -> DynamicOceanLayerAgent:
+        return self._agent
+
+    @property
+    def helper(self) -> DynamicOceanLayerHelper:
+        return self._helper
+
+    @property
+    def keeper(self) -> DynamicOceanLayerKeeper:
+        return self._keeper
+
+    def publish_update(self, **overrides: object) -> str:
+        signal = self._agent.capture_signal(
+            depth=overrides.get("depth"),
+            location=overrides.get("location"),
+            timestamp=overrides.get("timestamp"),
+        )
+        self._keeper.record(signal)
+        summary = None
+        try:
+            summary = self._agent.summarise()
+        except RuntimeError:
+            summary = None
+        return self._helper.compose_digest(signal, summary=summary)
+
+
+class DynamicEpipelagicBot(DynamicOceanLayerBot):
+    pass
+
+
+class DynamicMesopelagicBot(DynamicOceanLayerBot):
+    pass
+
+
+class DynamicBathypelagicBot(DynamicOceanLayerBot):
+    pass
+
+
+class DynamicAbyssopelagicBot(DynamicOceanLayerBot):
+    pass
+
+
+class DynamicHadalpelagicBot(DynamicOceanLayerBot):
+    pass

--- a/dynamic_helpers/__init__.py
+++ b/dynamic_helpers/__init__.py
@@ -21,6 +21,14 @@ _HELPER_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "summarise_recycling_events",
         "format_recycling_digest",
     ),
+    "dynamic_helpers.ocean": (
+        "DynamicOceanLayerHelper",
+        "DynamicEpipelagicHelper",
+        "DynamicMesopelagicHelper",
+        "DynamicBathypelagicHelper",
+        "DynamicAbyssopelagicHelper",
+        "DynamicHadalpelagicHelper",
+    ),
 }
 
 __all__ = sorted({symbol for symbols in _HELPER_EXPORTS.values() for symbol in symbols})

--- a/dynamic_helpers/ocean.py
+++ b/dynamic_helpers/ocean.py
@@ -1,0 +1,100 @@
+"""Helper utilities for financial dynamic ocean workflows."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from dynamic_ocean.finance import PelagicFinancialProfile, PelagicMarketSignal
+from dynamic_agents.ocean import OceanLayerAgentSummary
+
+__all__ = [
+    "DynamicOceanLayerHelper",
+    "DynamicEpipelagicHelper",
+    "DynamicMesopelagicHelper",
+    "DynamicBathypelagicHelper",
+    "DynamicAbyssopelagicHelper",
+    "DynamicHadalpelagicHelper",
+]
+
+
+class DynamicOceanLayerHelper:
+    """Formatting and payload helpers shared across pelagic bots."""
+
+    def __init__(self, profile: PelagicFinancialProfile) -> None:
+        self._profile = profile
+
+    @property
+    def profile(self) -> PelagicFinancialProfile:
+        return self._profile
+
+    def build_signal_payload(self, signal: PelagicMarketSignal) -> Mapping[str, float]:
+        return {
+            "liquidity": signal.liquidity_score,
+            "momentum": signal.momentum_score,
+            "volatility": signal.volatility_score,
+            "systemic_risk": signal.systemic_risk_score,
+            "sentiment": signal.sentiment_score,
+        }
+
+    def compose_digest(
+        self,
+        signal: PelagicMarketSignal,
+        *,
+        summary: OceanLayerAgentSummary | None = None,
+    ) -> str:
+        payload = self.build_signal_payload(signal)
+        header = f"🌊 {self._profile.layer_name} market update"
+        focus = ", ".join(self._profile.market_focus)
+        asset_classes = ", ".join(self._profile.asset_classes)
+        lines = [
+            header,
+            f"Focus: {focus}",
+            (
+                "Scores → Liquidity {liquidity:.2f} | Momentum {momentum:.2f} | "
+                "Volatility {volatility:.2f}"
+            ).format(**payload),
+            (
+                "Risk Sentiment → Systemic {systemic_risk:.2f} | Sentiment {sentiment:.2f}"
+            ).format(**payload),
+            f"Asset stack: {asset_classes}",
+        ]
+        if signal.alerts:
+            lines.append("Alerts:")
+            lines.extend(f"  • {alert}" for alert in signal.alerts)
+        lines.append("Recommendations:")
+        lines.extend(f"  → {item}" for item in signal.recommendations)
+        if summary is not None:
+            lines.append(
+                (
+                    "Averages {window} obs → Liquidity {avg_liq:.2f} | Momentum {avg_mom:.2f} | "
+                    "Volatility {avg_vol:.2f} | Systemic {avg_sys:.2f} | Sentiment {avg_sent:.2f}"
+                ).format(
+                    window=summary.window,
+                    avg_liq=summary.average_liquidity,
+                    avg_mom=summary.average_momentum,
+                    avg_vol=summary.average_volatility,
+                    avg_sys=summary.average_systemic_risk,
+                    avg_sent=summary.average_sentiment,
+                )
+            )
+        return "\n".join(lines)
+
+
+class DynamicEpipelagicHelper(DynamicOceanLayerHelper):
+    pass
+
+
+class DynamicMesopelagicHelper(DynamicOceanLayerHelper):
+    pass
+
+
+class DynamicBathypelagicHelper(DynamicOceanLayerHelper):
+    pass
+
+
+class DynamicAbyssopelagicHelper(DynamicOceanLayerHelper):
+    pass
+
+
+class DynamicHadalpelagicHelper(DynamicOceanLayerHelper):
+    pass

--- a/dynamic_keepers/__init__.py
+++ b/dynamic_keepers/__init__.py
@@ -57,6 +57,15 @@ _KEEPER_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "DynamicRecyclingKeeper",
         "RecyclingKeeperSnapshot",
     ),
+    "dynamic_keepers.ocean": (
+        "DynamicOceanLayerKeeper",
+        "DynamicEpipelagicKeeper",
+        "DynamicMesopelagicKeeper",
+        "DynamicBathypelagicKeeper",
+        "DynamicAbyssopelagicKeeper",
+        "DynamicHadalpelagicKeeper",
+        "KeeperTrendSnapshot",
+    ),
 }
 
 __all__ = sorted({symbol for symbols in _KEEPER_EXPORTS.values() for symbol in symbols})

--- a/dynamic_keepers/ocean.py
+++ b/dynamic_keepers/ocean.py
@@ -1,0 +1,102 @@
+"""State keepers for financial dynamic ocean insights."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Mapping
+
+from dynamic_agents.ocean import DynamicOceanLayerAgent
+from dynamic_ocean.finance import PelagicFinancialProfile, PelagicMarketSignal
+
+__all__ = [
+    "KeeperTrendSnapshot",
+    "DynamicOceanLayerKeeper",
+    "DynamicEpipelagicKeeper",
+    "DynamicMesopelagicKeeper",
+    "DynamicBathypelagicKeeper",
+    "DynamicAbyssopelagicKeeper",
+    "DynamicHadalpelagicKeeper",
+]
+
+
+@dataclass(slots=True)
+class KeeperTrendSnapshot:
+    """Rolling trend metrics produced by a keeper."""
+
+    profile: PelagicFinancialProfile
+    records: tuple[PelagicMarketSignal, ...]
+    averages: Mapping[str, float]
+    deltas: Mapping[str, float]
+
+
+class DynamicOceanLayerKeeper:
+    """Track derived signals for replay and trend analytics."""
+
+    def __init__(self, profile: PelagicFinancialProfile, *, limit: int = 144) -> None:
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        self._profile = profile
+        self._history: Deque[PelagicMarketSignal] = deque(maxlen=limit)
+
+    @property
+    def profile(self) -> PelagicFinancialProfile:
+        return self._profile
+
+    @property
+    def records(self) -> tuple[PelagicMarketSignal, ...]:
+        return tuple(self._history)
+
+    def record(self, signal: PelagicMarketSignal) -> None:
+        self._history.append(signal)
+
+    def capture(self, agent: DynamicOceanLayerAgent, /, **overrides: object) -> PelagicMarketSignal:
+        signal = agent.capture_signal(
+            depth=overrides.get("depth"),
+            location=overrides.get("location"),
+            timestamp=overrides.get("timestamp"),
+        )
+        self.record(signal)
+        return signal
+
+    def trend(self) -> KeeperTrendSnapshot:
+        if not self._history:
+            raise RuntimeError("no signals recorded")
+        records = self.records
+        averages = {
+            "liquidity": sum(signal.liquidity_score for signal in records) / len(records),
+            "momentum": sum(signal.momentum_score for signal in records) / len(records),
+            "volatility": sum(signal.volatility_score for signal in records) / len(records),
+            "systemic_risk": sum(signal.systemic_risk_score for signal in records) / len(records),
+            "sentiment": sum(signal.sentiment_score for signal in records) / len(records),
+        }
+        deltas = {
+            key: getattr(records[-1], f"{key}_score") - getattr(records[0], f"{key}_score")
+            for key in ("liquidity", "momentum", "volatility", "systemic_risk", "sentiment")
+        }
+        return KeeperTrendSnapshot(
+            profile=self._profile,
+            records=records,
+            averages=averages,
+            deltas=deltas,
+        )
+
+
+class DynamicEpipelagicKeeper(DynamicOceanLayerKeeper):
+    pass
+
+
+class DynamicMesopelagicKeeper(DynamicOceanLayerKeeper):
+    pass
+
+
+class DynamicBathypelagicKeeper(DynamicOceanLayerKeeper):
+    pass
+
+
+class DynamicAbyssopelagicKeeper(DynamicOceanLayerKeeper):
+    pass
+
+
+class DynamicHadalpelagicKeeper(DynamicOceanLayerKeeper):
+    pass

--- a/dynamic_ocean/__init__.py
+++ b/dynamic_ocean/__init__.py
@@ -1,0 +1,35 @@
+"""Dynamic ocean circulation analytics toolkit."""
+
+from .ocean import (
+    OceanCurrent,
+    OceanEvent,
+    OceanEventSeverity,
+    OceanLayer,
+    OceanSensor,
+    OceanSnapshot,
+    DynamicOcean,
+)
+from .finance import (
+    PelagicFinancialProfile,
+    PelagicMarketSignal,
+    DEFAULT_FINANCIAL_PROFILES,
+    build_financial_ocean,
+    derive_market_signal,
+    resolve_financial_profile,
+)
+
+__all__ = [
+    "OceanCurrent",
+    "OceanEvent",
+    "OceanEventSeverity",
+    "OceanLayer",
+    "OceanSensor",
+    "OceanSnapshot",
+    "DynamicOcean",
+    "PelagicFinancialProfile",
+    "PelagicMarketSignal",
+    "DEFAULT_FINANCIAL_PROFILES",
+    "build_financial_ocean",
+    "derive_market_signal",
+    "resolve_financial_profile",
+]

--- a/dynamic_ocean/finance.py
+++ b/dynamic_ocean/finance.py
@@ -1,0 +1,380 @@
+"""Financial orchestration primitives for the dynamic ocean engine.
+
+This module adapts the physical ``dynamic_ocean`` observability stack for
+capital markets monitoring.  Each pelagic layer is mapped to a trading
+mandate, complete with default instrumentation (currents and sensors)
+and scoring heuristics that translate oceanic signals into liquidity,
+momentum, volatility, systemic risk, and sentiment metrics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import Mapping, Sequence
+
+from .ocean import DynamicOcean, OceanCurrent, OceanLayer, OceanSensor, OceanSnapshot
+
+__all__ = [
+    "PelagicFinancialProfile",
+    "PelagicMarketSignal",
+    "DEFAULT_FINANCIAL_PROFILES",
+    "build_financial_ocean",
+    "derive_market_signal",
+    "resolve_financial_profile",
+]
+
+
+@dataclass(slots=True)
+class PelagicFinancialProfile:
+    """Mapping between an ocean stratum and a financial mandate."""
+
+    layer_name: str
+    market_focus: tuple[str, ...]
+    asset_classes: tuple[str, ...]
+    trading_horizon: str
+    risk_appetite: str
+    data_channels: tuple[str, ...]
+    macro_indicators: tuple[str, ...]
+    default_depth: float
+    default_location: tuple[float, float, float]
+
+
+@dataclass(slots=True)
+class PelagicMarketSignal:
+    """Derived financial insight produced from a single observation."""
+
+    profile: PelagicFinancialProfile
+    snapshot: OceanSnapshot
+    liquidity_score: float
+    momentum_score: float
+    volatility_score: float
+    systemic_risk_score: float
+    sentiment_score: float
+    alerts: tuple[str, ...]
+    recommendations: tuple[str, ...]
+
+
+def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+def _score_from_delta(value: float, baseline: float, *, scale: float) -> float:
+    if baseline == 0.0:
+        baseline = 1.0
+    normalised = (value - baseline) / (abs(baseline) * scale)
+    return _clamp(0.5 + normalised)
+
+
+_DEFAULT_LAYER_SPECS: Mapping[str, Mapping[str, object]] = {
+    "Epipelagic": {
+        "depth_range": (0.0, 200.0),
+        "temperature_c": 18.0,
+        "salinity_psu": 35.0,
+        "oxygen_mg_l": 6.5,
+        "turbidity_ntu": 2.0,
+    },
+    "Mesopelagic": {
+        "depth_range": (200.0, 1000.0),
+        "temperature_c": 4.0,
+        "salinity_psu": 34.6,
+        "oxygen_mg_l": 5.2,
+        "turbidity_ntu": 3.5,
+    },
+    "Bathypelagic": {
+        "depth_range": (1000.0, 4000.0),
+        "temperature_c": 2.0,
+        "salinity_psu": 34.7,
+        "oxygen_mg_l": 4.8,
+        "turbidity_ntu": 4.5,
+    },
+    "Abyssopelagic": {
+        "depth_range": (4000.0, 6000.0),
+        "temperature_c": 1.5,
+        "salinity_psu": 34.8,
+        "oxygen_mg_l": 4.2,
+        "turbidity_ntu": 5.2,
+    },
+    "Hadalpelagic": {
+        "depth_range": (6000.0, 11000.0),
+        "temperature_c": 1.0,
+        "salinity_psu": 34.9,
+        "oxygen_mg_l": 3.6,
+        "turbidity_ntu": 5.8,
+    },
+}
+
+
+DEFAULT_FINANCIAL_PROFILES: Mapping[str, PelagicFinancialProfile] = {
+    "Epipelagic": PelagicFinancialProfile(
+        layer_name="Epipelagic",
+        market_focus=("Global equities", "IPO pipeline", "Algorithmic trading"),
+        asset_classes=("Large-cap equities", "Equity index futures", "Equity options"),
+        trading_horizon="Intraday to short-term swings",
+        risk_appetite="Growth with disciplined drawdown controls",
+        data_channels=(
+            "Exchange order books",
+            "Primary issuance calendars",
+            "Newswire velocity feeds",
+        ),
+        macro_indicators=("PMI surprise", "Retail flows", "Volatility term structure"),
+        default_depth=100.0,
+        default_location=(0.0, 0.0, 100.0),
+    ),
+    "Mesopelagic": PelagicFinancialProfile(
+        layer_name="Mesopelagic",
+        market_focus=("Credit markets", "FX carry", "Private credit underwriting"),
+        asset_classes=("Investment-grade credit", "Sovereign FX", "Structured credit"),
+        trading_horizon="Multi-week positioning",
+        risk_appetite="Income-oriented with moderate leverage",
+        data_channels=(
+            "Corporate issuance trackers",
+            "Cross-currency basis monitors",
+            "Credit default swap curves",
+        ),
+        macro_indicators=("Yield curve slope", "Credit spreads", "FX reserve balances"),
+        default_depth=600.0,
+        default_location=(12.0, -8.0, 600.0),
+    ),
+    "Bathypelagic": PelagicFinancialProfile(
+        layer_name="Bathypelagic",
+        market_focus=("Commodities", "Volatility arbitrage", "Energy logistics"),
+        asset_classes=("Oil futures", "Base metals", "Volatility surfaces"),
+        trading_horizon="Tactical swing trading",
+        risk_appetite="Opportunistic with derivatives overlays",
+        data_channels=(
+            "Supply chain telemetry",
+            "Options surface snapshots",
+            "Weather derivatives pricing",
+        ),
+        macro_indicators=("Inventory levels", "Freight rates", "Volatility of volatility"),
+        default_depth=2200.0,
+        default_location=(-24.0, 18.0, 2200.0),
+    ),
+    "Abyssopelagic": PelagicFinancialProfile(
+        layer_name="Abyssopelagic",
+        market_focus=("Global macro", "Rates strategy", "Systemic risk monitoring"),
+        asset_classes=("Sovereign rates", "Inflation swaps", "Macro hedge funds"),
+        trading_horizon="Quarterly to annual rebalancing",
+        risk_appetite="Capital preservation with convex hedges",
+        data_channels=(
+            "Central bank transcripts",
+            "Macro regime classifiers",
+            "Systemic stress indicators",
+        ),
+        macro_indicators=("Global liquidity", "Fiscal balance", "Systemic risk index"),
+        default_depth=4800.0,
+        default_location=(40.0, -30.0, 4800.0),
+    ),
+    "Hadalpelagic": PelagicFinancialProfile(
+        layer_name="Hadalpelagic",
+        market_focus=("Tail-risk hedging", "Crisis playbooks", "Distressed opportunities"),
+        asset_classes=("Deep out-of-the-money options", "Distressed debt", "Catastrophe bonds"),
+        trading_horizon="Event-driven with opportunistic deployment",
+        risk_appetite="Protective with asymmetric payoffs",
+        data_channels=(
+            "Crisis indicator dashboards",
+            "Liquidity stress monitors",
+            "Policy intervention trackers",
+        ),
+        macro_indicators=("Systemic drawdown", "Liquidity premium", "Crisis severity"),
+        default_depth=9000.0,
+        default_location=(-65.0, 12.0, 9000.0),
+    ),
+}
+
+
+_DEFAULT_CURRENTS: Sequence[Mapping[str, object]] = (
+    {
+        "name": "Surface Momentum Jet",
+        "speed_mps": 1.4,
+        "direction": (0.9, 0.1, 0.0),
+        "depth": 120.0,
+        "origin": (0.0, 0.0, 95.0),
+        "influence_radius_km": 320.0,
+        "temperature_delta": 3.2,
+        "salinity_delta": 0.4,
+        "oxygen_delta": 0.6,
+        "turbulence_delta": 0.5,
+        "variability": 0.2,
+        "stability": 0.78,
+    },
+    {
+        "name": "Midwater Carry Stream",
+        "speed_mps": 0.9,
+        "direction": (0.2, -0.6, 0.1),
+        "depth": 550.0,
+        "origin": (18.0, -9.0, 560.0),
+        "influence_radius_km": 220.0,
+        "temperature_delta": -0.6,
+        "salinity_delta": 0.2,
+        "oxygen_delta": -0.3,
+        "turbulence_delta": 0.3,
+        "variability": 0.28,
+        "stability": 0.6,
+    },
+    {
+        "name": "Deep Vol Arb Gyre",
+        "speed_mps": 0.6,
+        "direction": (-0.3, 0.4, -0.2),
+        "depth": 2100.0,
+        "origin": (-28.0, 14.0, 2150.0),
+        "influence_radius_km": 260.0,
+        "temperature_delta": 0.4,
+        "salinity_delta": -0.2,
+        "oxygen_delta": -0.5,
+        "turbulence_delta": 0.6,
+        "variability": 0.35,
+        "stability": 0.55,
+    },
+    {
+        "name": "Macro Drift Current",
+        "speed_mps": 0.4,
+        "direction": (0.1, 0.2, 0.0),
+        "depth": 4700.0,
+        "origin": (42.0, -28.0, 4700.0),
+        "influence_radius_km": 380.0,
+        "temperature_delta": 0.2,
+        "salinity_delta": 0.1,
+        "oxygen_delta": -0.2,
+        "turbulence_delta": 0.3,
+        "variability": 0.18,
+        "stability": 0.7,
+    },
+    {
+        "name": "Crisis Undertow",
+        "speed_mps": 0.3,
+        "direction": (-0.4, 0.2, 0.3),
+        "depth": 8800.0,
+        "origin": (-60.0, 10.0, 8900.0),
+        "influence_radius_km": 420.0,
+        "temperature_delta": -0.3,
+        "salinity_delta": 0.3,
+        "oxygen_delta": -0.8,
+        "turbulence_delta": 0.5,
+        "variability": 0.4,
+        "stability": 0.48,
+    },
+)
+
+
+_DEFAULT_SENSORS: Sequence[Mapping[str, object]] = (
+    {
+        "name": "Surface-Liquidity-Array",
+        "position": (10.0, 5.0, 90.0),
+        "sensitivity": 1.2,
+        "detection_range": 300.0,
+        "noise_floor": 0.05,
+    },
+    {
+        "name": "Credit-Depth-Array",
+        "position": (25.0, -12.0, 620.0),
+        "sensitivity": 1.1,
+        "detection_range": 340.0,
+        "noise_floor": 0.06,
+    },
+    {
+        "name": "Commodity-Core-Array",
+        "position": (-30.0, 18.0, 2150.0),
+        "sensitivity": 0.95,
+        "detection_range": 360.0,
+        "noise_floor": 0.07,
+    },
+    {
+        "name": "Macro-Basin-Array",
+        "position": (38.0, -32.0, 4700.0),
+        "sensitivity": 0.9,
+        "detection_range": 420.0,
+        "noise_floor": 0.08,
+    },
+    {
+        "name": "Crisis-Trench-Array",
+        "position": (-66.0, 14.0, 9050.0),
+        "sensitivity": 0.85,
+        "detection_range": 480.0,
+        "noise_floor": 0.09,
+    },
+)
+
+
+def build_financial_ocean(*, max_history: int = 240) -> DynamicOcean:
+    """Instantiate ``DynamicOcean`` with the financial instrumentation."""
+
+    ocean = DynamicOcean(max_history=max_history)
+    for index, (name, spec) in enumerate(_DEFAULT_LAYER_SPECS.items()):
+        ocean.register_layer(
+            OceanLayer(name=name, **spec),
+            default=index == 0,
+        )
+    for current in _DEFAULT_CURRENTS:
+        ocean.add_current(OceanCurrent(**current))
+    for sensor in _DEFAULT_SENSORS:
+        ocean.add_sensor(OceanSensor(**sensor))
+    return ocean
+
+
+def resolve_financial_profile(layer_name: str) -> PelagicFinancialProfile:
+    """Return the canonical profile for ``layer_name``."""
+
+    try:
+        return DEFAULT_FINANCIAL_PROFILES[layer_name]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise KeyError(f"Unknown financial layer '{layer_name}'.") from exc
+
+
+def derive_market_signal(
+    snapshot: OceanSnapshot,
+    profile: PelagicFinancialProfile,
+) -> PelagicMarketSignal:
+    """Translate an :class:`OceanSnapshot` into a financial signal."""
+
+    layer = snapshot.layer
+    liquidity = _score_from_delta(snapshot.salinity_psu, layer.salinity_psu, scale=0.6)
+    momentum = _score_from_delta(snapshot.temperature_c, layer.temperature_c, scale=0.4)
+    turbidity_ratio = (snapshot.turbidity_ntu - layer.turbidity_ntu) / (max(layer.turbidity_ntu, 1.0) * 0.5)
+    energy_factor = sqrt(max(snapshot.current_energy, 0.0)) / 4.0
+    volatility = _clamp(0.5 + 0.3 * turbidity_ratio + 0.4 * energy_factor)
+    oxygen_delta = (layer.oxygen_mg_l - snapshot.oxygen_mg_l) / max(layer.oxygen_mg_l, 1.0)
+    systemic_risk = _clamp(0.4 + (1.0 - snapshot.stability_index) * 0.5 + max(oxygen_delta, 0.0) * 0.4)
+    sentiment = _clamp(
+        0.5
+        + 0.3 * (snapshot.temperature_c - layer.temperature_c) / max(abs(layer.temperature_c), 1.0)
+        + 0.3 * (snapshot.oxygen_mg_l - layer.oxygen_mg_l) / max(layer.oxygen_mg_l, 1.0)
+        - 0.2 * max(systemic_risk - 0.6, 0.0)
+    )
+
+    recommendations: list[str] = []
+    if liquidity > 0.7 and momentum > 0.6:
+        recommendations.append(
+            f"Scale into {profile.asset_classes[0]} while liquidity remains strong."
+        )
+    if volatility > 0.65:
+        recommendations.append(
+            "Deploy hedges via listed options or variance swaps to contain volatility risk."
+        )
+    if systemic_risk > 0.6:
+        recommendations.append(
+            f"Layer defensive overlays across {profile.asset_classes[-1]} to offset systemic stress."
+        )
+    if sentiment < 0.4:
+        recommendations.append(
+            f"Trim exposure within {profile.market_focus[0]} until sentiment stabilises."
+        )
+    if not recommendations:
+        recommendations.append("Maintain core positioning with dynamic rebalancing triggers engaged.")
+
+    return PelagicMarketSignal(
+        profile=profile,
+        snapshot=snapshot,
+        liquidity_score=liquidity,
+        momentum_score=momentum,
+        volatility_score=volatility,
+        systemic_risk_score=systemic_risk,
+        sentiment_score=sentiment,
+        alerts=snapshot.alerts,
+        recommendations=tuple(recommendations),
+    )

--- a/dynamic_ocean/ocean.py
+++ b/dynamic_ocean/ocean.py
@@ -1,0 +1,515 @@
+"""Dynamic ocean circulation analytics primitives."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from math import sqrt
+from typing import Deque, Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "OceanEventSeverity",
+    "OceanLayer",
+    "OceanCurrent",
+    "OceanSensor",
+    "OceanEvent",
+    "OceanSnapshot",
+    "DynamicOcean",
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalise_identifier(value: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise ValueError("identifier must not be empty")
+    return text
+
+
+def _clamp(value: float | int, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    numeric = float(value)
+    if numeric < lower:
+        return lower
+    if numeric > upper:
+        return upper
+    return numeric
+
+
+def _ensure_triplet(values: Sequence[float] | None, *, default_depth: float = 0.0) -> tuple[float, float, float]:
+    if values is None:
+        return (0.0, 0.0, default_depth)
+    items = list(values)
+    if len(items) not in {2, 3}:
+        raise ValueError("spatial coordinates must contain two or three components")
+    coords: list[float] = []
+    for item in items:
+        coords.append(float(item))
+    if len(coords) == 2:
+        coords.append(default_depth)
+    return coords[0], coords[1], coords[2]
+
+
+def _distance(a: Sequence[float], b: Sequence[float]) -> float:
+    ax, ay, az = a
+    bx, by, bz = b
+    return sqrt((ax - bx) ** 2 + (ay - by) ** 2 + (az - bz) ** 2)
+
+
+def _ensure_layer(value: OceanLayer | Mapping[str, object]) -> OceanLayer:
+    if isinstance(value, OceanLayer):
+        return value
+    if isinstance(value, Mapping):
+        return OceanLayer(**value)
+    raise TypeError("layers must be OceanLayer instances or mappings")
+
+
+def _ensure_current(value: OceanCurrent | Mapping[str, object]) -> OceanCurrent:
+    if isinstance(value, OceanCurrent):
+        return value
+    if isinstance(value, Mapping):
+        return OceanCurrent(**value)
+    raise TypeError("currents must be OceanCurrent instances or mappings")
+
+
+def _ensure_sensor(value: OceanSensor | Mapping[str, object]) -> OceanSensor:
+    if isinstance(value, OceanSensor):
+        return value
+    if isinstance(value, Mapping):
+        return OceanSensor(**value)
+    raise TypeError("sensors must be OceanSensor instances or mappings")
+
+
+# ---------------------------------------------------------------------------
+# data models
+
+
+class OceanEventSeverity(str, Enum):
+    """Severity levels for ocean monitoring alerts."""
+
+    INFO = "info"
+    ADVISORY = "advisory"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+@dataclass(slots=True)
+class OceanLayer:
+    """Describes a stratified layer within the water column."""
+
+    name: str
+    depth_range: tuple[float, float]
+    temperature_c: float
+    salinity_psu: float
+    oxygen_mg_l: float
+    turbidity_ntu: float = 1.0
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_identifier(self.name)
+        min_depth, max_depth = self.depth_range
+        self.depth_range = (float(min_depth), float(max_depth))
+        if self.depth_range[0] < 0 or self.depth_range[1] <= self.depth_range[0]:
+            raise ValueError("depth_range must be an increasing pair of non-negative values")
+        self.temperature_c = float(self.temperature_c)
+        self.salinity_psu = float(self.salinity_psu)
+        self.oxygen_mg_l = float(self.oxygen_mg_l)
+        self.turbidity_ntu = max(float(self.turbidity_ntu), 0.0)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):  # pragma: no cover - guard
+            raise TypeError("metadata must be a mapping if provided")
+
+    def contains_depth(self, depth: float) -> bool:
+        return self.depth_range[0] <= depth < self.depth_range[1]
+
+
+@dataclass(slots=True)
+class OceanCurrent:
+    """Represents a coherent current influencing the observation zone."""
+
+    name: str
+    speed_mps: float
+    direction: tuple[float, float, float]
+    depth: float = 0.0
+    origin: tuple[float, float, float] = field(default_factory=lambda: (0.0, 0.0, 0.0))
+    influence_radius_km: float = 150.0
+    temperature_delta: float = 0.0
+    salinity_delta: float = 0.0
+    oxygen_delta: float = 0.0
+    turbulence_delta: float = 0.0
+    variability: float = 0.1
+    stability: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_identifier(self.name)
+        self.speed_mps = max(float(self.speed_mps), 0.0)
+        self.direction = _ensure_triplet(self.direction)
+        self.depth = max(float(self.depth), 0.0)
+        self.origin = _ensure_triplet(self.origin, default_depth=self.depth)
+        self.influence_radius_km = max(float(self.influence_radius_km), 0.0)
+        self.temperature_delta = float(self.temperature_delta)
+        self.salinity_delta = float(self.salinity_delta)
+        self.oxygen_delta = float(self.oxygen_delta)
+        self.turbulence_delta = float(self.turbulence_delta)
+        self.variability = _clamp(float(self.variability), lower=0.0, upper=1.0)
+        self.stability = _clamp(float(self.stability), lower=0.0, upper=1.0)
+
+
+@dataclass(slots=True)
+class OceanSensor:
+    """Stationary sensor capturing conditions at a fixed point."""
+
+    name: str
+    position: tuple[float, float, float]
+    sensitivity: float = 1.0
+    detection_range: float = 100.0
+    noise_floor: float = 0.01
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_identifier(self.name)
+        self.position = _ensure_triplet(self.position)
+        self.sensitivity = max(float(self.sensitivity), 0.0)
+        self.detection_range = max(float(self.detection_range), 0.0)
+        self.noise_floor = max(float(self.noise_floor), 0.0)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):  # pragma: no cover
+            raise TypeError("metadata must be a mapping if provided")
+
+
+@dataclass(slots=True)
+class OceanEvent:
+    """Logged anomaly within the observed ocean region."""
+
+    timestamp: datetime
+    description: str
+    severity: OceanEventSeverity
+    impact: float
+    location: tuple[float, float, float] | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        self.description = _normalise_identifier(self.description)
+        if not isinstance(self.severity, OceanEventSeverity):
+            self.severity = OceanEventSeverity(str(self.severity).lower())
+        self.impact = max(float(self.impact), 0.0)
+        if self.location is not None:
+            self.location = _ensure_triplet(self.location)
+        cleaned_tags: list[str] = []
+        seen: set[str] = set()
+        for tag in self.tags:
+            cleaned = tag.strip().lower()
+            if cleaned and cleaned not in seen:
+                seen.add(cleaned)
+                cleaned_tags.append(cleaned)
+        self.tags = tuple(cleaned_tags)
+
+
+@dataclass(slots=True)
+class OceanSnapshot:
+    """Synthesis of the ocean state at a specific instant."""
+
+    timestamp: datetime
+    layer: OceanLayer
+    temperature_c: float
+    salinity_psu: float
+    oxygen_mg_l: float
+    turbidity_ntu: float
+    current_energy: float
+    stability_index: float
+    sensor_readings: Mapping[str, float]
+    alerts: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.timestamp.tzinfo is None:
+            self.timestamp = self.timestamp.replace(tzinfo=timezone.utc)
+        else:
+            self.timestamp = self.timestamp.astimezone(timezone.utc)
+        if not isinstance(self.sensor_readings, Mapping):  # pragma: no cover - guard
+            raise TypeError("sensor_readings must be a mapping")
+        self.temperature_c = float(self.temperature_c)
+        self.salinity_psu = float(self.salinity_psu)
+        self.oxygen_mg_l = float(self.oxygen_mg_l)
+        self.turbidity_ntu = max(float(self.turbidity_ntu), 0.0)
+        self.current_energy = max(float(self.current_energy), 0.0)
+        self.stability_index = _clamp(float(self.stability_index), lower=0.0, upper=1.0)
+        self.alerts = tuple(alert.strip() for alert in self.alerts if alert.strip())
+
+
+# ---------------------------------------------------------------------------
+# engine
+
+
+class DynamicOcean:
+    """Dynamic ocean manager orchestrating layers, currents, and sensors."""
+
+    def __init__(self, *, max_history: int = 120) -> None:
+        if max_history <= 0:
+            raise ValueError("max_history must be positive")
+        self._layers: MutableMapping[str, OceanLayer] = {}
+        self._currents: MutableMapping[str, OceanCurrent] = {}
+        self._sensors: MutableMapping[str, OceanSensor] = {}
+        self._history: Deque[OceanSnapshot] = deque(maxlen=max_history)
+        self._events: Deque[OceanEvent] = deque(maxlen=max_history * 2)
+        self._default_layer: str | None = None
+
+    @property
+    def layers(self) -> Mapping[str, OceanLayer]:
+        return dict(self._layers)
+
+    @property
+    def currents(self) -> Mapping[str, OceanCurrent]:
+        return dict(self._currents)
+
+    @property
+    def sensors(self) -> Mapping[str, OceanSensor]:
+        return dict(self._sensors)
+
+    @property
+    def history(self) -> Sequence[OceanSnapshot]:
+        return tuple(self._history)
+
+    @property
+    def events(self) -> Sequence[OceanEvent]:
+        return tuple(self._events)
+
+    def register_layer(self, layer: OceanLayer | Mapping[str, object], *, default: bool = False) -> OceanLayer:
+        resolved = _ensure_layer(layer)
+        self._layers[resolved.name] = resolved
+        if default or self._default_layer is None:
+            self._default_layer = resolved.name
+        return resolved
+
+    def select_layer(self, name: str) -> OceanLayer:
+        if name not in self._layers:
+            raise KeyError(f"unknown layer '{name}'")
+        self._default_layer = name
+        return self._layers[name]
+
+    def add_current(self, current: OceanCurrent | Mapping[str, object]) -> OceanCurrent:
+        resolved = _ensure_current(current)
+        self._currents[resolved.name] = resolved
+        return resolved
+
+    def remove_current(self, name: str) -> None:
+        self._currents.pop(name, None)
+
+    def add_sensor(self, sensor: OceanSensor | Mapping[str, object]) -> OceanSensor:
+        resolved = _ensure_sensor(sensor)
+        self._sensors[resolved.name] = resolved
+        return resolved
+
+    def remove_sensor(self, name: str) -> None:
+        self._sensors.pop(name, None)
+
+    def observe(
+        self,
+        *,
+        depth: float,
+        location: Sequence[float] | None = None,
+        timestamp: datetime | None = None,
+        layer: str | None = None,
+    ) -> OceanSnapshot:
+        if not self._layers:
+            raise RuntimeError("no layers registered")
+        if not self._sensors:
+            raise RuntimeError("no sensors registered")
+
+        depth_value = max(float(depth), 0.0)
+        point = _ensure_triplet(location or (0.0, 0.0, depth_value), default_depth=depth_value)
+        instant = timestamp or _utcnow()
+
+        target_layer = self._resolve_layer(depth_value, layer)
+
+        temperature = target_layer.temperature_c
+        salinity = target_layer.salinity_psu
+        oxygen = target_layer.oxygen_mg_l
+        turbidity = target_layer.turbidity_ntu
+        energy = 0.0
+        stability = 1.0
+
+        alerts: list[str] = []
+
+        for current in tuple(self._currents.values()):
+            influence = self._current_influence(current, point, depth_value)
+            if influence <= 0.0:
+                continue
+            temperature += current.temperature_delta * influence
+            salinity += current.salinity_delta * influence
+            oxygen += current.oxygen_delta * influence
+            turbidity += abs(current.turbulence_delta) * influence
+            energy += (current.speed_mps ** 2) * influence
+            stability *= 1.0 - min(current.variability * influence, 0.9)
+
+        stability = max(0.0, min(1.0, stability))
+
+        sensor_readings: dict[str, float] = {}
+        for sensor in tuple(self._sensors.values()):
+            reading = self._measure_sensor(
+                sensor,
+                point,
+                depth_value,
+                base_layer=target_layer,
+                temperature=temperature,
+                salinity=salinity,
+                oxygen=oxygen,
+                energy=energy,
+            )
+            sensor_readings[sensor.name] = reading
+            if reading > sensor.noise_floor * 12:
+                alerts.append(
+                    f"sensor {sensor.name} detected energetic surge at {reading:.2f} arbitrary units"
+                )
+
+        if temperature - target_layer.temperature_c > 2.0:
+            alerts.append("Surface warming above seasonal baseline.")
+        if oxygen < max(3.5, target_layer.oxygen_mg_l * 0.6):
+            alerts.append("Dissolved oxygen trending toward hypoxia.")
+        if turbidity > target_layer.turbidity_ntu * 1.5:
+            alerts.append("Elevated turbidity detected across monitoring grid.")
+        if stability < 0.3:
+            alerts.append("Circulation stability deteriorating; anticipate shear zones.")
+
+        snapshot = OceanSnapshot(
+            timestamp=instant,
+            layer=target_layer,
+            temperature_c=temperature,
+            salinity_psu=salinity,
+            oxygen_mg_l=oxygen,
+            turbidity_ntu=turbidity,
+            current_energy=energy,
+            stability_index=stability,
+            sensor_readings=sensor_readings,
+            alerts=tuple(alerts),
+        )
+
+        self._history.append(snapshot)
+        for alert in snapshot.alerts:
+            severity = self._classify_alert(alert)
+            self._events.append(
+                OceanEvent(
+                    timestamp=instant,
+                    description=alert,
+                    severity=severity,
+                    impact=max(snapshot.current_energy ** 0.5, 0.1),
+                    location=point,
+                )
+            )
+        return snapshot
+
+    def _resolve_layer(self, depth: float, requested: str | None) -> OceanLayer:
+        if requested:
+            requested = requested.strip()
+            if requested:
+                if requested not in self._layers:
+                    raise KeyError(f"unknown layer '{requested}'")
+                return self._layers[requested]
+        for layer in self._layers.values():
+            if layer.contains_depth(depth):
+                return layer
+        if self._default_layer and self._default_layer in self._layers:
+            return self._layers[self._default_layer]
+        return next(iter(self._layers.values()))
+
+    def _current_influence(self, current: OceanCurrent, point: tuple[float, float, float], depth: float) -> float:
+        if current.influence_radius_km <= 0.0:
+            spatial_factor = 1.0
+        else:
+            distance = _distance(point, current.origin)
+            spatial_factor = max(0.0, 1.0 - distance / max(current.influence_radius_km, 1e-6))
+        depth_factor = max(0.0, 1.0 - abs(depth - current.depth) / (current.depth + 100.0))
+        coherence = 0.5 + 0.5 * current.stability
+        influence = spatial_factor * depth_factor * coherence
+        return influence
+
+    def _measure_sensor(
+        self,
+        sensor: OceanSensor,
+        point: tuple[float, float, float],
+        depth: float,
+        *,
+        base_layer: OceanLayer,
+        temperature: float,
+        salinity: float,
+        oxygen: float,
+        energy: float,
+    ) -> float:
+        distance = _distance(point, sensor.position)
+        if sensor.detection_range <= 0.0:
+            span_factor = 0.0
+        else:
+            span_factor = max(0.0, 1.0 - distance / sensor.detection_range)
+        delta_temp = abs(temperature - base_layer.temperature_c)
+        delta_salinity = abs(salinity - base_layer.salinity_psu)
+        oxygen_stress = max(0.0, base_layer.oxygen_mg_l - oxygen)
+        signal = (
+            0.6 * delta_temp
+            + 0.3 * delta_salinity
+            + 0.5 * oxygen_stress
+            + 0.2 * sqrt(max(energy, 0.0))
+        )
+        reading = sensor.noise_floor + span_factor * sensor.sensitivity * signal
+        return max(reading, sensor.noise_floor)
+
+    def decay_currents(self, factor: float) -> None:
+        if factor <= 0:
+            raise ValueError("factor must be positive")
+        for name, current in list(self._currents.items()):
+            decayed = replace(
+                current,
+                speed_mps=current.speed_mps * factor,
+                temperature_delta=current.temperature_delta * factor,
+                salinity_delta=current.salinity_delta * factor,
+                oxygen_delta=current.oxygen_delta * factor,
+                turbulence_delta=current.turbulence_delta * factor,
+            )
+            if decayed.speed_mps <= 1e-6:
+                self._currents.pop(name)
+            else:
+                self._currents[name] = decayed
+
+    def record_event(
+        self,
+        description: str,
+        *,
+        severity: OceanEventSeverity | str = OceanEventSeverity.INFO,
+        impact: float,
+        location: Sequence[float] | None = None,
+    ) -> OceanEvent:
+        event = OceanEvent(
+            timestamp=_utcnow(),
+            description=description,
+            severity=severity,
+            impact=impact,
+            location=_ensure_triplet(location) if location is not None else None,
+        )
+        self._events.append(event)
+        return event
+
+    def recent_events(self, limit: int = 5) -> tuple[OceanEvent, ...]:
+        if limit <= 0:
+            return ()
+        return tuple(list(self._events)[-limit:])
+
+    def replay(self) -> Iterable[OceanSnapshot]:
+        return tuple(self._history)
+
+    def _classify_alert(self, alert: str) -> OceanEventSeverity:
+        alert_lower = alert.lower()
+        if "hypoxia" in alert_lower:
+            return OceanEventSeverity.CRITICAL
+        if "turbidity" in alert_lower or "surge" in alert_lower:
+            return OceanEventSeverity.WARNING
+        if "stability" in alert_lower:
+            return OceanEventSeverity.ADVISORY
+        return OceanEventSeverity.INFO

--- a/tests/test_dynamic_ocean.py
+++ b/tests/test_dynamic_ocean.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from dynamic_ocean import (
+    DynamicOcean,
+    OceanCurrent,
+    OceanEventSeverity,
+    OceanLayer,
+    OceanSensor,
+)
+
+
+def _build_ocean() -> DynamicOcean:
+    ocean = DynamicOcean()
+    ocean.register_layer(
+        OceanLayer(
+            name="Epipelagic",
+            depth_range=(0.0, 200.0),
+            temperature_c=18.0,
+            salinity_psu=35.0,
+            oxygen_mg_l=6.5,
+            turbidity_ntu=2.0,
+        ),
+        default=True,
+    )
+    ocean.register_layer(
+        {
+            "name": "Mesopelagic",
+            "depth_range": (200.0, 1000.0),
+            "temperature_c": 4.0,
+            "salinity_psu": 34.6,
+            "oxygen_mg_l": 5.2,
+            "turbidity_ntu": 3.5,
+        }
+    )
+    ocean.add_current(
+        OceanCurrent(
+            name="Gulf Stream",
+            speed_mps=1.2,
+            direction=(1.0, 0.2, 0.0),
+            depth=100.0,
+            origin=(0.0, 0.0, 90.0),
+            influence_radius_km=320.0,
+            temperature_delta=2.8,
+            salinity_delta=0.3,
+            oxygen_delta=0.6,
+            turbulence_delta=0.4,
+            variability=0.18,
+            stability=0.82,
+        )
+    )
+    ocean.add_current(
+        {
+            "name": "Subsurface Counter",
+            "speed_mps": 0.7,
+            "direction": (-0.5, 0.3, 0.1),
+            "depth": 250.0,
+            "origin": (30.0, -12.0, 240.0),
+            "influence_radius_km": 180.0,
+            "temperature_delta": -0.8,
+            "salinity_delta": 0.1,
+            "oxygen_delta": -0.4,
+            "turbulence_delta": 0.2,
+            "variability": 0.3,
+            "stability": 0.55,
+        }
+    )
+    ocean.add_sensor(
+        OceanSensor(
+            name="Array-A",
+            position=(20.0, 10.0, 80.0),
+            sensitivity=1.2,
+            detection_range=220.0,
+            noise_floor=0.05,
+        )
+    )
+    ocean.add_sensor(
+        {
+            "name": "Array-B",
+            "position": (-40.0, 15.0, 75.0),
+            "sensitivity": 0.9,
+            "detection_range": 260.0,
+            "noise_floor": 0.04,
+        }
+    )
+    return ocean
+
+
+def test_dynamic_ocean_observe_generates_snapshot_and_alerts() -> None:
+    ocean = _build_ocean()
+    timestamp = datetime(2024, 1, 1, 6, 0, tzinfo=timezone.utc)
+
+    snapshot = ocean.observe(depth=90.0, location=(10.0, 5.0, 90.0), timestamp=timestamp)
+
+    assert snapshot.layer.name == "Epipelagic"
+    assert snapshot.temperature_c > 18.0
+    assert snapshot.oxygen_mg_l > 6.0
+    assert snapshot.current_energy > 0.0
+    assert 0.0 <= snapshot.stability_index <= 1.0
+    assert set(snapshot.sensor_readings) == {"Array-A", "Array-B"}
+    assert all(value >= 0.04 for value in snapshot.sensor_readings.values())
+    assert snapshot.alerts
+    assert ocean.history[-1] is snapshot
+    assert ocean.events[-1].description == snapshot.alerts[-1]
+
+
+def test_dynamic_ocean_layer_resolution_and_decay() -> None:
+    ocean = _build_ocean()
+    before_speed = ocean.currents["Gulf Stream"].speed_mps
+
+    meso_snapshot = ocean.observe(depth=400.0, layer="Mesopelagic", location=(0.0, 0.0, 400.0))
+    assert meso_snapshot.layer.name == "Mesopelagic"
+
+    ocean.decay_currents(0.5)
+    assert pytest.approx(before_speed * 0.5, rel=1e-5) == ocean.currents["Gulf Stream"].speed_mps
+
+    ocean.decay_currents(1e-6)
+    assert "Gulf Stream" not in ocean.currents
+
+
+def test_dynamic_ocean_event_logging_and_recent_events() -> None:
+    ocean = _build_ocean()
+    event = ocean.record_event(
+        "Manual ROV inspection completed",
+        severity=OceanEventSeverity.INFO,
+        impact=0.2,
+        location=(5.0, -2.0, 95.0),
+    )
+    assert event.description == "Manual ROV inspection completed"
+    assert ocean.recent_events(limit=1) == (event,)
+
+    # Invoking observe should append new alerts to the log
+    ocean.observe(depth=90.0, location=(5.0, 0.0, 90.0))
+    assert ocean.events[-1].timestamp >= event.timestamp

--- a/tests/test_dynamic_ocean_finance.py
+++ b/tests/test_dynamic_ocean_finance.py
@@ -1,0 +1,113 @@
+import pytest
+
+from dynamic_ocean import (
+    DEFAULT_FINANCIAL_PROFILES,
+    build_financial_ocean,
+)
+from dynamic_agents.ocean import (
+    DynamicAbyssopelagicAgent,
+    DynamicBathypelagicAgent,
+    DynamicEpipelagicAgent,
+    DynamicHadalpelagicAgent,
+    DynamicMesopelagicAgent,
+)
+from dynamic_helpers.ocean import (
+    DynamicAbyssopelagicHelper,
+    DynamicBathypelagicHelper,
+    DynamicEpipelagicHelper,
+    DynamicHadalpelagicHelper,
+    DynamicMesopelagicHelper,
+)
+from dynamic_keepers.ocean import (
+    DynamicAbyssopelagicKeeper,
+    DynamicBathypelagicKeeper,
+    DynamicEpipelagicKeeper,
+    DynamicHadalpelagicKeeper,
+    DynamicMesopelagicKeeper,
+)
+from dynamic_bots.ocean import (
+    DynamicAbyssopelagicBot,
+    DynamicBathypelagicBot,
+    DynamicEpipelagicBot,
+    DynamicHadalpelagicBot,
+    DynamicMesopelagicBot,
+)
+
+
+def test_build_financial_ocean_registers_all_layers() -> None:
+    ocean = build_financial_ocean()
+    assert set(ocean.layers) == set(DEFAULT_FINANCIAL_PROFILES)
+    assert len(ocean.sensors) >= 5
+    assert len(ocean.currents) >= 5
+
+
+@pytest.mark.parametrize(
+    (
+        "agent_cls",
+        "helper_cls",
+        "keeper_cls",
+        "bot_cls",
+    ),
+    [
+        (
+            DynamicEpipelagicAgent,
+            DynamicEpipelagicHelper,
+            DynamicEpipelagicKeeper,
+            DynamicEpipelagicBot,
+        ),
+        (
+            DynamicMesopelagicAgent,
+            DynamicMesopelagicHelper,
+            DynamicMesopelagicKeeper,
+            DynamicMesopelagicBot,
+        ),
+        (
+            DynamicBathypelagicAgent,
+            DynamicBathypelagicHelper,
+            DynamicBathypelagicKeeper,
+            DynamicBathypelagicBot,
+        ),
+        (
+            DynamicAbyssopelagicAgent,
+            DynamicAbyssopelagicHelper,
+            DynamicAbyssopelagicKeeper,
+            DynamicAbyssopelagicBot,
+        ),
+        (
+            DynamicHadalpelagicAgent,
+            DynamicHadalpelagicHelper,
+            DynamicHadalpelagicKeeper,
+            DynamicHadalpelagicBot,
+        ),
+    ],
+)
+def test_pelagic_layer_pipeline(agent_cls, helper_cls, keeper_cls, bot_cls) -> None:
+    engine = build_financial_ocean()
+    agent = agent_cls(engine=engine)
+    signal = agent.capture_signal()
+    assert 0.0 <= signal.liquidity_score <= 1.0
+    assert 0.0 <= signal.volatility_score <= 1.0
+    assert signal.recommendations
+
+    helper = helper_cls(agent.profile)
+    digest = helper.compose_digest(signal, summary=agent.summarise())
+    assert agent.profile.layer_name in digest
+    assert "Scores" in digest
+
+    keeper = keeper_cls(agent.profile, limit=4)
+    keeper.record(signal)
+    keeper.record(agent.capture_signal())
+    trend = keeper.trend()
+    assert set(trend.averages) >= {
+        "liquidity",
+        "momentum",
+        "volatility",
+        "systemic_risk",
+        "sentiment",
+    }
+
+    bot = bot_cls(agent=agent, helper=helper, keeper=keeper)
+    message = bot.publish_update()
+    assert isinstance(message, str)
+    assert agent.profile.layer_name in message
+    assert "Recommendations" in message


### PR DESCRIPTION
## Summary
- add a financial orchestration layer for the dynamic ocean engine with default market profiles, sensors, and scoring heuristics
- implement layer-specific agents, helpers, keepers, and bots covering the epipelagic through hadalpelagic strata
- exercise the new workflow with parametrized tests that validate the financial pipeline for every pelagic depth

## Testing
- npm run format
- npm run lint
- npm run typecheck
- pytest tests/test_dynamic_ocean.py tests/test_dynamic_ocean_finance.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a4ed3d988322a79295e156f472ee