### PR TITLE
Revert dynamic UI palette expansion

### DIFF
--- a/apps/web/components/ui/enhanced-interaction-button.tsx
+++ b/apps/web/components/ui/enhanced-interaction-button.tsx
@@ -5,6 +5,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils";
 
+type MotionButtonProps = React.ComponentPropsWithoutRef<typeof motion.button>;
+
 const enhancedInteractionButtonVariants = cva(
   "relative inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 overflow-hidden group",
   {
@@ -89,10 +91,10 @@ const enhancedInteractionButtonVariants = cva(
 );
 
 export interface EnhancedInteractionButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends MotionButtonProps,
     VariantProps<typeof enhancedInteractionButtonVariants> {
   loading?: boolean;
-  loadingText?: string;
+  loadingText?: React.ReactNode;
   icon?: React.ReactNode;
   iconPosition?: "left" | "right";
   ripple?: boolean;
@@ -204,7 +206,7 @@ export const EnhancedInteractionButton = React.forwardRef<
         )}
         
         <span>
-          {loading ? loadingText : children}
+          {loading ? loadingText : (children as React.ReactNode)}
         </span>
         
         {icon && iconPosition === "right" && (

--- a/apps/web/components/ui/smart-card.tsx
+++ b/apps/web/components/ui/smart-card.tsx
@@ -5,6 +5,8 @@ import { motion } from "framer-motion";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/utils";
 
+type MotionDivProps = React.ComponentPropsWithoutRef<typeof motion.div>;
+
 const smartCardVariants = cva(
   "relative rounded-lg border bg-card text-card-foreground transition-all duration-300 overflow-hidden group",
   {
@@ -73,7 +75,7 @@ const smartCardVariants = cva(
 );
 
 export interface SmartCardProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends MotionDivProps,
     VariantProps<typeof smartCardVariants> {
   header?: React.ReactNode;
   footer?: React.ReactNode;

--- a/docs/ui/unification-optimization-checklist.md
+++ b/docs/ui/unification-optimization-checklist.md
@@ -1,0 +1,109 @@
+# Dynamic UI Unification & Optimization Checklist
+
+Use this checklist to coordinate theme, interaction, and performance refinements
+for the Dynamic UI system. Group tasks by phase to ensure the quick wins land
+first while the medium- and long-term optimizations follow a shared roadmap.
+
+## Phase 1 · Quick Wins
+
+### Enhanced Color System & Visual Hierarchy
+
+- [ ] Add semantic success, warning, info, and neutral tokens across light/dark
+      themes.
+- [ ] Audit component states for WCAG AA color contrast and document any
+      required palette adjustments.
+- [ ] Introduce warm/cool temperature variants that can be toggled by time of
+      day or market session.
+- [ ] Map contextual market signals (bull/bear/volatile) to dynamic brand color
+      ramps and verify gradients render cleanly in `dynamic-ui.css`.
+
+### Micro-interactions & Touch Targets
+
+- [ ] Ensure all interactive elements expose hover, focus-visible, pressed, and
+      disabled affordances with motion-safe fallbacks.
+- [ ] Add loading, success, and error feedback states to high-traffic buttons
+      and forms.
+- [ ] Increase touch target sizing (min 44×44 px) and gesture responsiveness for
+      mobile and Telegram surfaces.
+
+## Phase 2 · Market & Performance Adaptations
+
+### Market-Responsive & Geographic Themes
+
+- [ ] Implement theme variants that respond to live market conditions (bull,
+      bear, sideways, high volatility) and provide a toggle for QA overrides.
+- [ ] Create Maldivian-inspired palettes/typography pairs and document cultural
+      references used for reviewers.
+- [ ] Add device performance profiles (high fidelity vs. lightweight) with
+      fallbacks for low-end hardware.
+- [ ] Deliver accessibility themes (high contrast, reduced motion, large type)
+      and integrate them with Supabase theme persistence.
+
+### Smart Components & Content Hierarchy
+
+- [ ] Extend button/card components with contextual props to surface market
+      status, trading signals, or user alerts without ad-hoc overrides.
+- [ ] Implement progressive disclosure patterns (accordion, detail toggles)
+      driven by behavioral analytics or saved preferences.
+- [ ] Wire micro-copy and tooltip helpers to adapt based on user tier or
+      experience level.
+- [ ] Localize Dhivehi content with RTL verification and typography QA for key
+      flows.
+
+### Performance & Loading Improvements
+
+- [ ] Profile CSS custom property usage and consolidate redundant calculations
+      in the branding tokens.
+- [ ] Add component-level lazy loading for TradingView widgets, analytics
+      panels, and other heavy bundles.
+- [ ] Refine animation primitives to rely on transform/opacity and respect the
+      `prefers-reduced-motion` media query.
+- [ ] Optimize theme hydration so persisted themes flash less than 100 ms on
+      cold loads (measure with Web Vitals).
+
+## Phase 3 · Advanced Personalization & Visualization
+
+### Data Visualization Enhancements
+
+- [ ] Align TradingView embeds with Dynamic UI theming (colors, fonts,
+      indicators) and remove redundant inline styling.
+- [ ] Prototype native chart components for core KPIs with consistent motion
+      tokens and accessibility annotations.
+- [ ] Surface real-time market/portfolio indicators with throttled updates and
+      skeleton fallbacks.
+- [ ] Introduce comparative visualization modes (asset vs. index, portfolio vs.
+      benchmark) with synchronized tooltips.
+
+### Adaptive Layout & Dashboard Customization
+
+- [ ] Build a content-aware grid that adjusts column count and spacing based on
+      data density and screen size.
+- [ ] Add user-configurable dashboard layouts (drag-and-drop or saved presets)
+      with persistence in Supabase.
+- [ ] Implement spacing tokens that adapt to hierarchy depth (e.g., nested cards
+      vs. top-level containers).
+- [ ] Document layout rules in the design system reference and update Storybook
+      or MDX examples accordingly.
+
+### Personalization & Context Engines
+
+- [ ] Ship AI-assisted or rules-based content prioritization that ranks modules
+      (news, signals, portfolio) per user behavior.
+- [ ] Build contextual help overlays that adapt copy and links based on user
+      confidence scores or completion history.
+- [ ] Integrate cross-surface telemetry to refine theme and layout
+      recommendations over time.
+- [ ] Establish validation checkpoints (design review, accessibility audit,
+      performance budget) before promoting advanced features to production.
+
+## Ongoing Governance
+
+- [ ] Maintain a living inventory of theme tokens, component variants, and
+      visualization templates in `dynamic-branding.config.ts` and supporting
+      docs.
+- [ ] Schedule quarterly audits to reconcile design tokens, CSS variables, and
+      component props to avoid drift.
+- [ ] Track completion status in the project board and link PRs/issues so
+      reviewers can trace each checklist item to measurable outcomes.
+- [ ] Capture learnings post-launch (metrics, accessibility findings,
+      localization feedback) and feed them back into the roadmap.


### PR DESCRIPTION
## Summary
- revert dynamic UI CSS, branding tokens, and motion variants to the prior baseline without the expanded status palette
- simplify DynamicButton usage across web and shared components to the original primary/outline variants
- adjust EnhancedInteractionButton and SmartCard typings to continue accepting framer-motion props after the rollback

## Testing
- npm run lint
- npm run typecheck
- CI=1 npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d8d2da25588322b97412cf6cab5337