### PR TITLE
perf: cache dynamic team catalogue

### DIFF
--- a/dynamic_team/__init__.py
+++ b/dynamic_team/__init__.py
@@ -1,0 +1,274 @@
+"""Dynamic team operations toolkit built on the canonical playbooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Mapping
+from types import MappingProxyType
+
+from algorithms.python.desk_sync import (
+    DynamicTeamRoleSyncAlgorithm,
+    TeamRolePlaybook,
+    TeamRoleSyncResult,
+)
+from algorithms.python.multi_llm import LLMConfig
+from algorithms.python.team_operations import (
+    TEAM_OPERATIONS_PLAYBOOKS,
+    TeamOperationsAlignmentReport,
+    TeamOperationsLLMPlanner,
+    build_team_operations_playbooks as _build_team_operations_playbooks,
+    build_team_operations_sync_algorithm as _build_team_operations_sync_algorithm,
+)
+
+__all__ = [
+    "TEAM_PLAYBOOKS",
+    "TeamOperationsAlignmentReport",
+    "TeamOperationsLLMPlanner",
+    "LLMConfig",
+    "TeamAgentResult",
+    "DynamicTeamAgent",
+    "build_team_playbooks",
+    "build_team_sync",
+    "get_team_playbook",
+    "list_team_agents",
+    "plan_team_alignment",
+    "synchronise_team",
+]
+
+TEAM_PLAYBOOKS = TEAM_OPERATIONS_PLAYBOOKS
+
+_FOCUS_KEYS = (
+    "focus",
+    "priorities",
+    "tickets",
+    "initiatives",
+    "milestones",
+    "epics",
+)
+
+
+def _normalise_strings(value: Any) -> tuple[str, ...]:
+    """Return a tuple of cleaned string values extracted from ``value``."""
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if isinstance(value, Mapping):
+        return _normalise_strings(value.values())
+    if isinstance(value, Iterable):
+        results: list[str] = []
+        for item in value:
+            if isinstance(item, Mapping):
+                results.extend(_normalise_strings(item.values()))
+            elif isinstance(item, (list, tuple, set)):
+                results.extend(_normalise_strings(item))
+            else:
+                text = str(item).strip()
+                if text:
+                    results.append(text)
+        return tuple(results)
+    text = str(value).strip()
+    return (text,) if text else ()
+
+
+def _extract_focus(context: Mapping[str, Any]) -> tuple[str, ...]:
+    """Gather any focus indicators present in ``context``."""
+
+    focus_items: list[str] = []
+    for key in _FOCUS_KEYS:
+        focus_items.extend(_normalise_strings(context.get(key)))
+    seen: set[str] = set()
+    unique_focus: list[str] = []
+    for item in focus_items:
+        if item not in seen:
+            seen.add(item)
+            unique_focus.append(item)
+    return tuple(unique_focus)
+
+
+def _serialise_notes(context: Mapping[str, Any]) -> Dict[str, Any]:
+    """Serialise arbitrary context values into JSON-friendly structures."""
+
+    notes: Dict[str, Any] = {}
+    for key, value in context.items():
+        if key in _FOCUS_KEYS or value is None:
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            notes[key] = value
+            continue
+        if isinstance(value, Mapping):
+            nested = {str(nk): nv for nk, nv in value.items() if nv not in (None, "")}
+            if nested:
+                notes[key] = nested
+            continue
+        if isinstance(value, (list, tuple, set)):
+            values = [str(item).strip() for item in value if str(item).strip()]
+            if values:
+                notes[key] = values
+            continue
+        text = str(value).strip()
+        if text:
+            notes[key] = text
+    return notes
+
+
+@dataclass(slots=True)
+class TeamAgentResult:
+    """Structured response emitted by a dynamic team agent."""
+
+    role: str
+    objectives: tuple[str, ...]
+    workflow: tuple[str, ...]
+    outputs: tuple[str, ...]
+    kpis: tuple[str, ...]
+    focus: tuple[str, ...] = field(default_factory=tuple)
+    notes: Dict[str, Any] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        """Return a concise human-readable summary."""
+
+        steps = len(self.workflow)
+        summary = f"{self.role} playbook with {steps} workflow steps"
+        if self.focus:
+            summary = f"{summary}; focus on {', '.join(self.focus)}"
+        return summary
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-friendly representation of the result."""
+
+        payload: Dict[str, Any] = {
+            "role": self.role,
+            "objectives": list(self.objectives),
+            "workflow": list(self.workflow),
+            "outputs": list(self.outputs),
+            "kpis": list(self.kpis),
+            "focus": list(self.focus),
+            "summary": self.summary(),
+        }
+        if self.notes:
+            payload["notes"] = dict(self.notes)
+        return payload
+
+
+class DynamicTeamAgent:
+    """Lightweight wrapper around a team operations playbook."""
+
+    def __init__(self, playbook: TeamRolePlaybook) -> None:
+        self._playbook = playbook
+
+    @property
+    def name(self) -> str:
+        """Return the role name for this agent."""
+
+        return self._playbook.name
+
+    def plan(self) -> TeamRolePlaybook:
+        """Expose the underlying playbook for downstream use."""
+
+        return self._playbook
+
+    def run(self, context: Mapping[str, Any] | None = None) -> TeamAgentResult:
+        """Return the structured plan for this role."""
+
+        context_payload: Mapping[str, Any]
+        if context is None:
+            context_payload = {}
+        else:
+            context_payload = context
+        focus = _extract_focus(context_payload)
+        notes = _serialise_notes(context_payload)
+        return TeamAgentResult(
+            role=self._playbook.name,
+            objectives=tuple(self._playbook.objectives),
+            workflow=tuple(self._playbook.workflow),
+            outputs=tuple(self._playbook.outputs),
+            kpis=tuple(self._playbook.kpis),
+            focus=focus,
+            notes=notes,
+        )
+
+
+@lru_cache(maxsize=2)
+def _cached_team_playbooks(include_optional: bool) -> Mapping[str, TeamRolePlaybook]:
+    """Return a cached, read-only mapping of team playbooks."""
+
+    return MappingProxyType(
+        _build_team_operations_playbooks(include_optional=include_optional)
+    )
+
+
+def build_team_playbooks(*, include_optional: bool = True) -> Dict[str, TeamRolePlaybook]:
+    """Return Dynamic Capital team playbooks keyed by role name."""
+
+    return dict(_cached_team_playbooks(include_optional))
+
+
+def get_team_playbook(role: str, *, include_optional: bool = True) -> TeamRolePlaybook:
+    """Return the playbook for ``role`` from the team catalogue."""
+
+    playbooks = build_team_playbooks(include_optional=include_optional)
+    try:
+        return playbooks[role]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise KeyError(f"Unknown team role: {role}") from exc
+
+
+@lru_cache(maxsize=2)
+def _cached_team_agents(include_optional: bool) -> Mapping[str, DynamicTeamAgent]:
+    """Return cached dynamic team agents keyed by role name."""
+
+    playbooks = _cached_team_playbooks(include_optional)
+    agents = {name: DynamicTeamAgent(playbook) for name, playbook in playbooks.items()}
+    return MappingProxyType(agents)
+
+
+def list_team_agents(*, include_optional: bool = True) -> Dict[str, DynamicTeamAgent]:
+    """Return ready-to-use agents keyed by role name."""
+
+    return dict(_cached_team_agents(include_optional))
+
+
+@lru_cache(maxsize=2)
+def _cached_team_sync(include_optional: bool) -> DynamicTeamRoleSyncAlgorithm:
+    """Return a cached sync algorithm for the selected team playbooks."""
+
+    return _build_team_operations_sync_algorithm(include_optional=include_optional)
+
+
+def build_team_sync(*, include_optional: bool = True) -> DynamicTeamRoleSyncAlgorithm:
+    """Construct a sync algorithm for the selected team playbooks."""
+
+    return _cached_team_sync(include_optional)
+
+
+def synchronise_team(
+    *,
+    focus: Iterable[str] | None = None,
+    context: Mapping[str, Any] | None = None,
+    include_optional: bool = True,
+) -> TeamRoleSyncResult:
+    """Synchronise the team playbooks and return the result."""
+
+    algorithm = build_team_sync(include_optional=include_optional)
+    return algorithm.synchronise(focus=focus, context=context)
+
+
+def plan_team_alignment(
+    planner: TeamOperationsLLMPlanner,
+    *,
+    focus: Iterable[str] | None = None,
+    context: Mapping[str, Any] | None = None,
+    playbooks: Mapping[str, TeamRolePlaybook] | None = None,
+    include_optional: bool = True,
+) -> TeamOperationsAlignmentReport:
+    """Generate a cross-team alignment report using the supplied planner."""
+
+    catalogue: Mapping[str, TeamRolePlaybook]
+    if playbooks is not None:
+        catalogue = playbooks
+    else:
+        catalogue = build_team_playbooks(include_optional=include_optional)
+    return planner.generate(catalogue, focus=focus, context=context)

--- a/tests_python/test_dynamic_team.py
+++ b/tests_python/test_dynamic_team.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dynamic_team import (  # noqa: E402  - path mutation for test isolation
+    DynamicTeamAgent,
+    LLMConfig,
+    TEAM_PLAYBOOKS,
+    TeamOperationsLLMPlanner,
+    build_team_playbooks,
+    build_team_sync,
+    get_team_playbook,
+    list_team_agents,
+    plan_team_alignment,
+    synchronise_team,
+)
+
+
+def test_get_team_playbook_returns_expected_role() -> None:
+    playbook = get_team_playbook("Marketing Strategist")
+    assert playbook.name == "Marketing Strategist"
+    assert playbook.objectives[0].startswith("Align")
+
+
+def test_list_team_agents_respects_optional_flag() -> None:
+    all_agents = list_team_agents()
+    core_agents = list_team_agents(include_optional=False)
+
+    assert "Growth Hacker" in all_agents
+    assert "Growth Hacker" not in core_agents
+
+    strategist_result = all_agents["Marketing Strategist"].run({"focus": ["Launch"]})
+    assert strategist_result.focus == ("Launch",)
+    assert strategist_result.role == "Marketing Strategist"
+
+
+def test_synchronise_team_filters_focus() -> None:
+    result = synchronise_team(
+        focus=["Marketing Strategist", "Community Manager"],
+        context={"initiative": "Product Launch"},
+    )
+
+    assert set(result.playbooks) == {"Marketing Strategist", "Community Manager"}
+    assert result.context["initiative"] == "Product Launch"
+    assert result.focus == ("Marketing Strategist", "Community Manager")
+
+
+@dataclass
+class _StubClient:
+    responses: Iterable[str]
+
+    def __post_init__(self) -> None:
+        self._iterator = iter(self.responses)
+
+    def complete(self, prompt: str, *, temperature: float, max_tokens: int, nucleus_p: float) -> str:  # noqa: D401 - protocol stub
+        try:
+            return next(self._iterator)
+        except StopIteration:  # pragma: no cover - defensive guard
+            raise AssertionError("LLM client invoked more times than expected") from None
+
+
+def test_plan_team_alignment_uses_default_playbooks() -> None:
+    strategy_response = """
+    {
+      "summary": "Coordinate marketing and community around launch readiness.",
+      "priorities": ["Launch readiness"],
+      "dependencies": ["Marketing Strategist ↔ Community Manager"],
+      "next_actions": ["Run launch huddle"]
+    }
+    """
+
+    client = _StubClient((strategy_response,))
+
+    strategy = LLMConfig(
+        name="strategy",
+        client=client,
+        temperature=0.0,
+        nucleus_p=1.0,
+        max_tokens=256,
+    )
+
+    planner = TeamOperationsLLMPlanner(strategy=strategy)
+    report = plan_team_alignment(
+        planner,
+        focus=["Marketing Strategist", "Community Manager"],
+        context={"initiative": "Launch"},
+    )
+
+    assert report.summary == "Coordinate marketing and community around launch readiness."
+    assert "Launch readiness" in report.priorities
+    assert "Marketing Strategist ↔ Community Manager" in report.dependencies
+    assert report.metadata["context"]["initiative"] == "Launch"
+
+
+def test_build_team_playbooks_matches_constant() -> None:
+    playbooks = build_team_playbooks()
+    assert set(playbooks) == set(TEAM_PLAYBOOKS)
+    assert isinstance(list(TEAM_PLAYBOOKS.values())[0].workflow, tuple)
+
+
+def test_dynamic_team_agent_plan_returns_playbook() -> None:
+    playbook = get_team_playbook("Community Manager")
+    agent = DynamicTeamAgent(playbook)
+    assert agent.plan() is playbook
+
+
+def test_build_team_playbooks_reuses_catalogue_instances() -> None:
+    first = build_team_playbooks()
+    second = build_team_playbooks()
+
+    role = "Marketing Strategist"
+    assert first[role] is second[role]
+
+
+def test_list_team_agents_returns_cached_agent_instances() -> None:
+    first = list_team_agents()
+    second = list_team_agents()
+
+    assert first["Marketing Strategist"] is second["Marketing Strategist"]
+
+
+def test_build_team_sync_returns_cached_algorithm() -> None:
+    assert build_team_sync() is build_team_sync()


### PR DESCRIPTION
## Summary
- cache the team operations playbooks, agents, and sync algorithm to avoid repeated construction
- streamline agent execution by removing redundant context copies
- extend the dynamic team test suite with coverage for the new caching behaviour

## Testing
- pytest tests_python/test_dynamic_team.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d8c2736f508322860952161c7f50d2