### PR TITLE
feat: extend dynamic mapping with domain helpers

### DIFF
--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -114,6 +114,7 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_metacognition": ("DynamicMetacognition",),
     "dynamic_mentorship": ("DynamicMentorshipEngine",),
     "dynamic_numbers": ("DynamicNumberComposer",),
+    "dynamic_mapping": ("DynamicMappingEngine",),
     "dynamic_package": ("DynamicPackageDesigner",),
     "dynamic_playbook": (
         "DynamicPlaybookAgent",

--- a/dynamic_mapping/__init__.py
+++ b/dynamic_mapping/__init__.py
@@ -1,0 +1,93 @@
+"""Dynamic mapping engine exports."""
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import (
+    MapNode,
+    MapConnection,
+    MapLayer,
+    MapOverlay,
+    MapScenario,
+    MapBlueprint,
+    MapView,
+    DynamicMappingEngine,
+)
+from .agents import (
+    build_agent_layer,
+    build_agent_overlay,
+    register_agent_layer,
+    register_agent_overlay,
+)
+from .helpers import (
+    build_helper_layer,
+    build_helper_overlay,
+    register_helper_layer,
+    register_helper_overlay,
+)
+from .mods import (
+    build_mod_layer,
+    build_mod_overlay,
+    register_mod_layer,
+    register_mod_overlay,
+)
+from .keepers import (
+    build_keeper_layer,
+    build_keeper_overlay,
+    register_keeper_layer,
+    register_keeper_overlay,
+)
+from .bots import (
+    build_bot_layer,
+    build_bot_overlay,
+    register_bot_layer,
+    register_bot_overlay,
+)
+from .sync import (
+    build_sync_layer,
+    build_sync_overlay,
+    register_sync_layer,
+    register_sync_overlay,
+)
+
+__all__ = [
+    "MapNode",
+    "MapConnection",
+    "MapLayer",
+    "MapOverlay",
+    "MapScenario",
+    "MapBlueprint",
+    "MapView",
+    "DynamicMappingEngine",
+    "DomainEntitySpec",
+    "DomainRelationSpec",
+    "build_domain_layer",
+    "build_domain_overlay",
+    "build_agent_layer",
+    "build_agent_overlay",
+    "register_agent_layer",
+    "register_agent_overlay",
+    "build_helper_layer",
+    "build_helper_overlay",
+    "register_helper_layer",
+    "register_helper_overlay",
+    "build_mod_layer",
+    "build_mod_overlay",
+    "register_mod_layer",
+    "register_mod_overlay",
+    "build_keeper_layer",
+    "build_keeper_overlay",
+    "register_keeper_layer",
+    "register_keeper_overlay",
+    "build_bot_layer",
+    "build_bot_overlay",
+    "register_bot_layer",
+    "register_bot_overlay",
+    "build_sync_layer",
+    "build_sync_overlay",
+    "register_sync_layer",
+    "register_sync_overlay",
+]

--- a/dynamic_mapping/agents.py
+++ b/dynamic_mapping/agents.py
@@ -1,0 +1,91 @@
+"""Agent-specific helpers for the dynamic mapping engine."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import DynamicMappingEngine, MapLayer, MapOverlay
+
+__all__ = [
+    "build_agent_layer",
+    "build_agent_overlay",
+    "register_agent_layer",
+    "register_agent_overlay",
+]
+
+
+def build_agent_layer(
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    *,
+    name: str = "Agent Network",
+    description: str = "Operational agents and their collaboration pathways",
+) -> MapLayer:
+    """Create a layer describing the relationship graph between agents."""
+
+    return build_domain_layer(
+        name=name,
+        description=description,
+        entities=entities,
+        relations=relations or (),
+    )
+
+
+def build_agent_overlay(
+    *,
+    name: str = "Priority Agents",
+    description: str = "Highlight agents aligned to the current mission",
+    focus_tags: Sequence[str] | None = None,
+    focus_agents: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Create an overlay to emphasise specific agents or competencies."""
+
+    return build_domain_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_entities=focus_agents,
+        weight=weight,
+    )
+
+
+def register_agent_layer(
+    engine: DynamicMappingEngine,
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    **kwargs,
+) -> MapLayer:
+    """Build and register an agent layer with the supplied engine."""
+
+    layer = build_agent_layer(entities, relations, **kwargs)
+    engine.register_layer(layer)
+    return layer
+
+
+def register_agent_overlay(
+    engine: DynamicMappingEngine,
+    *,
+    name: str = "Priority Agents",
+    description: str = "Highlight agents aligned to the current mission",
+    focus_tags: Sequence[str] | None = None,
+    focus_agents: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Build and register an agent overlay with the supplied engine."""
+
+    overlay = build_agent_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_agents=focus_agents,
+        weight=weight,
+    )
+    engine.register_overlay(overlay)
+    return overlay

--- a/dynamic_mapping/bots.py
+++ b/dynamic_mapping/bots.py
@@ -1,0 +1,91 @@
+"""Bot-centric helpers for the dynamic mapping engine."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import DynamicMappingEngine, MapLayer, MapOverlay
+
+__all__ = [
+    "build_bot_layer",
+    "build_bot_overlay",
+    "register_bot_layer",
+    "register_bot_overlay",
+]
+
+
+def build_bot_layer(
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    *,
+    name: str = "Bot Mesh",
+    description: str = "Automation bots and notification flows",
+) -> MapLayer:
+    """Create a layer visualising bots and their interactions."""
+
+    return build_domain_layer(
+        name=name,
+        description=description,
+        entities=entities,
+        relations=relations or (),
+    )
+
+
+def build_bot_overlay(
+    *,
+    name: str = "Active Bots",
+    description: str = "Highlight bots engaged in the current cycle",
+    focus_tags: Sequence[str] | None = None,
+    focus_bots: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Create an overlay emphasising selected bots."""
+
+    return build_domain_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_entities=focus_bots,
+        weight=weight,
+    )
+
+
+def register_bot_layer(
+    engine: DynamicMappingEngine,
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    **kwargs,
+) -> MapLayer:
+    """Build and register a bot layer with the supplied engine."""
+
+    layer = build_bot_layer(entities, relations, **kwargs)
+    engine.register_layer(layer)
+    return layer
+
+
+def register_bot_overlay(
+    engine: DynamicMappingEngine,
+    *,
+    name: str = "Active Bots",
+    description: str = "Highlight bots engaged in the current cycle",
+    focus_tags: Sequence[str] | None = None,
+    focus_bots: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Build and register a bot overlay with the supplied engine."""
+
+    overlay = build_bot_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_bots=focus_bots,
+        weight=weight,
+    )
+    engine.register_overlay(overlay)
+    return overlay

--- a/dynamic_mapping/domain.py
+++ b/dynamic_mapping/domain.py
@@ -1,0 +1,109 @@
+"""Domain helpers for constructing mapping layers and overlays."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from .engine import MapConnection, MapLayer, MapNode, MapOverlay
+
+__all__ = [
+    "DomainEntitySpec",
+    "DomainRelationSpec",
+    "build_domain_layer",
+    "build_domain_overlay",
+]
+
+
+@dataclass(slots=True)
+class DomainEntitySpec:
+    """Specification for translating a domain object into a :class:`MapNode`."""
+
+    identifier: str
+    name: str | None = None
+    category: str | None = None
+    weight: float = 1.0
+    tags: Sequence[str] = ()
+    metadata: Mapping[str, object] | None = None
+
+
+@dataclass(slots=True)
+class DomainRelationSpec:
+    """Specification for translating a relation into a :class:`MapConnection`."""
+
+    source: str
+    target: str
+    relation: str
+    intensity: float = 0.5
+    directed: bool = False
+    metadata: Mapping[str, object] | None = None
+
+
+def _build_nodes(specs: Iterable[DomainEntitySpec]) -> tuple[MapNode, ...]:
+    nodes: list[MapNode] = []
+    for spec in specs:
+        nodes.append(
+            MapNode(
+                identifier=spec.identifier,
+                name=spec.name or spec.identifier,
+                category=spec.category,
+                weight=spec.weight,
+                tags=tuple(spec.tags),
+                metadata=spec.metadata,
+            )
+        )
+    return tuple(nodes)
+
+
+def _build_connections(
+    relations: Iterable[DomainRelationSpec],
+) -> tuple[MapConnection, ...]:
+    connections: list[MapConnection] = []
+    for relation in relations:
+        connections.append(
+            MapConnection(
+                source=relation.source,
+                target=relation.target,
+                relation=relation.relation,
+                intensity=relation.intensity,
+                directed=relation.directed,
+                metadata=relation.metadata,
+            )
+        )
+    return tuple(connections)
+
+
+def build_domain_layer(
+    *,
+    name: str,
+    description: str,
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+) -> MapLayer:
+    """Construct a :class:`MapLayer` from domain entity specifications."""
+
+    return MapLayer(
+        name=name,
+        description=description,
+        nodes=_build_nodes(entities),
+        connections=_build_connections(relations or ()),
+    )
+
+
+def build_domain_overlay(
+    *,
+    name: str,
+    description: str,
+    focus_tags: Sequence[str] | None = None,
+    focus_entities: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Construct a :class:`MapOverlay` tailored to the supplied domain."""
+
+    return MapOverlay(
+        name=name,
+        description=description,
+        focus_tags=tuple(focus_tags or ()),
+        focus_nodes=tuple(focus_entities or ()),
+        weight=weight,
+    )

--- a/dynamic_mapping/engine.py
+++ b/dynamic_mapping/engine.py
@@ -1,0 +1,495 @@
+"""Dynamic Mapping Engine for orchestrating knowledge maps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+__all__ = [
+    "MapNode",
+    "MapConnection",
+    "MapLayer",
+    "MapOverlay",
+    "MapScenario",
+    "MapBlueprint",
+    "MapView",
+    "DynamicMappingEngine",
+]
+
+
+def _normalise_text(value: str | None, *, fallback: str | None = None) -> str:
+    text = (value or "").strip()
+    if text:
+        return text
+    if fallback is not None:
+        candidate = (fallback or "").strip()
+        if candidate:
+            return candidate
+    raise ValueError("text value must not be empty")
+
+
+def _normalise_tags(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw in values:
+        candidate = raw.strip().lower()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        ordered.append(candidate)
+    return tuple(ordered)
+
+
+def _normalise_identifier(value: str) -> str:
+    return _normalise_text(value).lower().replace(" ", "_")
+
+
+def _tag_alignment(tags: Sequence[str], focus: Sequence[str]) -> float:
+    if not tags or not focus:
+        return 0.0
+    tag_set = {tag.lower() for tag in tags if tag}
+    focus_set = {tag.lower() for tag in focus if tag}
+    if not tag_set or not focus_set:
+        return 0.0
+    intersection = len(tag_set & focus_set)
+    union = len(tag_set | focus_set)
+    if union == 0:
+        return 0.0
+    return intersection / union
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    return max(minimum, min(maximum, float(value)))
+
+
+@dataclass(slots=True)
+class MapNode:
+    """Representation of a node in the mapping fabric."""
+
+    identifier: str
+    name: str
+    category: str | None = None
+    weight: float = 1.0
+    coordinates: tuple[float, float] | None = None
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.identifier = _normalise_identifier(self.identifier)
+        self.name = _normalise_text(self.name, fallback=self.identifier)
+        self.category = (
+            _normalise_text(self.category) if self.category is not None else None
+        )
+        self.weight = _clamp(self.weight, 0.0, 100.0)
+        if self.coordinates is not None:
+            if len(self.coordinates) != 2:
+                raise ValueError("coordinates must contain two values")
+            self.coordinates = (float(self.coordinates[0]), float(self.coordinates[1]))
+        self.tags = _normalise_tags(self.tags)
+        if self.metadata is None:
+            self.metadata = {}
+        else:
+            self.metadata = dict(self.metadata)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        data: MutableMapping[str, object] = {
+            "id": self.identifier,
+            "name": self.name,
+            "weight": self.weight,
+            "tags": list(self.tags),
+        }
+        if self.category:
+            data["category"] = self.category
+        if self.coordinates is not None:
+            data["coordinates"] = list(self.coordinates)
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data
+
+
+@dataclass(slots=True)
+class MapConnection:
+    """Directional or undirected relationship between two nodes."""
+
+    source: str
+    target: str
+    relation: str
+    intensity: float = 0.5
+    directed: bool = False
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.source = _normalise_identifier(self.source)
+        self.target = _normalise_identifier(self.target)
+        if self.source == self.target:
+            raise ValueError("source and target must be different")
+        self.relation = _normalise_text(self.relation)
+        self.intensity = _clamp(self.intensity, 0.0, 1.0)
+        if self.metadata is None:
+            self.metadata = {}
+        else:
+            self.metadata = dict(self.metadata)
+
+    def involves(self, node_id: str) -> bool:
+        identifier = _normalise_identifier(node_id)
+        return self.source == identifier or self.target == identifier
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        payload: MutableMapping[str, object] = {
+            "source": self.source,
+            "target": self.target,
+            "relation": self.relation,
+            "intensity": self.intensity,
+            "directed": self.directed,
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class MapLayer:
+    """Collection of related nodes and connections."""
+
+    name: str
+    description: str
+    nodes: tuple[MapNode, ...] = field(default_factory=tuple)
+    connections: tuple[MapConnection, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.description = _normalise_text(self.description)
+        node_index: dict[str, MapNode] = {}
+        normalised_nodes: list[MapNode] = []
+        for node in self.nodes:
+            if not isinstance(node, MapNode):
+                raise TypeError("nodes must contain MapNode instances")
+            if node.identifier in node_index:
+                raise ValueError(f"duplicate node identifier: {node.identifier}")
+            node_index[node.identifier] = node
+            normalised_nodes.append(node)
+        normalised_connections: list[MapConnection] = []
+        for connection in self.connections:
+            if not isinstance(connection, MapConnection):
+                raise TypeError("connections must contain MapConnection instances")
+            if connection.source not in node_index:
+                raise ValueError(
+                    f"connection source '{connection.source}' not present in layer"
+                )
+            if connection.target not in node_index:
+                raise ValueError(
+                    f"connection target '{connection.target}' not present in layer"
+                )
+            normalised_connections.append(connection)
+        self.nodes = tuple(normalised_nodes)
+        self.connections = tuple(normalised_connections)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "nodes": [node.as_dict() for node in self.nodes],
+            "connections": [connection.as_dict() for connection in self.connections],
+        }
+
+
+@dataclass(slots=True)
+class MapOverlay:
+    """Qualitative overlay that emphasises nodes with specific properties."""
+
+    name: str
+    description: str
+    focus_tags: tuple[str, ...] = field(default_factory=tuple)
+    focus_nodes: tuple[str, ...] = field(default_factory=tuple)
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.description = _normalise_text(self.description)
+        self.focus_tags = _normalise_tags(self.focus_tags)
+        self.focus_nodes = tuple(_normalise_identifier(node) for node in self.focus_nodes)
+        self.weight = _clamp(self.weight, 0.0, 10.0)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "focus_tags": list(self.focus_tags),
+            "focus_nodes": list(self.focus_nodes),
+            "weight": self.weight,
+        }
+
+
+@dataclass(slots=True)
+class MapScenario:
+    """Scenario describing which layers and priorities to combine."""
+
+    name: str
+    objective: str
+    key_layers: tuple[str, ...]
+    focus_tags: tuple[str, ...] = field(default_factory=tuple)
+    focus_nodes: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.name = _normalise_text(self.name)
+        self.objective = _normalise_text(self.objective)
+        if not self.key_layers:
+            raise ValueError("scenario must reference at least one layer")
+        self.key_layers = tuple(_normalise_text(layer) for layer in self.key_layers)
+        self.focus_tags = _normalise_tags(self.focus_tags)
+        self.focus_nodes = tuple(_normalise_identifier(node) for node in self.focus_nodes)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "name": self.name,
+            "objective": self.objective,
+            "key_layers": list(self.key_layers),
+            "focus_tags": list(self.focus_tags),
+            "focus_nodes": list(self.focus_nodes),
+        }
+
+
+@dataclass(slots=True)
+class MapView:
+    """Configuration describing how a scenario should be rendered."""
+
+    title: str
+    narrative: str
+    overlay_names: tuple[str, ...] = field(default_factory=tuple)
+    highlight_limit: int = 8
+
+    def __post_init__(self) -> None:
+        self.title = _normalise_text(self.title)
+        self.narrative = _normalise_text(self.narrative)
+        self.overlay_names = tuple(_normalise_text(name) for name in self.overlay_names)
+        self.highlight_limit = max(int(self.highlight_limit), 1)
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "title": self.title,
+            "narrative": self.narrative,
+            "overlay_names": list(self.overlay_names),
+            "highlight_limit": self.highlight_limit,
+        }
+
+
+@dataclass(slots=True)
+class MapBlueprint:
+    """Resulting structure once the engine composes a scenario and view."""
+
+    scenario: MapScenario
+    view: MapView
+    layers: tuple[MapLayer, ...]
+    overlays: tuple[MapOverlay, ...]
+    highlighted_nodes: tuple[MapNode, ...]
+    highlighted_connections: tuple[MapConnection, ...]
+    insights: tuple[str, ...]
+    recommended_actions: tuple[str, ...]
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "scenario": self.scenario.as_dict(),
+            "view": self.view.as_dict(),
+            "layers": [layer.as_dict() for layer in self.layers],
+            "overlays": [overlay.as_dict() for overlay in self.overlays],
+            "highlighted_nodes": [node.as_dict() for node in self.highlighted_nodes],
+            "highlighted_connections": [
+                connection.as_dict() for connection in self.highlighted_connections
+            ],
+            "insights": list(self.insights),
+            "recommended_actions": list(self.recommended_actions),
+        }
+
+
+class DynamicMappingEngine:
+    """Orchestrate layers, overlays, and insights into a living map."""
+
+    def __init__(self) -> None:
+        self._layers: Dict[str, MapLayer] = {}
+        self._overlays: Dict[str, MapOverlay] = {}
+
+    # ---------------------------------------------------------------- layers
+    def register_layer(self, layer: MapLayer) -> None:
+        if not isinstance(layer, MapLayer):  # pragma: no cover - guard
+            raise TypeError("layer must be a MapLayer instance")
+        if layer.name in self._layers:
+            raise ValueError(f"layer '{layer.name}' already registered")
+        self._layers[layer.name] = layer
+
+    def register_layers(self, layers: Iterable[MapLayer]) -> None:
+        for layer in layers:
+            self.register_layer(layer)
+
+    def get_layer(self, name: str) -> MapLayer:
+        key = _normalise_text(name)
+        try:
+            return self._layers[key]
+        except KeyError as exc:  # pragma: no cover - guard
+            raise KeyError(f"layer '{name}' not found") from exc
+
+    # ---------------------------------------------------------------- overlays
+    def register_overlay(self, overlay: MapOverlay) -> None:
+        if not isinstance(overlay, MapOverlay):  # pragma: no cover - guard
+            raise TypeError("overlay must be a MapOverlay instance")
+        if overlay.name in self._overlays:
+            raise ValueError(f"overlay '{overlay.name}' already registered")
+        self._overlays[overlay.name] = overlay
+
+    def register_overlays(self, overlays: Iterable[MapOverlay]) -> None:
+        for overlay in overlays:
+            self.register_overlay(overlay)
+
+    def get_overlay(self, name: str) -> MapOverlay:
+        key = _normalise_text(name)
+        try:
+            return self._overlays[key]
+        except KeyError as exc:  # pragma: no cover - guard
+            raise KeyError(f"overlay '{name}' not found") from exc
+
+    # ----------------------------------------------------------------- engine
+    def compose(self, scenario: MapScenario, view: MapView) -> MapBlueprint:
+        layer_bundle = [self.get_layer(name) for name in scenario.key_layers]
+        overlay_bundle = [self.get_overlay(name) for name in view.overlay_names]
+
+        node_index: Dict[str, MapNode] = {}
+        adjacency: Dict[str, List[MapConnection]] = {}
+        for layer in layer_bundle:
+            for node in layer.nodes:
+                if node.identifier not in node_index:
+                    node_index[node.identifier] = node
+                    adjacency[node.identifier] = []
+            for connection in layer.connections:
+                adjacency[connection.source].append(connection)
+                adjacency[connection.target].append(connection)
+
+        if not node_index:
+            raise RuntimeError("scenario resolved to zero nodes")
+
+        highlighted_nodes = self._select_highlighted_nodes(
+            node_index,
+            adjacency,
+            scenario,
+            overlay_bundle,
+            limit=view.highlight_limit,
+        )
+        highlighted_connections = self._select_highlighted_connections(
+            highlighted_nodes, adjacency
+        )
+        insights = self._generate_insights(
+            highlighted_nodes, highlighted_connections, scenario
+        )
+        actions = self._generate_actions(highlighted_nodes, scenario)
+        return MapBlueprint(
+            scenario=scenario,
+            view=view,
+            layers=tuple(layer_bundle),
+            overlays=tuple(overlay_bundle),
+            highlighted_nodes=highlighted_nodes,
+            highlighted_connections=highlighted_connections,
+            insights=insights,
+            recommended_actions=actions,
+        )
+
+    # ------------------------------------------------------------- heuristics
+    def _select_highlighted_nodes(
+        self,
+        node_index: Mapping[str, MapNode],
+        adjacency: Mapping[str, Sequence[MapConnection]],
+        scenario: MapScenario,
+        overlays: Sequence[MapOverlay],
+        *,
+        limit: int,
+    ) -> tuple[MapNode, ...]:
+        focus_lookup = {node_id: True for node_id in scenario.focus_nodes}
+        for overlay in overlays:
+            for node_id in overlay.focus_nodes:
+                focus_lookup.setdefault(node_id, True)
+
+        def score(node: MapNode) -> float:
+            base = node.weight
+            base += 0.75 * _tag_alignment(node.tags, scenario.focus_tags)
+            degree = len(adjacency.get(node.identifier, ()))
+            base += min(degree, 8) * 0.05
+            if node.identifier in focus_lookup:
+                base += 1.5
+            for overlay in overlays:
+                overlay_bonus = 0.0
+                if node.identifier in overlay.focus_nodes:
+                    overlay_bonus += overlay.weight
+                overlay_bonus += overlay.weight * _tag_alignment(
+                    node.tags, overlay.focus_tags
+                )
+                base += overlay_bonus
+            return base
+
+        ranked = sorted(node_index.values(), key=score, reverse=True)
+        selected = ranked[:limit]
+        return tuple(selected)
+
+    def _select_highlighted_connections(
+        self,
+        nodes: Sequence[MapNode],
+        adjacency: Mapping[str, Sequence[MapConnection]],
+    ) -> tuple[MapConnection, ...]:
+        node_ids = {node.identifier for node in nodes}
+        connection_map: Dict[Tuple[str, str, str], MapConnection] = {}
+        for node in nodes:
+            for connection in adjacency.get(node.identifier, ()):
+                other = connection.target if connection.source == node.identifier else connection.source
+                if other not in node_ids:
+                    continue
+                key = tuple(sorted((connection.source, connection.target))) + (
+                    connection.relation,
+                )
+                existing = connection_map.get(key)
+                if existing is None or connection.intensity > existing.intensity:
+                    connection_map[key] = connection
+        return tuple(connection_map.values())
+
+    def _generate_insights(
+        self,
+        nodes: Sequence[MapNode],
+        connections: Sequence[MapConnection],
+        scenario: MapScenario,
+    ) -> tuple[str, ...]:
+        insights: list[str] = []
+        if nodes:
+            strongest = max(nodes, key=lambda node: node.weight)
+            insights.append(
+                f"{strongest.name} anchors the scenario with a weight of {strongest.weight:.2f}."
+            )
+        if connections:
+            densest = max(connections, key=lambda conn: conn.intensity)
+            insights.append(
+                f"The {densest.relation} link between {densest.source} and {densest.target}"
+                f" exhibits the highest intensity at {densest.intensity:.2f}."
+            )
+        if scenario.focus_tags:
+            insights.append(
+                "Focus tags emphasised: " + ", ".join(sorted(scenario.focus_tags))
+            )
+        if not insights:
+            insights.append("Scenario composed successfully with no dominant signals yet identified.")
+        return tuple(insights)
+
+    def _generate_actions(
+        self, nodes: Sequence[MapNode], scenario: MapScenario
+    ) -> tuple[str, ...]:
+        actions: list[str] = []
+        for node in nodes:
+            action = (
+                f"Activate {node.name} to accelerate {scenario.objective.lower()}"
+                if scenario.objective
+                else f"Engage {node.name} to progress scenario goals"
+            )
+            actions.append(action)
+        if not actions:
+            actions.append("Incorporate additional nodes to enable actionable recommendations.")
+        return tuple(actions)
+
+    # ----------------------------------------------------------------- utility
+    def clear(self) -> None:
+        self._layers.clear()
+        self._overlays.clear()

--- a/dynamic_mapping/helpers.py
+++ b/dynamic_mapping/helpers.py
@@ -1,0 +1,91 @@
+"""Helper-centric utilities for the dynamic mapping engine."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import DynamicMappingEngine, MapLayer, MapOverlay
+
+__all__ = [
+    "build_helper_layer",
+    "build_helper_overlay",
+    "register_helper_layer",
+    "register_helper_overlay",
+]
+
+
+def build_helper_layer(
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    *,
+    name: str = "Helper Fabric",
+    description: str = "Support helpers coordinating operations",
+) -> MapLayer:
+    """Create a layer highlighting helper utilities and interactions."""
+
+    return build_domain_layer(
+        name=name,
+        description=description,
+        entities=entities,
+        relations=relations or (),
+    )
+
+
+def build_helper_overlay(
+    *,
+    name: str = "Essential Helpers",
+    description: str = "Surface helpers critical to the initiative",
+    focus_tags: Sequence[str] | None = None,
+    focus_helpers: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Create an overlay targeting helpers by tag or identifier."""
+
+    return build_domain_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_entities=focus_helpers,
+        weight=weight,
+    )
+
+
+def register_helper_layer(
+    engine: DynamicMappingEngine,
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    **kwargs,
+) -> MapLayer:
+    """Build and register a helper layer with the supplied engine."""
+
+    layer = build_helper_layer(entities, relations, **kwargs)
+    engine.register_layer(layer)
+    return layer
+
+
+def register_helper_overlay(
+    engine: DynamicMappingEngine,
+    *,
+    name: str = "Essential Helpers",
+    description: str = "Surface helpers critical to the initiative",
+    focus_tags: Sequence[str] | None = None,
+    focus_helpers: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Build and register a helper overlay with the supplied engine."""
+
+    overlay = build_helper_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_helpers=focus_helpers,
+        weight=weight,
+    )
+    engine.register_overlay(overlay)
+    return overlay

--- a/dynamic_mapping/keepers.py
+++ b/dynamic_mapping/keepers.py
@@ -1,0 +1,91 @@
+"""Keeper-focused utilities for the dynamic mapping engine."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import DynamicMappingEngine, MapLayer, MapOverlay
+
+__all__ = [
+    "build_keeper_layer",
+    "build_keeper_overlay",
+    "register_keeper_layer",
+    "register_keeper_overlay",
+]
+
+
+def build_keeper_layer(
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    *,
+    name: str = "Keeper Network",
+    description: str = "Keeper algorithms safeguarding the platform",
+) -> MapLayer:
+    """Create a layer representing keeper responsibilities and links."""
+
+    return build_domain_layer(
+        name=name,
+        description=description,
+        entities=entities,
+        relations=relations or (),
+    )
+
+
+def build_keeper_overlay(
+    *,
+    name: str = "Keeper Watchlist",
+    description: str = "Emphasise keepers handling sensitive systems",
+    focus_tags: Sequence[str] | None = None,
+    focus_keepers: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Create an overlay highlighting priority keepers."""
+
+    return build_domain_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_entities=focus_keepers,
+        weight=weight,
+    )
+
+
+def register_keeper_layer(
+    engine: DynamicMappingEngine,
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    **kwargs,
+) -> MapLayer:
+    """Build and register a keeper layer with the supplied engine."""
+
+    layer = build_keeper_layer(entities, relations, **kwargs)
+    engine.register_layer(layer)
+    return layer
+
+
+def register_keeper_overlay(
+    engine: DynamicMappingEngine,
+    *,
+    name: str = "Keeper Watchlist",
+    description: str = "Emphasise keepers handling sensitive systems",
+    focus_tags: Sequence[str] | None = None,
+    focus_keepers: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Build and register a keeper overlay with the supplied engine."""
+
+    overlay = build_keeper_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_keepers=focus_keepers,
+        weight=weight,
+    )
+    engine.register_overlay(overlay)
+    return overlay

--- a/dynamic_mapping/mods.py
+++ b/dynamic_mapping/mods.py
@@ -1,0 +1,91 @@
+"""Module and mod-centric helpers for the dynamic mapping engine."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import DynamicMappingEngine, MapLayer, MapOverlay
+
+__all__ = [
+    "build_mod_layer",
+    "build_mod_overlay",
+    "register_mod_layer",
+    "register_mod_overlay",
+]
+
+
+def build_mod_layer(
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    *,
+    name: str = "Module Topology",
+    description: str = "Mod components and their integration pathways",
+) -> MapLayer:
+    """Create a layer describing platform mods or modules."""
+
+    return build_domain_layer(
+        name=name,
+        description=description,
+        entities=entities,
+        relations=relations or (),
+    )
+
+
+def build_mod_overlay(
+    *,
+    name: str = "Critical Mods",
+    description: str = "Highlight mods driving the current initiative",
+    focus_tags: Sequence[str] | None = None,
+    focus_mods: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Create an overlay to emphasise key mods or modules."""
+
+    return build_domain_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_entities=focus_mods,
+        weight=weight,
+    )
+
+
+def register_mod_layer(
+    engine: DynamicMappingEngine,
+    entities: Sequence[DomainEntitySpec],
+    relations: Sequence[DomainRelationSpec] | None = None,
+    **kwargs,
+) -> MapLayer:
+    """Build and register a mod layer with the supplied engine."""
+
+    layer = build_mod_layer(entities, relations, **kwargs)
+    engine.register_layer(layer)
+    return layer
+
+
+def register_mod_overlay(
+    engine: DynamicMappingEngine,
+    *,
+    name: str = "Critical Mods",
+    description: str = "Highlight mods driving the current initiative",
+    focus_tags: Sequence[str] | None = None,
+    focus_mods: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Build and register a mod overlay with the supplied engine."""
+
+    overlay = build_mod_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_mods=focus_mods,
+        weight=weight,
+    )
+    engine.register_overlay(overlay)
+    return overlay

--- a/dynamic_mapping/sync.py
+++ b/dynamic_mapping/sync.py
@@ -1,0 +1,91 @@
+"""Synchronisation insights for the dynamic mapping engine."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .domain import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    build_domain_layer,
+    build_domain_overlay,
+)
+from .engine import DynamicMappingEngine, MapLayer, MapOverlay
+
+__all__ = [
+    "build_sync_layer",
+    "build_sync_overlay",
+    "register_sync_layer",
+    "register_sync_overlay",
+]
+
+
+def build_sync_layer(
+    systems: Sequence[DomainEntitySpec],
+    dependencies: Sequence[DomainRelationSpec] | None = None,
+    *,
+    name: str = "Sync Systems",
+    description: str = "Synchronized systems and their dependencies",
+) -> MapLayer:
+    """Create a layer representing synchronisation systems and flows."""
+
+    return build_domain_layer(
+        name=name,
+        description=description,
+        entities=systems,
+        relations=dependencies or (),
+    )
+
+
+def build_sync_overlay(
+    *,
+    name: str = "Sync Hotspots",
+    description: str = "Highlight synchronisation points requiring attention",
+    focus_tags: Sequence[str] | None = None,
+    focus_systems: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Create an overlay emphasising synchronisation hotspots."""
+
+    return build_domain_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_entities=focus_systems,
+        weight=weight,
+    )
+
+
+def register_sync_layer(
+    engine: DynamicMappingEngine,
+    systems: Sequence[DomainEntitySpec],
+    dependencies: Sequence[DomainRelationSpec] | None = None,
+    **kwargs,
+) -> MapLayer:
+    """Build and register a sync layer with the supplied engine."""
+
+    layer = build_sync_layer(systems, dependencies, **kwargs)
+    engine.register_layer(layer)
+    return layer
+
+
+def register_sync_overlay(
+    engine: DynamicMappingEngine,
+    *,
+    name: str = "Sync Hotspots",
+    description: str = "Highlight synchronisation points requiring attention",
+    focus_tags: Sequence[str] | None = None,
+    focus_systems: Sequence[str] | None = None,
+    weight: float = 1.0,
+) -> MapOverlay:
+    """Build and register a sync overlay with the supplied engine."""
+
+    overlay = build_sync_overlay(
+        name=name,
+        description=description,
+        focus_tags=focus_tags,
+        focus_systems=focus_systems,
+        weight=weight,
+    )
+    engine.register_overlay(overlay)
+    return overlay

--- a/tests_python/test_dynamic_mapping.py
+++ b/tests_python/test_dynamic_mapping.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dynamic_mapping import (  # noqa: E402  - path mutation for test isolation
+    DynamicMappingEngine,
+    MapConnection,
+    MapLayer,
+    MapNode,
+    MapOverlay,
+    MapScenario,
+    MapView,
+)
+
+
+def _build_sample_layer() -> MapLayer:
+    nodes = (
+        MapNode(
+            identifier="North Hub",
+            name="North Hub",
+            category="hub",
+            weight=0.9,
+            tags=("strategic", "north"),
+        ),
+        MapNode(
+            identifier="South Hub",
+            name="South Hub",
+            category="hub",
+            weight=0.8,
+            tags=("south", "logistics"),
+        ),
+        MapNode(
+            identifier="Innovation Lab",
+            name="Innovation Lab",
+            category="lab",
+            weight=0.7,
+            tags=("strategic", "innovation"),
+        ),
+    )
+    connections = (
+        MapConnection(
+            source="North Hub",
+            target="South Hub",
+            relation="supply",
+            intensity=0.8,
+        ),
+        MapConnection(
+            source="North Hub",
+            target="Innovation Lab",
+            relation="insight",
+            intensity=0.6,
+        ),
+        MapConnection(
+            source="South Hub",
+            target="Innovation Lab",
+            relation="feedback",
+            intensity=0.4,
+        ),
+    )
+    return MapLayer(
+        name="Operational Network",
+        description="Core operational nodes",
+        nodes=nodes,
+        connections=connections,
+    )
+
+
+def test_dynamic_mapping_engine_compose_blueprint() -> None:
+    engine = DynamicMappingEngine()
+    layer = _build_sample_layer()
+    overlay = MapOverlay(
+        name="Strategic Overlay",
+        description="Highlight strategic assets",
+        focus_tags=("strategic",),
+        focus_nodes=("Innovation Lab",),
+        weight=1.2,
+    )
+    scenario = MapScenario(
+        name="Growth Push",
+        objective="Expand strategic throughput",
+        key_layers=("Operational Network",),
+        focus_tags=("innovation",),
+    )
+    view = MapView(
+        title="Executive Overview",
+        narrative="Surface critical nodes and relationships",
+        overlay_names=("Strategic Overlay",),
+        highlight_limit=2,
+    )
+
+    engine.register_layer(layer)
+    engine.register_overlay(overlay)
+
+    blueprint = engine.compose(scenario, view)
+
+    assert blueprint.layers[0].name == "Operational Network"
+    assert blueprint.overlays[0].name == "Strategic Overlay"
+    assert len(blueprint.highlighted_nodes) == 2
+    assert all(node.identifier in {"north_hub", "innovation_lab", "south_hub"} for node in blueprint.highlighted_nodes)
+    assert blueprint.highlighted_connections
+    assert blueprint.insights
+    assert blueprint.recommended_actions
+    payload = blueprint.as_dict()
+    assert payload["scenario"]["name"] == "Growth Push"
+    assert payload["highlighted_nodes"], "highlighted nodes should serialise"
+
+
+def test_layer_rejects_missing_node_connections() -> None:
+    nodes = (MapNode(identifier="alpha", name="Alpha"),)
+    connections = (MapConnection(source="alpha", target="beta", relation="link"),)
+    try:
+        MapLayer(
+            name="Invalid",
+            description="Broken connection",
+            nodes=nodes,
+            connections=connections,
+        )
+    except ValueError as exc:
+        assert "connection target" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("MapLayer should reject connections referencing unknown nodes")

--- a/tests_python/test_dynamic_mapping_domains.py
+++ b/tests_python/test_dynamic_mapping_domains.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import pytest
+
+from dynamic_mapping import (
+    DomainEntitySpec,
+    DomainRelationSpec,
+    DynamicMappingEngine,
+    MapScenario,
+    MapView,
+    build_agent_layer,
+    build_agent_overlay,
+    register_agent_layer,
+    register_agent_overlay,
+    build_helper_layer,
+    build_helper_overlay,
+    register_helper_layer,
+    register_helper_overlay,
+    build_mod_layer,
+    build_mod_overlay,
+    register_mod_layer,
+    register_mod_overlay,
+    build_keeper_layer,
+    build_keeper_overlay,
+    register_keeper_layer,
+    register_keeper_overlay,
+    build_bot_layer,
+    build_bot_overlay,
+    register_bot_layer,
+    register_bot_overlay,
+    build_sync_layer,
+    build_sync_overlay,
+    register_sync_layer,
+    register_sync_overlay,
+)
+
+
+DOMAIN_VARIANTS = (
+    (
+        "agents",
+        build_agent_layer,
+        build_agent_overlay,
+        register_agent_layer,
+        register_agent_overlay,
+        "focus_agents",
+    ),
+    (
+        "helpers",
+        build_helper_layer,
+        build_helper_overlay,
+        register_helper_layer,
+        register_helper_overlay,
+        "focus_helpers",
+    ),
+    (
+        "mods",
+        build_mod_layer,
+        build_mod_overlay,
+        register_mod_layer,
+        register_mod_overlay,
+        "focus_mods",
+    ),
+    (
+        "keepers",
+        build_keeper_layer,
+        build_keeper_overlay,
+        register_keeper_layer,
+        register_keeper_overlay,
+        "focus_keepers",
+    ),
+    (
+        "bots",
+        build_bot_layer,
+        build_bot_overlay,
+        register_bot_layer,
+        register_bot_overlay,
+        "focus_bots",
+    ),
+    (
+        "sync",
+        build_sync_layer,
+        build_sync_overlay,
+        register_sync_layer,
+        register_sync_overlay,
+        "focus_systems",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "domain, layer_builder, overlay_builder, layer_register, overlay_register, focus_param",
+    DOMAIN_VARIANTS,
+)
+def test_domain_helpers_build_and_register(
+    domain: str,
+    layer_builder,
+    overlay_builder,
+    layer_register,
+    overlay_register,
+    focus_param: str,
+) -> None:
+    entities = [
+        DomainEntitySpec(
+            identifier=f"{domain}_alpha",
+            name=f"{domain.title()} Alpha",
+            tags=(domain, "core"),
+            weight=0.9,
+        ),
+        DomainEntitySpec(
+            identifier=f"{domain}_beta",
+            name=f"{domain.title()} Beta",
+            tags=("support",),
+            weight=0.7,
+        ),
+    ]
+    relations = [
+        DomainRelationSpec(
+            source=f"{domain}_alpha",
+            target=f"{domain}_beta",
+            relation="supports",
+            intensity=0.6,
+        )
+    ]
+
+    layer_name = f"{domain.title()} Layer"
+    layer_description = f"{domain.title()} relationship graph"
+    layer = layer_builder(
+        entities,
+        relations,
+        name=layer_name,
+        description=layer_description,
+    )
+    assert layer.name == layer_name
+    assert layer.connections
+
+    focus_kwargs = {"focus_tags": (domain,)}
+    focus_kwargs[focus_param] = (entities[0].identifier,)
+    overlay_name = f"{domain.title()} Overlay"
+    overlay_description = f"{domain.title()} focus"
+    overlay = overlay_builder(
+        name=overlay_name,
+        description=overlay_description,
+        **focus_kwargs,
+    )
+    assert overlay.name == overlay_name
+
+    engine = DynamicMappingEngine()
+    registered_layer = layer_register(
+        engine,
+        entities,
+        relations,
+        name=layer_name,
+        description=layer_description,
+    )
+    assert registered_layer.name == layer_name
+
+    registered_overlay = overlay_register(
+        engine,
+        name=overlay_name,
+        description=overlay_description,
+        **focus_kwargs,
+    )
+    assert registered_overlay.name == overlay_name
+
+    scenario = MapScenario(
+        name=f"{domain.title()} Scenario",
+        objective="Demonstrate domain mapping",
+        key_layers=(layer_name,),
+        focus_tags=(domain,),
+    )
+    view = MapView(
+        title=f"{domain.title()} View",
+        narrative="Highlight critical actors",
+        overlay_names=(overlay_name,),
+        highlight_limit=1,
+    )
+
+    blueprint = engine.compose(scenario, view)
+
+    assert blueprint.layers[0].name == layer_name
+    assert blueprint.overlays[0].name == overlay_name
+    assert blueprint.highlighted_nodes, "expected highlighted nodes for domain mapping"


### PR DESCRIPTION
## Summary
- add reusable domain entity and relation specifications to simplify mapping layer construction
- provide agent, helper, mod, keeper, bot, and sync wrappers that register layers and overlays on the mapping engine
- cover the new helpers with parametrized tests exercising all domain variants

## Testing
- npm run format
- npm run lint
- npm run typecheck
- pytest tests_python/test_dynamic_mapping.py tests_python/test_dynamic_mapping_domains.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d06b8cbc83229a4aec1d42a12999