### PR TITLE
Add Dynamic AGI local machine integration

### DIFF
--- a/docs/dynamic_agi_inventory.md
+++ b/docs/dynamic_agi_inventory.md
@@ -25,3 +25,8 @@ The package entrypoint re-exports the orchestrator model, self-improvement loop,
 - **Example and batch wrappers** – `FineTuneExample` and `FineTuneBatch` wrap prompt/completion pairs with metadata, tags, and snapshot timing so that training corpora remain structured and reproducible.【F:dynamic_agi/fine_tune.py†L14-L162】
 - **Rolling dataset management** – `DynamicFineTuneDataset` enforces capacity bounds, tracks character budgets, and maintains tag histograms while supporting snapshot/export operations for auditability.【F:dynamic_agi/fine_tune.py†L164-L231】
 - **Telemetry-to-dataset bridge** – `DynamicAGIFineTuner` converts `LearningSnapshot` telemetry into prompt/completion examples, optionally batches them, and returns dataset summaries with default tag context for downstream fine-tuning jobs.【F:dynamic_agi/fine_tune.py†L233-L285】
+
+## Local machine integration (`local_machine.py`)
+
+- **Task configuration** – `AGILocalMachineTaskConfig` supplies default command templates plus category- or action-specific overrides, keeping working directory, environment, and resource estimates consistent when converting plans into automation tasks.【F:dynamic_agi/local_machine.py†L52-L117】
+- **Plan materialisers** – `build_local_machine_plan_from_improvement` and `build_local_machine_plan_from_output` translate improvement plans or AGI outputs into `LocalMachinePlan` instances so Dynamic AGI recommendations can execute on workstation automation pipelines.【F:dynamic_agi/local_machine.py†L119-L188】

--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -7,6 +7,12 @@ from .fine_tune import (
     FineTuneExample,
     __all__ as _fine_tune_all,
 )
+from .local_machine import (
+    AGILocalMachineTaskConfig,
+    build_local_machine_plan_from_improvement,
+    build_local_machine_plan_from_output,
+    __all__ as _local_machine_all,
+)
 from .model import (
     AGIDiagnostics,
     AGIOutput,
@@ -26,4 +32,9 @@ from .self_improvement import (
     __all__ as _self_improvement_all,
 )
 
-__all__ = [*_model_all, *_self_improvement_all, *_fine_tune_all]
+__all__ = [
+    *_model_all,
+    *_self_improvement_all,
+    *_fine_tune_all,
+    *_local_machine_all,
+]

--- a/dynamic_agi/local_machine.py
+++ b/dynamic_agi/local_machine.py
@@ -1,0 +1,234 @@
+"""Bridge Dynamic AGI improvement plans into local machine automation tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from dynamic_local_machine import (
+    DynamicLocalMachineEngine,
+    LocalMachinePlan,
+    LocalMachineTask,
+)
+
+from .model import AGIOutput
+from .self_improvement import ImprovementPlan
+
+__all__ = [
+    "AGILocalMachineTaskConfig",
+    "build_local_machine_plan_from_improvement",
+    "build_local_machine_plan_from_output",
+]
+
+
+def _slugify(value: str) -> str:
+    text = "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-")
+    if not text:
+        return "task"
+    while "--" in text:
+        text = text.replace("--", "-")
+    return text
+
+
+def _normalise_actions(actions: Sequence[object] | None) -> tuple[str, ...]:
+    if not actions:
+        return ()
+    normalised: list[str] = []
+    for raw in actions:
+        text = str(raw).strip()
+        if text:
+            normalised.append(text)
+    return tuple(normalised)
+
+
+def _normalise_roadmap(
+    roadmap: Sequence[Mapping[str, object]] | None,
+) -> tuple[MutableMapping[str, Any], ...]:
+    if not roadmap:
+        return ()
+    steps: list[MutableMapping[str, Any]] = []
+    for payload in roadmap:
+        if not isinstance(payload, Mapping):
+            continue
+        steps.append(dict(payload))
+    return tuple(steps)
+
+
+@dataclass(slots=True)
+class AGILocalMachineTaskConfig:
+    """Configuration for materialising AGI improvement plans into tasks."""
+
+    default_command: tuple[str, ...] = ("echo", "{description}")
+    default_estimated_duration: float = 1.0
+    default_cpu_cost: float = 0.5
+    default_memory_cost: float = 0.25
+    working_directory: str | None = None
+    environment: Mapping[str, str] = field(default_factory=dict)
+    action_commands: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    category_commands: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    sequential_dependencies: bool = True
+
+    def command_for_action(self, action: str) -> tuple[str, ...]:
+        key = action.lower()
+        for alias, command in self.action_commands.items():
+            if key == alias.lower():
+                return tuple(str(segment) for segment in command)
+        return self._render_default_command(description=action, action=action)
+
+    def command_for_category(
+        self, category: str | None, *, description: str
+    ) -> tuple[str, ...]:
+        if category:
+            key = category.lower()
+            for alias, command in self.category_commands.items():
+                if key == alias.lower():
+                    return tuple(str(segment) for segment in command)
+        return self._render_default_command(
+            description=description, category=category or ""
+        )
+
+    def build_task(
+        self,
+        *,
+        identifier: str,
+        command: Sequence[str],
+        description: str,
+        dependencies: Sequence[str] = (),
+        extra_environment: Mapping[str, Any] | None = None,
+    ) -> LocalMachineTask:
+        environment: dict[str, str] = dict(self.environment)
+        if extra_environment:
+            for key, value in extra_environment.items():
+                if value is None:
+                    continue
+                environment[str(key)] = str(value)
+        return LocalMachineTask(
+            identifier=identifier,
+            command=tuple(str(segment) for segment in command),
+            description=description,
+            working_directory=self.working_directory,
+            environment=environment,
+            estimated_duration=self.default_estimated_duration,
+            cpu_cost=self.default_cpu_cost,
+            memory_cost=self.default_memory_cost,
+            dependencies=tuple(dependencies),
+        )
+
+    def _render_default_command(
+        self,
+        *,
+        description: str,
+        action: str | None = None,
+        category: str | None = None,
+    ) -> tuple[str, ...]:
+        context = {
+            "description": description,
+            "action": action or "",
+            "category": category or "",
+        }
+        return tuple(str(segment).format(**context) for segment in self.default_command)
+
+
+def build_local_machine_plan_from_improvement(
+    improvement: ImprovementPlan | Mapping[str, Any],
+    *,
+    engine: DynamicLocalMachineEngine | None = None,
+    config: AGILocalMachineTaskConfig | None = None,
+) -> LocalMachinePlan:
+    """Convert an improvement plan into a local machine execution blueprint."""
+
+    engine = engine or DynamicLocalMachineEngine()
+    config = config or AGILocalMachineTaskConfig()
+
+    if isinstance(improvement, ImprovementPlan):
+        payload = improvement.to_dict()
+    else:
+        payload = dict(improvement)
+
+    actions = _normalise_actions(payload.get("actions"))
+    roadmap = _normalise_roadmap(payload.get("roadmap"))
+
+    tasks: list[LocalMachineTask] = []
+    previous_identifier: str | None = None
+
+    for index, action in enumerate(actions, start=1):
+        identifier = f"agi-action-{index:02d}-{_slugify(action)}"
+        description = f"Dynamic AGI action: {action}"
+        dependencies = (
+            (previous_identifier,)
+            if config.sequential_dependencies and previous_identifier
+            else ()
+        )
+        task = config.build_task(
+            identifier=identifier,
+            command=config.command_for_action(action),
+            description=description,
+            dependencies=dependencies,
+            extra_environment={
+                "AGI_ACTION": action,
+            },
+        )
+        tasks.append(task)
+        if config.sequential_dependencies:
+            previous_identifier = identifier
+
+    for index, step in enumerate(roadmap, start=1):
+        category = (
+            str(step.get("category", "")) if step.get("category") is not None else ""
+        )
+        description = str(
+            step.get("description")
+            or step.get("intent")
+            or category
+            or f"Roadmap step {index}"
+        )
+        identifier = f"agi-roadmap-{index:02d}-{_slugify(category or description)}"
+        dependencies = (
+            (previous_identifier,)
+            if config.sequential_dependencies and previous_identifier
+            else ()
+        )
+        extra_environment: dict[str, Any] = {
+            "AGI_CATEGORY": category,
+            "AGI_INTENT": step.get("intent"),
+            "AGI_FOCUS_METRIC": step.get("focus_metric"),
+        }
+        habits = step.get("suggested_habits")
+        if habits:
+            extra_environment["AGI_SUGGESTED_HABITS"] = " | ".join(
+                str(habit) for habit in habits
+            )
+        task = config.build_task(
+            identifier=identifier,
+            command=config.command_for_category(category, description=description),
+            description=f"Dynamic AGI roadmap: {description}",
+            dependencies=dependencies,
+            extra_environment=extra_environment,
+        )
+        tasks.append(task)
+        if config.sequential_dependencies:
+            previous_identifier = identifier
+
+    if not tasks:
+        raise ValueError(
+            "improvement plan does not contain any actions or roadmap steps"
+        )
+
+    return engine.build_plan(tasks)
+
+
+def build_local_machine_plan_from_output(
+    output: AGIOutput,
+    *,
+    engine: DynamicLocalMachineEngine | None = None,
+    config: AGILocalMachineTaskConfig | None = None,
+) -> LocalMachinePlan:
+    """Convenience helper that accepts an ``AGIOutput`` instance."""
+
+    if output.improvement is None:
+        raise ValueError("AGI output does not include an improvement plan")
+    return build_local_machine_plan_from_improvement(
+        output.improvement,
+        engine=engine,
+        config=config,
+    )

--- a/tests_python/test_dynamic_agi_local_machine.py
+++ b/tests_python/test_dynamic_agi_local_machine.py
@@ -1,0 +1,128 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from dynamic_agi import (
+    AGIDiagnostics,
+    AGILocalMachineTaskConfig,
+    AGIOutput,
+    build_local_machine_plan_from_improvement,
+    build_local_machine_plan_from_output,
+)
+from dynamic_ai import AISignal
+
+
+def _diagnostics() -> AGIDiagnostics:
+    return AGIDiagnostics(context={}, composite={}, consensus={})
+
+
+def _agi_output(improvement: Dict[str, object]) -> AGIOutput:
+    return AGIOutput(
+        signal=AISignal(action="HOLD", confidence=0.5, reasoning="stub"),
+        research={},
+        risk_adjusted={},
+        sizing=None,
+        market_making={},
+        diagnostics=_diagnostics(),
+        improvement=improvement,
+        version="0.0.0",
+        version_info={},
+        generated_at=datetime.now(timezone.utc),
+    )
+
+
+def test_build_plan_from_improvement_applies_overrides() -> None:
+    improvement = {
+        "actions": ["Tighten risk controls", "Run integration tests"],
+        "roadmap": [
+            {
+                "category": "Daily Operating System",
+                "description": "Structure deep work blocks",
+                "intent": "Amplify workflow cadence",
+                "focus_metric": "execution_cadence",
+                "suggested_habits": ["Plan focus cycles"],
+            },
+            {
+                "category": "Skill Growth & Knowledge",
+                "description": "Invest time in deliberate practice",
+            },
+        ],
+    }
+
+    config = AGILocalMachineTaskConfig(
+        action_commands={
+            "tighten risk controls": ("python", "manage.py", "risk_audit"),
+        },
+        category_commands={
+            "daily operating system": ("npm", "run", "plan-routine"),
+        },
+        default_command=("echo", "{description}"),
+        default_estimated_duration=2.0,
+        default_cpu_cost=1.2,
+        default_memory_cost=0.8,
+        environment={"CI": "1"},
+    )
+
+    plan = build_local_machine_plan_from_improvement(improvement, config=config)
+
+    assert [task.identifier for task in plan.tasks] == [
+        "agi-action-01-tighten-risk-controls",
+        "agi-action-02-run-integration-tests",
+        "agi-roadmap-01-daily-operating-system",
+        "agi-roadmap-02-skill-growth-knowledge",
+    ]
+
+    action_task = plan.tasks[0]
+    assert action_task.command == ("python", "manage.py", "risk_audit")
+    assert action_task.dependencies == ()
+    assert action_task.estimated_duration == pytest.approx(2.0)
+    assert action_task.environment_mapping()["CI"] == "1"
+    assert action_task.environment_mapping()["AGI_ACTION"] == "Tighten risk controls"
+
+    roadmap_task = plan.tasks[2]
+    assert roadmap_task.command == ("npm", "run", "plan-routine")
+    assert roadmap_task.dependencies == ("agi-action-02-run-integration-tests",)
+    assert (
+        roadmap_task.environment_mapping()["AGI_SUGGESTED_HABITS"]
+        == "Plan focus cycles"
+    )
+
+
+def test_build_plan_from_output_requires_improvement() -> None:
+    improvement = {
+        "actions": ["Refine execution"],
+        "roadmap": [],
+    }
+    plan = build_local_machine_plan_from_output(_agi_output(improvement))
+    assert [task.identifier for task in plan.tasks] == [
+        "agi-action-01-refine-execution",
+    ]
+
+    base_output = _agi_output({})
+    output_without_plan = AGIOutput(
+        signal=base_output.signal,
+        research=base_output.research,
+        risk_adjusted=base_output.risk_adjusted,
+        sizing=base_output.sizing,
+        market_making=base_output.market_making,
+        diagnostics=base_output.diagnostics,
+        improvement=None,
+        version=base_output.version,
+        version_info=base_output.version_info,
+        generated_at=base_output.generated_at,
+    )
+
+    with pytest.raises(ValueError):
+        build_local_machine_plan_from_output(output_without_plan)
+
+
+def test_build_plan_from_improvement_validates_content() -> None:
+    with pytest.raises(ValueError):
+        build_local_machine_plan_from_improvement({"actions": [], "roadmap": []})


### PR DESCRIPTION
## Summary
- add a local machine bridge that turns AGI improvement plans into executable task plans
- expose the bridge via the dynamic_agi package and document the new integration surface
- cover the new helpers with focused unit tests for plan generation behaviour

## Testing
- `pytest tests_python/test_dynamic_agi_local_machine.py`


------
https://chatgpt.com/codex/tasks/task_e_68d921a834e48322a6776530d1a342a2