### PR TITLE
Document go-live checklist dry run

### DIFF
--- a/docs/checklist-run-log.md
+++ b/docs/checklist-run-log.md
@@ -1,25 +1,108 @@
 # Checklist Runner Log
 
-This log captures useful invocations of the internal checklist tooling along with
-notes on the resulting output. Use it as a quick reference when deciding which
-entry point to reach for.
+This log captures useful invocations of the internal checklist tooling along
+with notes on the resulting output. Reference it when deciding which entry point
+is the best fit for the task at hand.
+
+## Table of Contents
+
+- [Quick Reference](#quick-reference)
+- [Command Playbooks](#command-playbooks)
+  - [2025-09-28 — Current Checklist Catalog Verification](#2025-09-28--current-checklist-catalog-verification)
+  - [2025-09-28 — Go-Live Checklist Dry Run](#2025-09-28--go-live-checklist-dry-run)
+  - [2024-02-24 — Listing Available Checklists](#2024-02-24--listing-available-checklists)
+  - [2024-02-24 — Viewing CLI Help](#2024-02-24--viewing-cli-help)
 
 ## Quick Reference
 
-| Scenario | Command | Notes |
-| --- | --- | --- |
-| Fast local runs that bypass npm wrappers. | `node scripts/run-checklists.js --list` | Emits the raw listing immediately. Use when iterating on the script itself. |
-| Runs that require project hooks or environment bootstrapping. | `npm run checklists -- --list` | Executes through npm so lifecycle hooks (`prechecklists`, `.env` loading, etc.) run automatically. |
-| Need usage guidance before choosing a subcommand. | `npm run checklists` | Shows help text describing `--list`, named checklists, and additional options. |
+| Scenario | Command | When to Use | Output Highlights |
+| --- | --- | --- | --- |
+| Fast local runs that bypass npm wrappers. | `node scripts/run-checklists.js --list` | Iterate on the script directly without lifecycle hooks or npm overhead. | Streams the checklist metadata immediately in plain text. |
+| Runs that require project hooks or environment bootstrapping. | `npm run checklists -- --list` | Respect npm lifecycle hooks (`prechecklists`, `.env` loading, etc.) while listing the catalog. | Mirrors the raw list while honoring repository setup requirements. |
+| Preview a specific checklist without executing tasks. | `node scripts/run-checklists.js --checklist <name> --dry-run` | Validate the task inventory before running the automation in CI or production. | Prints the planned tasks, references, and notes without triggering side effects. |
+| Need usage guidance before choosing a subcommand. | `npm run checklists` | Remind yourself of the supported options or share quick guidance with teammates. | Displays the built-in help banner with usage examples. |
 
-## 2024-02-24 — Listing Available Checklists
+## Command Playbooks
 
-The first comparison between the direct Node entry point and the npm wrapper highlighted a few practical differences:
+### 2025-09-28 — Current Checklist Catalog Verification
 
-- **Node script** — streams the full checklist metadata (name, description, references, and library entries) without extra framing.
-- **npm wrapper** — mirrors the same listing while ensuring project-level environment variables and npm lifecycle hooks fire before execution.
+**Command**
 
-### Output Snapshot
+```bash
+node scripts/run-checklists.js --list
+```
+
+**Purpose**
+
+Confirm the latest catalog of checklists and surface any newly added entries or
+task descriptions.
+
+**Highlights**
+
+- Matches the snapshot below and now includes additional checklist families such
+  as `dynamic-ui`, `variables-and-links`, `go-live`, and `setup-followups`.
+- Each entry links to the reference documentation and enumerates the associated
+  required tasks.
+
+### 2025-09-28 — Go-Live Checklist Dry Run
+
+**Command**
+
+```bash
+node scripts/run-checklists.js --checklist go-live --dry-run
+```
+
+**Purpose**
+
+Preview the go-live verification flow without invoking external dependencies
+while confirming the required task inventory.
+
+**Highlights**
+
+- Surfaces a single required task that checks the Telegram webhook
+  configuration.
+- References the primary documentation for deeper instructions and stores the
+  task definition under the `go-live` checklist.
+- Demonstrates the dry-run experience so operators know what to expect before
+  executing the checklist in production.
+
+**Output Snapshot**
+
+```text
+[checklists] TELEGRAM_BOT_TOKEN missing; using fixtures/telegram-webhook-info.json for webhook checks.
+Planned tasks (1):
+
+1. Check Telegram webhook configuration (deno run -A scripts/check-webhook.ts)
+   Command: deno run -A scripts/check-webhook.ts
+   Type: required
+   Sources: go-live
+   References: docs/dynamic-capital-checklist.md
+   Notes: Verifies that the Telegram bot webhook is reachable and configured with the expected URL.
+
+Dry run enabled. No commands were executed.
+```
+
+### 2024-02-24 — Listing Available Checklists
+
+**Command**
+
+```bash
+node scripts/run-checklists.js --list
+```
+
+**Purpose**
+
+Compare the direct Node entry point with the npm wrapper and document the
+differences that matter during local development.
+
+**Highlights**
+
+- Node script streams the full checklist metadata (name, description,
+  references, and library entries) without extra framing.
+- npm wrapper mirrors the same listing while ensuring project-level environment
+  variables and npm lifecycle hooks fire before execution.
+
+**Output Snapshot**
 
 ```text
 Available checklists:
@@ -36,47 +119,21 @@ Available checklists:
 > The listing continues for every checklist, surfacing each description,
 > reference document, and associated tasks (including optional items where noted).
 
-## 2025-09-28 — Current Checklist Catalog Verification
+### 2024-02-24 — Viewing CLI Help
 
-- Command: `node scripts/run-checklists.js --list`
-- Purpose: Confirm the latest catalog of checklists and surface any newly added
-  entries or task descriptions.
-- Output summary: Matches the snapshot above and now includes new checklist families such as:
-  - `dynamic-ui`
-  - `variables-and-links`
-  - `go-live`
-  - `setup-followups`
-  Each entry links to reference documentation and enumerates the required tasks.
+**Command**
 
-## 2025-09-28 — Go-Live Checklist Dry Run
-
-- Command: `node scripts/run-checklists.js --checklist go-live --dry-run`
-- Purpose: Preview the go-live verification flow without invoking external
-  dependencies while confirming the required task inventory.
-- Output summary: Shows a single required task that checks the Telegram webhook
-  configuration and links back to the primary documentation for deeper
-  instructions.
-
-### Output Snapshot
-
-```text
-[checklists] TELEGRAM_BOT_TOKEN missing; using fixtures/telegram-webhook-info.json for webhook checks.
-Planned tasks (1):
-
-1. Check Telegram webhook configuration (deno run -A scripts/check-webhook.ts)
-   Command: deno run -A scripts/check-webhook.ts
-   Type: required
-   Sources: go-live
-   References: docs/dynamic-capital-checklist.md
-   Notes: Verifies that the Telegram bot webhook is reachable and configured with the expected URL.
-
-Dry run enabled. No commands were executed.
+```bash
+npm run checklists
 ```
 
-## 2024-02-24 — Viewing CLI Help
+**Purpose**
 
-- Command: `npm run checklists`
-- Purpose: Displays usage guidance and supported options for the checklist
-  runner.
-- Output summary: Shows the default help banner and reminds you to supply
-  `--list`, a checklist name, or other parameters to run targeted entries.
+Display usage guidance and supported options for the checklist runner.
+
+**Highlights**
+
+- Shows the default help banner and reminds you to supply `--list`, a checklist
+  name, or other parameters to run targeted entries.
+- Helpful when onboarding teammates or refreshing your memory of supported
+  commands.


### PR DESCRIPTION
## Summary
- log the go-live checklist dry-run command and its output snapshot for quick reference
- explain the purpose of the dry-run invocation and how it validates the Telegram webhook task

## Testing
- `node scripts/run-checklists.js --checklist go-live --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68d8eba776948322861457db96628e61