### PR TITLE
Add Dynamic Capital company dossier

### DIFF
--- a/docs/company-profile-dossier.md
+++ b/docs/company-profile-dossier.md
@@ -1,0 +1,56 @@
+# Dynamic Capital Company Dossier
+
+## Company Profile
+- **Founding context:** The repository does not document an incorporation date or origin story for Dynamic Capital; no founding narrative is presently available.
+- **Registered headquarters:** Compliance records list the head office at 650 Market Street, Suite 1200, San Francisco, CA 94105, USA, under the ISO/IEC 27001 certificate of registration.【F:docs/compliance/iso-27001.md†L1-L45】
+- **Operating desk location:** Product content defaults to the Indian/Maldives timezone with a Malé, Maldives label, reflecting the trading desk’s working hours and on-the-ground presence.【F:apps/web/resources/content.tsx†L18-L40】
+- **Business model:** Dynamic Capital runs a Telegram-first deposit automation platform with an optional Next.js Mini App that verifies bank receipts and crypto transfers, couples automation guardrails to mentor workflows, and offers institutional-grade trading tooling.【F:README.md†L1-L58】【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L191-L239】
+- **Primary audience:** Service copy highlights specialist cohorts for founders, funds, operators, and disciplined traders who require readiness scoring, automation guardrails, and mentor oversight.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L60-L108】【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L223-L239】
+- **Owner and contacts:** The founder is Abdul Mumin Ibun Aflhal, with contact channels spanning email, Telegram, phone, and public profiles maintained in the marketing content bundle.【F:apps/web/resources/content.tsx†L31-L94】【F:content/people.json†L1-L8】
+- **Mission & purpose:** The core playbook centers on building merciful, ethical wealth that uplifts communities, enforced through quarterly mission reviews and explicit mission briefs for every initiative.【F:docs/dynamic-capital-core-playbook.md†L1-L35】
+- **First six-month milestones:** The milestone ladder targets a Foundation stage in weeks 0–8 (unified telemetry, automations) followed by Productization in months 3–6 (revenue-grade onboarding and verified settlement pathways).【F:docs/dynamic-capital-milestones.md†L9-L36】
+
+## Company Details
+- **Services offered:** Desk Intake, Automation Ops, Mentor Bridge, Loss Recovery Programme, and Capital Bridge deliver guided planning, automated risk controls, mentor escalations, loss turnaround audits, and funding handoffs once readiness scores pass threshold.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L191-L276】
+- **Delivery model:** Customer journeys calibrate playbooks in the first week, with automation guardrails syncing journals, risk locks, and mentor reviews; deposit flows run through Telegram bots and Supabase approvals for verified activation.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L77-L168】【F:docs/FLOW_OVERVIEW.md†L1-L21】
+- **Monthly service spend:** Budget guidance allocates MVR 15k–30k per month for office space, MVR 5k–10k for social advertising, and MVR 50k–100k for salaries, alongside other legal, licensing, marketing, and capital reserves.【F:docs/dct-budget-audit.md†L18-L99】
+- **Quality control:** Web observability SLOs enforce 99.9% availability, P95 latency ≤500 ms, and saturation limits with Prometheus-backed alerts, while the security playbook mandates <2% non-compliant endpoints, sub-15-minute detection, and layered incident runbooks.【F:docs/observability-slos.md†L1-L80】【F:docs/dynamic-capital-security-playbook.md†L1-L158】
+
+## Service Footprint & Market Position
+- **Geographic coverage:** Trust marks tout London, Dubai, and Singapore desks to keep coverage across major market opens, with compliance-first controls and regulated connectivity.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L170-L189】
+- **Target customers:** Automation metrics and mentor features emphasise readiness automation for professional desks, with specialist cohorts and risk-first turnaround for disciplined traders.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L60-L145】【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L223-L239】
+- **Competitive landscape:** The repository does not list peer companies or formal competitor summaries.
+- **Market advantages & gaps:** Differentiators include compliance-aligned guardrails, automated risk locks, mentor escalations, and institutional funding bridges; no explicit disadvantages are recorded in the documentation.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L128-L239】
+
+## Marketing & Growth
+- **Promotion channels:** Published channels cover the website, Telegram, Instagram, Facebook, TradingView, email, and phone, complemented by promo-code, referral, broadcast, and funnel tracking flows in the growth phase playbook.【F:apps/web/resources/content.tsx†L53-L94】【F:docs/PHASE_08_GROWTH.md†L1-L40】
+- **Monthly profit outlook:** No monthly profit estimates are documented in the repository.
+- **Differentiation strategy:** Messaging leans on compliance-first workflows, automation guardrails, and mentor access to stand out against generic trading communities.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L66-L168】
+- **Annual gain projections:** The repository does not disclose historical or forecast gain percentages.
+
+## Management & Talent
+- **Job opportunities:** The trading team compensation guide outlines salaried bands for administrative staff, analysts, and risk managers alongside trader profit-sharing, IB commissions, and bonus frameworks.【F:docs/human-resources/trading-compensation.md†L1-L139】
+- **Organization chart:** No formal organization chart is published.
+- **Investors & entities:** Budget segmentation describes three operating entities—Token Issuer Ltd., Asset Management Ltd., and Platform Services Ltd.—with respective licensing obligations; individual investors are not enumerated.【F:docs/dct-budget-audit.md†L10-L16】
+- **Employee development:** People & Culture practices include quarterly talent calibration, monthly mentorship circles, role scorecards, and mentorship chain tracking to grow team capability.【F:docs/dynamic-capital-core-playbook.md†L104-L119】
+
+## Work Plan & Financing
+- **Expansion expenses:** Planned outlays include company registration (MVR 10k–20k), licensing (MVR 20k–50k), branding (MVR 10k–30k), social advertising (MVR 5k–10k/month), workshops (MVR 5k–15k/event), proprietary trading capital (USD 50k–100k), and payroll (MVR 50k–100k/month).【F:docs/dct-budget-audit.md†L18-L83】
+- **Capital invested:** No aggregate invested-capital figure is provided.
+- **Loan facilities:** The documentation does not describe any loan amounts or structures.
+- **Loan deployment plan:** Without loan data, no staged loan utilization roadmap is available.
+
+## Cost, Expense & Profit Outlook
+- **12-month cost view:** While the audit lists recurring monthly ranges for rent, salaries, and marketing, it does not roll them into a full 12-month projection; these ranges remain the best available view.【F:docs/dct-budget-audit.md†L45-L83】
+- **Four-year estimates:** Long-range cost or expense forecasts are not documented.
+- **Profit expectations:** The repository does not provide profit projections.
+- **Loan repayment:** Repayment schedules are absent due to the lack of loan disclosures.
+
+## Future Strategy & Contingency
+- **Long-term roadmap:** Beyond the first six months, milestones progress through Network Proof (months 6–9) for community loops, Capital Scale (months 9–15) for liquidity expansion, and a Regenerative Flywheel (15+ months) for autonomous incentives and reinvestment loops.【F:docs/dynamic-capital-milestones.md†L9-L54】
+- **Loss recovery planning:** The Loss Recovery Programme offers audited turnaround plans with senior strategists, supported by adaptive resilience pillars that require scenario planning and contingency reserves.【F:apps/web/components/dynamic-portfolio/DynamicCapitalLandingPage.tsx†L223-L228】【F:docs/dynamic-capital-pillars-playbook.md†L13-L60】
+- **Future projects:** Stage playbooks call for guardian councils, builder readiness indices, liquidity stress tests, and automated incentive tuning as the roadmap advances through later milestones.【F:docs/dynamic-capital-milestones.md†L31-L54】
+
+## Societal Impact & Principles
+- **Service to society:** Pillars commit to community wealth and justice through mission-aligned investment criteria, impact dashboards, and equitable governance, reinforcing that capital must uplift vulnerable communities.【F:docs/dynamic-capital-pillars-playbook.md†L7-L49】
+- **Foundational principles:** The Values Playbook codifies Tawhid, Amanah, Adl, Ihsan, Rahmah, Sabr, Shura, and Barakah—calling for ethical stewardship, justice, excellence, mercy, resilience, consultation, and community-benefiting growth before launching any initiative.【F:docs/dynamic-capital-values-playbook.md†L1-L80】


### PR DESCRIPTION
## Summary
- add a company-profile dossier that consolidates existing documentation into a single reference
- surface available data on services, budgets, roadmap, and values while noting undisclosed areas

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d8e48429948322aa077f123dd072c5