### PR TITLE
Document new trading resource OneDrive shares

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,13 @@ documenting which assets were consulted.
 | 6.9  | [trading-data-organization.md](./trading-data-organization.md)                       | Folder taxonomy for templates, journals, KPIs, and backtests across each horizon bucket.                |
 | 6.10 | [dai-webhook-routing.md](./dai-webhook-routing.md)                                   | Options for single-endpoint vs. auto-provisioned TradingView webhook routes managed by DAI.             |
 | 6.11 | [dynamic-market-notes.md](./dynamic-market-notes.md)                                 | Dynamic Market stack overview covering DMDA feeds, DMM quoting levers, and treasury coordination notes. |
+| 6.12 | [onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md](./onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md) | Share metadata, Graph helpers, and access notes for the trading PDF OneDrive folder. |
+| 6.13 | [onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md](./onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md) | Datasets share identifiers and Graph commands for refreshing training corpora. |
+| 6.14 | [onedrive-shares/eiqlwt1h9xpjk-7gpxzswqubhctetgb-e1khqcgjdyowjw-folder.md](./onedrive-shares/eiqlwt1h9xpjk-7gpxzswqubhctetgb-e1khqcgjdyowjw-folder.md) | Documentation PDFs share metadata and retrieval notes for the trading agent. |
+| 6.15 | [onedrive-shares/eq5pnm_tcvdnggzwqer7mzubpqvlwljacc8dt8ike04u9a-folder.md](./onedrive-shares/eq5pnm_tcvdnggzwqer7mzubpqvlwljacc8dt8ike04u9a-folder.md) | Knowledge base share identifiers for syncing reference materials. |
+| 6.16 | [onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md](./onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md) | Combined logs and model artifacts share metadata for telemetry/model reconciliation. |
+| 6.17 | [onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md](./onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md) | Trading reports share identifiers for ingesting supplemental analytics. |
+| 6.18 | [onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md](./onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md) | Standalone `read_me.md` text share metadata for onboarding notes. |
 
 ## 7. Operational Runbooks & Launch Phases
 

--- a/docs/onedrive-shares/eiqlwt1h9xpjk-7gpxzswqubhctetgb-e1khqcgjdyowjw-folder.md
+++ b/docs/onedrive-shares/eiqlwt1h9xpjk-7gpxzswqubhctetgb-e1khqcgjdyowjw-folder.md
@@ -1,0 +1,39 @@
+# EiQLwT1h9XpJk-7gPXzswQUBhCtETgb-e1khqcGjDYoWJw Share
+
+This share contains supporting **documentation PDFs** for the trading agent. The
+identifiers below make it easy to authenticate and mirror the folder in internal
+tooling.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/EiQLwT1h9XpJk-7gPXzswQUBhCtETgb-e1khqcGjDYoWJw?e=9irW1n
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0VpUUx3VDFoOVhwSmstN2dQWHpzd1FVQmhDdEVUZ2ItZTFraHFjR2pEWW9XSnc`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!s3dc10b24f561497a93eee03d7cecc105`
+
+## Access notes
+
+- Use `curl -I` to capture the redirect headers that reveal the `resid` value:
+
+  ```bash
+  curl -I "https://1drv.ms/f/c/2ff0428a2f57c7a4/EiQLwT1h9XpJk-7gPXzswQUBhCtETgb-e1khqcGjDYoWJw"
+  ```
+
+- Anonymous requests are blocked with HTTP 403 once redirected to
+  `onedrive.live.com`. Authenticate before attempting to list the PDFs.
+
+## Fetching metadata
+
+Follow the same token export and helper commands outlined in the datasets share,
+substituting this link:
+
+```bash
+tsx scripts/onedrive/dump-drive-item.ts \
+  "https://1drv.ms/f/c/2ff0428a2f57c7a4/EiQLwT1h9XpJk-7gPXzswQUBhCtETgb-e1khqcGjDYoWJw" \
+  docs/onedrive-shares/eiqlwt1h9xpjk-7gpxzswqubhctetgb-e1khqcgjdyowjw-folder.metadata.json
+```
+
+Record Graph responses to keep the PDF manifest aligned with upstream changes.

--- a/docs/onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md
+++ b/docs/onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md
@@ -1,0 +1,36 @@
+# Ejhj6-c4fJdOpaW-PHw5zL8BWuMO2lYzHwBRHbknD4GvbQ Share
+
+This OneDrive folder houses both the trading **logs** and archived **model
+artifacts** referenced in the latest upload. Track the identifiers here so the
+platform can reconcile telemetry and model updates.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/Ejhj6-c4fJdOpaW-PHw5zL8BWuMO2lYzHwBRHbknD4GvbQ?e=6oC1xb
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0VqaGo2LWM0ZkpkT3BhVy1QSHc1ekw4Qld1TU8ybFl6SHdCUkhia25ENEd2YlE`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!se7eb63387c384e97a5a5be3c7c39ccbf`
+
+## Access notes
+
+- Capture the redirect header to confirm `resid` before wiring automation:
+
+  ```bash
+  curl -I "https://1drv.ms/f/c/2ff0428a2f57c7a4/Ejhj6-c4fJdOpaW-PHw5zL8BWuMO2lYzHwBRHbknD4GvbQ"
+  ```
+
+- Authentication is required to browse the combined logs/models folder after the
+  redirect.
+
+## Fetching metadata
+
+Use the shared helper scripts to export the folder manifest and child items:
+
+```bash
+tsx scripts/onedrive/dump-drive-item.ts \
+  "https://1drv.ms/f/c/2ff0428a2f57c7a4/Ejhj6-c4fJdOpaW-PHw5zL8BWuMO2lYzHwBRHbknD4GvbQ" \
+  docs/onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.metadata.json
+```

--- a/docs/onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md
+++ b/docs/onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md
@@ -1,0 +1,75 @@
+# Ekqbarlpv7hLjyb9tgPdMqcBZpxonB18K7RHjp2IV6ofmQ Share
+
+This note records the metadata helpers for the newly provided OneDrive folder
+that contains the trading PDFs. Mirror the information here into any runbooks or
+scripts that need to access the remote resources.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/Ekqbarlpv7hLjyb9tgPdMqcBZpxonB18K7RHjp2IV6ofmQ?e=fn9fo0
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0VrcWJhcmxwdjdoTGp5Yjl0Z1BkTXFjQlpweG9uQjE4SzdSSGpwMklWNm9mbVE`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!sb96a9b4abf694bb88f26fdb603dd32a7`
+
+## Access notes
+
+- A simple `curl -I` against the share returns a redirect that exposes the
+  `resid` parameter shown above. Keep this handy when wiring the share into
+  Microsoft Graph calls or S3 wrapper manifests. The redirect looks like:
+
+  ```bash
+  curl -I "https://1drv.ms/f/c/2ff0428a2f57c7a4/Ekqbarlpv7hLjyb9tgPdMqcBZpxonB18K7RHjp2IV6ofmQ"
+  ```
+
+  ```text
+  HTTP/1.1 302 Found
+  Location: https://onedrive.live.com/redir?resid=2FF0428A2F57C7A4!sb96a9b4abf694bb88f26fdb603dd32a7&authkey=!AJAc...&cid=2FF0428A2F57C7A4
+  ```
+
+- Following the redirect anonymously currently returns "The request is blocked"
+  (HTTP 403) from `onedrive.live.com`. Authenticate with a Microsoft account or
+  use an app-only token to enumerate the folder contents.
+
+## Fetching metadata
+
+1. Export a Microsoft Graph access token that can read the shared folder:
+
+   ```bash
+   export ONEDRIVE_ACCESS_TOKEN="<token>"
+   ```
+
+2. Request the manifest entry with the repository helper:
+
+   ```bash
+   tsx scripts/onedrive/fetch-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/Ekqbarlpv7hLjyb9tgPdMqcBZpxonB18K7RHjp2IV6ofmQ"
+   ```
+
+3. Persist the metadata (including child items) for downstream automation or
+   auditing:
+
+   ```bash
+   tsx scripts/onedrive/dump-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/Ekqbarlpv7hLjyb9tgPdMqcBZpxonB18K7RHjp2IV6ofmQ" \
+     docs/onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.metadata.json
+   ```
+
+   Pass `false` as the optional third argument if you do **not** need the
+   `expand=children` query.
+
+4. Alternatively, query Microsoft Graph directly:
+
+   ```bash
+   curl \
+     --header "Authorization: Bearer ${ONEDRIVE_ACCESS_TOKEN}" \
+     --header "Accept: application/json" \
+     "https://graph.microsoft.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0VrcWJhcmxwdjdoTGp5Yjl0Z1BkTXFjQlpweG9uQjE4SzdSSGpwMklWNm9mbVE/driveItem?expand=children"
+   ```
+
+The Graph response will include the item metadata and any child PDF files once
+valid credentials are supplied. Snapshot the payload in
+`docs/onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.metadata.json`
+to keep the repository's knowledge base aligned with the external share.

--- a/docs/onedrive-shares/eq5pnm_tcvdnggzwqer7mzubpqvlwljacc8dt8ike04u9a-folder.md
+++ b/docs/onedrive-shares/eq5pnm_tcvdnggzwqer7mzubpqvlwljacc8dt8ike04u9a-folder.md
@@ -1,0 +1,37 @@
+# Eq5pNm_TcvdNgGzwqER7MZUBpQvLwljACC8dT8IKE04U9A Share
+
+This folder is the external **knowledge base** that augments the trading
+assistant's reasoning. Store its identifiers here so automations can hydrate the
+local cache when upstream documents change.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/Eq5pNm_TcvdNgGzwqER7MZUBpQvLwljACC8dT8IKE04U9A?e=3XpkSi
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0VxNXBObV9UY3ZkTmdHendxRVI3TVpVQnBRdkx3bGpBQ0M4ZFQ4SUtFMDRVOUE`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!s6f3669ae72d34df7806cf0a8447b3195`
+
+## Access notes
+
+- Run a header-only request to reveal the `resid` parameter before Graph calls:
+
+  ```bash
+  curl -I "https://1drv.ms/f/c/2ff0428a2f57c7a4/Eq5pNm_TcvdNgGzwqER7MZUBpQvLwljACC8dT8IKE04U9A"
+  ```
+
+- As with the other shares, anonymous redirects currently return HTTP 403.
+  Acquire the proper credentials before attempting to read contents.
+
+## Fetching metadata
+
+Use the shared scripts with this link to capture the latest manifest and child
+items for offline search:
+
+```bash
+tsx scripts/onedrive/dump-drive-item.ts \
+  "https://1drv.ms/f/c/2ff0428a2f57c7a4/Eq5pNm_TcvdNgGzwqER7MZUBpQvLwljACC8dT8IKE04U9A" \
+  docs/onedrive-shares/eq5pnm_tcvdnggzwqer7mzubpqvlwljacc8dt8ike04u9a-folder.metadata.json
+```

--- a/docs/onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md
+++ b/docs/onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md
@@ -1,0 +1,36 @@
+# EskWDphQepxIhQmATzjdduUBkm_lSDXT-Jvm-1SmjJgFeA Share
+
+This folder stores uploaded trading **reports** that complement the other
+resource bundles. Keep its identifiers readily available for report ingestion
+and auditing tasks.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/EskWDphQepxIhQmATzjdduUBkm_lSDXT-Jvm-1SmjJgFeA?e=kHBcZS
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0Vza1dEcGhRZXB4SWhRbUFUempkZHVVQmttX2xTRFhULUp2bS0xU21qSmdGZUE`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!s980e16c97a50489c8509804f38dd76e5`
+
+## Access notes
+
+- Use a header-only request to capture the redirect metadata:
+
+  ```bash
+  curl -I "https://1drv.ms/f/c/2ff0428a2f57c7a4/EskWDphQepxIhQmATzjdduUBkm_lSDXT-Jvm-1SmjJgFeA"
+  ```
+
+- Authentication is required after redirection; anonymous browsing receives an
+  HTTP 403 response.
+
+## Fetching metadata
+
+Export the current manifest for downstream reconciliations with:
+
+```bash
+tsx scripts/onedrive/dump-drive-item.ts \
+  "https://1drv.ms/f/c/2ff0428a2f57c7a4/EskWDphQepxIhQmATzjdduUBkm_lSDXT-Jvm-1SmjJgFeA" \
+  docs/onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.metadata.json
+```

--- a/docs/onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md
+++ b/docs/onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md
@@ -1,0 +1,36 @@
+# EToElNePqHhHiis2vl7QE_ABZ618nQf2vgNrykCx0PrHwA Share
+
+The `read_me.md` document for the trading upload is shared separately as a text
+file. Use this reference to retrieve it for onboarding or archival purposes.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/t/c/2ff0428a2f57c7a4/EToElNePqHhHiis2vl7QE_ABZ618nQf2vgNrykCx0PrHwA?e=8efbYM
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL3QvYy8yZmYwNDI4YTJmNTdjN2E0L0VUb0VsTmVQcUhoSGlpczJ2bDdRRV9BQlo2MThuUWYydmdOcnlrQ3gwUHJId0E`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!sd794043aa88f47788a2b36be5ed013f0`
+  - `ithint=file,txt`
+
+## Access notes
+
+- Inspect the redirect headers to copy the `resid` and `ithint` metadata:
+
+  ```bash
+  curl -I "https://1drv.ms/t/c/2ff0428a2f57c7a4/EToElNePqHhHiis2vl7QE_ABZ618nQf2vgNrykCx0PrHwA"
+  ```
+
+- The text file also requires authentication once redirected to OneDrive.
+
+## Fetching metadata
+
+When dumping the item metadata, target a `.file.metadata.json` path to
+acknowledge the single-document scope:
+
+```bash
+tsx scripts/onedrive/dump-drive-item.ts \
+  "https://1drv.ms/t/c/2ff0428a2f57c7a4/EToElNePqHhHiis2vl7QE_ABZ618nQf2vgNrykCx0PrHwA" \
+  docs/onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.metadata.json
+```

--- a/docs/onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md
+++ b/docs/onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md
@@ -1,0 +1,69 @@
+# Eu8_tRb65JdBrLL39T1GVwQBaieBW24rkUU17Wcuk-C_QA Share
+
+This folder hosts the external **datasets** that the trading agent reviews. The
+notes below capture the identifiers needed for Microsoft Graph workflows and
+repository scripts that sync the folder metadata.
+
+## Share details
+
+- **Original link:**
+  https://1drv.ms/f/c/2ff0428a2f57c7a4/Eu8_tRb65JdBrLL39T1GVwQBaieBW24rkUU17Wcuk-C_QA?e=7mWyfY
+- **Graph share identifier:**
+  `u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0V1OF90UmI2NUpkQnJMTDM5VDFHVndRQmFpZUJXMjRya1VVMTdXY3VrLUNfUUE`
+- **Decoded parameters:**
+  - `cid=2ff0428a2f57c7a4`
+  - `resid=2FF0428A2F57C7A4!s16b53fefe4fa4197acb2f7f53d465704`
+
+## Access notes
+
+- A `curl -I` request exposes the redirect that includes the `resid` and `cid`
+  values required for Microsoft Graph calls:
+
+  ```bash
+  curl -I "https://1drv.ms/f/c/2ff0428a2f57c7a4/Eu8_tRb65JdBrLL39T1GVwQBaieBW24rkUU17Wcuk-C_QA"
+  ```
+
+- The redirect currently responds with HTTP 403 when followed anonymously.
+  Authenticate with a Microsoft account or app-only token before enumerating
+  child items.
+
+## Fetching metadata
+
+1. Export a Microsoft Graph access token that can read the shared folder:
+
+   ```bash
+   export ONEDRIVE_ACCESS_TOKEN="<token>"
+   ```
+
+2. Request the manifest entry with the repository helper:
+
+   ```bash
+   tsx scripts/onedrive/fetch-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/Eu8_tRb65JdBrLL39T1GVwQBaieBW24rkUU17Wcuk-C_QA"
+   ```
+
+3. Persist the metadata (including child items) for downstream automation or
+   auditing:
+
+   ```bash
+   tsx scripts/onedrive/dump-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/Eu8_tRb65JdBrLL39T1GVwQBaieBW24rkUU17Wcuk-C_QA" \
+     docs/onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.metadata.json
+   ```
+
+   Pass `false` as the optional third argument if you do **not** need the
+   `expand=children` query.
+
+4. Alternatively, query Microsoft Graph directly:
+
+   ```bash
+   curl \
+     --header "Authorization: Bearer ${ONEDRIVE_ACCESS_TOKEN}" \
+     --header "Accept: application/json" \
+     "https://graph.microsoft.com/v1.0/shares/u!aHR0cHM6Ly8xZHJ2Lm1zL2YvYy8yZmYwNDI4YTJmNTdjN2E0L0V1OF90UmI2NUpkQnJMTDM5VDFHVndRQmFpZUJXMjRya1VVMTdXY3VrLUNfUUE/driveItem?expand=children"
+   ```
+
+The Graph response returns folder metadata and dataset files when the token is
+valid. Snapshot the payload in
+`docs/onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.metadata.json`
+so the repository can track changes to the external share.


### PR DESCRIPTION
## Summary
- add documentation pages for each newly shared trading OneDrive folder and the read_me text link with Graph metadata, redirect headers, and fetch commands
- index the new share references in the trading operations section of the docs catalog for easy discovery

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d91786a788832280b8add5ff555dbf