### PR TITLE
Optimize refresh animation loading

### DIFF
--- a/apps/web/components/dynamic-portfolio/home/FxMarketSnapshotSection.tsx
+++ b/apps/web/components/dynamic-portfolio/home/FxMarketSnapshotSection.tsx
@@ -33,6 +33,7 @@ import {
   getInstrumentMetadata,
   PRIMARY_CURRENCY_CODES,
 } from "@/data/instruments";
+import { RefreshAnimation } from "./RefreshAnimation";
 
 type CurrencyStrength = {
   code: string;
@@ -925,23 +926,33 @@ export function FxMarketSnapshotSection() {
       shadow="l"
     >
       <Column gap="12" maxWidth={32}>
-        <Row gap="12" vertical="center">
+        <Row gap="12" vertical="center" wrap>
           <Heading
             id="fx-market-snapshot-heading"
             variant="display-strong-xs"
           >
             Dynamic market snapshot
           </Heading>
-          <Tag
-            size="s"
-            background={statusTone}
-            prefixIcon="clock"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {statusLabel}
-          </Tag>
+          <Row gap="4" vertical="center">
+            <Tag
+              size="s"
+              background={statusTone}
+              prefixIcon="clock"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {statusLabel}
+            </Tag>
+            <RefreshAnimation
+              active={isFetching}
+              ariaLabel={
+                isFetching
+                  ? "Refreshing FX market snapshot"
+                  : "FX market snapshot idle"
+              }
+            />
+          </Row>
         </Row>
         <Text variant="body-default-l" onBackground="neutral-weak">
           A desk-level digest of where momentum, volatility, and cross-asset

--- a/apps/web/components/dynamic-portfolio/home/MarketWatchlist.tsx
+++ b/apps/web/components/dynamic-portfolio/home/MarketWatchlist.tsx
@@ -19,6 +19,7 @@ import {
   findInstrumentMetadata,
   getInstrumentMetadata,
 } from "@/data/instruments";
+import { RefreshAnimation } from "./RefreshAnimation";
 
 interface StrategyPlaybook {
   automation: string;
@@ -970,7 +971,24 @@ export function MarketWatchlist() {
           </Row>
         </Column>
         <Row gap="8" vertical="center" wrap>
-          <Tag size="s">{statusLabel}</Tag>
+          <Row gap="4" vertical="center">
+            <Tag
+              size="s"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              {statusLabel}
+            </Tag>
+            <RefreshAnimation
+              active={isFetching}
+              ariaLabel={
+                isFetching
+                  ? "Refreshing market watchlist data"
+                  : "Market watchlist data idle"
+              }
+            />
+          </Row>
           {error
             ? (
               <Text variant="label-default-s" onBackground="danger-strong">

--- a/apps/web/components/dynamic-portfolio/home/RefreshAnimation.module.css
+++ b/apps/web/components/dynamic-portfolio/home/RefreshAnimation.module.css
@@ -1,0 +1,81 @@
+.frame {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 1.5rem;
+  pointer-events: none;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  overflow: visible;
+}
+
+.glow {
+  position: absolute;
+  inset: -25%;
+  background: radial-gradient(
+    circle at center,
+    rgba(0, 240, 255, 0.38),
+    rgba(0, 152, 234, 0.08) 55%,
+    rgba(0, 152, 234, 0) 85%
+  );
+  filter: blur(12px);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.animation,
+.placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  pointer-events: none;
+}
+
+.placeholder {
+  background: linear-gradient(
+    120deg,
+    rgba(0, 152, 234, 0.22) 0%,
+    rgba(0, 240, 255, 0.45) 50%,
+    rgba(0, 152, 234, 0.25) 100%
+  );
+  background-size: 180% 180%;
+  box-shadow: 0 0 12px rgba(0, 152, 234, 0.35);
+  animation: tonSweep 1.6s ease-in-out infinite;
+}
+
+.canvas {
+  width: 100%;
+  height: 100%;
+  opacity: 0.92;
+  mix-blend-mode: screen;
+  filter: drop-shadow(0 0 10px rgba(0, 152, 234, 0.35));
+}
+
+@keyframes tonSweep {
+  0% {
+    background-position: 0% 50%;
+    opacity: 0.5;
+    transform: scale(0.94);
+  }
+  50% {
+    background-position: 100% 50%;
+    opacity: 0.95;
+    transform: scale(1);
+  }
+  100% {
+    background-position: 0% 50%;
+    opacity: 0.5;
+    transform: scale(0.94);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .placeholder {
+    animation: none;
+  }
+}

--- a/apps/web/components/dynamic-portfolio/home/RefreshAnimation.tsx
+++ b/apps/web/components/dynamic-portfolio/home/RefreshAnimation.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { type ComponentType, memo, useEffect, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import { cn } from "@/utils";
+
+import type { InteractiveAsciiProps } from "@/components/landing/InteractiveAscii";
+import styles from "./RefreshAnimation.module.css";
+
+type InteractiveAsciiComponent = ComponentType<InteractiveAsciiProps>;
+
+type RefreshAnimationProps = {
+  active: boolean;
+  ariaLabel?: string;
+  className?: string;
+};
+
+const ASCII_PRESET = {
+  backgroundColor: "transparent",
+  outputWidth: 68,
+  brightness: 11,
+  contrast: 19,
+  ditheringMode: "ordered",
+  characterSet: "detailed",
+  color: {
+    mode: "gradient",
+    color1: "#0098EA",
+    color1Point: 14,
+    color2: "#00F0FF",
+    color2Point: 88,
+  },
+  cursor: {
+    style: "gradient",
+    width: 16,
+    smoothing: 26,
+    invert: false,
+  },
+  glow: { blur: 18, opacity: 0.28 },
+  staticEffect: { interval: 0.32 },
+  font: { fontSize: "10px", lineHeight: "1.08em", fontWeight: 600 },
+} satisfies Partial<InteractiveAsciiProps>;
+
+function RefreshAnimationComponent({
+  active,
+  ariaLabel = "Live data refreshing",
+  className,
+}: RefreshAnimationProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const [interactiveAscii, setInteractiveAscii] = useState<
+    InteractiveAsciiComponent | null
+  >(null);
+
+  useEffect(() => {
+    if (!active || prefersReducedMotion || interactiveAscii) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void import("@/components/landing/InteractiveAscii").then((module) => {
+      if (!cancelled) {
+        setInteractiveAscii(() => module.InteractiveAscii);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [active, interactiveAscii, prefersReducedMotion]);
+
+  const Ascii = interactiveAscii;
+  const shouldAnimate = Boolean(Ascii && active);
+  const label = ariaLabel;
+
+  if (prefersReducedMotion) {
+    return null;
+  }
+
+  return (
+    <span className={cn(styles.frame, className)}>
+      <span className={styles.glow} aria-hidden="true" />
+      <AnimatePresence initial={false} mode="wait">
+        {shouldAnimate
+          ? (
+            <motion.span
+              key="refresh-ascii"
+              className={styles.animation}
+              role="img"
+              aria-label={label}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.24, ease: "easeOut" }}
+            >
+              <Ascii className={styles.canvas} {...ASCII_PRESET} />
+            </motion.span>
+          )
+          : active
+          ? (
+            <motion.span
+              key="refresh-placeholder"
+              className={styles.placeholder}
+              role="img"
+              aria-label={label}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.95 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            />
+          )
+          : null}
+      </AnimatePresence>
+    </span>
+  );
+}
+
+export const RefreshAnimation = memo(RefreshAnimationComponent);
+
+export type { RefreshAnimationProps };


### PR DESCRIPTION
## Summary
- lazy-load the InteractiveAscii effect only when refresh activity is present to avoid eager bundle work
- retune the animation preset and fallback styling with TON-inspired gradients and a lightweight placeholder glow for active states

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8e006979c83229cb3a940e700e02a