### PR TITLE
feat: add dynamic wallet engine

### DIFF
--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -128,6 +128,14 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_ultimate_reality": ("DynamicUltimateReality",),
     "dynamic_volume": ("DynamicVolumeAlgo",),
     "dynamic_wisdom": ("DynamicWisdomEngine",),
+    "dynamic_wallet": (
+        "DynamicWalletEngine",
+        "WalletAccount",
+        "WalletAction",
+        "WalletBalance",
+        "WalletExposure",
+        "WalletSummary",
+    ),
 }
 
 __all__ = sorted({symbol for symbols in _ENGINE_EXPORTS.values() for symbol in symbols})

--- a/dynamic_wallet/__init__.py
+++ b/dynamic_wallet/__init__.py
@@ -1,0 +1,19 @@
+"""Dynamic wallet analytics engine exports."""
+
+from .engine import (
+    DynamicWalletEngine,
+    WalletAccount,
+    WalletAction,
+    WalletBalance,
+    WalletExposure,
+    WalletSummary,
+)
+
+__all__ = [
+    "DynamicWalletEngine",
+    "WalletAccount",
+    "WalletAction",
+    "WalletBalance",
+    "WalletExposure",
+    "WalletSummary",
+]

--- a/dynamic_wallet/engine.py
+++ b/dynamic_wallet/engine.py
@@ -1,0 +1,356 @@
+"""Wallet analytics and intervention planning for Dynamic Capital."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "WalletAccount",
+    "WalletBalance",
+    "WalletExposure",
+    "WalletAction",
+    "WalletSummary",
+    "DynamicWalletEngine",
+]
+
+
+_ALLOWED_RISK_TIERS = {"conservative", "standard", "aggressive"}
+_ALLOWED_PRIORITIES = {"low", "normal", "high"}
+_RISK_BUFFER_TARGETS = {"conservative": 0.35, "standard": 0.2, "aggressive": 0.1}
+
+
+def _normalise_text(value: str) -> str:
+    if not isinstance(value, str):  # pragma: no cover - defensive guard
+        raise TypeError("value must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError("value must not be empty")
+    return text
+
+
+def _normalise_upper(value: str) -> str:
+    return _normalise_text(value).upper()
+
+
+def _normalise_lower(value: str) -> str:
+    return _normalise_text(value).lower()
+
+
+def _normalise_tags(tags: Iterable[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    cleaned: list[str] = []
+    for tag in tags:
+        text = tag.strip()
+        if text:
+            cleaned.append(text.lower())
+    return tuple(dict.fromkeys(cleaned))
+
+
+def _ensure_non_negative(value: float) -> float:
+    coerced = float(value)
+    if coerced < 0:
+        raise ValueError("value must be non-negative")
+    return coerced
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, float(value)))
+
+
+@dataclass(slots=True)
+class WalletAccount:
+    """Metadata describing a managed wallet."""
+
+    address: str
+    owner: str
+    risk_tier: str = "standard"
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.address = _normalise_upper(self.address)
+        self.owner = _normalise_text(self.owner)
+        risk = _normalise_lower(self.risk_tier)
+        if risk not in _ALLOWED_RISK_TIERS:
+            allowed = ", ".join(sorted(_ALLOWED_RISK_TIERS))
+            raise ValueError(f"risk_tier must be one of {allowed}")
+        self.risk_tier = risk
+        self.tags = _normalise_tags(self.tags)
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+
+@dataclass(slots=True)
+class WalletBalance:
+    """Balance snapshot for a given asset."""
+
+    asset: str
+    total: float
+    available: float | None = None
+    locked: float = 0.0
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.asset = _normalise_upper(self.asset)
+        self.total = _ensure_non_negative(self.total)
+        self.locked = _ensure_non_negative(self.locked)
+        if self.available is None:
+            self.available = max(self.total - self.locked, 0.0)
+        else:
+            self.available = min(self.total, _ensure_non_negative(self.available))
+        if self.available + self.locked - self.total > 1e-9:
+            raise ValueError("available plus locked exceeds total balance")
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+    @property
+    def utilisation(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return _clamp(1.0 - (self.available / self.total))
+
+
+@dataclass(slots=True)
+class WalletExposure:
+    """Derived exposure metrics for a wallet asset."""
+
+    asset: str
+    balance_total: float
+    balance_available: float
+    balance_locked: float
+    usd_value: float
+    share: float
+    utilisation: float
+
+    def __post_init__(self) -> None:
+        self.asset = _normalise_upper(self.asset)
+        self.balance_total = _ensure_non_negative(self.balance_total)
+        self.balance_available = _ensure_non_negative(self.balance_available)
+        self.balance_locked = _ensure_non_negative(self.balance_locked)
+        self.usd_value = max(0.0, float(self.usd_value))
+        self.share = _clamp(self.share)
+        self.utilisation = _clamp(self.utilisation)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "asset": self.asset,
+            "balance_total": self.balance_total,
+            "balance_available": self.balance_available,
+            "balance_locked": self.balance_locked,
+            "usd_value": self.usd_value,
+            "share": self.share,
+            "utilisation": self.utilisation,
+        }
+
+
+@dataclass(slots=True)
+class WalletAction:
+    """Actionable recommendation for a wallet operator."""
+
+    category: str
+    description: str
+    priority: str = "normal"
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.category = _normalise_lower(self.category)
+        self.description = _normalise_text(self.description)
+        priority = _normalise_lower(self.priority)
+        if priority not in _ALLOWED_PRIORITIES:
+            allowed = ", ".join(sorted(_ALLOWED_PRIORITIES))
+            raise ValueError(f"priority must be one of {allowed}")
+        self.priority = priority
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping if provided")
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        payload: MutableMapping[str, object] = {
+            "category": self.category,
+            "description": self.description,
+            "priority": self.priority,
+        }
+        if self.metadata is not None:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class WalletSummary:
+    """Aggregated analytics for a wallet."""
+
+    account: WalletAccount
+    total_value_usd: float
+    available_value_usd: float
+    buffer_ratio: float
+    diversification_score: float
+    exposures: tuple[WalletExposure, ...]
+    actions: tuple[WalletAction, ...]
+    alerts: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "account": {
+                "address": self.account.address,
+                "owner": self.account.owner,
+                "risk_tier": self.account.risk_tier,
+                "tags": list(self.account.tags),
+            },
+            "total_value_usd": self.total_value_usd,
+            "available_value_usd": self.available_value_usd,
+            "buffer_ratio": self.buffer_ratio,
+            "diversification_score": self.diversification_score,
+            "exposures": [exposure.as_dict() for exposure in self.exposures],
+            "actions": [action.as_dict() for action in self.actions],
+            "alerts": list(self.alerts),
+        }
+
+
+class DynamicWalletEngine:
+    """Analyse wallet health and highlight operational interventions."""
+
+    def __init__(
+        self,
+        *,
+        exposure_limits: Mapping[str, float] | None = None,
+        base_buffer_target: float = 0.18,
+    ) -> None:
+        self._accounts: dict[str, WalletAccount] = {}
+        self._balances: dict[str, dict[str, WalletBalance]] = {}
+        limits: dict[str, float] = {}
+        for asset, limit in (exposure_limits or {}).items():
+            limits[_normalise_upper(asset)] = _clamp(limit)
+        self._exposure_limits = limits
+        self._base_buffer_target = _clamp(base_buffer_target)
+
+    def register_account(self, account: WalletAccount) -> None:
+        if account.address in self._accounts:
+            raise ValueError(f"wallet {account.address} already registered")
+        self._accounts[account.address] = account
+        self._balances.setdefault(account.address, {})
+
+    def ingest_balances(self, address: str, balances: Sequence[WalletBalance]) -> None:
+        wallet = self._require_account(address)
+        snapshot: dict[str, WalletBalance] = {}
+        for balance in balances:
+            snapshot[balance.asset] = balance
+        self._balances[wallet.address] = snapshot
+
+    def evaluate_wallet(
+        self,
+        address: str,
+        price_map: Mapping[str, float],
+    ) -> WalletSummary:
+        wallet = self._require_account(address)
+        balances = self._balances.get(wallet.address, {})
+        if not balances:
+            raise ValueError(f"no balances recorded for wallet {wallet.address}")
+
+        prices = {asset.upper(): max(0.0, float(price)) for asset, price in price_map.items()}
+        exposures: list[WalletExposure] = []
+        total_value = 0.0
+        available_value = 0.0
+        alerts: list[str] = []
+
+        for asset, balance in sorted(balances.items()):
+            price = prices.get(asset)
+            if price is None:
+                alerts.append(f"Missing price for {asset}; assuming zero valuation")
+                price = 0.0
+            usd_value = balance.total * price
+            total_value += usd_value
+            available_value += balance.available * price
+            exposures.append(
+                WalletExposure(
+                    asset=asset,
+                    balance_total=balance.total,
+                    balance_available=balance.available,
+                    balance_locked=balance.locked,
+                    usd_value=usd_value,
+                    share=0.0,  # placeholder updated below
+                    utilisation=balance.utilisation,
+                )
+            )
+
+        if total_value == 0:
+            diversification = 1.0
+            shares = [0.0 for _ in exposures]
+        else:
+            shares = [exposure.usd_value / total_value for exposure in exposures]
+            diversification = 1.0 - sum(share**2 for share in shares)
+
+        actions: list[WalletAction] = []
+        for index, share in enumerate(shares):
+            exposure = exposures[index]
+            exposures[index] = WalletExposure(
+                asset=exposure.asset,
+                balance_total=exposure.balance_total,
+                balance_available=exposure.balance_available,
+                balance_locked=exposure.balance_locked,
+                usd_value=exposure.usd_value,
+                share=share,
+                utilisation=exposure.utilisation,
+            )
+            limit = self._exposure_limits.get(exposure.asset)
+            if limit is not None and share > limit:
+                actions.append(
+                    WalletAction(
+                        category="rebalance",
+                        description=(
+                            f"Reduce {exposure.asset} exposure to <= {limit:.0%} of portfolio (currently {share:.0%})."
+                        ),
+                        priority="high",
+                        metadata={
+                            "asset": exposure.asset,
+                            "share": share,
+                            "limit": limit,
+                        },
+                    )
+                )
+
+        target_buffer = max(self._base_buffer_target, _RISK_BUFFER_TARGETS[wallet.risk_tier])
+        buffer_ratio = 1.0 if total_value == 0 else _clamp(available_value / total_value)
+        if buffer_ratio < target_buffer:
+            actions.append(
+                WalletAction(
+                    category="liquidity",
+                    description=(
+                        "Increase liquid reserves; buffer below target "
+                        f"({buffer_ratio:.0%} vs {target_buffer:.0%})."
+                    ),
+                    priority="high" if wallet.risk_tier != "aggressive" else "normal",
+                    metadata={
+                        "buffer_ratio": buffer_ratio,
+                        "target_buffer": target_buffer,
+                    },
+                )
+            )
+
+        if diversification < 0.35 and total_value > 0:
+            actions.append(
+                WalletAction(
+                    category="diversify",
+                    description="Diversification score is weak; evaluate adding non-correlated assets.",
+                    priority="normal",
+                    metadata={"diversification_score": diversification},
+                )
+            )
+
+        return WalletSummary(
+            account=wallet,
+            total_value_usd=total_value,
+            available_value_usd=available_value,
+            buffer_ratio=buffer_ratio,
+            diversification_score=_clamp(diversification),
+            exposures=tuple(exposures),
+            actions=tuple(actions),
+            alerts=tuple(alerts),
+        )
+
+    def _require_account(self, address: str) -> WalletAccount:
+        key = _normalise_upper(address)
+        try:
+            return self._accounts[key]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"wallet {key} is not registered") from exc

--- a/tests/dynamic_wallet/test_engine.py
+++ b/tests/dynamic_wallet/test_engine.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from dynamic_wallet import (
+    DynamicWalletEngine,
+    WalletAccount,
+    WalletBalance,
+)
+
+
+@pytest.fixture()
+def engine() -> DynamicWalletEngine:
+    return DynamicWalletEngine(exposure_limits={"TON": 0.6, "USDT": 0.5})
+
+
+@pytest.fixture()
+def registered_wallet(engine: DynamicWalletEngine) -> WalletAccount:
+    wallet = WalletAccount(address="EQ123", owner="Operations Desk", risk_tier="standard")
+    engine.register_account(wallet)
+    return wallet
+
+
+def test_wallet_summary_flags_excess_exposure(engine: DynamicWalletEngine, registered_wallet: WalletAccount) -> None:
+    engine.ingest_balances(
+        registered_wallet.address,
+        [
+            WalletBalance(asset="ton", total=1_000, available=600),
+            WalletBalance(asset="usdt", total=4_000, available=4_000),
+        ],
+    )
+    summary = engine.evaluate_wallet(
+        registered_wallet.address,
+        price_map={"ton": 2.0, "usdt": 1.0},
+    )
+
+    assert math.isclose(summary.total_value_usd, 6_000.0)
+    # USDT exceeds its 50% limit so a high priority rebalance action should be generated.
+    assert any(action.category == "rebalance" and action.priority == "high" for action in summary.actions)
+
+
+def test_liquidity_buffer_action_for_conservative_wallet(engine: DynamicWalletEngine) -> None:
+    wallet = WalletAccount(address="EQ321", owner="Treasury", risk_tier="conservative")
+    engine.register_account(wallet)
+    engine.ingest_balances(
+        wallet.address,
+        [
+            WalletBalance(asset="usdt", total=10_000, available=2_000),
+        ],
+    )
+    summary = engine.evaluate_wallet(wallet.address, price_map={"usdt": 1.0})
+
+    assert summary.buffer_ratio < 0.35
+    assert any(action.category == "liquidity" for action in summary.actions)
+
+
+def test_missing_price_emits_alert(engine: DynamicWalletEngine, registered_wallet: WalletAccount) -> None:
+    engine.ingest_balances(
+        registered_wallet.address,
+        [
+            WalletBalance(asset="ton", total=500, available=500),
+        ],
+    )
+    summary = engine.evaluate_wallet(registered_wallet.address, price_map={})
+
+    assert "Missing price for TON" in summary.alerts[0]
+
+
+def test_duplicate_registration_is_rejected(engine: DynamicWalletEngine, registered_wallet: WalletAccount) -> None:
+    with pytest.raises(ValueError):
+        engine.register_account(registered_wallet)


### PR DESCRIPTION
## Summary
- add a dedicated `dynamic_wallet` package providing wallet account, balance, exposure, action, and summary dataclasses with an analysis engine
- expose the wallet engine through the legacy `dynamic_engines` compatibility shim for backwards compatibility
- cover rebalance triggers, liquidity buffers, price alerts, and duplicate registration protections with targeted tests

## Testing
- pytest tests/dynamic_wallet -q

------
https://chatgpt.com/codex/tasks/task_e_68d8c29659188322ac4c166891993f4a