### PR TITLE
Add domain schema drop-ins and simplify equation templates

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,60 @@
+# Model Documentation Templates
+
+This directory provides reusable building blocks for documenting dynamic models consistently. Use the templates to stand up a new folder quickly, then tailor the content to the specific domain.
+
+## Quickstart checklist
+
+1. **Create a module directory** under `models/<domain>`.
+2. **Copy the schema skeleton** from `models/TEMPLATE/schema.md` and fill in the problem definition (state, controls, parameters, and constraints).
+3. **Add equation notes** by duplicating `models/TEMPLATE/eq_template.md` or adapting one of the prebuilt drop-ins below.
+4. **Document calibration** for every equation so that parameter estimation can be reproduced.
+5. **Link modules** by stating which outputs feed into downstream models and which upstream signals are required.
+
+## Template overview
+
+| File | Purpose |
+| ---- | ------- |
+| `models/TEMPLATE/schema.md` | Canonical structure for a model specification, including state evolution, objectives, and constraint sets. |
+| `models/TEMPLATE/eq_template.md` | Standard layout for a single equation, highlighting assumptions and calibration data sources. |
+
+When copying a template, replace placeholders in angle brackets (`<...>`) and delete any sections that do not apply.
+
+## Domain starter schemas
+
+These schema files instantiate the template for common domains. Use them as blueprints when bootstrapping a new model folder, then tailor the state, control, and calibration details to your scenario.
+
+| Path | Captures |
+| ---- | -------- |
+| `models/dynamic_agents/schema.md` | Assignment workflows with backlog and agent capacity states. |
+| `models/dynamic_blockchain/schema.md` | Difficulty, hash rate, and mempool interactions for proof-of-work systems. |
+| `models/dynamic_cache/schema.md` | Cache sizing under the Che approximation with smoothed arrival rates. |
+| `models/dynamic_forecast/schema.md` | Linear-Gaussian state estimation using Kalman filter structure. |
+| `models/dynamic_message_queue/schema.md` | Queue length management via controllable service rates. |
+| `models/dynamic_thinking/schema.md` | Multi-armed bandit tracking of posterior means and counts. |
+| `models/dynamic_token/schema.md` | Token market clearing with linear demand and supply curves. |
+| `models/dynamic_troposphere/schema.md` | Tropospheric pressure profiling with lapse-rate adjustments. |
+
+## Ready-to-use equation snippets
+
+Each of the files below follows the equation template and can be dropped into a new module. Update variable names and calibration notes as needed.
+
+| Path | Captures |
+| ---- | -------- |
+| `models/dynamic_agents/eq_assignment.md` | Binary assignment objective with feasibility constraints for matching agents to tasks. |
+| `models/dynamic_blockchain/eq_pow.md` | Expected block time under proof-of-work, linking difficulty and aggregate hash rate. |
+| `models/dynamic_cache/eq_che.md` | Che approximation for cache hit probabilities and cache sizing. |
+| `models/dynamic_message_queue/eq_mm1.md` | M/M/1 queue steady-state utilization, wait time, and queue length relationships. |
+| `models/dynamic_forecast/eq_kalman.md` | Kalman filter prediction and update recursions for linear-Gaussian state space models. |
+| `models/dynamic_troposphere/eq_barometric.md` | Barometric formula relating altitude to pressure under an isothermal assumption. |
+| `models/dynamic_token/eq_equilibrium.md` | Linear demand/supply equilibrium condition for market-clearing token prices. |
+| `models/dynamic_thinking/eq_ucb.md` | Upper Confidence Bound (UCB) policy for exploration in multi-armed bandits. |
+
+## Recommended authoring flow
+
+- **Scope the dynamics**: Specify the state vector, control variables, and stochastic terms in the schema before detailing equations.
+- **Pair equations with calibration**: For every derived expression, note the datasets, estimation horizon, and mapping to model parameters.
+- **Surface dependencies early**: Document how signals (forecasts, prices, capacities, etc.) move between modules. This keeps multi-model pipelines traceable.
+- **Version your assumptions**: When refining a model, timestamp revisions or provide scenario labels so historical documentation remains interpretable.
+- **Cross-check units**: Ensure dimensions are consistent across linked modules to avoid mismatched integrations.
+
+By keeping schema, equations, and calibration narratives synchronized, you can iterate on dynamic models rapidly while maintaining reproducibility.

--- a/models/TEMPLATE/eq_template.md
+++ b/models/TEMPLATE/eq_template.md
@@ -1,0 +1,20 @@
+Name: <short label>
+Purpose: <why this relation matters in the module>
+
+Equation(s):
+```math
+<LaTeX formulation>
+```
+
+Assumptions:
+- <modeling assumption>
+- <operational assumption>
+
+Calibration:
+- **Data**: <dataset(s) and sampling cadence>
+- **Method**: <estimation or fitting routine>
+- **Parameter mapping**: <how estimated quantities map into $\theta$>
+
+Usage notes:
+- <how downstream modules consume this equation>
+- <edge cases or stability considerations>

--- a/models/TEMPLATE/schema.md
+++ b/models/TEMPLATE/schema.md
@@ -1,0 +1,53 @@
+# <dir> model
+
+## Problem statement
+
+- **State**: $x_t = [\ldots]$
+- **Controls**: $u_t = [\ldots]$
+- **Parameters**: $\theta = [\ldots]$
+- **Disturbances / shocks**: $\xi_t = [\ldots]$
+- **Horizon**: $t = 0, \ldots, T$
+
+## Dynamics
+
+$$
+x_{t+1} = f(x_t, u_t, \xi_t; \theta)
+$$
+
+Specify any piecewise structure or switching regimes here. Note how exogenous inputs alter the transition function.
+
+## Outputs / observables
+
+$$
+y_t = g(x_t; \theta)
+$$
+
+Describe which components of $y_t$ are consumed by other modules or exposed to downstream analytics.
+
+## Objective
+
+$$
+\min_{\{u_t\}} J = \sum_{t=0}^{T} \Big[ \ell(y_t, u_t) + \sum_k w_k \, \varphi_k(x_t, u_t) \Big]
+$$
+
+Clarify the economic or engineering interpretation of $\ell(\cdot)$ and each regularization/penalty term $\varphi_k(\cdot)$.
+
+## Constraints
+
+- **Equality**: $h(x_t, u_t; \theta) = 0$
+- **Inequality**: $c(x_t, u_t; \theta) \le 0$
+
+Include state/control bounds, integral constraints, or safety envelopes as needed.
+
+## Initial conditions & calibration hooks
+
+- Initial state $x_0 = [\ldots]$
+- Prior over parameters $p(\theta)$ or reference estimates.
+- Data sources required to fit or validate the model.
+
+## Interfaces
+
+- **Inputs consumed**: <upstream signals>
+- **Outputs produced**: <downstream dependencies>
+
+Document how this module composes with others in the system.

--- a/models/dynamic_agents/eq_assignment.md
+++ b/models/dynamic_agents/eq_assignment.md
@@ -1,0 +1,19 @@
+Name: Binary assignment program
+
+Equation(s):
+```math
+\begin{aligned}
+& \min_{a_{ij}} && \sum_i \sum_j c_{ij} a_{ij} \\
+& \text{s.t.} && \sum_i a_{ij} = 1 \quad \forall j \\
+& && \sum_j a_{ij} \le 1 \quad \forall i \\
+& && a_{ij} \in \{0,1\}
+\end{aligned}
+```
+
+Assumptions:
+- Each task is completed by exactly one agent; capacity is at most one task per agent.
+- Costs $c_{ij}$ are known at decision time and incorporate task-agent suitability.
+
+Calibration:
+- Collect historical assignment outcomes or expert scoring to estimate $c_{ij}$.
+- Normalize costs so that feasibility constraints dominate tie-breaking instead of scale artifacts.

--- a/models/dynamic_agents/schema.md
+++ b/models/dynamic_agents/schema.md
@@ -1,0 +1,18 @@
+# dynamic_agents model
+
+State: x_t = [b_t, s_t]  (task backlog, available agent capacity)
+Controls: u_t = [A_t]  (binary assignment matrix)
+Params: θ = [c_t, λ_t, r_t]  (cost matrix, task arrivals, agent return rates)
+
+Dynamics:
+b_{t+1} = b_t + λ_t - (A_t \, \mathbf{1})
+s_{t+1} = s_t + r_t - (A_t^\top \, \mathbf{1})
+
+Outputs:
+y_t = A_t
+
+Objective:
+min J = Σ_t [⟨c_t, A_t⟩]
+
+Constraints:
+A_t \, \mathbf{1} = \mathbf{1},  A_t^\top \, \mathbf{1} ≤ s_t,  A_t ∈ {0,1}

--- a/models/dynamic_blockchain/eq_pow.md
+++ b/models/dynamic_blockchain/eq_pow.md
@@ -1,0 +1,14 @@
+Name: Proof-of-work block interval
+
+Equation(s):
+```math
+\mathbb{E}[T] = \frac{D}{H}
+```
+
+Assumptions:
+- Hash rate $H$ remains approximately constant during the averaging window.
+- Difficulty $D$ reflects the expected hashes required per block under uniform miner effort.
+
+Calibration:
+- Derive $H$ from observed block intervals or miner telemetry over the target epoch.
+- Use protocol difficulty snapshots for $D$ and update estimates whenever retargeting occurs.

--- a/models/dynamic_blockchain/schema.md
+++ b/models/dynamic_blockchain/schema.md
@@ -1,0 +1,19 @@
+# dynamic_blockchain model
+
+State: x_t = [D_t, H_t, q_t]  (difficulty, aggregate hash rate, mempool size)
+Controls: u_t = [ΔD_t]  (protocol difficulty adjustment)
+Params: θ = [τ_*, α_H, α_q]  (target block interval, hash-rate response, transaction arrival rate)
+
+Dynamics:
+D_{t+1} = D_t + ΔD_t
+H_{t+1} = H_t + α_H (ξ^H_t)
+q_{t+1} = q_t + α_q - \frac{H_t}{D_t} + ξ^q_t
+
+Outputs:
+y_t = [T_t, \text{throughput}_t] = [D_t / H_t, \min(q_t, H_t / D_t)]
+
+Objective:
+min J = Σ_t [(T_t - τ_*)^2 + w_q q_t]
+
+Constraints:
+D_t > 0,  H_t > 0,  q_t ≥ 0

--- a/models/dynamic_cache/eq_che.md
+++ b/models/dynamic_cache/eq_che.md
@@ -1,0 +1,14 @@
+Name: Che approximation for cache hits
+
+Equation(s):
+```math
+h_i = 1 - \exp(-\lambda_i T_C), \quad \text{choose } T_C \text{ such that } \sum_i h_i = C
+```
+
+Assumptions:
+- Request arrivals for object $i$ follow a Poisson process with rate $\lambda_i$.
+- Cache is fully associative and admits a shared characteristic time $T_C$.
+
+Calibration:
+- Estimate $\lambda_i$ from request logs using exponential smoothing or windowed counts.
+- Solve for $T_C$ with root-finding so the aggregate hit rate matches capacity $C$.

--- a/models/dynamic_cache/schema.md
+++ b/models/dynamic_cache/schema.md
@@ -1,0 +1,18 @@
+# dynamic_cache model
+
+State: x_t = [λ_t, T_{C,t}]  (per-object arrival rates, characteristic time)
+Controls: u_t = [T_{C,t}]  (cache residence tuning)
+Params: θ = [C, β]  (cache capacity, smoothing factor)
+
+Dynamics:
+λ_{i,t+1} = (1-β) λ_{i,t} + β d_{i,t}
+T_{C,t+1} = T_{C,t} + u_t + ξ^T_t
+
+Outputs:
+y_t = h_t = 1 - \exp(-λ_t T_{C,t})
+
+Objective:
+min J = Σ_t \left[(\sum_i h_{i,t} - C)^2 + w_T u_t^2\right]
+
+Constraints:
+0 ≤ h_{i,t} ≤ 1,  Σ_i h_{i,t} = C

--- a/models/dynamic_forecast/eq_kalman.md
+++ b/models/dynamic_forecast/eq_kalman.md
@@ -1,0 +1,18 @@
+Name: Kalman filter recursions
+
+Equation(s):
+```math
+\begin{aligned}
+\hat{x}_{t|t-1} &= A \hat{x}_{t-1|t-1} + B u_{t-1} \\
+K_t &= P_{t|t-1} H^{\top} (H P_{t|t-1} H^{\top} + R)^{-1} \\
+\hat{x}_{t|t} &= \hat{x}_{t|t-1} + K_t (y_t - H \hat{x}_{t|t-1})
+\end{aligned}
+```
+
+Assumptions:
+- Dynamics and observations are linear with Gaussian noise.
+- Control input $u_t$ is known without error at update time.
+
+Calibration:
+- Estimate $A$, $B$, $H$, $Q$, and $R$ via expectation-maximization or subspace identification.
+- Validate the filter by checking innovation covariance against $H P_{t|t-1} H^{\top} + R$.

--- a/models/dynamic_forecast/schema.md
+++ b/models/dynamic_forecast/schema.md
@@ -1,0 +1,18 @@
+# dynamic_forecast model
+
+State: x_t = [\hat{x}_{t|t}, P_{t|t}]  (posterior state estimate, covariance)
+Controls: u_t = [u_t]  (exogenous control input)
+Params: θ = [A, B, H, Q, R]  (state transition, control, observation, process noise, observation noise)
+
+Dynamics:
+\hat{x}_{t+1|t} = A \hat{x}_{t|t} + B u_t + ξ^x_t
+P_{t+1|t} = A P_{t|t} A^\top + Q
+
+Outputs:
+y_t = H \hat{x}_{t|t}
+
+Objective:
+min J = Σ_t [ (y_t - y^{\text{obs}}_t)^\top R^{-1} (y_t - y^{\text{obs}}_t) + \operatorname{tr}(P_{t|t}) ]
+
+Constraints:
+P_{t|t} \succeq 0,  R \succ 0,  Q \succeq 0

--- a/models/dynamic_message_queue/eq_mm1.md
+++ b/models/dynamic_message_queue/eq_mm1.md
@@ -1,0 +1,14 @@
+Name: M/M/1 steady-state metrics
+
+Equation(s):
+```math
+\rho = \frac{\lambda}{\mu}, \quad W = \frac{1}{\mu - \lambda}, \quad L = \lambda W
+```
+
+Assumptions:
+- Arrivals are Poisson with rate $\lambda$ and service times are exponential with rate $\mu$.
+- System operates in steady state with $\lambda < \mu$.
+
+Calibration:
+- Fit $\lambda$ and $\mu$ from arrival and service telemetry using maximum likelihood or moment matching.
+- Confirm the stability condition $\lambda < \mu$ before applying the formulas.

--- a/models/dynamic_message_queue/schema.md
+++ b/models/dynamic_message_queue/schema.md
@@ -1,0 +1,19 @@
+# dynamic_message_queue model
+
+State: x_t = [L_t, λ_t, μ_t]  (queue length, arrival rate, service rate)
+Controls: u_t = [μ_t]  (server provisioning)
+Params: θ = [c_W, c_μ, β_λ]  (wait time penalty, service cost, arrival smoothing)
+
+Dynamics:
+λ_{t+1} = (1-β_λ) λ_t + β_λ d_t
+L_{t+1} = \max\{0, L_t + λ_t - μ_t + ξ^L_t\}
+μ_{t+1} = μ_t + u_t
+
+Outputs:
+y_t = [ρ_t, W_t, L_t] = [λ_t / μ_t, 1 / (μ_t - λ_t), L_t]
+
+Objective:
+min J = Σ_t [c_W W_t + c_μ u_t^2]
+
+Constraints:
+0 ≤ λ_t < μ_t,  μ_t ≥ μ_{\min}

--- a/models/dynamic_thinking/eq_ucb.md
+++ b/models/dynamic_thinking/eq_ucb.md
@@ -1,0 +1,14 @@
+Name: Upper Confidence Bound policy
+
+Equation(s):
+```math
+a_t = \arg\max_i \left[ \hat{\mu}_i + \kappa \sqrt{\frac{\ln t}{n_i}} \right]
+```
+
+Assumptions:
+- Rewards are bounded so concentration inequalities apply.
+- Each arm has been sampled at least once so $n_i > 0$.
+
+Calibration:
+- Maintain empirical means $\hat{\mu}_i$ and counts $n_i$ from historical pulls.
+- Tune $\kappa$ via simulation or regret minimization to balance exploration and exploitation.

--- a/models/dynamic_thinking/schema.md
+++ b/models/dynamic_thinking/schema.md
@@ -1,0 +1,18 @@
+# dynamic_thinking model
+
+State: x_t = [\hat{μ}_t, n_t]  (posterior mean rewards per arm, pull counts)
+Controls: u_t = [a_t]  (arm selection)
+Params: θ = [κ, β]  (exploration weight, prior strength)
+
+Dynamics:
+\hat{μ}_{i,t+1} = \frac{n_{i,t} \hat{μ}_{i,t} + r_{i,t+1}}{n_{i,t} + 1} \mathbb{1}\{a_t = i\} + \hat{μ}_{i,t} \mathbb{1}\{a_t \ne i\}
+n_{i,t+1} = n_{i,t} + \mathbb{1}\{a_t = i\}
+
+Outputs:
+y_t = a_t = \arg\max_i [\hat{μ}_{i,t} + κ \sqrt{\ln t / n_{i,t}}]
+
+Objective:
+min J = -Σ_t r_{a_t,t}
+
+Constraints:
+n_{i,t} ≥ 1 \ \forall i,  κ ≥ 0

--- a/models/dynamic_token/eq_equilibrium.md
+++ b/models/dynamic_token/eq_equilibrium.md
@@ -1,0 +1,14 @@
+Name: Linear demand-supply equilibrium
+
+Equation(s):
+```math
+Q_D = \alpha - \beta P, \quad Q_S = \gamma + \delta P, \quad P^* = \frac{\alpha - \gamma}{\beta + \delta}
+```
+
+Assumptions:
+- Demand and supply curves are linear around the operating regime.
+- Market clears instantly with no inventory backlogs.
+
+Calibration:
+- Regress observed quantities on prices to estimate $\alpha, \beta, \gamma, \delta$.
+- Recompute $P^*$ whenever structural shifts in demand or supply elasticities are detected.

--- a/models/dynamic_token/schema.md
+++ b/models/dynamic_token/schema.md
@@ -1,0 +1,19 @@
+# dynamic_token model
+
+State: x_t = [P_t, Q_{D,t}, Q_{S,t}]  (price, demand, supply)
+Controls: u_t = [m_t]  (market operations or issuance decisions)
+Params: θ = [α_t, β_t, γ_t, δ_t, P_*]  (demand intercept, demand slope, supply intercept, supply slope, target price)
+
+Dynamics:
+Q_{D,t+1} = α_{t+1} - β_{t+1} P_t + ξ^D_t
+Q_{S,t+1} = γ_{t+1} + δ_{t+1} P_t + ξ^S_t
+P_{t+1} = P_t + m_t + ξ^P_t
+
+Outputs:
+y_t = P^*_t = \frac{α_t - γ_t}{β_t + δ_t}
+
+Objective:
+min J = Σ_t [(P_t - P_*)^2 + c_m m_t^2]
+
+Constraints:
+β_t + δ_t > 0,  Q_{D,t}, Q_{S,t} ≥ 0

--- a/models/dynamic_troposphere/eq_barometric.md
+++ b/models/dynamic_troposphere/eq_barometric.md
@@ -1,0 +1,14 @@
+Name: Barometric pressure profile
+
+Equation(s):
+```math
+p(h) = p_0 \exp\left(- \frac{M g h}{R T}\right)
+```
+
+Assumptions:
+- Temperature $T$ is constant with altitude in the layer of interest.
+- Air behaves as an ideal gas with constant molar mass $M$ and gravity $g$.
+
+Calibration:
+- Use surface pressure $p_0$ and temperature readings to parameterize the profile.
+- Validate against radiosonde measurements to adjust $T$ or incorporate lapse-rate corrections.

--- a/models/dynamic_troposphere/schema.md
+++ b/models/dynamic_troposphere/schema.md
@@ -1,0 +1,18 @@
+# dynamic_troposphere model
+
+State: x_t = [p_t, T_t]  (pressure profile, layer temperature)
+Controls: u_t = [ℓ_t]  (lapse-rate adjustment)
+Params: θ = [p_0, M, g, R]  (surface pressure, molar mass of air, gravity, gas constant)
+
+Dynamics:
+T_{t+1} = T_t + ℓ_t + ξ^T_t
+p_{t+1}(h) = p_0 \exp\left(- \frac{M g h}{R T_{t+1}}\right)
+
+Outputs:
+y_t = p_t(h)
+
+Objective:
+min J = Σ_t \int_h (p_t(h) - p^{\text{obs}}_t(h))^2 \, dh
+
+Constraints:
+T_t > 0,  ℓ_t ∈ [ℓ_{\min}, ℓ_{\max}]


### PR DESCRIPTION
## Summary
- add domain-specific schema blueprints for agents, blockchain, cache, forecasting, queueing, thinking, token, and tropospheric models
- document the available schema starters in the models README for easier discovery
- trim the equation snippets back to the minimal template structure so they are quicker to copy and adapt

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d913f85c308322a22e0af62bdf4988