### PR TITLE
Expose Dynamic AGI identity metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ ranked focus areas, aggregated metrics, and the latest introspection reports.
 See `tests/dynamic_agi/test_dynamic_self_improvement.py` for an end-to-end
 example.
 
+**Dynamic AGI** abbreviates **Driving Yield of New Advancements in Minds,
+Intelligence & Creation — Adapting Global Intelligence**. The
+`dynamic_agi.DynamicAGIModel.identity` helper exposes this expansion and its
+three pillars (`Driving Yield of New Advancements in Minds`, `Intelligence &
+Creation`, `Adapting Global Intelligence`) so downstream services can surface
+consistent branding while reinforcing the platform's mandate to compound
+innovation under adaptive intelligence safeguards.
+
 ## Dynamic Theme System
 
 The web console and Mini App share a synchronized theming pipeline so traders

--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -3,9 +3,11 @@
 from .model import (
     AGIDiagnostics,
     AGIOutput,
+    DynamicAGIIdentity,
     DynamicAGIModel,
     MODEL_VERSION,
     MODEL_VERSION_INFO,
+    DYNAMIC_AGI_EXPANSION,
 )
 from .self_improvement import (
     DynamicSelfImprovement,
@@ -17,9 +19,11 @@ from .self_improvement import (
 __all__ = [
     "AGIDiagnostics",
     "AGIOutput",
+    "DynamicAGIIdentity",
     "DynamicAGIModel",
     "MODEL_VERSION",
     "MODEL_VERSION_INFO",
+    "DYNAMIC_AGI_EXPANSION",
     "DynamicSelfImprovement",
     "ImprovementPlan",
     "ImprovementSignal",

--- a/dynamic_agi/model.py
+++ b/dynamic_agi/model.py
@@ -24,6 +24,17 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+DYNAMIC_AGI_EXPANSION = (
+    "Driving Yield of New Advancements in Minds, Intelligence & Creation — "
+    "Adapting Global Intelligence"
+)
+
+_DEFAULT_IDENTITY_PILLARS = (
+    "Driving Yield of New Advancements in Minds",
+    "Intelligence & Creation",
+    "Adapting Global Intelligence",
+)
+
 MODEL_VERSION_INFO = ModelVersion(
     name="Dynamic AGI",
     number=VersionNumber(major=0, minor=1),
@@ -98,6 +109,24 @@ class AGIDiagnostics:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class DynamicAGIIdentity:
+    """Identity metadata describing the Dynamic AGI expansion."""
+
+    name: str = "Dynamic AGI"
+    acronym: str = "Dynamic AGI"
+    expansion: str = DYNAMIC_AGI_EXPANSION
+    pillars: tuple[str, ...] = _DEFAULT_IDENTITY_PILLARS
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "acronym": self.acronym,
+            "expansion": self.expansion,
+            "pillars": list(self.pillars),
+        }
+
+
 @dataclass(slots=True)
 class AGIOutput:
     """Aggregated response combining signal, research, and risk views."""
@@ -154,12 +183,19 @@ class DynamicAGIModel:
         self.self_improvement = self_improvement
         self.version = MODEL_VERSION
         self.version_info = _default_version_info()
+        self._identity = DynamicAGIIdentity()
 
     @property
     def version_metadata(self) -> Dict[str, Any]:
         """Return a copy of the model version metadata."""
 
         return deepcopy(self.version_info)
+
+    @property
+    def identity(self) -> DynamicAGIIdentity:
+        """Expose the canonical Dynamic AGI naming expansion."""
+
+        return self._identity
 
     def evaluate(
         self,

--- a/tests/dynamic_agi/test_identity.py
+++ b/tests/dynamic_agi/test_identity.py
@@ -1,0 +1,26 @@
+"""Tests for the Dynamic AGI identity metadata."""
+
+from dynamic_agi import (
+    DYNAMIC_AGI_EXPANSION,
+    DynamicAGIIdentity,
+    DynamicAGIModel,
+)
+
+
+def test_identity_metadata_is_canonical() -> None:
+    model = DynamicAGIModel()
+    identity = model.identity
+
+    assert isinstance(identity, DynamicAGIIdentity)
+    assert identity.acronym == "Dynamic AGI"
+    assert identity.expansion == DYNAMIC_AGI_EXPANSION
+    assert identity.pillars == (
+        "Driving Yield of New Advancements in Minds",
+        "Intelligence & Creation",
+        "Adapting Global Intelligence",
+    )
+
+    payload = identity.as_dict()
+    assert payload["acronym"] == "Dynamic AGI"
+    assert payload["expansion"] == DYNAMIC_AGI_EXPANSION
+    assert payload["pillars"] == list(identity.pillars)


### PR DESCRIPTION
## Summary
- add a typed DynamicAGIIdentity helper that captures the canonical Dynamic AGI expansion and pillars
- expose the identity metadata through dynamic_agi exports and document the helper in the README
- cover the new helper with unit tests that assert the expansion and pillars remain stable

## Testing
- pytest tests/dynamic_agi/test_identity.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ad841634832299a1d0aacd095e56