### PR TITLE
Optimize playbook synchronizer ordering

### DIFF
--- a/tests/test_dynamic_playbook_engine.py
+++ b/tests/test_dynamic_playbook_engine.py
@@ -259,17 +259,26 @@ def test_playbook_synchronizer_caches_ordering_until_dirty() -> None:
     second = synchronizer.catalogue()
     assert first is second
 
+    serialised_first = synchronizer._serialised_entries()
+    serialised_second = synchronizer._serialised_entries()
+    assert serialised_first is serialised_second
+
     synchronizer.update("Initial Play", readiness=0.75)
     refreshed = synchronizer.catalogue()
     assert refreshed is not second
+
+    serialised_third = synchronizer._serialised_entries()
+    assert serialised_third is not serialised_first
 
     unchanged = synchronizer.update("Initial Play")
     assert unchanged is refreshed[0]
     after_noop = synchronizer.catalogue()
     assert after_noop is refreshed
+    assert synchronizer._serialised_entries() is serialised_third
 
     synchronizer.remove("Initial Play")
     assert synchronizer.catalogue() == ()
+    assert synchronizer._serialised_entries() == ()
 
 
 def test_playbook_discipline_stack_cooperates() -> None:


### PR DESCRIPTION
## Summary
- allow `PlaybookSynchronizer.update` to reindex entries when their title changes and guard against collisions
- cache ordered catalogue results, skipping engine refreshes when updates are no-ops
- add regression tests covering rename/update/remove flows and the ordering cache behaviour

## Testing
- pytest tests/test_dynamic_playbook_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d0e00ecc832290b9f3a3051c569c