### PR TITLE
Add dynamic assignment, script, loop, and heal engines

### DIFF
--- a/dynamic_assign/__init__.py
+++ b/dynamic_assign/__init__.py
@@ -1,0 +1,12 @@
+"""Dynamic assignment heuristics for pairing teams with work."""
+
+from __future__ import annotations
+
+from .engine import AssignmentDecision, AssignableTask, AgentProfile, DynamicAssignEngine
+
+__all__ = [
+    "AssignmentDecision",
+    "AssignableTask",
+    "AgentProfile",
+    "DynamicAssignEngine",
+]

--- a/dynamic_assign/engine.py
+++ b/dynamic_assign/engine.py
@@ -1,0 +1,191 @@
+"""Assignment heuristics for routing initiatives to the best owners."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "AssignableTask",
+    "AgentProfile",
+    "AssignmentDecision",
+    "DynamicAssignEngine",
+]
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("text value must not be empty")
+    return cleaned
+
+
+def _normalise_tuple(items: Iterable[str] | None, *, lower: bool = False) -> tuple[str, ...]:
+    if not items:
+        return ()
+    seen: set[str] = set()
+    normalised: list[str] = []
+    for item in items:
+        cleaned = item.strip()
+        if not cleaned:
+            continue
+        if lower:
+            cleaned = cleaned.lower()
+        if cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class AssignableTask:
+    """Unit of work that requires an accountable owner."""
+
+    identifier: str
+    description: str
+    priority: float = 0.5
+    required_skills: tuple[str, ...] = field(default_factory=tuple)
+    estimated_effort_hours: float = 4.0
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.identifier = _normalise_text(self.identifier)
+        self.description = _normalise_text(self.description)
+        self.priority = _clamp(float(self.priority))
+        self.required_skills = _normalise_tuple(self.required_skills, lower=True)
+        self.estimated_effort_hours = max(float(self.estimated_effort_hours), 0.0)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+
+@dataclass(slots=True)
+class AgentProfile:
+    """Capability profile describing an execution owner."""
+
+    name: str
+    skills: tuple[str, ...]
+    available_hours: float
+    focus_areas: tuple[str, ...] = field(default_factory=tuple)
+    confidence: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.skills = _normalise_tuple(self.skills, lower=True)
+        if not self.skills:
+            raise ValueError("an agent must expose at least one skill")
+        self.available_hours = max(float(self.available_hours), 0.0)
+        self.focus_areas = _normalise_tuple(self.focus_areas, lower=True)
+        self.confidence = _clamp(float(self.confidence))
+
+    def skill_overlap(self, requirements: Iterable[str]) -> float:
+        required = set(requirements)
+        if not required:
+            return 1.0
+        matched = len(required.intersection(self.skills))
+        return matched / len(required)
+
+
+@dataclass(slots=True)
+class AssignmentDecision:
+    """Engine output describing a recommended assignment."""
+
+    task_id: str
+    agent: str
+    rationale: str
+    confidence: float
+    skill_match: float
+    load_factor: float
+    issued_at: datetime = field(default_factory=_utcnow)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "task_id": self.task_id,
+            "agent": self.agent,
+            "rationale": self.rationale,
+            "confidence": self.confidence,
+            "skill_match": self.skill_match,
+            "load_factor": self.load_factor,
+            "issued_at": self.issued_at.isoformat(),
+        }
+
+
+class DynamicAssignEngine:
+    """Heuristic planner that pairs tasks with accountable agents."""
+
+    def __init__(self) -> None:
+        self._history: list[AssignmentDecision] = []
+
+    @staticmethod
+    def _score(agent: AgentProfile, task: AssignableTask) -> tuple[float, float, float]:
+        skill_match = agent.skill_overlap(task.required_skills)
+        if agent.available_hours <= 0:
+            return (0.0, skill_match, 1.0)
+        load_factor = min(task.estimated_effort_hours / agent.available_hours, 1.0)
+        availability_score = 1.0 - load_factor
+        overall = (skill_match * 0.6) + (availability_score * 0.3) + (agent.confidence * 0.1)
+        return overall, skill_match, load_factor
+
+    def recommend_assignments(
+        self,
+        tasks: Sequence[AssignableTask],
+        agents: Sequence[AgentProfile],
+        *,
+        limit: int | None = None,
+    ) -> list[AssignmentDecision]:
+        if not tasks:
+            return []
+        if not agents:
+            raise ValueError("at least one agent is required to generate assignments")
+
+        working_agents = [replace(agent) for agent in agents]
+        # Sort tasks from highest to lowest priority.
+        ordered_tasks = sorted(tasks, key=lambda task: task.priority, reverse=True)
+        decisions: list[AssignmentDecision] = []
+
+        for task in ordered_tasks:
+            best: tuple[float, AgentProfile, float, float] | None = None
+            for agent in working_agents:
+                score, skill_match, load = self._score(agent, task)
+                if best is None or score > best[0]:
+                    best = (score, agent, skill_match, load)
+            if best is None:
+                continue
+
+            score, agent, skill_match, load_factor = best
+            rationale_parts = [
+                f"Matched by {agent.name} with {skill_match:.0%} skill coverage",
+                f"priority {task.priority:.0%}",
+            ]
+            if task.required_skills:
+                rationale_parts.append(
+                    "skills: " + ", ".join(sorted(task.required_skills))
+                )
+            rationale = "; ".join(rationale_parts)
+            decision = AssignmentDecision(
+                task_id=task.identifier,
+                agent=agent.name,
+                rationale=rationale,
+                confidence=_clamp(score),
+                skill_match=skill_match,
+                load_factor=load_factor,
+            )
+            decisions.append(decision)
+            agent.available_hours = max(agent.available_hours - task.estimated_effort_hours, 0.0)
+            if limit is not None and len(decisions) >= limit:
+                break
+
+        self._history.extend(decisions)
+        return decisions
+
+    @property
+    def history(self) -> tuple[AssignmentDecision, ...]:
+        return tuple(self._history)

--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -23,6 +23,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "DynamicArchitectBot",
     ),
     "dynamic_agents": ("DynamicChatAgent",),
+    "dynamic_assign": ("DynamicAssignEngine",),
     "dynamic_ai": (
         "DynamicFusionAlgo",
         "DynamicAnalysis",
@@ -72,6 +73,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_critical_thinking": ("DynamicCriticalThinking",),
     "dynamic_effect": ("DynamicEffectEngine",),
     "dynamic_emoticon": ("DynamicEmoticon",),
+    "dynamic_heal": ("DynamicHealEngine",),
     "dynamic_encryption": ("DynamicEncryptionEngine",),
     "dynamic_engineer": (
         "DynamicEngineer",
@@ -81,6 +83,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     ),
     "dynamic_implicit_memory": ("DynamicImplicitMemory",),
     "dynamic_index": ("DynamicIndex",),
+    "dynamic_loop": ("DynamicLoopEngine",),
     "dynamic_letter_index": ("DynamicLetterIndex",),
     "dynamic_indicators": ("DynamicIndicators",),
     "dynamic_keepers": (
@@ -102,6 +105,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_pillars": ("DynamicPillarFramework",),
     "dynamic_quote": ("DynamicQuote",),
     "dynamic_reference": ("DynamicReference",),
+    "dynamic_script": ("DynamicScriptEngine",),
     "dynamic_self_awareness": ("DynamicSelfAwareness",),
     "dynamic_skeleton": ("DynamicGovernanceAlgo", "DynamicComplianceAlgo"),
     "dynamic_space.engine": ("DynamicSpaceEngine",),

--- a/dynamic_heal/__init__.py
+++ b/dynamic_heal/__init__.py
@@ -1,0 +1,19 @@
+"""Dynamic healing orchestrator utilities."""
+
+from __future__ import annotations
+
+from .engine import (
+    DynamicHealEngine,
+    HealingAction,
+    HealingCapability,
+    HealingPlan,
+    HealingSignal,
+)
+
+__all__ = [
+    "DynamicHealEngine",
+    "HealingAction",
+    "HealingCapability",
+    "HealingPlan",
+    "HealingSignal",
+]

--- a/dynamic_heal/engine.py
+++ b/dynamic_heal/engine.py
@@ -1,0 +1,180 @@
+"""Resilience heuristics for coordinating recovery and healing responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "HealingSignal",
+    "HealingCapability",
+    "HealingAction",
+    "HealingPlan",
+    "DynamicHealEngine",
+]
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("text value must not be empty")
+    return cleaned
+
+
+def _normalise_tuple(items: Iterable[str] | None, *, lower: bool = False) -> tuple[str, ...]:
+    if not items:
+        return ()
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        cleaned = item.strip()
+        if not cleaned:
+            continue
+        if lower:
+            cleaned = cleaned.lower()
+        if cleaned not in seen:
+            seen.add(cleaned)
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class HealingSignal:
+    """Indicator describing an incident or health degradation."""
+
+    identifier: str
+    narrative: str
+    severity: float
+    affected_domains: tuple[str, ...] = field(default_factory=tuple)
+    blast_radius: float = 0.3
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.identifier = _normalise_text(self.identifier)
+        self.narrative = _normalise_text(self.narrative)
+        self.severity = _clamp(self.severity)
+        self.affected_domains = _normalise_tuple(self.affected_domains, lower=True)
+        self.blast_radius = _clamp(self.blast_radius)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+
+@dataclass(slots=True)
+class HealingCapability:
+    """Capability resource that can participate in healing."""
+
+    name: str
+    domains: tuple[str, ...]
+    capacity: float = 1.0
+    response_time: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.domains = _normalise_tuple(self.domains, lower=True)
+        if not self.domains:
+            raise ValueError("healing capability must cover at least one domain")
+        self.capacity = _clamp(self.capacity)
+        self.response_time = _clamp(self.response_time)
+
+    def coverage(self, domains: Iterable[str]) -> float:
+        affected = set(domain.lower() for domain in domains)
+        if not affected:
+            return 1.0
+        matches = affected.intersection(self.domains)
+        return len(matches) / len(affected)
+
+
+@dataclass(slots=True)
+class HealingAction:
+    """Single action within a healing plan."""
+
+    owner: str
+    description: str
+    priority: float
+    confidence: float
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "owner": self.owner,
+            "description": self.description,
+            "priority": self.priority,
+            "confidence": self.confidence,
+        }
+
+
+@dataclass(slots=True)
+class HealingPlan:
+    """Structured response plan for orchestrating healing actions."""
+
+    actions: tuple[HealingAction, ...]
+    overall_priority: float
+    severity_index: float
+    issued_at: datetime = field(default_factory=_utcnow)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "actions": [action.as_dict() for action in self.actions],
+            "overall_priority": self.overall_priority,
+            "severity_index": self.severity_index,
+            "issued_at": self.issued_at.isoformat(),
+        }
+
+
+class DynamicHealEngine:
+    """Coordinate recovery by translating signals into actionable steps."""
+
+    def orchestrate(
+        self,
+        signals: Sequence[HealingSignal],
+        capabilities: Sequence[HealingCapability],
+    ) -> HealingPlan:
+        if not signals:
+            raise ValueError("at least one healing signal is required")
+        if not capabilities:
+            raise ValueError("healing requires available capabilities")
+
+        highest_severity = max(signal.severity for signal in signals)
+        severity_index = _clamp(
+            sum(signal.severity * (0.6 + signal.blast_radius * 0.4) for signal in signals)
+            / len(signals)
+        )
+
+        actions: list[HealingAction] = []
+        for signal in sorted(signals, key=lambda item: item.severity, reverse=True):
+            best_capability: tuple[float, HealingCapability] | None = None
+            for capability in capabilities:
+                coverage = capability.coverage(signal.affected_domains)
+                urgency = 1.0 - capability.response_time
+                score = (coverage * 0.7) + (urgency * 0.2) + (capability.capacity * 0.1)
+                if best_capability is None or score > best_capability[0]:
+                    best_capability = (score, capability)
+            if best_capability is None:
+                continue
+            score, capability = best_capability
+            description = (
+                f"Stabilise {', '.join(signal.affected_domains) or 'core systems'}"
+                f" in response to {signal.identifier}: {signal.narrative}"
+            )
+            action = HealingAction(
+                owner=capability.name,
+                description=description,
+                priority=_clamp(signal.severity * 0.7 + signal.blast_radius * 0.3),
+                confidence=_clamp(score),
+            )
+            actions.append(action)
+
+        overall_priority = _clamp((highest_severity * 0.8) + (severity_index * 0.2))
+        return HealingPlan(
+            actions=tuple(actions),
+            overall_priority=overall_priority,
+            severity_index=severity_index,
+        )

--- a/dynamic_loop/__init__.py
+++ b/dynamic_loop/__init__.py
@@ -1,0 +1,12 @@
+"""Dynamic loop analytics for cadence monitoring."""
+
+from __future__ import annotations
+
+from .engine import DynamicLoopEngine, LoopRecommendation, LoopSignal, LoopState
+
+__all__ = [
+    "DynamicLoopEngine",
+    "LoopRecommendation",
+    "LoopSignal",
+    "LoopState",
+]

--- a/dynamic_loop/engine.py
+++ b/dynamic_loop/engine.py
@@ -1,0 +1,197 @@
+"""Feedback loop analytics for Dynamic Capital execution cadences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "LoopSignal",
+    "LoopState",
+    "LoopRecommendation",
+    "DynamicLoopEngine",
+]
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("text value must not be empty")
+    return cleaned
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, float(value)))
+
+
+def _normalise_tuple(items: Iterable[str] | None) -> tuple[str, ...]:
+    if not items:
+        return ()
+    normalised: list[str] = []
+    for item in items:
+        cleaned = item.strip()
+        if cleaned:
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class LoopSignal:
+    """Observation captured while monitoring a system or execution loop."""
+
+    metric: str
+    value: float
+    weight: float = 1.0
+    trend: float = 0.5
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.metric = _normalise_text(self.metric).lower()
+        self.value = float(self.value)
+        self.weight = max(float(self.weight), 0.0)
+        self.trend = _clamp(float(self.trend))
+        self.tags = _normalise_tuple(self.tags)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+
+@dataclass(slots=True)
+class LoopState:
+    """Current health summary of a monitored feedback loop."""
+
+    stability: float
+    momentum: float
+    fatigue: float
+    insights: tuple[str, ...]
+    updated_at: datetime = field(default_factory=_utcnow)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "stability": self.stability,
+            "momentum": self.momentum,
+            "fatigue": self.fatigue,
+            "insights": list(self.insights),
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class LoopRecommendation:
+    """Actionable suggestion generated from loop diagnostics."""
+
+    focus: str
+    narrative: str
+    priority: float
+    tags: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "focus": self.focus,
+            "narrative": self.narrative,
+            "priority": self.priority,
+            "tags": list(self.tags),
+        }
+
+
+class DynamicLoopEngine:
+    """Aggregate loop signals and highlight interventions."""
+
+    def __init__(self) -> None:
+        self._states: list[LoopState] = []
+        self._recommendations: list[LoopRecommendation] = []
+
+    def _compute_state(self, signals: Sequence[LoopSignal]) -> LoopState:
+        if not signals:
+            raise ValueError("loop signals are required to compute state")
+
+        weighted_sum = sum(signal.value * signal.weight for signal in signals)
+        total_weight = sum(signal.weight for signal in signals) or 1.0
+        average_variance = weighted_sum / total_weight
+        stability = _clamp(1.0 - min(abs(average_variance), 1.0))
+
+        positive_trends = [signal.trend for signal in signals if signal.value >= 0]
+        negative_trends = [signal.trend for signal in signals if signal.value < 0]
+        if positive_trends:
+            momentum = _clamp(fmean(positive_trends))
+        else:
+            momentum = 0.3
+        if negative_trends:
+            fatigue = _clamp(fmean(negative_trends))
+        else:
+            fatigue = 0.2
+
+        metric_groups: dict[str, list[float]] = {}
+        for signal in signals:
+            metric_groups.setdefault(signal.metric, []).append(signal.value)
+
+        insights = tuple(
+            f"Signal '{metric}' variance {abs(fmean(values)):.2f}"
+            for metric, values in sorted(metric_groups.items())
+        )
+
+        return LoopState(
+            stability=stability,
+            momentum=momentum,
+            fatigue=fatigue,
+            insights=insights,
+        )
+
+    def _derive_recommendations(self, state: LoopState) -> list[LoopRecommendation]:
+        recommendations: list[LoopRecommendation] = []
+        if state.stability < 0.4:
+            recommendations.append(
+                LoopRecommendation(
+                    focus="stabilise",
+                    narrative="Stability degraded; trigger incident review cadence.",
+                    priority=0.9,
+                    tags=("stability", "incident"),
+                )
+            )
+        if state.momentum < 0.5:
+            recommendations.append(
+                LoopRecommendation(
+                    focus="momentum",
+                    narrative="Momentum trending low; introduce fast feedback experiments.",
+                    priority=0.7,
+                    tags=("experimentation", "loop"),
+                )
+            )
+        if state.fatigue > 0.6:
+            recommendations.append(
+                LoopRecommendation(
+                    focus="recovery",
+                    narrative="Fatigue rising; schedule recovery window or rotate ownership.",
+                    priority=0.8,
+                    tags=("resilience", "capacity"),
+                )
+            )
+        if not recommendations:
+            recommendations.append(
+                LoopRecommendation(
+                    focus="sustain",
+                    narrative="Loop healthy; maintain cadence and monitor leading signals.",
+                    priority=0.4,
+                    tags=("maintenance",),
+                )
+            )
+        return recommendations
+
+    def evaluate(self, signals: Sequence[LoopSignal]) -> LoopState:
+        state = self._compute_state(signals)
+        self._states.append(state)
+        recommendations = self._derive_recommendations(state)
+        self._recommendations.extend(recommendations)
+        return state
+
+    def latest_recommendations(self) -> tuple[LoopRecommendation, ...]:
+        return tuple(self._recommendations)
+
+    def history(self) -> tuple[LoopState, ...]:
+        return tuple(self._states)

--- a/dynamic_script/__init__.py
+++ b/dynamic_script/__init__.py
@@ -1,0 +1,19 @@
+"""Dynamic script planning primitives for operational playbooks."""
+
+from __future__ import annotations
+
+from .engine import (
+    DynamicScriptEngine,
+    ScriptContext,
+    ScriptDirective,
+    ScriptPlan,
+    ScriptStep,
+)
+
+__all__ = [
+    "DynamicScriptEngine",
+    "ScriptContext",
+    "ScriptDirective",
+    "ScriptPlan",
+    "ScriptStep",
+]

--- a/dynamic_script/engine.py
+++ b/dynamic_script/engine.py
@@ -1,0 +1,210 @@
+"""Domain-specific script engine for orchestrating operational playbooks."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "ScriptDirective",
+    "ScriptContext",
+    "ScriptStep",
+    "ScriptPlan",
+    "DynamicScriptEngine",
+]
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("text value must not be empty")
+    return cleaned
+
+
+def _normalise_tuple(items: Iterable[str] | None) -> tuple[str, ...]:
+    if not items:
+        return ()
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        cleaned = item.strip()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            ordered.append(cleaned)
+    return tuple(ordered)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True)
+class ScriptDirective:
+    """High-level intent for an automation or process script."""
+
+    name: str
+    objective: str
+    dependencies: tuple[str, ...] = field(default_factory=tuple)
+    impact: float = 0.5
+    effort: float = 0.5
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.objective = _normalise_text(self.objective)
+        self.dependencies = _normalise_tuple(self.dependencies)
+        self.impact = _clamp(self.impact)
+        self.effort = _clamp(self.effort)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+
+@dataclass(slots=True)
+class ScriptContext:
+    """Constraints and environment references for executing a script."""
+
+    environment: str
+    guardrails: tuple[str, ...] = field(default_factory=tuple)
+    change_window: str | None = None
+    approval_reference: str | None = None
+
+    def __post_init__(self) -> None:
+        self.environment = _normalise_text(self.environment)
+        self.guardrails = _normalise_tuple(self.guardrails)
+        if self.change_window is not None:
+            self.change_window = _normalise_text(self.change_window)
+        if self.approval_reference is not None:
+            self.approval_reference = _normalise_text(self.approval_reference)
+
+
+@dataclass(slots=True)
+class ScriptStep:
+    """Single executable step inside a generated script plan."""
+
+    name: str
+    action: str
+    readiness: float
+    notes: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "action": self.action,
+            "readiness": self.readiness,
+            "notes": list(self.notes),
+        }
+
+
+@dataclass(slots=True)
+class ScriptPlan:
+    """Materialised plan for executing directives in a safe sequence."""
+
+    context: ScriptContext
+    steps: tuple[ScriptStep, ...]
+    coverage: float
+    issued_at: datetime = field(default_factory=_utcnow)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "context": {
+                "environment": self.context.environment,
+                "guardrails": list(self.context.guardrails),
+                "change_window": self.context.change_window,
+                "approval_reference": self.context.approval_reference,
+            },
+            "steps": [step.as_dict() for step in self.steps],
+            "coverage": self.coverage,
+            "issued_at": self.issued_at.isoformat(),
+        }
+
+
+class DynamicScriptEngine:
+    """Compile script directives into a coherent, dependency-aware plan."""
+
+    def _topological_order(self, directives: Sequence[ScriptDirective]) -> list[ScriptDirective]:
+        dependency_map: dict[str, set[str]] = {}
+        dependents: dict[str, set[str]] = {}
+        nodes: dict[str, ScriptDirective] = {}
+
+        for directive in directives:
+            name = directive.name
+            if name in nodes:
+                raise ValueError(f"duplicate directive name detected: {name}")
+            nodes[name] = directive
+            dependency_map[name] = set(directive.dependencies)
+            for dep in directive.dependencies:
+                dependents.setdefault(dep, set()).add(name)
+
+        queue: deque[str] = deque(
+            sorted(name for name, deps in dependency_map.items() if not deps)
+        )
+        ordered: list[ScriptDirective] = []
+        resolved: set[str] = set()
+
+        while queue:
+            current = queue.popleft()
+            resolved.add(current)
+            ordered.append(nodes[current])
+            for dependent in sorted(dependents.get(current, ())):
+                remaining = dependency_map[dependent]
+                remaining.discard(current)
+                if not remaining and dependent not in resolved:
+                    queue.append(dependent)
+
+        if len(ordered) != len(directives):
+            unresolved = sorted(
+                name for name, deps in dependency_map.items() if deps
+            )
+            raise ValueError(
+                "cycle detected in directives: " + ", ".join(unresolved)
+            )
+        return ordered
+
+    def build_plan(
+        self,
+        directives: Sequence[ScriptDirective],
+        context: ScriptContext,
+    ) -> ScriptPlan:
+        if not directives:
+            raise ValueError("at least one directive is required to build a plan")
+
+        name_to_directive = {directive.name: directive for directive in directives}
+        for directive in directives:
+            unknown = [dep for dep in directive.dependencies if dep not in name_to_directive]
+            if unknown:
+                joined = ", ".join(unknown)
+                raise ValueError(
+                    f"directive '{directive.name}' references unknown dependencies: {joined}"
+                )
+
+        ordered = self._topological_order(directives)
+
+        max_impact = max(directive.impact for directive in ordered) or 1.0
+        cumulative_impact = 0.0
+        steps: list[ScriptStep] = []
+
+        for directive in ordered:
+            readiness = (directive.impact * 0.7) + (1.0 - directive.effort) * 0.3
+            readiness = _clamp(readiness)
+            notes: list[str] = []
+            if directive.dependencies:
+                notes.append("Depends on: " + ", ".join(directive.dependencies))
+            if directive.metadata:
+                notes.append("Context: " + ", ".join(sorted(directive.metadata.keys())))
+            step = ScriptStep(
+                name=directive.name,
+                action=directive.objective,
+                readiness=readiness,
+                notes=tuple(notes),
+            )
+            steps.append(step)
+            cumulative_impact += directive.impact
+
+        coverage = _clamp(cumulative_impact / (max_impact * len(ordered)))
+        return ScriptPlan(context=context, steps=tuple(steps), coverage=coverage)


### PR DESCRIPTION
## Summary
- add a dynamic assignment engine that scores work items against agent capacity and skill coverage
- introduce a script planning engine that enforces dependency integrity and produces ordered playbooks
- extend the engine registry with loop analytics and healing orchestration modules for operational resilience

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d8b8702ae883228c932502070180ee