### PR TITLE
Add OneDrive share metadata dump utility

### DIFF
--- a/docs/onedrive-shares/evlumlqt-folder.md
+++ b/docs/onedrive-shares/evlumlqt-folder.md
@@ -1,0 +1,58 @@
+# EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg Share
+
+This note captures the metadata helpers for the provided OneDrive share link.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0V2THVNTHFUdEZSUHBSUzZPSVdXdmlvQmNGQUpkREFYSFpxTjhiWXkzSlV5eWc`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!sba30eef2b4934f54a514ba388596be2a`
+
+Use the identifier with Microsoft Graph or the OneDrive API to inspect the
+remote folder. The share currently requires an authenticated access token;
+anonymous requests return `InvalidAuthenticationToken`.
+
+## Fetching metadata
+
+1. Export a Microsoft Graph access token with permissions to read the shared
+   item:
+
+   ```bash
+   export ONEDRIVE_ACCESS_TOKEN="<token>"
+   ```
+
+2. Request the manifest entry with the repository helper:
+
+   ```bash
+   tsx scripts/onedrive/fetch-drive-item.ts "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg"
+   ```
+
+3. Persist the metadata (including the child listing) to disk for later
+   inspection:
+
+   ```bash
+   tsx scripts/onedrive/dump-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg" \
+     docs/onedrive-shares/evlumlqt-folder.metadata.json
+   ```
+
+   Pass `false` as the optional third argument to skip the `expand=children`
+   query parameter if you only need the root item metadata.
+
+4. Alternatively, query Microsoft Graph directly:
+
+   ```bash
+   curl \
+     --header "Authorization: Bearer ${ONEDRIVE_ACCESS_TOKEN}" \
+     --header "Accept: application/json" \
+     "https://graph.microsoft.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0V2THVNTHFUdEZSUHBSUzZPSVdXdmlvQmNGQUpkREFYSFpxTjhiWXkzSlV5eWc/driveItem?expand=children"
+   ```
+
+The response payload includes the item metadata and, when available, the
+children of the shared folder. Save the output to
+`docs/onedrive-shares/evlumlqt-folder.metadata.json` to snapshot the latest
+state.

--- a/scripts/onedrive/dump-drive-item.ts
+++ b/scripts/onedrive/dump-drive-item.ts
@@ -1,0 +1,44 @@
+import { writeFile } from "node:fs/promises";
+import process from "node:process";
+
+import { fetchDriveItem } from "./share-utils.ts";
+
+const { env, argv } = process;
+
+async function main() {
+  const [, , shareLink, outputPath] = argv;
+
+  if (!shareLink || !outputPath) {
+    console.error(
+      "Usage: tsx scripts/onedrive/dump-drive-item.ts <share-link> <output-path> [expand-children]",
+    );
+    process.exit(1);
+  }
+
+  const expandChildren = argv[4] !== "false";
+
+  const accessToken = env.ONEDRIVE_ACCESS_TOKEN;
+
+  if (!accessToken) {
+    console.error(
+      "Set the ONEDRIVE_ACCESS_TOKEN environment variable before running this script.",
+    );
+    process.exit(1);
+  }
+
+  try {
+    const driveItem = await fetchDriveItem({
+      shareLink,
+      accessToken,
+      query: expandChildren ? { expand: "children" } : undefined,
+    });
+
+    await writeFile(outputPath, `${JSON.stringify(driveItem, null, 2)}\n`);
+    console.log(`Wrote metadata to ${outputPath}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/scripts/onedrive/fetch-drive-item.ts
+++ b/scripts/onedrive/fetch-drive-item.ts
@@ -1,35 +1,8 @@
-import { Buffer } from "node:buffer";
 import process from "node:process";
 
+import { fetchDriveItem } from "./share-utils.ts";
+
 const { env, argv } = process;
-
-function toShareId(shareLink: string): string {
-  const base64 = Buffer.from(shareLink, "utf-8").toString("base64");
-  const base64Url = base64.replace(/\+/g, "-").replace(/\//g, "_").replace(
-    /=+$/u,
-    "",
-  );
-  return `u!${base64Url}`;
-}
-
-async function fetchDriveItem(shareLink: string, accessToken: string) {
-  const shareId = toShareId(shareLink);
-  const url = `https://graph.microsoft.com/v1.0/shares/${shareId}/driveItem`;
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(
-      `Microsoft Graph request failed with ${response.status} ${response.statusText}: ${body}`,
-    );
-  }
-
-  return response.json();
-}
 
 async function main() {
   const [, , shareLink] = argv;
@@ -51,7 +24,7 @@ async function main() {
   }
 
   try {
-    const driveItem = await fetchDriveItem(shareLink, accessToken);
+    const driveItem = await fetchDriveItem({ shareLink, accessToken });
     console.log(JSON.stringify(driveItem, null, 2));
   } catch (error) {
     console.error(error instanceof Error ? error.message : error);

--- a/scripts/onedrive/share-utils.ts
+++ b/scripts/onedrive/share-utils.ts
@@ -1,0 +1,51 @@
+import { Buffer } from "node:buffer";
+
+export function toShareId(shareLink: string): string {
+  const base64 = Buffer.from(shareLink, "utf-8").toString("base64");
+  const base64Url = base64.replace(/\+/g, "-").replace(/\//g, "_").replace(
+    /=+$/u,
+    "",
+  );
+  return `u!${base64Url}`;
+}
+
+export interface FetchDriveItemOptions {
+  shareLink: string;
+  accessToken: string;
+  query?: Record<string, string | undefined>;
+}
+
+export async function fetchDriveItem({
+  shareLink,
+  accessToken,
+  query,
+}: FetchDriveItemOptions): Promise<unknown> {
+  const shareId = toShareId(shareLink);
+  const url = new URL(
+    `https://graph.microsoft.com/v1.0/shares/${shareId}/driveItem`,
+  );
+
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value) {
+        url.searchParams.set(key, value);
+      }
+    }
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Microsoft Graph request failed with ${response.status} ${response.statusText}: ${body}`,
+    );
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add a reusable helper for computing share identifiers and requesting metadata from Microsoft Graph
- introduce a dump-drive-item script that persists OneDrive share metadata (with optional child expansion)
- expand the EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg documentation with decoded identifiers and the new workflow

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8abf46fbc83228b925413c8c13fe0