### PR TITLE
Add meta-model reference and plug-in equation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ import { FiActivity, FiHome, FiUser } from "react-icons/fi";
 
 Explore the broader platform anatomy and contributor guides:
 
+- [Master meta-model reference](models/meta_model.md) — shared state/control/dynamics grammar with module index.
 - [Dynamic Capital ecosystem anatomy](docs/dynamic-capital-ecosystem-anatomy.md)
 - [Dynamic AI overview](docs/dynamic-ai-overview.md)
 - [Dynamic Trading ALGO vs LOGIC](docs/dynamic-trading-algo-vs-logic.md)

--- a/models/dynamic_agents/eq_consensus.md
+++ b/models/dynamic_agents/eq_consensus.md
@@ -1,0 +1,27 @@
+# Multi-Agent Consensus Update
+
+**Modules:** `dynamic_agents`, `dynamic_syncronization`
+
+## Overview
+
+Average consensus pushes local states toward neighborhood means using a shared step size.
+
+## Dynamics
+
+For agent $i$ at iteration $k$:
+$$x_i(k+1) = x_i(k) + \alpha \sum_{j \in \mathcal{N}(i)} \big( x_j(k) - x_i(k) \big).$$
+
+## Parameters
+
+- $\alpha$ — consensus gain in $\theta$; select $0 < \alpha < 1/\Delta$ where $\Delta$ is the maximum node degree to ensure stability.
+- $\mathcal{N}(i)$ — neighborhood defined by the communication graph.
+
+## Meta-Model Mapping
+
+- State $x_t$ collects the stacked agent opinions.
+- Control $u_t$ may tune $\alpha$ or trigger asynchronous updates.
+- Disturbances $\xi_t$ capture link failures or delayed messages.
+
+## Notes
+
+Consensus residuals provide natural convergence metrics for $y_t$ and feed loss terms $\ell(y_t, u_t)$ measuring disagreement.

--- a/models/dynamic_agents/eq_mdp.md
+++ b/models/dynamic_agents/eq_mdp.md
@@ -1,0 +1,30 @@
+# Reinforcement Learning Skeleton
+
+**Modules:** `dynamic_agents`, `dynamic_assign`, `dynamic_task_manager`
+
+## Overview
+
+Markov decision processes capture sequential decision-making for agent policies and task dispatch.
+
+## Value Functions
+
+- State-value under policy $\pi$:
+  $$V^{\pi}(s) = \mathbb{E} \left[ \sum_{t \ge 0} \gamma^t r_t \mid s_0 = s \right].$$
+- Optimal policy selection:
+  $$\pi^* = \arg\max_{\pi} V^{\pi}(s).$$
+
+## Q-Learning Update
+
+Iterative value improvement follows
+$$Q(s,a) \leftarrow Q(s,a) + \eta \big( r + \gamma \max_{a'} Q(s', a') - Q(s,a) \big).$$
+
+## Parameters
+
+- Discount $\gamma \in [0,1)$ and learning rate $\eta$ reside in $\theta$.
+- Rewards $r$ derive from the loss $\ell(y_t, u_t)$ or domain-specific payoffs.
+
+## Integration Notes
+
+- The state $x_t$ encodes the environment representation, while $u_t$ indexes policy actions.
+- Convergence diagnostics for $Q$ updates can populate $y_t$ metrics (e.g., Bellman error norms).
+- Constraints ensure valid action spaces or task feasibility during learning.

--- a/models/dynamic_agents/eq_task_assignment.md
+++ b/models/dynamic_agents/eq_task_assignment.md
@@ -1,0 +1,30 @@
+# Task Assignment MILP
+
+**Modules:** `dynamic_agents`, `dynamic_assign`, `dynamic_task_manager`
+
+## Overview
+
+This formulation assigns agents to tasks with binary decision variables while minimizing total cost.
+
+## Decision Variables
+
+- $a_{ij} \in \{0, 1\}$ — assignment of agent $i$ to task $j$.
+
+## Objective
+
+Minimize the weighted assignment cost:
+$$\min_{a_{ij}} \sum_{i \in \text{agents}} \sum_{j \in \text{tasks}} c_{ij} \, a_{ij}.$$
+
+## Constraints
+
+- Every task is covered: $$\sum_{i} a_{ij} = 1 \quad \forall j.$$
+- Agents are single-tasked: $$\sum_{j} a_{ij} \le 1 \quad \forall i.$$
+- Binary feasibility: $$a_{ij} \in \{0,1\}.$$
+
+These constraints map to $c(x_t, u_t) \le 0$ by embedding the equality and inequality conditions as residuals.
+
+## Notes
+
+- $x_t$ captures task backlog state; $u_t$ includes the binary assignment matrix.
+- Cost coefficients $c_{ij}$ belong to $\theta$ and encode travel time, skill fit, or priority penalties.
+- Relaxations (e.g., continuous $a_{ij}$) can be introduced for large-scale heuristics; document the impact in module README files.

--- a/models/dynamic_api/eq_query_cost.md
+++ b/models/dynamic_api/eq_query_cost.md
@@ -1,0 +1,19 @@
+# Query Cost Estimation
+
+**Modules:** `dynamic_api`, `dynamic_graphql`, `dynamic_http`
+
+## Overview
+
+Aggregates per-field costs weighted by fan-out within a query plan.
+
+## Equation
+
+$$C(q) = \sum_{f \in q} \kappa_f \cdot \text{fanout}_f.$$
+
+- $\kappa_f$ — cost coefficients in $\theta$.
+- $\text{fanout}_f$ — expected expansion factor stored in $x_t$.
+
+## Notes
+
+- Controls $u_t$ apply query shaping or throttling when $C(q)$ exceeds thresholds.
+- Output metrics track cumulative query cost to enforce budgets.

--- a/models/dynamic_api/eq_token_bucket.md
+++ b/models/dynamic_api/eq_token_bucket.md
@@ -1,0 +1,20 @@
+# Token Bucket Rate Limiting
+
+**Modules:** `dynamic_api`, `dynamic_rate_limit`
+
+## Overview
+
+Controls request throughput using replenishing tokens.
+
+## Update Rule
+
+$$b_{t+1} = \min\big(B,\; b_t + \rho \Delta t - \text{cost}_t\big).$$
+
+- $B$ — bucket capacity ($\theta$).
+- $\rho$ — refill rate.
+- $\text{cost}_t$ — tokens consumed by current requests (control decision).
+
+## Notes
+
+- Enforce $b_{t+1} \ge 0$ via constraints; reject or defer traffic when depleted.
+- Output metrics include instantaneous token levels and rejection counts.

--- a/models/dynamic_benchmark/eq_error_metrics.md
+++ b/models/dynamic_benchmark/eq_error_metrics.md
@@ -1,0 +1,21 @@
+# Error Metrics (MAE and RMSE)
+
+**Modules:** `dynamic_benchmark`
+
+## Overview
+
+Quantifies predictive performance using mean absolute error and root-mean-square error.
+
+## Equations
+
+\[
+\text{MAE} = \frac{1}{n} \sum |y - \hat{y}|, \qquad \text{RMSE} = \sqrt{\frac{1}{n} \sum (y - \hat{y})^2}.
+\]
+
+- $y$ — observed outcomes, $\hat{y}$ — predictions (components of $y_t$ and $g(x_t)$).
+- Sample size $n$ tracked in state.
+
+## Notes
+
+- Loss terms include MAE/RMSE to penalize forecasting deviations.
+- Controls $u_t$ may switch models based on these metrics.

--- a/models/dynamic_benchmark/eq_throughput_latency.md
+++ b/models/dynamic_benchmark/eq_throughput_latency.md
@@ -1,0 +1,19 @@
+# Throughput and Parallel Latency Metrics
+
+**Modules:** `dynamic_benchmark`, `dynamic_version`
+
+## Overview
+
+Defines throughput as jobs per time and parallel latency via harmonic mean.
+
+## Equations
+
+$$X = \frac{N}{T}, \qquad T_p = \left( \sum_i \frac{1}{t_i} \right)^{-1}.$$
+
+- $N$ — completed units, $T$ — elapsed time.
+- $t_i$ — per-worker runtimes.
+
+## Notes
+
+- Track $X$ in outputs for performance baselines.
+- Controls adjust resource allocations to target $T_p$ improvements.

--- a/models/dynamic_blockchain/eq_51_attack.md
+++ b/models/dynamic_blockchain/eq_51_attack.md
@@ -1,0 +1,21 @@
+# 51% Attack Success Probability
+
+**Modules:** `dynamic_blockchain`, `dynamic_proof_of_work`
+
+## Overview
+
+Approximate probability that an attacker with hash share $q < 0.5$ overtakes $k$ confirmation blocks.
+
+## Equation
+
+$$P_{\text{success}} \approx \exp\big(-2 (1 - 2q)^2 k \big).$$
+
+## Parameters
+
+- $q$ — attacker hash share embedded in $\theta$ or derived from state $x_t$.
+- $k$ — confirmation depth configured by governance controls $u_t$.
+
+## Notes
+
+- Sensitivity analysis over $q$ informs security dashboards ($y_t$).
+- Constraint enforcement can require $P_{\text{success}} \le \epsilon$ for target security level.

--- a/models/dynamic_blockchain/eq_burn_stake.md
+++ b/models/dynamic_blockchain/eq_burn_stake.md
@@ -1,0 +1,19 @@
+# Effective Stake with Burns
+
+**Modules:** `dynamic_blockchain`, `dynamic_proof_of_burn`, `dynamic_stake`, `dynamic_token`
+
+## Overview
+
+Burn events modify validator weight by applying leverage on destroyed tokens.
+
+## Equation
+
+$$s_i' = s_i + \beta b_i$$
+
+- $s_i$ — pre-burn stake balance in $x_t$.
+- $b_i$ — burn amount captured in disturbance $\xi_t$ or control $u_t$.
+- $\beta$ — leverage factor defined in $\theta$.
+
+## Notes
+
+The updated stake $s_i'$ feeds downstream PoS selection probabilities and staking APY computations.

--- a/models/dynamic_blockchain/eq_poa_safety.md
+++ b/models/dynamic_blockchain/eq_poa_safety.md
@@ -1,0 +1,19 @@
+# Proof-of-Authority Finality Condition
+
+**Modules:** `dynamic_blockchain`, `dynamic_proof_of_authority`
+
+## Overview
+
+Proof-of-authority chains finalize blocks once enough validators sign, guaranteeing Byzantine fault tolerance.
+
+## Condition
+
+$$m \ge 2f + 1$$
+
+- $m$ — number of validator signatures collected (observed in $x_t$).
+- $f$ — maximum tolerated Byzantine nodes parameterized in $\theta$.
+
+## Integration
+
+- Controls $u_t$ influence signature solicitation strategies or validator rotation.
+- Constraints enforce the inequality to mark finality.

--- a/models/dynamic_blockchain/eq_pos_selection.md
+++ b/models/dynamic_blockchain/eq_pos_selection.md
@@ -1,0 +1,19 @@
+# Proof-of-Stake Selection Weight
+
+**Modules:** `dynamic_blockchain`, `dynamic_proof_of_stake`, `dynamic_validator`, `dynamic_wallet`
+
+## Overview
+
+Probability that validator $i$ proposes the next block based on stake weight.
+
+## Equation
+
+$$\Pr(i \text{ proposes}) = \frac{s_i}{\sum_j s_j}.$$
+
+- $s_i$ — effective stake for validator $i$ captured in state $x_t$.
+- The denominator aggregates across all active validators, potentially influenced by $\xi_t$ (joins/leaves).
+
+## Usage
+
+- Controls $u_t$ can adjust delegation strategies.
+- Output metrics track fairness and decentralization using this distribution.

--- a/models/dynamic_blockchain/eq_pow_expected_time.md
+++ b/models/dynamic_blockchain/eq_pow_expected_time.md
@@ -1,0 +1,19 @@
+# Proof-of-Work Expected Block Time
+
+**Modules:** `dynamic_blockchain`, `dynamic_proof_of_work`
+
+## Overview
+
+Proof-of-work mining yields stochastic block discovery with expected inter-arrival time proportional to network difficulty and inverse hash power.
+
+## Equation
+
+$$\mathbb{E}[T] = \frac{D}{H}$$
+
+- $D$ — current difficulty target (in $\theta$).
+- $H$ — aggregate network hash rate modeled as part of $x_t$ or disturbance $\xi_t$.
+
+## Usage
+
+- Controls $u_t$ include miner allocation or hash rate provisioning decisions.
+- The resulting $T$ feeds latency metrics $y_t$ and loss terms penalizing slow block production.

--- a/models/dynamic_blockchain/eq_space_probability.md
+++ b/models/dynamic_blockchain/eq_space_probability.md
@@ -1,0 +1,17 @@
+# Proof-of-Space Winning Probability
+
+**Modules:** `dynamic_blockchain`, `dynamic_proof_of_space`
+
+## Overview
+
+Proof-of-space leaders are selected proportionally to plot quality and storage capacity.
+
+## Relationship
+
+$$\Pr(\text{win}_i) \propto \text{quality}(\text{plot}_i) \times \text{capacity}_i.$$
+
+## Integration
+
+- Normalize the proportional relationship to obtain a valid probability distribution.
+- Plot quality metrics are stored in $x_t$; capacity adjustments may be controls $u_t$.
+- Outputs monitor fairness and reward allocation variance.

--- a/models/dynamic_blockchain/eq_staking_apy.md
+++ b/models/dynamic_blockchain/eq_staking_apy.md
@@ -1,0 +1,23 @@
+# Staking Annual Percentage Yield
+
+**Modules:** `dynamic_blockchain`, `dynamic_stake`, `dynamic_validator`
+
+## Overview
+
+Approximate the simple APY for staking rewards subject to slashing risk.
+
+## Equation
+
+$$\text{APY} \approx \frac{R_{\text{epoch}}}{\text{TotalStake}} \times \text{epochs}_{\text{year}} - \text{slashing\_risk}.$$
+
+## Parameters
+
+- $R_{\text{epoch}}$ — rewards per epoch in $\theta$.
+- $\text{TotalStake}$ — aggregate stake tracked in $x_t$.
+- $\text{epochs}_{\text{year}}$ — schedule parameter controlling compounding horizon.
+- $\text{slashing\_risk}$ — expected penalty rate from validator misbehavior.
+
+## Notes
+
+- Controls $u_t$ can rebalance delegations to target desired APY.
+- Output metrics compare realized yield versus the approximation to detect drift.

--- a/models/dynamic_blockchain/eq_token_emission.md
+++ b/models/dynamic_blockchain/eq_token_emission.md
@@ -1,0 +1,17 @@
+# Token Supply Evolution
+
+**Modules:** `dynamic_blockchain`, `dynamic_token`
+
+## Overview
+
+Tracks circulating supply via cumulative mints and burns.
+
+## Equation
+
+$$S(t) = S_0 + \sum_{\tau \le t} \text{mint}(\tau) - \sum_{\tau \le t} \text{burn}(\tau).$$
+
+## Notes
+
+- $S_0$ initializes the state $x_0$.
+- Mint and burn flows may enter as disturbances $\xi_t$ or be governed by controls $u_t$ (e.g., treasury actions).
+- Supply $S(t)$ feeds tokenomics dashboards and staking yield calculations.

--- a/models/dynamic_cache/eq_cache_hit.md
+++ b/models/dynamic_cache/eq_cache_hit.md
@@ -1,0 +1,19 @@
+# Cache Hit Rate (Che Approximation)
+
+**Modules:** `dynamic_cache`, `dynamic_cdn`
+
+## Overview
+
+Models item hit probability under the independent reference model.
+
+## Equation
+
+$$h_i = 1 - \exp(-\lambda_i T_C).$$
+
+- $\lambda_i$ — request rate for item $i$ (disturbance $\xi_t$).
+- $T_C$ — characteristic time determined from cache capacity constraint $\sum_i h_i \le C$.
+
+## Notes
+
+- Solve for $T_C$ numerically to satisfy capacity in the control loop.
+- Hit rates drive cache efficiency metrics in $y_t$ and penalty terms in $\ell(y_t, u_t)$.

--- a/models/dynamic_cache/eq_latency_budget.md
+++ b/models/dynamic_cache/eq_latency_budget.md
@@ -1,0 +1,19 @@
+# Latency Budget Aggregation
+
+**Modules:** `dynamic_http`, `dynamic_proxy`, `dynamic_load_balancer`
+
+## Overview
+
+Serial services accumulate latency budgets along the request path.
+
+## Equation
+
+$$T_{\text{end2end}} = \sum_k T_k.$$
+
+- $T_k$ — latency of stage $k$ (state component or disturbance).
+- Controls $u_t$ may re-order or bypass stages to manage the budget.
+
+## Notes
+
+- Constraint: $T_{\text{end2end}} \le T_{\text{SLO}}$ ensures overall response targets.
+- Monitor contributions per stage to prioritize optimization.

--- a/models/dynamic_cache/eq_load_split.md
+++ b/models/dynamic_cache/eq_load_split.md
@@ -1,0 +1,19 @@
+# Load Splitting Weights
+
+**Modules:** `dynamic_load_balancer`
+
+## Overview
+
+Distributes incoming traffic across servers to minimize the maximum utilization.
+
+## Constraints
+
+- Traffic allocation: $$\lambda_k = w_k \lambda.$$
+- Utilization: $$\rho_k = \frac{\lambda_k}{\mu_k}.$$
+- Optimization goal: $$\min_{w_k} \max_k \rho_k.$$
+
+## Notes
+
+- Decision variables $w_k$ belong to $u_t$ with $\sum_k w_k = 1$, $w_k \ge 0$.
+- Service rates $\mu_k$ reside in $\theta$.
+- Resulting utilizations update queueing metrics in $y_t$.

--- a/models/dynamic_cache/eq_mm1_queue.md
+++ b/models/dynamic_cache/eq_mm1_queue.md
@@ -1,0 +1,23 @@
+# M/M/1 Queue Performance
+
+**Modules:** `dynamic_cache`, `dynamic_cdn`, `dynamic_load_balancer`, `dynamic_http`, `dynamic_message_queue`, `dynamic_proxy`
+
+## Overview
+
+Models single-server queueing behavior per hop or service endpoint.
+
+## Equations
+
+\[
+\rho = \frac{\lambda}{\mu}, \qquad W = \frac{1}{\mu - \lambda}, \qquad L = \lambda W.
+\]
+
+## Parameters
+
+- $\lambda$ — arrival rate captured by disturbances $\xi_t$ or controls (traffic shaping).
+- $\mu$ — service rate parameter in $\theta$.
+
+## Notes
+
+- Stability requires $\rho < 1$; enforce via constraints.
+- Latency $W$ feeds SLO metrics in $y_t$.

--- a/models/dynamic_contracts/eq_kyc_risk.md
+++ b/models/dynamic_contracts/eq_kyc_risk.md
@@ -1,0 +1,19 @@
+# KYC Risk Scoring
+
+**Modules:** `dynamic_kyc`
+
+## Overview
+
+Logistic regression over feature vector to estimate probability of risk.
+
+## Equation
+
+$$p(\text{risk}=1 \mid x) = \sigma(w^\top x).$$
+
+- $x$ — applicant features (state or disturbance).
+- $w$ — weight vector parameter in $\theta$.
+
+## Notes
+
+- Controls $u_t$ set thresholds for manual review.
+- Risk scores populate compliance dashboards.

--- a/models/dynamic_contracts/eq_npv.md
+++ b/models/dynamic_contracts/eq_npv.md
@@ -1,0 +1,19 @@
+# Net Present Value of Contracts
+
+**Modules:** `dynamic_contracts`, `dynamic_reference`
+
+## Overview
+
+Discounts future cash flows to assess contract value.
+
+## Equation
+
+$$\text{NPV} = \sum_t \frac{CF_t}{(1 + r)^t}.$$
+
+- $CF_t$ — cash flow at period $t$ (disturbance or control).
+- $r$ — discount rate parameter in $\theta$.
+
+## Notes
+
+- Output metrics compare NPV to liability thresholds.
+- Controls $u_t$ can modify payment schedules to optimize NPV.

--- a/models/dynamic_contracts/eq_reputation.md
+++ b/models/dynamic_contracts/eq_reputation.md
@@ -1,0 +1,23 @@
+# Reputation Posterior (Beta-Bernoulli)
+
+**Modules:** `dynamic_review`, `dynamic_reference`
+
+## Overview
+
+Bayesian update for success/failure feedback represented by a Beta distribution.
+
+## Posterior
+
+$$\text{Beta}(\alpha + s,\; \beta + f).$$
+
+- $s$, $f$ — counts of positive and negative outcomes (state increments).
+- $\alpha$, $\beta$ — prior hyperparameters ($\theta$).
+
+## Mean Reputation
+
+$$\mathbb{E}[p] = \frac{\alpha + s}{\alpha + \beta + s + f}.$$
+
+## Notes
+
+- Controls $u_t$ manage weighting schemes (e.g., recency adjustments).
+- Reputation metrics inform contract approval policies.

--- a/models/dynamic_database/eq_quorum.md
+++ b/models/dynamic_database/eq_quorum.md
@@ -1,0 +1,18 @@
+# Quorum Conditions
+
+**Modules:** `dynamic_cap_theorem`
+
+## Overview
+
+Ensures strong reads in quorum-based systems.
+
+## Condition
+
+$$R + W > N.$$
+
+- $R$ — read quorum size, $W$ — write quorum size, $N$ — replica count.
+
+## Notes
+
+- Decision variables $u_t$ adjust quorum sizes to balance latency and consistency.
+- Increasing $R$ reduces staleness probability at cost of higher read latency captured in $\ell(y_t, u_t)$.

--- a/models/dynamic_database/eq_replication_lag.md
+++ b/models/dynamic_database/eq_replication_lag.md
@@ -1,0 +1,19 @@
+# Replication Lag Dynamics
+
+**Modules:** `dynamic_database`, `dynamic_chain`, `dynamic_consistency`
+
+## Overview
+
+Models lag between primary and replica databases.
+
+## Equation
+
+$$\dot{\ell} = \lambda_w - \mu_r.$$
+
+- $\lambda_w$ — write arrival rate (disturbance $\xi_t$).
+- $\mu_r$ — replica apply rate (control or parameter $\theta$).
+
+## Notes
+
+- Integrate to compute lag $\ell$; enforce $\ell \le \ell_{\max}$ via constraints.
+- Output metrics include staleness alerts and replica health.

--- a/models/dynamic_domain/eq_dns_staleness.md
+++ b/models/dynamic_domain/eq_dns_staleness.md
@@ -1,0 +1,19 @@
+# DNS Cache Staleness Probability
+
+**Modules:** `dynamic_domain`, `dynamic_domain_name_system`, `dynamic_domain_names`
+
+## Overview
+
+Probability that cached records are stale given Poisson update arrivals.
+
+## Equation
+
+$$p_{\text{stale}} = \exp(-\lambda \cdot \text{TTL}).$$
+
+- $\lambda$ — record update rate ($\theta$ or disturbance $\xi_t$).
+- TTL — cache lifetime setting (control $u_t$).
+
+## Notes
+
+- Constraint ensures $p_{\text{stale}} \le p_{\max}$ for reliability targets.
+- Outputs monitor DNS cache effectiveness.

--- a/models/dynamic_domain/eq_ip_allocation.md
+++ b/models/dynamic_domain/eq_ip_allocation.md
@@ -1,0 +1,19 @@
+# IP Allocation Pressure
+
+**Modules:** `dynamic_ip_address`
+
+## Overview
+
+Tracks address pool pressure from requests and returns.
+
+## Dynamics
+
+$$A_{t+1} = A_t + \text{req}_t - \text{return}_t.$$
+
+- $A_t$ — allocated addresses (state variable).
+- Requests and returns can be controls ($u_t$) or disturbances ($\xi_t$).
+
+## Notes
+
+- Constraints enforce $0 \le A_t \le A_{\max}$ to avoid exhaustion.
+- Outputs report utilization percentages for planning.

--- a/models/dynamic_energy/eq_battery_soc.md
+++ b/models/dynamic_energy/eq_battery_soc.md
@@ -1,0 +1,20 @@
+# Battery State of Charge Update
+
+**Modules:** `dynamic_energy`
+
+## Overview
+
+Discrete-time update for battery state of charge including charge/discharge efficiencies.
+
+## Equation
+
+$$\text{SoC}_{t+1} = \text{SoC}_t + \frac{\eta_c I_c - I_d / \eta_d}{C} \Delta t.$$
+
+- $I_c$, $I_d$ — charge/discharge currents (controls $u_t$).
+- $\eta_c$, $\eta_d$ — efficiencies in $\theta$.
+- $C$ — battery capacity parameter.
+
+## Notes
+
+- Enforce $0 \le \text{SoC}_t \le 1$ via constraints.
+- Disturbances $\xi_t$ capture temperature effects or unexpected loads.

--- a/models/dynamic_energy/eq_dispatch.md
+++ b/models/dynamic_energy/eq_dispatch.md
@@ -1,0 +1,25 @@
+# Generation Dispatch Optimization
+
+**Modules:** `dynamic_energy`, `dynamic_generator`
+
+## Overview
+
+Relaxes unit commitment to continuous power decisions with capacity constraints.
+
+## Problem
+
+\[
+\begin{aligned}
+&\min_{\{P_t\}} \sum_t c(P_t) \\
+\text{s.t.}\quad &0 \le P_t \le P_{\max}, \\
+&\sum_i P_{i,t} = D_t.
+\end{aligned}
+\]
+
+- $c(\cdot)$ — generation cost curve in $\theta$.
+- $D_t$ — demand requirement (disturbance $\xi_t$).
+
+## Notes
+
+- Decision variable $P_t$ belongs to $u_t$.
+- Equality constraint enforces load balance per timestep.

--- a/models/dynamic_energy/eq_power_efficiency.md
+++ b/models/dynamic_energy/eq_power_efficiency.md
@@ -1,0 +1,19 @@
+# Power and Efficiency Relationships
+
+**Modules:** `dynamic_energy`, `dynamic_fuel`, `dynamic_generator`
+
+## Overview
+
+Links torque, angular velocity, and power while quantifying conversion efficiency.
+
+## Equations
+
+$$P = \tau \omega, \qquad \eta = \frac{P_{\text{out}}}{P_{\text{in}}}.$$
+
+- $\tau$ — torque (control or disturbance).
+- $\omega$ — angular velocity (state variable).
+- Efficiency $\eta$ belongs to $\theta$ when modeled as constant or derived from lookup tables.
+
+## Notes
+
+Outputs include fuel usage and generation KPIs derived from $P$ and $\eta$.

--- a/models/dynamic_event/eq_event_sourcing.md
+++ b/models/dynamic_event/eq_event_sourcing.md
@@ -1,0 +1,19 @@
+# Event Sourcing State Fold
+
+**Modules:** `dynamic_event`, `dynamic_point_in_time`, `dynamic_states`
+
+## Overview
+
+Accumulates application state by folding ordered events.
+
+## Equation
+
+$$x_t = \text{fold}(x_{t-1}, e_t), \qquad e_t \sim \mathcal{E}.$$
+
+- $e_t$ — event emitted at step $t$ (disturbance input).
+- Fold operator applies deterministic transition logic encoded in module code.
+
+## Notes
+
+- Controls $u_t$ may alter event replay strategies (e.g., snapshots).
+- Outputs read materialized views derived from $x_t$.

--- a/models/dynamic_forecast/eq_ar1.md
+++ b/models/dynamic_forecast/eq_ar1.md
@@ -1,0 +1,18 @@
+# AR(1) Process
+
+**Modules:** `dynamic_forecast`, `dynamic_predictive`, `dynamic_indicators`, `dynamic_candles`
+
+## Overview
+
+Autoregressive model of order 1 capturing persistence in time series.
+
+## Equation
+
+$$y_t = \phi y_{t-1} + \epsilon_t.$$
+
+- $\phi$ — autoregressive coefficient ($\theta$).
+- $\epsilon_t$ — white-noise disturbance mapped to $\xi_t$.
+
+## Notes
+
+- State $x_t$ stores lagged observations; controls may adjust $\phi$ via learning routines.

--- a/models/dynamic_forecast/eq_arima.md
+++ b/models/dynamic_forecast/eq_arima.md
@@ -1,0 +1,18 @@
+# ARIMA(p, d, q) Structure
+
+**Modules:** `dynamic_forecast`, `dynamic_predictive`
+
+## Overview
+
+Autoregressive integrated moving average models extend AR processes with differencing and moving-average terms.
+
+## Equation
+
+Apply $d$ successive differences to $y_t$ before fitting ARMA$(p,q)$:
+$$\nabla^d y_t = c + \sum_{i=1}^p \phi_i \nabla^d y_{t-i} + \sum_{j=1}^q \theta_j \epsilon_{t-j} + \epsilon_t.$$
+
+## Notes
+
+- Differencing order $d$ is part of $\theta$.
+- Controls $u_t$ can trigger parameter re-estimation windows.
+- Innovations $\epsilon_t$ map to disturbances $\xi_t$.

--- a/models/dynamic_forecast/eq_atr.md
+++ b/models/dynamic_forecast/eq_atr.md
@@ -1,0 +1,18 @@
+# Average True Range
+
+**Modules:** `dynamic_indicators`
+
+## Overview
+
+Measures market volatility via the exponential average of true range.
+
+## Equation
+
+$$\text{ATR} = \text{EMA}(\text{TR}).$$
+
+- True range (TR) derives from high/low/close data within $x_t$.
+- Same EMA update as defined in `eq_ema.md` applied to TR values.
+
+## Notes
+
+ATR informs risk controls $u_t$ (position sizing) and outputs volatility dashboards.

--- a/models/dynamic_forecast/eq_ema.md
+++ b/models/dynamic_forecast/eq_ema.md
@@ -1,0 +1,19 @@
+# Exponential Moving Average
+
+**Modules:** `dynamic_indicators`, `dynamic_candles`
+
+## Overview
+
+Smooths price series with exponential weighting.
+
+## Recurrence
+
+$$\text{EMA}_t = \alpha p_t + (1 - \alpha) \text{EMA}_{t-1}.$$
+
+- $p_t$ — observed price (part of $y_t$ / $x_t$).
+- $\alpha$ — smoothing factor ($\theta$).
+
+## Notes
+
+- Initialization uses $\text{EMA}_0$ from prior average.
+- Control $u_t$ can adapt $\alpha$ based on volatility regimes.

--- a/models/dynamic_forecast/eq_kalman_filter.md
+++ b/models/dynamic_forecast/eq_kalman_filter.md
@@ -1,0 +1,31 @@
+# Kalman Filter Recursions
+
+**Modules:** `dynamic_forecast`, `dynamic_predictive`
+
+## Overview
+
+Linear Gaussian state-space inference used for smoothing and forecasting.
+
+## Prediction Step
+
+\[
+\begin{aligned}
+x_{t|t-1} &= A x_{t-1} + B u_{t-1}, \\
+P_{t|t-1} &= A P_{t-1} A^\top + Q.
+\end{aligned}
+\]
+
+## Update Step
+
+\[
+\begin{aligned}
+K_t &= P_{t|t-1} H^\top (H P_{t|t-1} H^\top + R)^{-1}, \\
+x_{t|t} &= x_{t|t-1} + K_t (y_t - H x_{t|t-1}), \\
+P_{t|t} &= (I - K_t H) P_{t|t-1}.
+\end{aligned}
+\]
+
+## Notes
+
+- Matrices $A, B, H, Q, R$ lie in $\theta$.
+- Output residuals $(y_t - H x_{t|t-1})$ power indicator diagnostics.

--- a/models/dynamic_integration/eq_bottleneck.md
+++ b/models/dynamic_integration/eq_bottleneck.md
@@ -1,0 +1,18 @@
+# Pipeline Throughput Bottleneck
+
+**Modules:** `dynamic_bridge`, `dynamic_pipeline`
+
+## Overview
+
+End-to-end throughput limited by slowest stage.
+
+## Equation
+
+$$X = \min_k X_k.$$
+
+- $X_k$ — throughput of stage $k$ (state or parameter).
+
+## Notes
+
+- Controls $u_t$ allocate resources to the bottleneck stage to lift overall throughput.
+- Monitor $X$ alongside latency metrics to maintain integration SLAs.

--- a/models/dynamic_integration/eq_etl_success.md
+++ b/models/dynamic_integration/eq_etl_success.md
@@ -1,0 +1,18 @@
+# End-to-End ETL Success Probability
+
+**Modules:** `dynamic_bridge`, `dynamic_pipeline`, `dynamic_proxy`
+
+## Overview
+
+Probability that all stages in an integration pipeline succeed.
+
+## Equation
+
+$$P(\text{end-to-end}) = \prod_k P_k.$$
+
+- $P_k$ — success probability of stage $k$ (parameter or state estimate).
+
+## Notes
+
+- Controls $u_t$ add retries or redundancy to increase $P(\text{end-to-end})$.
+- Outputs track cumulative reliability for integration SLAs.

--- a/models/dynamic_memory/eq_drift_diffusion.md
+++ b/models/dynamic_memory/eq_drift_diffusion.md
@@ -1,0 +1,20 @@
+# Drift–Diffusion Decision Process
+
+**Modules:** `dynamic_self_awareness`, `dynamic_critical_thinking`
+
+## Overview
+
+Stochastic differential equation modeling evidence accumulation until decision bounds are reached.
+
+## Equation
+
+$$dx = v\,dt + \sigma\,dW_t.$$
+
+- $v$ — drift rate parameter ($\theta$) reflecting evidence strength.
+- $\sigma$ — diffusion coefficient.
+- $W_t$ — Wiener process driving randomness ($\xi_t$).
+
+## Notes
+
+- Decision occurs when $x$ hits upper/lower bounds encoded in constraints.
+- Controls $u_t$ adjust thresholds based on risk tolerance.

--- a/models/dynamic_memory/eq_forgetting_curve.md
+++ b/models/dynamic_memory/eq_forgetting_curve.md
@@ -1,0 +1,19 @@
+# Forgetting Curve
+
+**Modules:** `dynamic_memory`, `dynamic_implicit_memory`, `dynamic_memory_reconsolidation`
+
+## Overview
+
+Models retention decay over time without reinforcement.
+
+## Equation
+
+$$R(t) = \exp\left(-\frac{t}{\tau}\right).$$
+
+- $R(t)$ — retention level (state component).
+- $\tau$ — decay time constant in $\theta$.
+
+## Notes
+
+- Controls $u_t$ (practice sessions) reset or boost retention.
+- Outputs feed training cadence recommendations.

--- a/models/dynamic_memory/eq_metacognitive_confidence.md
+++ b/models/dynamic_memory/eq_metacognitive_confidence.md
@@ -1,0 +1,20 @@
+# Metacognitive Confidence Signal
+
+**Modules:** `dynamic_metacognition`
+
+## Overview
+
+Sigmoid-transformed evidence forms subjective confidence levels.
+
+## Equation
+
+$$c = \sigma(w^\top z).$$
+
+- $z$ — feature vector summarizing decision evidence (state component).
+- $w$ — weight vector in $\theta$.
+- $\sigma(\cdot)$ — logistic function.
+
+## Notes
+
+- Controls $u_t$ may regularize or recalibrate weights.
+- Confidence scores feed monitoring dashboards and adaptive thresholds.

--- a/models/dynamic_memory/eq_rescorla_wagner.md
+++ b/models/dynamic_memory/eq_rescorla_wagner.md
@@ -1,0 +1,20 @@
+# Rescorla–Wagner Learning Rule
+
+**Modules:** `dynamic_memory`, `dynamic_consciousness`, `dynamic_metacognition`
+
+## Overview
+
+Classical conditioning update capturing association strength adjustments.
+
+## Equation
+
+$$\Delta V = \alpha \beta (\lambda - V).$$
+
+- $V$ — current associative strength (state variable).
+- $\alpha$, $\beta$ — learning rate parameters ($\theta$).
+- $\lambda$ — expected reinforcement.
+
+## Notes
+
+- Update $V \leftarrow V + \Delta V$ per trial.
+- Disturbances $\xi_t$ model stochastic reinforcement availability.

--- a/models/dynamic_memory/eq_ucb.md
+++ b/models/dynamic_memory/eq_ucb.md
@@ -1,0 +1,20 @@
+# Upper Confidence Bound Exploration
+
+**Modules:** `dynamic_mindset`, `dynamic_thinking`, `dynamic_creative_thinking`
+
+## Overview
+
+Balances exploration and exploitation in bandit problems.
+
+## Selection Rule
+
+$$a = \arg\max_i \left( \hat{\mu}_i + \kappa \sqrt{\frac{\ln t}{n_i}} \right).$$
+
+- $\hat{\mu}_i$ — empirical mean reward (state variable).
+- $n_i$ — count of pulls for arm $i$.
+- $\kappa$ — exploration parameter in $\theta$.
+
+## Notes
+
+- Time $t$ increments with each decision step.
+- Controls $u_t$ tune $\kappa$ or impose fairness constraints.

--- a/models/dynamic_microservices/eq_error_budget.md
+++ b/models/dynamic_microservices/eq_error_budget.md
@@ -1,0 +1,18 @@
+# Error Budget and Burn Rate
+
+**Modules:** `dynamic_microservices`, `dynamic_logging`
+
+## Overview
+
+Monitors SLO consumption via remaining error budget and burn rate.
+
+## Equations
+
+\[
+E = 1 - \text{SLO}, \qquad b = \frac{\text{errors in window}}{E \cdot \text{window}}.
+\]
+
+## Usage
+
+- $E$ and $b$ contribute to observability dashboards ($y_t$).
+- Controls $u_t$ may throttle features when burn rate exceeds thresholds.

--- a/models/dynamic_microservices/eq_parallel_availability.md
+++ b/models/dynamic_microservices/eq_parallel_availability.md
@@ -1,0 +1,16 @@
+# Parallel Availability (Active-Active)
+
+**Modules:** `dynamic_microservices`, `dynamic_logging`
+
+## Overview
+
+Active-active replicas increase availability by failing over to healthy nodes.
+
+## Equation
+
+$$A_{\text{parallel}} = 1 - \prod_i (1 - A_i).$$
+
+## Notes
+
+- Redundant replicas appear in state $x_t$; controls toggle capacity allocations.
+- Logging modules use $A_{\text{parallel}}$ to verify SLO compliance.

--- a/models/dynamic_microservices/eq_series_availability.md
+++ b/models/dynamic_microservices/eq_series_availability.md
@@ -1,0 +1,17 @@
+# Series Availability
+
+**Modules:** `dynamic_microservices`, `dynamic_framework`
+
+## Overview
+
+When services are chained in series, the overall availability is the product of component availabilities.
+
+## Equation
+
+$$A_{\text{series}} = \prod_i A_i.$$
+
+## Notes
+
+- State $x_t$ can track per-service uptime.
+- Control $u_t$ includes redundancy planning or maintenance scheduling.
+- Availability enters the loss through outage penalties.

--- a/models/dynamic_ocean/eq_shallow_water.md
+++ b/models/dynamic_ocean/eq_shallow_water.md
@@ -1,0 +1,25 @@
+# Shallow-Water Equations (1-D)
+
+**Modules:** `dynamic_ocean`
+
+## Overview
+
+Captures conservation of mass and momentum for shallow-water flows.
+
+## Equations
+
+\[
+\begin{aligned}
+\partial_t \eta + \partial_x (h u) &= 0, \\
+\partial_t u + u \partial_x u + g \partial_x \eta &= 0.
+\end{aligned}
+\]
+
+- $\eta$ — surface elevation perturbation (state variable).
+- $u$ — depth-averaged velocity.
+- $h$ — mean water depth; $g$ — gravitational acceleration.
+
+## Notes
+
+- Discretize for numerical simulation consistent with the meta-model.
+- Boundary controls $u_t$ can inject flux or set wall conditions.

--- a/models/dynamic_space/eq_barometric.md
+++ b/models/dynamic_space/eq_barometric.md
@@ -1,0 +1,19 @@
+# Barometric Formula (Isothermal Atmosphere)
+
+**Modules:** `dynamic_troposphere`, `dynamic_stratosphere`, `dynamic_mesosphere`, `dynamic_thermosphere`, `dynamic_exosphere`
+
+## Overview
+
+Models atmospheric pressure decrease with altitude under isothermal conditions.
+
+## Equation
+
+$$p(h) = p_0 \exp\left(-\frac{M g h}{R T}\right).$$
+
+- $p_0$ — reference pressure at sea level ($\theta$).
+- $M$ — molar mass of air, $g$ — gravitational acceleration, $R$ — universal gas constant, $T$ — absolute temperature.
+
+## Notes
+
+- Altitude $h$ is part of state $x_t$; temperature variations can be disturbances $\xi_t$.
+- Outputs include density and pressure used by aerospace modules.

--- a/models/dynamic_space/eq_hohmann.md
+++ b/models/dynamic_space/eq_hohmann.md
@@ -1,0 +1,21 @@
+# Hohmann Transfer Delta-V
+
+**Modules:** `dynamic_space`, `dynamic_interplanetary_space`
+
+## Overview
+
+Delta-v requirements for transferring between circular coplanar orbits using a Hohmann maneuver.
+
+## Equation
+
+\[
+\Delta v = \sqrt{\frac{\mu}{r_1}}\left(\sqrt{\frac{2 r_2}{r_1 + r_2}} - 1\right) + \sqrt{\frac{\mu}{r_2}}\left(1 - \sqrt{\frac{2 r_1}{r_1 + r_2}}\right).
+\]
+
+- $r_1$, $r_2$ — initial and target orbital radii.
+- $\mu$ — gravitational parameter.
+
+## Notes
+
+- Controls $u_t$ schedule burns; disturbances include navigation errors.
+- Delta-v budgets feed mission planning objectives.

--- a/models/dynamic_space/eq_orbital_period.md
+++ b/models/dynamic_space/eq_orbital_period.md
@@ -1,0 +1,19 @@
+# Orbital Period (Kepler's Third Law)
+
+**Modules:** `dynamic_space`, `dynamic_astronomy`, `dynamic_interplanetary_space`
+
+## Overview
+
+Relates semi-major axis to orbital period around a central body.
+
+## Equation
+
+$$T = 2\pi \sqrt{\frac{a^3}{\mu}}, \qquad \mu = G M.$$
+
+- $a$ — semi-major axis (state variable).
+- $\mu$ — standard gravitational parameter determined by gravitational constant $G$ and mass $M$.
+
+## Notes
+
+- Control $u_t$ may adjust maneuver planning to target specific $T$.
+- Disturbances $\xi_t$ capture perturbations like drag or third-body effects.

--- a/models/dynamic_supply/eq_inventory_balance.md
+++ b/models/dynamic_supply/eq_inventory_balance.md
@@ -1,0 +1,19 @@
+# Inventory and Emission Balance
+
+**Modules:** `dynamic_supply`, `dynamic_token`
+
+## Overview
+
+Tracks inventory evolution considering production, sales, and burns.
+
+## Dynamics
+
+$$\dot{I} = \text{production} - \text{sales} - \text{burn}.$$
+
+- $I$ — inventory state variable in $x_t$.
+- Production and sales may be controlled via $u_t$; burns can be disturbances $\xi_t$.
+
+## Notes
+
+- Integrating $\dot{I}$ over time yields discrete inventory updates for planning horizons.
+- Constraint checks ensure $I \ge 0$ or maintain safety stock levels.

--- a/models/dynamic_supply/eq_linear_supply_demand.md
+++ b/models/dynamic_supply/eq_linear_supply_demand.md
@@ -1,0 +1,28 @@
+# Linear Supply and Demand Equilibrium
+
+**Modules:** `dynamic_supply`, `dynamic_demand`, `dynamic_stake`
+
+## Overview
+
+Computes market-clearing price and quantity for linear demand and supply curves.
+
+## Equations
+
+\[
+\begin{aligned}
+Q_D &= \alpha - \beta P, \\
+Q_S &= \gamma + \delta P, \\
+P^* &= \frac{\alpha - \gamma}{\beta + \delta}, \\
+Q^* &= \alpha - \beta P^*.
+\end{aligned}
+\]
+
+## Parameters
+
+- $\alpha, \beta$ — demand intercept and slope.
+- $\gamma, \delta$ — supply intercept and slope.
+
+## Integration
+
+- $x_t$ tracks inventory and demand signals; $u_t$ adjusts pricing controls.
+- Output metrics expose surplus and price deviations from $P^*$.

--- a/models/dynamic_team/eq_skill_accumulation.md
+++ b/models/dynamic_team/eq_skill_accumulation.md
@@ -1,0 +1,20 @@
+# Skill Accumulation Dynamics
+
+**Modules:** `dynamic_mentorship`, `dynamic_skills`
+
+## Overview
+
+Models skill growth through practice with forgetting.
+
+## Equation
+
+$$s_{t+1} = s_t + \eta \cdot \text{practice}_t - \delta s_t.$$
+
+- $s_t$ — skill level (state variable).
+- $\eta$ — learning efficiency, $\delta$ — decay rate (parameters in $\theta$).
+- $\text{practice}_t$ — training effort control $u_t$.
+
+## Notes
+
+- Enforce bounds $s_t \ge 0$ via constraints.
+- Outputs report competency trajectories for workforce planning.

--- a/models/dynamic_team/eq_staffing_curve.md
+++ b/models/dynamic_team/eq_staffing_curve.md
@@ -1,0 +1,19 @@
+# Staffing Productivity Curve
+
+**Modules:** `dynamic_development_team`, `dynamic_team`
+
+## Overview
+
+Captures ramp-up of team productivity as members learn workflows.
+
+## Equation
+
+$$P_t = P_{\max} \big(1 - e^{-k t}\big).$$
+
+- $P_{\max}$ — asymptotic productivity ($\theta$).
+- $k$ — learning rate parameter.
+
+## Notes
+
+- Time $t$ may correspond to tenure tracked in state $x_t$.
+- Controls $u_t$ include onboarding investments that modify $k$.

--- a/models/dynamic_team/eq_utilization.md
+++ b/models/dynamic_team/eq_utilization.md
@@ -1,0 +1,17 @@
+# Utilization Ratio
+
+**Modules:** `dynamic_team`, `dynamic_human_resources`, `dynamic_routine`
+
+## Overview
+
+Measures proportion of time spent on productive tasks.
+
+## Equation
+
+$$U = \frac{\text{busy time}}{\text{total time}}.$$
+
+## Notes
+
+- Busy and total time accrue in state $x_t$ via time-tracking signals.
+- Controls $u_t$ adjust scheduling or automation to maintain target utilization.
+- Utilization enters objectives balancing workload and burnout risk.

--- a/models/dynamic_text/eq_fk_readability.md
+++ b/models/dynamic_text/eq_fk_readability.md
@@ -1,0 +1,16 @@
+# Flesch–Kincaid Readability Grade
+
+**Modules:** `dynamic_text`, `dynamic_glossary`, `dynamic_summary`, `dynamic_letter_index`
+
+## Overview
+
+Estimates reading grade level from sentence and syllable statistics.
+
+## Equation
+
+$$0.39 \frac{\text{words}}{\text{sentences}} + 11.8 \frac{\text{syllables}}{\text{words}} - 15.59.$$
+
+## Notes
+
+- Word/sentence counts derive from outputs of NLP pipelines ($y_t$).
+- Controls $u_t$ enforce readability targets for documentation.

--- a/models/dynamic_text/eq_tfidf.md
+++ b/models/dynamic_text/eq_tfidf.md
@@ -1,0 +1,19 @@
+# Term Frequency–Inverse Document Frequency
+
+**Modules:** `dynamic_arrow`, `dynamic_ascii`, `dynamic_vocabulary`, `dynamic_index`
+
+## Overview
+
+Scores term relevance across a corpus using TF-IDF weighting.
+
+## Equation
+
+$$w_{t,d} = \text{tf}_{t,d} \cdot \log\left(\frac{N}{\text{df}_t}\right).$$
+
+- $\text{tf}_{t,d}$ — term frequency in document $d$ (state feature).
+- $N$ — total documents; $\text{df}_t$ — document frequency for term $t$.
+
+## Notes
+
+- Controls $u_t$ define thresholding for indexing or summarization.
+- TF-IDF vectors feed downstream similarity metrics in outputs.

--- a/models/dynamic_wave/eq_harmonic_oscillator.md
+++ b/models/dynamic_wave/eq_harmonic_oscillator.md
@@ -1,0 +1,19 @@
+# Harmonic Oscillator
+
+**Modules:** `dynamic_physics`
+
+## Overview
+
+Models simple oscillatory systems such as springs or pendulums near equilibrium.
+
+## Equation
+
+$$\ddot{x} + \omega^2 x = 0.$$
+
+- $x$ — displacement state.
+- $\omega$ — natural frequency parameter in $\theta$.
+
+## Notes
+
+- Convert to first-order system for simulation by augmenting velocity state.
+- Control inputs may perturb the oscillator for resonance analysis.

--- a/models/dynamic_wave/eq_wave_equation.md
+++ b/models/dynamic_wave/eq_wave_equation.md
@@ -1,0 +1,19 @@
+# Wave Equation
+
+**Modules:** `dynamic_wave`, `dynamic_physics`
+
+## Overview
+
+Describes propagation of waves with speed $c$ across spatial domain.
+
+## Equation
+
+$$\frac{\partial^2 u}{\partial t^2} = c^2 \nabla^2 u.$$
+
+- $u$ — field variable stored in state $x_t$ (e.g., displacement).
+- Wave speed $c$ resides in parameters $\theta$ with relation $c = f \lambda$ when wavelength $\lambda$ and frequency $f$ are known.
+
+## Notes
+
+- Discretize using finite differences to embed into the discrete meta-model.
+- Outputs track energy or boundary conditions derived from $u$.

--- a/models/meta_model.md
+++ b/models/meta_model.md
@@ -1,0 +1,80 @@
+# Dynamic Capital Master Meta-Model
+
+The Dynamic Capital platform models every subsystem using a shared control-theoretic grammar. This meta-model defines the symbols, governing equations, and optimization scaffold that individual domain modules extend through plug-in equation sheets.
+
+## Core Elements
+
+| Symbol | Description |
+| --- | --- |
+| $x_t \in \mathbb{R}^n$ | System state at step $t$ capturing latent variables. |
+| $u_t$ | Control action or decision variables applied at step $t$. |
+| $\xi_t$ | Exogenous inputs or disturbances that affect the state transition. |
+| $\theta$ | Fixed model parameters for a module (learned or configured). |
+| $y_t$ | Observable outputs or KPIs derived from the state. |
+| $c(x_t, u_t)$ | Constraint vector that must remain non-positive. |
+| $\ell(y_t, u_t)$ | Stage loss incorporating operational penalties. |
+| $\phi_k(x_t, u_t)$ | Auxiliary objective components with weight $w_k$. |
+
+## Dynamics Templates
+
+Each module specifies dynamics in either discrete or continuous time using the shared notation:
+
+- **Discrete-time transition**
+  $$x_{t+1} = f(x_t, u_t, \xi_t; \theta)$$
+
+- **Continuous-time evolution**
+  $$\dot{x} = f(x, u, \xi; \theta)$$
+
+Modules may linearize or approximate $f(\cdot)$, but the contract of state-input-disturbance-parameter arguments is conserved.
+
+## Output and Metrics
+
+Outputs are computed via
+$$y_t = g(x_t; \theta)$$
+where $g(\cdot)$ maps latent state into metrics, alerts, or decision features. Plug-in sheets should document how the outputs feed front-end analytics, trading bots, or governance dashboards.
+
+## Constraints
+
+All hard or soft feasibility limits are encoded as
+$$c(x_t, u_t) \le 0.$$
+Modules note slack variables or dual interpretations when applicable (e.g., queue stability, regulatory caps, risk budgets).
+
+## Objective Structure
+
+Optimization problems adopt a weighted loss formulation:
+$$\min_{\{u_t\}_{t=0}^T} J = \sum_{t=0}^T \Big( \ell(y_t, u_t) + \sum_k w_k \, \phi_k(x_t, u_t) \Big).$$
+Weights $w_k$ configure trade-offs such as risk-adjusted return, energy efficiency, or latency versus throughput. Individual equation sheets reference this scaffold and describe module-specific loss terms.
+
+## Using the Meta-Model
+
+1. Identify the relevant module directory under `models/` and review the associated `eq_*.md` sheet(s).
+2. Instantiate the state, control, and disturbance variables consistent with the shared notation.
+3. Apply the documented dynamics, constraints, and objectives, substituting module-specific parameters $\theta$.
+4. Integrate the resulting equations into simulations, optimizers, or monitoring pipelines.
+
+### Module Equation Index
+
+The following plug-in equation sheets reuse the meta-model grammar:
+
+- [Agent coordination and tasking](dynamic_agents/) — task assignment MILPs, consensus flows, and reinforcement learning updates.
+- [Blockchain and cryptoeconomic primitives](dynamic_blockchain/) — proof systems, staking, supply emission, and validator risk models.
+- [Market interaction and supply-demand modeling](dynamic_supply/).
+- [Networking, caching, and service-layer queues](dynamic_cache/).
+- [Microservices reliability and logging SLOs](dynamic_microservices/).
+- [Forecasting and indicator analytics](dynamic_forecast/).
+- [Energy systems and battery dispatch](dynamic_energy/).
+- [Wave and physics simulators](dynamic_wave/).
+- [Atmosphere, orbital, and space dynamics](dynamic_space/).
+- [Oceanographic flows](dynamic_ocean/).
+- [Cognitive and decision processes](dynamic_memory/).
+- [API, cryptography, and rate limits](dynamic_api/).
+- [Domain services and addressing](dynamic_domain/).
+- [Compliance, contracts, and reputation](dynamic_contracts/).
+- [Database replication and consistency](dynamic_database/).
+- [Team operations and learning curves](dynamic_team/).
+- [Benchmarking and scoring](dynamic_benchmark/).
+- [Text analytics and glossary tooling](dynamic_text/).
+- [Event sourcing and state transitions](dynamic_event/).
+- [Integration bridges and pipelines](dynamic_integration/).
+
+Each sheet references the implementing `dynamic_*` package(s) and may introduce additional derived quantities, but the state/control conventions remain unchanged.


### PR DESCRIPTION
## Summary
- add `models/meta_model.md` to document the shared state/control/dynamics grammar and index module equations
- create plug-in equation sheets under `models/dynamic_*` directories to capture the formulas outlined in the Dynamic Capital spec
- update the README architecture section to reference the new master meta-model documentation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d91252cfd08322bc1451abecccae79