### PR TITLE
Update Dynamic Capital acronyms

### DIFF
--- a/dynamic_acronym/acronym.py
+++ b/dynamic_acronym/acronym.py
@@ -11,6 +11,8 @@ __all__ = [
     "AcronymSnapshot",
     "AcronymDigest",
     "DynamicAcronym",
+    "DEFAULT_ACRONYMS",
+    "create_default_acronym_registry",
 ]
 
 
@@ -350,3 +352,82 @@ class DynamicAcronym:
             ambiguous_acronyms=top_ambiguous,
             last_reviewed=last_reviewed,
         )
+
+
+# ---------------------------------------------------------------------------
+# curated defaults
+
+
+DEFAULT_ACRONYMS: tuple[AcronymEntry, ...] = (
+    AcronymEntry(
+        acronym="DYNAMIC",
+        expansions=(
+            "Driving Yield of New Advancements in Markets, Investing & Capital",
+        ),
+        description=(
+            "Defines the D.Y.N.A.M.I.C. base — a relentless push to uncover "
+            "fresh advantages across markets, investing, and capital strategy."
+        ),
+        categories=("vision", "markets", "innovation"),
+        usage_notes=(
+            "D.Y.N.A.M.I.C.",
+            "Use when highlighting the discovery engine that fuels Dynamic Capital.",
+        ),
+        metadata={
+            "source": "community",
+            "context": "Updated Dynamic Capital prefix expansion shared by the user.",
+        },
+        confidence=0.85,
+        familiarity=0.65,
+    ),
+    AcronymEntry(
+        acronym="CAPITAL",
+        expansions=(
+            "Creating Asset Profitability through Intelligent Trading, Algorithms & Leverage",
+        ),
+        description=(
+            "Captures the C.A.P.I.T.A.L. foundation — disciplined systems that "
+            "translate insight into compounding performance."
+        ),
+        categories=("strategy", "finance", "execution"),
+        usage_notes=(
+            "C.A.P.I.T.A.L.",
+            "Use when focusing on the intelligent trading stack that scales returns.",
+        ),
+        metadata={
+            "source": "community",
+            "context": "Companion acronym completing the Dynamic Capital formula.",
+        },
+        confidence=0.83,
+        familiarity=0.62,
+    ),
+    AcronymEntry(
+        acronym="DYNAMIC CAPITAL",
+        expansions=(
+            "Dynamic Capital = Driving Yield of New Advancements in Markets, Investing & Capital — "
+            "Creating Asset Profitability through Intelligent Trading, Algorithms & Leverage",
+        ),
+        description=(
+            "Final form statement that unifies the D.Y.N.A.M.I.C. discovery engine with the "
+            "C.A.P.I.T.A.L. execution layer."
+        ),
+        categories=("vision", "strategy", "identity"),
+        usage_notes=(
+            "D.Y.N.A.M.I.C.",
+            "C.A.P.I.T.A.L.",
+            "Use for the complete Dynamic Capital mantra.",
+        ),
+        metadata={
+            "source": "community",
+            "context": "Combined articulation aligning the two companion acronyms.",
+        },
+        confidence=0.88,
+        familiarity=0.7,
+    ),
+)
+
+
+def create_default_acronym_registry() -> DynamicAcronym:
+    """Return a registry pre-populated with curated acronym entries."""
+
+    return DynamicAcronym(DEFAULT_ACRONYMS)

--- a/tests_python/test_acronym.py
+++ b/tests_python/test_acronym.py
@@ -1,0 +1,62 @@
+"""Tests for the dynamic acronym registry defaults."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+
+from dynamic_acronym import DynamicAcronym
+from dynamic_acronym.acronym import DEFAULT_ACRONYMS, create_default_acronym_registry
+
+
+def test_dynamic_entry_uses_updated_expansion() -> None:
+    registry = create_default_acronym_registry()
+    entry = registry.lookup("D.Y.N.A.M.I.C.")
+    assert entry is not None
+    assert (
+        entry.primary_expansion
+        == "Driving Yield of New Advancements in Markets, Investing & Capital"
+    )
+
+
+def test_default_acronym_tokens_cover_simplified_spelling() -> None:
+    registry = create_default_acronym_registry()
+    entry = registry.lookup("dynamic")
+    assert entry is not None
+    assert entry.acronym == "DYNAMIC"
+
+
+def test_capital_entry_supports_stylized_lookup() -> None:
+    registry = create_default_acronym_registry()
+    entry = registry.lookup("C.A.P.I.T.A.L.")
+    assert entry is not None
+    assert (
+        entry.primary_expansion
+        == "Creating Asset Profitability through Intelligent Trading, Algorithms & Leverage"
+    )
+
+
+def test_dynamic_capital_combination_available() -> None:
+    registry = create_default_acronym_registry()
+    entry = registry.lookup("Dynamic Capital")
+    assert entry is not None
+    assert entry.acronym == "DYNAMIC CAPITAL"
+    assert entry.primary_expansion.startswith("Dynamic Capital = Driving Yield")
+
+
+def test_default_constant_is_immutable_tuple() -> None:
+    assert isinstance(DEFAULT_ACRONYMS, tuple)
+    assert {entry.acronym for entry in DEFAULT_ACRONYMS} >= {
+        "DYNAMIC",
+        "CAPITAL",
+        "DYNAMIC CAPITAL",
+    }
+    registry = DynamicAcronym(DEFAULT_ACRONYMS)
+    dynamic_entry = registry.lookup("dynamic")
+    assert dynamic_entry is not None


### PR DESCRIPTION
## Summary
- refresh the default D.Y.N.A.M.I.C. expansion with the updated community wording
- add curated entries for C.A.P.I.T.A.L. and the combined Dynamic Capital statement
- extend the acronym default tests to cover the new entries and combined mantra lookup

## Testing
- pytest tests_python/test_acronym.py


------
https://chatgpt.com/codex/tasks/task_e_68d8ac595d5c8322b81a860038bb3b2f