### PR TITLE
Align Dynamic AGI exports with module definitions

### DIFF
--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -1,5 +1,12 @@
 """Dynamic AGI package exposing orchestrator utilities."""
 
+from .fine_tune import (
+    DynamicAGIFineTuner,
+    DynamicFineTuneDataset,
+    FineTuneBatch,
+    FineTuneExample,
+    __all__ as _fine_tune_all,
+)
 from .model import (
     AGIDiagnostics,
     AGIOutput,
@@ -9,25 +16,14 @@ from .model import (
     MODEL_VERSION_INFO,
     MODEL_VERSION_PLAN,
     DYNAMIC_AGI_EXPANSION,
+    __all__ as _model_all,
 )
 from .self_improvement import (
     DynamicSelfImprovement,
     ImprovementPlan,
     ImprovementSignal,
     LearningSnapshot,
+    __all__ as _self_improvement_all,
 )
 
-__all__ = [
-    "AGIDiagnostics",
-    "AGIOutput",
-    "DynamicAGIIdentity",
-    "DynamicAGIModel",
-    "MODEL_VERSION",
-    "MODEL_VERSION_INFO",
-    "MODEL_VERSION_PLAN",
-    "DYNAMIC_AGI_EXPANSION",
-    "DynamicSelfImprovement",
-    "ImprovementPlan",
-    "ImprovementSignal",
-    "LearningSnapshot",
-]
+__all__ = [*_model_all, *_self_improvement_all, *_fine_tune_all]

--- a/dynamic_agi/model.py
+++ b/dynamic_agi/model.py
@@ -61,6 +61,17 @@ MODEL_VERSION_INFO = MODEL_VERSION_PLAN.to_model_version(
 )
 MODEL_VERSION = MODEL_VERSION_INFO.tag
 
+__all__ = [
+    "AGIDiagnostics",
+    "AGIOutput",
+    "DynamicAGIIdentity",
+    "DynamicAGIModel",
+    "MODEL_VERSION",
+    "MODEL_VERSION_INFO",
+    "MODEL_VERSION_PLAN",
+    "DYNAMIC_AGI_EXPANSION",
+]
+
 
 def _default_version_info() -> Dict[str, Any]:
     return MODEL_VERSION_INFO.as_dict()


### PR DESCRIPTION
## Summary
- reuse the fine-tune and self-improvement module `__all__` definitions when re-exporting from the package init to prevent duplication
- add an explicit `__all__` declaration to `dynamic_agi.model` so the package-level exports stay in sync automatically

## Testing
- pytest tests_python -q

------
https://chatgpt.com/codex/tasks/task_e_68d8c98fcf948322a3d53e116df86dba