### PR TITLE
Implement dynamic property analytics engines

### DIFF
--- a/docs/ulam-solitaire-playbook.md
+++ b/docs/ulam-solitaire-playbook.md
@@ -1,0 +1,41 @@
+# Ulam & Solitaire Playbook
+
+## 1. Core Story
+- In 1946, while recovering from illness, Stanisław Ulam played countless games of solitaire.
+- He posed a question: *What’s the probability of winning if the deck is shuffled at random?*
+- The analytical math was brutal, so he reframed the problem: *simulate the game repeatedly and observe the outcomes*.
+- This practical experiment inspired the Monte Carlo Method.
+
+## 2. Principles Learned
+- **Simulation beats complexity:** When formulas are too unwieldy, simulate instead.
+- **Law of Large Numbers:** The more games you simulate, the closer you approximate the true probability.
+- **Randomness as a tool:** Use random sampling to approximate reality when closed-form answers are unavailable.
+
+## 3. Ulam’s Solitaire Method (Step-by-Step)
+1. **Define the Problem** – Determine the question you want to answer (e.g., probability of winning solitaire).
+2. **Model the Random Process** – Translate the problem into a stochastic model (e.g., shuffle a deck to create a trial).
+3. **Run Simulations** – Play solitaire (manually or via computer) many times.
+4. **Record Outcomes** – Track wins and losses across trials.
+5. **Estimate Probability** – Use $\hat{p} = w / N$, where $w$ is wins and $N$ is total trials.
+6. **Improve Accuracy** – Increase $N$ to reduce the estimator’s variability; the standard error shrinks proportionally to $1/\sqrt{N}$, so quadrupling trials roughly halves the sampling noise.
+
+## 4. Example Simulation
+- 100 solitaire games yield 18 wins → $\hat{p} = 18 / 100 = 0.18$.
+- 10,000 games yield 1,770 wins → $\hat{p} = 1,770 / 10,000 = 0.177$.
+- Estimates stabilize around the true probability as trials increase.
+
+## 5. Applications Beyond Solitaire
+- **Physics:** Modeling nuclear chain reactions.
+- **Finance:** Evaluating portfolio risk and pricing options.
+- **AI:** Powering Monte Carlo Tree Search strategies (e.g., AlphaGo).
+- **Engineering:** Testing reliability and quality through randomized trials.
+- **Everyday decisions:** Approximating probabilities in games and complex choices.
+
+## 6. Playbook Rules
+- When exact formulas are too complex, simulate.
+- Run large numbers of trials to harness the Law of Large Numbers.
+- Keep results organized and average them appropriately.
+- Increase trials to improve accuracy; expect diminishing noise at the $1/\sqrt{N}$ rate.
+- Apply these principles beyond games to science, finance, AI, and life decisions.
+
+**Summary:** Ulam’s solitaire curiosity birthed the Monte Carlo method—one of modern science’s most powerful tools.

--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -105,6 +105,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_library": ("DynamicLibrary",),
     "dynamic_memory": ("DynamicMemoryConsolidator",),
     "dynamic_memory_reconsolidation": ("DynamicMemoryReconsolidation",),
+    "dynamic_memoryless_property": ("DynamicMemorylessPropertyEngine",),
     "dynamic_method": (
         "DynamicMethodEngine",
         "MethodSignal",
@@ -116,6 +117,11 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_numbers": ("DynamicNumberComposer",),
     "dynamic_package": ("DynamicPackageDesigner",),
     "dynamic_pillars": ("DynamicPillarFramework",),
+    "dynamic_property": (
+        "PropertySnapshot",
+        "PropertyProfile",
+        "DynamicPropertyEngine",
+    ),
     "dynamic_quote": ("DynamicQuote",),
     "dynamic_reference": ("DynamicReference",),
     "dynamic_script": ("DynamicScriptEngine",),

--- a/dynamic_memoryless_property/__init__.py
+++ b/dynamic_memoryless_property/__init__.py
@@ -1,0 +1,5 @@
+"""Adaptive property analytics without historical retention."""
+
+from .engine import DynamicMemorylessPropertyEngine
+
+__all__ = ["DynamicMemorylessPropertyEngine"]

--- a/dynamic_memoryless_property/engine.py
+++ b/dynamic_memoryless_property/engine.py
@@ -1,0 +1,87 @@
+"""Memoryless property analytics derived from exponential smoothing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dynamic_property import PropertyProfile, PropertySnapshot
+
+__all__ = ["DynamicMemorylessPropertyEngine"]
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+def _blend(previous: float, current: float, weight: float) -> float:
+    return (1.0 - weight) * previous + weight * current
+
+
+def _trend_delta(snapshot: PropertySnapshot, baseline: PropertyProfile) -> float:
+    anchor = baseline.average_valuation or snapshot.valuation or 1.0
+    delta = snapshot.valuation - baseline.average_valuation
+    return delta / abs(anchor)
+
+
+def _stability_from_delta(delta: float) -> float:
+    return 1.0 / (1.0 + abs(delta))
+
+
+@dataclass(slots=True)
+class DynamicMemorylessPropertyEngine:
+    """State-light property analytics that prioritise the latest signal."""
+
+    smoothing: float = 0.35
+    _profile: PropertyProfile | None = None
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.smoothing <= 1.0:
+            raise ValueError("smoothing must be in the interval (0, 1]")
+
+    @property
+    def profile(self) -> PropertyProfile:
+        return self._profile or PropertyProfile.empty()
+
+    def reset(self) -> None:
+        self._profile = None
+
+    def observe(self, snapshot: PropertySnapshot) -> PropertyProfile:
+        if self._profile is None or self._profile.sample_size == 0:
+            self._profile = PropertyProfile(
+                sample_size=1,
+                average_valuation=snapshot.valuation,
+                average_noi=snapshot.net_operating_income,
+                average_noi_margin=snapshot.noi_margin,
+                occupancy_rate=snapshot.occupancy,
+                valuation_trend=0.0,
+                stability_score=1.0,
+                last_updated=snapshot.timestamp,
+            )
+            return self._profile
+
+        weight = self.smoothing
+        previous = self._profile
+        delta = _trend_delta(snapshot, previous)
+        stability = _blend(previous.stability_score, _stability_from_delta(delta), weight)
+
+        self._profile = PropertyProfile(
+            sample_size=previous.sample_size + 1,
+            average_valuation=_blend(previous.average_valuation, snapshot.valuation, weight),
+            average_noi=_blend(previous.average_noi, snapshot.net_operating_income, weight),
+            average_noi_margin=_clamp(
+                _blend(previous.average_noi_margin, snapshot.noi_margin, weight),
+                lower=-1.0,
+                upper=1.0,
+            ),
+            occupancy_rate=_clamp(
+                _blend(previous.occupancy_rate, snapshot.occupancy, weight)
+            ),
+            valuation_trend=_blend(previous.valuation_trend, delta, weight),
+            stability_score=_clamp(stability, lower=0.0, upper=1.0),
+            last_updated=snapshot.timestamp,
+        )
+        return self._profile

--- a/dynamic_property/__init__.py
+++ b/dynamic_property/__init__.py
@@ -1,0 +1,13 @@
+"""High-signal analytics for property level intelligence."""
+
+from .engine import (
+    PropertySnapshot,
+    PropertyProfile,
+    DynamicPropertyEngine,
+)
+
+__all__ = [
+    "PropertySnapshot",
+    "PropertyProfile",
+    "DynamicPropertyEngine",
+]

--- a/dynamic_property/engine.py
+++ b/dynamic_property/engine.py
@@ -1,0 +1,195 @@
+"""Dynamic property intelligence with cache-aware analytics."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Deque, Iterable, Mapping, Sequence
+
+__all__ = [
+    "PropertySnapshot",
+    "PropertyProfile",
+    "DynamicPropertyEngine",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_utc(timestamp: datetime | None) -> datetime:
+    if timestamp is None:
+        return _utcnow()
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+def _normalise_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(metadata)
+
+
+@dataclass(slots=True)
+class PropertySnapshot:
+    """Single observation of a property's financial footing."""
+
+    timestamp: datetime
+    valuation: float
+    rental_income: float
+    operating_expenses: float
+    occupancy: float
+    units: int = 1
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.timestamp = _ensure_utc(self.timestamp)
+        self.valuation = float(self.valuation)
+        self.rental_income = float(self.rental_income)
+        self.operating_expenses = float(self.operating_expenses)
+        if self.units <= 0:
+            raise ValueError("units must be positive")
+        self.occupancy = _clamp(float(self.occupancy))
+        self.metadata = _normalise_metadata(self.metadata)
+
+    @property
+    def net_operating_income(self) -> float:
+        return self.rental_income - self.operating_expenses
+
+    @property
+    def noi_margin(self) -> float:
+        if self.rental_income == 0:
+            return 0.0
+        return max(-1.0, min(1.0, self.net_operating_income / self.rental_income))
+
+    @property
+    def effective_occupancy(self) -> float:
+        return self.occupancy * self.units
+
+
+@dataclass(slots=True)
+class PropertyProfile:
+    """Aggregated insight derived from a collection of property snapshots."""
+
+    sample_size: int = 0
+    average_valuation: float = 0.0
+    average_noi: float = 0.0
+    average_noi_margin: float = 0.0
+    occupancy_rate: float = 0.0
+    valuation_trend: float = 0.0
+    stability_score: float = 1.0
+    last_updated: datetime | None = None
+
+    @classmethod
+    def empty(cls) -> "PropertyProfile":
+        return cls()
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "sample_size": self.sample_size,
+            "average_valuation": self.average_valuation,
+            "average_noi": self.average_noi,
+            "average_noi_margin": self.average_noi_margin,
+            "occupancy_rate": self.occupancy_rate,
+            "valuation_trend": self.valuation_trend,
+            "stability_score": self.stability_score,
+            "last_updated": self.last_updated,
+        }
+
+
+class DynamicPropertyEngine:
+    """Maintains a rolling window of property observations for analytics."""
+
+    def __init__(self, *, window: int = 60) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._snapshots: Deque[PropertySnapshot] = deque(maxlen=window)
+        self._dirty = True
+        self._cached_profile: PropertyProfile | None = None
+
+    @property
+    def window(self) -> int:
+        maxlen = self._snapshots.maxlen
+        return 0 if maxlen is None else maxlen
+
+    def __len__(self) -> int:  # pragma: no cover - trivial glue
+        return len(self._snapshots)
+
+    @property
+    def profile(self) -> PropertyProfile:
+        if not self._snapshots:
+            return PropertyProfile.empty()
+        if self._dirty or self._cached_profile is None:
+            self._cached_profile = self._compute_profile(tuple(self._snapshots))
+            self._dirty = False
+        return self._cached_profile
+
+    def observe(self, snapshot: PropertySnapshot) -> PropertyProfile:
+        if self._snapshots.maxlen is not None and len(self._snapshots) == self._snapshots.maxlen:
+            # ``deque`` will drop the oldest snapshot, so mark cache dirty.
+            self._snapshots.popleft()
+        self._snapshots.append(snapshot)
+        self._dirty = True
+        return self.profile
+
+    def observe_many(self, snapshots: Iterable[PropertySnapshot]) -> PropertyProfile:
+        for snapshot in snapshots:
+            self.observe(snapshot)
+        return self.profile
+
+    def clear(self) -> None:
+        self._snapshots.clear()
+        self._cached_profile = None
+        self._dirty = True
+
+    def valuation_series(self) -> tuple[float, ...]:
+        return tuple(snapshot.valuation for snapshot in self._snapshots)
+
+    def _compute_profile(self, snapshots: Sequence[PropertySnapshot]) -> PropertyProfile:
+        sample_size = len(snapshots)
+        valuations = [snapshot.valuation for snapshot in snapshots]
+        nois = [snapshot.net_operating_income for snapshot in snapshots]
+        noi_margins = [snapshot.noi_margin for snapshot in snapshots]
+        units_total = sum(snapshot.units for snapshot in snapshots)
+        occupancy = sum(snapshot.effective_occupancy for snapshot in snapshots)
+
+        average_valuation = sum(valuations) / sample_size
+        average_noi = sum(nois) / sample_size
+        average_noi_margin = sum(noi_margins) / sample_size
+        occupancy_rate = occupancy / units_total if units_total else 0.0
+
+        if sample_size > 1:
+            base = valuations[0]
+            change = valuations[-1] - base
+            normaliser = abs(base) if base else 1.0
+            valuation_trend = change / normaliser
+            mean_val = average_valuation
+            variance = sum((value - mean_val) ** 2 for value in valuations) / sample_size
+            volatility = variance ** 0.5
+            stability_score = 1.0 / (1.0 + volatility / max(abs(mean_val), 1.0))
+        else:
+            valuation_trend = 0.0
+            stability_score = 1.0
+
+        return PropertyProfile(
+            sample_size=sample_size,
+            average_valuation=average_valuation,
+            average_noi=average_noi,
+            average_noi_margin=average_noi_margin,
+            occupancy_rate=_clamp(occupancy_rate),
+            valuation_trend=valuation_trend,
+            stability_score=_clamp(stability_score, lower=0.0, upper=1.0),
+            last_updated=snapshots[-1].timestamp,
+        )

--- a/tests_python/test_dynamic_property_engine.py
+++ b/tests_python/test_dynamic_property_engine.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from dynamic_memoryless_property import DynamicMemorylessPropertyEngine
+from dynamic_property import DynamicPropertyEngine, PropertySnapshot
+
+
+def _snapshot(
+    *,
+    days: int,
+    valuation: float,
+    rental_income: float,
+    operating_expenses: float,
+    occupancy: float,
+    units: int = 10,
+) -> PropertySnapshot:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return PropertySnapshot(
+        timestamp=base + timedelta(days=days),
+        valuation=valuation,
+        rental_income=rental_income,
+        operating_expenses=operating_expenses,
+        occupancy=occupancy,
+        units=units,
+    )
+
+
+def test_property_engine_profile_computes_expected_metrics() -> None:
+    engine = DynamicPropertyEngine(window=5)
+    snapshots = [
+        _snapshot(days=0, valuation=1_000_000, rental_income=100_000, operating_expenses=40_000, occupancy=0.90),
+        _snapshot(days=7, valuation=1_050_000, rental_income=110_000, operating_expenses=45_000, occupancy=0.95),
+        _snapshot(days=14, valuation=1_100_000, rental_income=120_000, operating_expenses=50_000, occupancy=0.80, units=12),
+    ]
+    profile = engine.observe_many(snapshots)
+
+    assert profile.sample_size == 3
+    assert profile.average_valuation == pytest.approx(1_050_000)
+    assert profile.average_noi == pytest.approx(65_000)
+    assert profile.average_noi_margin == pytest.approx((0.6 + 65_000 / 110_000 + 70_000 / 120_000) / 3)
+    assert profile.occupancy_rate == pytest.approx((9 + 9.5 + 9.6) / (10 + 10 + 12))
+    assert profile.valuation_trend == pytest.approx(0.1)
+    assert 0.95 < profile.stability_score <= 1.0
+    assert profile.last_updated == snapshots[-1].timestamp
+
+    cached_profile = engine.profile
+    assert cached_profile is engine.profile
+
+
+def test_property_snapshot_requires_positive_units() -> None:
+    with pytest.raises(ValueError):
+        _snapshot(
+            days=0,
+            valuation=1_000_000,
+            rental_income=100_000,
+            operating_expenses=40_000,
+            occupancy=0.9,
+            units=0,
+        )
+
+
+def test_memoryless_engine_smooths_signals() -> None:
+    engine = DynamicMemorylessPropertyEngine(smoothing=0.5)
+    first = _snapshot(days=0, valuation=1_000_000, rental_income=100_000, operating_expenses=40_000, occupancy=0.90)
+    second = _snapshot(days=1, valuation=1_200_000, rental_income=130_000, operating_expenses=55_000, occupancy=0.70)
+
+    profile_first = engine.observe(first)
+    assert profile_first.sample_size == 1
+    assert profile_first.average_valuation == 1_000_000
+    assert profile_first.occupancy_rate == pytest.approx(0.90)
+
+    profile_second = engine.observe(second)
+    assert profile_second.sample_size == 2
+    assert profile_second.average_valuation == pytest.approx(1_100_000)
+    assert profile_second.average_noi == pytest.approx(67_500)
+    expected_margin = (0.6 + (75_000 / 130_000)) / 2
+    assert profile_second.average_noi_margin == pytest.approx(expected_margin)
+    assert profile_second.occupancy_rate == pytest.approx(0.80)
+    assert profile_second.valuation_trend == pytest.approx(0.1)
+    assert profile_second.stability_score == pytest.approx((1 + 1 / (1 + 0.2)) / 2)
+    assert profile_second.last_updated == second.timestamp
+
+    engine.reset()
+    assert engine.profile.sample_size == 0


### PR DESCRIPTION
## Summary
- add a dynamic_property package that aggregates rolling property analytics with cached profiles
- introduce a memoryless property engine that applies exponential smoothing to single-snapshot updates
- cover the new engines with property-focused unit tests and expose them through the legacy dynamic_engines shim

## Testing
- pytest tests_python/test_dynamic_property_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c60678788322ae42db3e502b8381