### PR TITLE
Optimize ASCII engine rendering

### DIFF
--- a/dynamic_ascii/__init__.py
+++ b/dynamic_ascii/__init__.py
@@ -1,0 +1,21 @@
+"""ASCII art orchestration for collectible generation."""
+
+from __future__ import annotations
+
+from .engine import (
+    AsciiCanvas,
+    AsciiConversionError,
+    AsciiNFT,
+    AsciiPalette,
+    DynamicAsciiEngine,
+    DEFAULT_ASCII_PALETTE,
+)
+
+__all__ = [
+    "AsciiCanvas",
+    "AsciiConversionError",
+    "AsciiNFT",
+    "AsciiPalette",
+    "DynamicAsciiEngine",
+    "DEFAULT_ASCII_PALETTE",
+]

--- a/dynamic_ascii/engine.py
+++ b/dynamic_ascii/engine.py
@@ -1,0 +1,341 @@
+"""Dynamic ASCII engine for generating collectible-friendly art."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from hashlib import sha256
+from io import BytesIO
+from pathlib import Path
+from typing import BinaryIO, Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "AsciiPalette",
+    "AsciiCanvas",
+    "AsciiNFT",
+    "AsciiConversionError",
+    "DynamicAsciiEngine",
+    "DEFAULT_ASCII_PALETTE",
+]
+
+
+class AsciiConversionError(RuntimeError):
+    """Raised when an ASCII rendering operation cannot be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class AsciiPalette:
+    """Mapping between intensity values and printable glyphs."""
+
+    characters: tuple[str, ...]
+    _lookup: tuple[str, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.characters:
+            raise ValueError("characters must not be empty")
+        normalised: list[str] = []
+        for char in self.characters:
+            if not isinstance(char, str):  # pragma: no cover - defensive guard
+                raise TypeError("palette entries must be strings")
+            cleaned = char.strip("\n\r")
+            if not cleaned:
+                raise ValueError("palette entries must contain printable characters")
+            normalised.append(cleaned)
+        palette = tuple(normalised)
+        object.__setattr__(self, "characters", palette)
+        object.__setattr__(self, "_lookup", self._build_lookup(palette))
+
+    def map_intensity(self, value: float | int) -> str:
+        """Return the glyph that best represents *value* in the palette."""
+
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            raise ValueError("intensity values must be finite")
+        if numeric <= 0.0:
+            return self._lookup[0]
+        if numeric >= 255.0:
+            return self._lookup[255]
+        if numeric <= 1.0:
+            index = int(numeric * 255.0 + 0.5)
+        else:
+            index = int(numeric + 0.5)
+        return self._lookup[min(index, 255)]
+
+    def __len__(self) -> int:
+        return len(self.characters)
+
+    @staticmethod
+    def _build_lookup(palette: tuple[str, ...]) -> tuple[str, ...]:
+        if len(palette) == 1:
+            return (palette[0],) * 256
+        scale = len(palette) - 1
+        lookup = [palette[0]] * 256
+        for value in range(256):
+            index = ((value * scale) + 127) // 255
+            lookup[value] = palette[min(index, scale)]
+        return tuple(lookup)
+
+
+DEFAULT_ASCII_PALETTE = AsciiPalette(tuple(" .:-=+*#%@"))
+
+
+@dataclass(slots=True)
+class AsciiCanvas:
+    """Immutable ASCII canvas representing rendered art."""
+
+    width: int
+    height: int
+    rows: tuple[str, ...]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError("width and height must be positive")
+        if len(self.rows) != self.height:
+            raise ValueError("rows length must match height")
+        for row in self.rows:
+            if len(row) != self.width:
+                raise ValueError("all rows must have width characters")
+        if not isinstance(self.metadata, Mapping):  # pragma: no cover - defensive guard
+            raise TypeError("metadata must be a mapping")
+
+    def as_text(self) -> str:
+        return "\n".join(self.rows)
+
+
+@dataclass(slots=True)
+class AsciiNFT:
+    """Representation of an ASCII-based NFT collectible."""
+
+    title: str
+    description: str
+    ascii_art: AsciiCanvas
+    fingerprint: str
+    attributes: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.title:
+            raise ValueError("title must not be empty")
+        if not self.description:
+            raise ValueError("description must not be empty")
+        if not self.fingerprint:
+            raise ValueError("fingerprint must not be empty")
+        if not isinstance(self.attributes, Mapping):  # pragma: no cover - defensive guard
+            raise TypeError("attributes must be a mapping")
+
+    def as_metadata(self) -> Mapping[str, object]:
+        """Return a serialisable metadata representation."""
+
+        payload: MutableMapping[str, object] = {
+            "name": self.title,
+            "description": self.description,
+            "image": self.ascii_art.as_text(),
+            "hash": self.fingerprint,
+        }
+        if self.attributes:
+            payload["attributes"] = dict(self.attributes)
+        return payload
+
+
+class DynamicAsciiEngine:
+    """Engine for transforming imagery into ASCII art collectibles."""
+
+    def __init__(
+        self,
+        palette: AsciiPalette | None = None,
+        *,
+        height_scale: float = 0.55,
+    ) -> None:
+        if height_scale <= 0:
+            raise ValueError("height_scale must be positive")
+        self.palette = palette or DEFAULT_ASCII_PALETTE
+        self.height_scale = float(height_scale)
+
+    def render_ascii(
+        self,
+        image: Sequence[Sequence[float]] | Sequence[Sequence[int]] | str | Path | BinaryIO | bytes,
+        *,
+        width: int | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> AsciiCanvas:
+        """Render *image* into an :class:`AsciiCanvas`."""
+
+        pixel_matrix = self._load_pixels(image)
+        source_height = len(pixel_matrix)
+        if source_height == 0:
+            raise AsciiConversionError("image must contain at least one row")
+        source_width = len(pixel_matrix[0])
+        if source_width == 0:
+            raise AsciiConversionError("image must contain at least one column")
+        if width is None:
+            target_width = source_width
+        else:
+            target_width = int(width)
+        if target_width <= 0:
+            raise ValueError("width must be positive")
+        aspect_ratio = source_height / source_width
+        target_height = max(1, int(round(target_width * aspect_ratio * self.height_scale)))
+        resized = self._resize_pixels(pixel_matrix, target_width, target_height)
+        rows = tuple(
+            "".join(self.palette.map_intensity(value) for value in row)
+            for row in resized
+        )
+        canvas_metadata: dict[str, object] = {
+            "source_width": source_width,
+            "source_height": source_height,
+            "palette": "".join(self.palette.characters),
+        }
+        if metadata:
+            canvas_metadata.update(dict(metadata))
+        return AsciiCanvas(
+            width=target_width,
+            height=len(rows),
+            rows=rows,
+            metadata=canvas_metadata,
+        )
+
+    def create_nft(
+        self,
+        image: Sequence[Sequence[float]] | Sequence[Sequence[int]] | str | Path | BinaryIO | bytes,
+        *,
+        name: str,
+        description: str,
+        width: int | None = None,
+        attributes: Mapping[str, object] | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> AsciiNFT:
+        """Create an :class:`AsciiNFT` from *image*."""
+
+        canvas = self.render_ascii(image, width=width, metadata=metadata)
+        ascii_payload = canvas.as_text().encode("utf-8")
+        digest = sha256(ascii_payload).hexdigest()
+        merged_attributes: dict[str, object] = {
+            "width": canvas.width,
+            "height": canvas.height,
+            "palette_size": len(self.palette),
+        }
+        if attributes:
+            merged_attributes.update(dict(attributes))
+        return AsciiNFT(
+            title=name,
+            description=description,
+            ascii_art=canvas,
+            fingerprint=digest,
+            attributes=merged_attributes,
+        )
+
+    # ------------------------------------------------------------------
+    # internal helpers
+
+    def _load_pixels(
+        self,
+        image: Sequence[Sequence[float]] | Sequence[Sequence[int]] | str | Path | BinaryIO | bytes,
+    ) -> list[list[int]]:
+        if isinstance(image, (str, Path)):
+            return self._load_from_pillow(Path(image))
+        if isinstance(image, bytes):
+            return self._load_from_pillow(BytesIO(image))
+        if hasattr(image, "read") and callable(image.read):  # BinaryIO protocol
+            return self._load_from_pillow(image)  # type: ignore[arg-type]
+        if self._looks_like_matrix(image):
+            return self._normalise_matrix(image)  # type: ignore[arg-type]
+        # Pillow Image instance support
+        pil_image = getattr(image, "convert", None)
+        if callable(pil_image):
+            return self._load_from_pillow(image)
+        raise AsciiConversionError("unsupported image type for ASCII conversion")
+
+    def _looks_like_matrix(
+        self, value: Sequence[Sequence[float]] | Sequence[Sequence[int]]
+    ) -> bool:
+        if not isinstance(value, Sequence):
+            return False
+        if not value:
+            return False
+        first = value[0]
+        if not isinstance(first, Sequence):
+            return False
+        return True
+
+    def _normalise_matrix(
+        self, matrix: Sequence[Sequence[float]] | Sequence[Sequence[int]]
+    ) -> list[list[int]]:
+        width: int | None = None
+        normalised: list[list[int]] = []
+        for row in matrix:
+            if not isinstance(row, Sequence):
+                raise AsciiConversionError("rows must be sequences")
+            if width is None:
+                width = len(row)
+                if width == 0:
+                    raise AsciiConversionError("rows must contain values")
+            elif len(row) != width:
+                raise AsciiConversionError("rows must be of equal length")
+            normalised_row: list[int] = []
+            for value in row:
+                normalised_row.append(self._clamp(float(value)))
+            normalised.append(normalised_row)
+        return normalised
+
+    def _load_from_pillow(self, source: Path | BinaryIO | object) -> list[list[int]]:
+        try:
+            from PIL import Image
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise AsciiConversionError(
+                "Pillow is required to load image sources"
+            ) from exc
+        try:
+            if isinstance(source, Path):
+                with Image.open(source) as img:
+                    return self._image_to_matrix(img)
+            if hasattr(source, "seek"):
+                pos = source.seek(0, 1)  # type: ignore[arg-type]
+            else:
+                pos = None
+            image = Image.open(source)
+            try:
+                return self._image_to_matrix(image)
+            finally:
+                image.close()
+                if pos is not None and hasattr(source, "seek"):
+                    source.seek(pos)  # type: ignore[arg-type]
+        except FileNotFoundError as exc:
+            raise AsciiConversionError("image path could not be found") from exc
+        except OSError as exc:
+            raise AsciiConversionError("failed to decode image") from exc
+
+    def _image_to_matrix(self, image: object) -> list[list[int]]:
+        convert = getattr(image, "convert")
+        gray = convert("L")
+        width, height = gray.size
+        pixels = list(gray.getdata())
+        matrix: list[list[int]] = []
+        for y in range(height):
+            row = pixels[y * width : (y + 1) * width]
+            matrix.append([self._clamp(float(value)) for value in row])
+        return matrix
+
+    def _resize_pixels(
+        self, matrix: Sequence[Sequence[int]], width: int, height: int
+    ) -> list[list[int]]:
+        source_height = len(matrix)
+        source_width = len(matrix[0])
+        if source_height == height and source_width == width:
+            return [list(row) for row in matrix]
+        scale_x = source_width / width
+        scale_y = source_height / height
+        x_indices = [min(int(x * scale_x), source_width - 1) for x in range(width)]
+        y_indices = [min(int(y * scale_y), source_height - 1) for y in range(height)]
+        resized: list[list[int]] = []
+        for source_y in y_indices:
+            row_source = matrix[source_y]
+            resized.append([row_source[source_x] for source_x in x_indices])
+        return resized
+
+    @staticmethod
+    def _clamp(value: float) -> int:
+        if value <= 0.0:
+            return 0
+        if value >= 255.0:
+            return 255
+        return int(value + 0.5)

--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -22,6 +22,14 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "DynamicArchitectAgent",
         "DynamicArchitectBot",
     ),
+    "dynamic_ascii": (
+        "DynamicAsciiEngine",
+        "AsciiNFT",
+        "AsciiCanvas",
+        "AsciiPalette",
+        "DEFAULT_ASCII_PALETTE",
+        "AsciiConversionError",
+    ),
     "dynamic_agents": ("DynamicChatAgent",),
     "dynamic_assign": ("DynamicAssignEngine",),
     "dynamic_ai": (

--- a/tests_python/test_dynamic_ascii.py
+++ b/tests_python/test_dynamic_ascii.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from dynamic_ascii import (  # noqa: E402  (import after path setup)
+    DEFAULT_ASCII_PALETTE,
+    AsciiNFT,
+    AsciiPalette,
+    DynamicAsciiEngine,
+)
+
+
+def _sample_matrix() -> list[list[int]]:
+    return [
+        [0, 64, 128, 255],
+        [255, 128, 64, 0],
+        [30, 90, 190, 220],
+        [5, 10, 15, 20],
+    ]
+
+
+def test_render_ascii_from_matrix() -> None:
+    palette = AsciiPalette((" ", ".", "#"))
+    engine = DynamicAsciiEngine(palette=palette, height_scale=1.0)
+    canvas = engine.render_ascii(_sample_matrix(), width=4)
+
+    assert canvas.width == 4
+    assert canvas.height == 4
+    assert canvas.rows[0] == " ..#"
+    assert canvas.rows[1] == "#.. "
+    assert "source_width" in canvas.metadata
+    assert canvas.metadata["palette"] == " .#"
+
+
+def test_create_nft_generates_consistent_fingerprint() -> None:
+    engine = DynamicAsciiEngine(height_scale=1.0)
+    canvas = engine.render_ascii(_sample_matrix(), width=4)
+    nft = engine.create_nft(_sample_matrix(), name="Nebula", description="A test", width=4)
+
+    assert isinstance(nft, AsciiNFT)
+    assert nft.ascii_art.rows == canvas.rows
+    expected_hash = sha256(canvas.as_text().encode("utf-8")).hexdigest()
+    assert nft.fingerprint == expected_hash
+    assert nft.attributes["palette_size"] == len(DEFAULT_ASCII_PALETTE)
+
+
+def test_render_ascii_rejects_invalid_width() -> None:
+    engine = DynamicAsciiEngine()
+    with pytest.raises(ValueError):
+        engine.render_ascii(_sample_matrix(), width=0)


### PR DESCRIPTION
## Summary
- precompute ASCII palette lookup tables and allow byte intensities to avoid repeated float math per pixel
- normalize rendering helpers to operate on 0-255 byte matrices and reuse resize indices for faster downscaling

## Testing
- pytest tests_python/test_dynamic_ascii.py
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d8e343186c832281d7a6d807afab35