### PR TITLE
feat: add Supabase connectivity verification

### DIFF
--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -25,5 +25,13 @@ from .self_improvement import (
     LearningSnapshot,
     __all__ as _self_improvement_all,
 )
+from .supabase import (
+    DYNAMIC_AGI_SUPABASE_BUCKETS,
+    DYNAMIC_AGI_SUPABASE_FUNCTIONS,
+    DYNAMIC_AGI_SUPABASE_TABLES,
+    build_dynamic_agi_supabase_engine,
+    verify_dynamic_agi_supabase_connectivity,
+    __all__ as _supabase_all,
+)
 
-__all__ = [*_model_all, *_self_improvement_all, *_fine_tune_all]
+__all__ = [*_model_all, *_self_improvement_all, *_fine_tune_all, *_supabase_all]

--- a/dynamic_agi/supabase.py
+++ b/dynamic_agi/supabase.py
@@ -1,0 +1,152 @@
+"""Supabase configuration primitives for the Dynamic AGI stack."""
+
+from __future__ import annotations
+
+from typing import Callable, Mapping, Sequence
+
+from dynamic_supabase import (
+    DynamicSupabaseEngine,
+    SupabaseBucketBlueprint,
+    SupabaseFunctionBlueprint,
+    SupabaseTableBlueprint,
+)
+
+__all__ = [
+    "DYNAMIC_AGI_SUPABASE_TABLES",
+    "DYNAMIC_AGI_SUPABASE_FUNCTIONS",
+    "DYNAMIC_AGI_SUPABASE_BUCKETS",
+    "build_dynamic_agi_supabase_engine",
+    "verify_dynamic_agi_supabase_connectivity",
+]
+
+
+AGI_EVALUATIONS_TABLE = SupabaseTableBlueprint(
+    name="agi_evaluations",
+    schema="public",
+    primary_keys=("id",),
+    indexes=(
+        "agi_evaluations_generated_idx",
+        "agi_evaluations_version_idx",
+        "agi_evaluations_signal_idx",
+    ),
+    row_estimate=12_000,
+    freshness_score=0.92,
+    retention_hours=24 * 180,
+    description=(
+        "Stores Dynamic AGI orchestrator outputs, diagnostics, and market synthesis."
+    ),
+)
+
+AGI_LEARNING_SNAPSHOTS_TABLE = SupabaseTableBlueprint(
+    name="agi_learning_snapshots",
+    schema="public",
+    primary_keys=("id",),
+    indexes=(
+        "agi_learning_snapshots_observed_idx",
+        "agi_learning_snapshots_evaluation_idx",
+    ),
+    row_estimate=24_000,
+    freshness_score=0.9,
+    retention_hours=24 * 365,
+    description="Telemetry for Dynamic AGI self-improvement and evaluation signals.",
+)
+
+DYNAMIC_AGI_SUPABASE_TABLES: tuple[SupabaseTableBlueprint, ...] = (
+    AGI_EVALUATIONS_TABLE,
+    AGI_LEARNING_SNAPSHOTS_TABLE,
+)
+
+DYNAMIC_AGI_SUPABASE_FUNCTIONS: tuple[SupabaseFunctionBlueprint, ...] = (
+    SupabaseFunctionBlueprint(
+        name="dynamic-agi-evaluate",
+        endpoint="/functions/v1/dynamic-agi-evaluate",
+        version="v1",
+        invocation_count=128,
+        error_rate=0.01,
+        average_latency_ms=380.0,
+        metadata={
+            "description": "Edge function orchestrating Dynamic AGI end-to-end runs.",
+            "writes": ["agi_evaluations", "agi_learning_snapshots"],
+        },
+    ),
+    SupabaseFunctionBlueprint(
+        name="dynamic-agi-digest",
+        endpoint="/functions/v1/dynamic-agi-digest",
+        version="v1",
+        invocation_count=72,
+        error_rate=0.0,
+        average_latency_ms=215.0,
+        metadata={
+            "description": "Generates human oversight digests from AGI telemetry for review.",
+            "reads": ["agi_evaluations", "agi_learning_snapshots"],
+        },
+    ),
+)
+
+DYNAMIC_AGI_SUPABASE_BUCKETS: tuple[SupabaseBucketBlueprint, ...] = (
+    SupabaseBucketBlueprint(
+        name="agi-artifacts",
+        is_public=False,
+        object_count=0,
+        total_size_mb=0.0,
+        lifecycle_rules=(
+            "retain-latest-evaluation-packages",
+            "archive-monthly-governance-reports",
+        ),
+        region="us-east-1",
+        metadata={
+            "description": "Model cards, fine-tuning exports, and governance artifacts from Dynamic AGI.",
+        },
+    ),
+)
+
+
+def build_dynamic_agi_supabase_engine(
+    *,
+    tables: Sequence[SupabaseTableBlueprint | Mapping[str, object]] | None = None,
+    functions: Sequence[SupabaseFunctionBlueprint | Mapping[str, object]] | None = None,
+    buckets: Sequence[SupabaseBucketBlueprint | Mapping[str, object]] | None = None,
+) -> DynamicSupabaseEngine:
+    """Instantiate a :class:`DynamicSupabaseEngine` preloaded for Dynamic AGI."""
+
+    resolved_tables: list[SupabaseTableBlueprint | Mapping[str, object]] = list(
+        DYNAMIC_AGI_SUPABASE_TABLES
+    )
+    if tables:
+        resolved_tables.extend(tables)
+
+    resolved_functions: list[SupabaseFunctionBlueprint | Mapping[str, object]] = list(
+        DYNAMIC_AGI_SUPABASE_FUNCTIONS
+    )
+    if functions:
+        resolved_functions.extend(functions)
+
+    resolved_buckets: list[SupabaseBucketBlueprint | Mapping[str, object]] = list(
+        DYNAMIC_AGI_SUPABASE_BUCKETS
+    )
+    if buckets:
+        resolved_buckets.extend(buckets)
+
+    return DynamicSupabaseEngine(
+        tables=resolved_tables,
+        functions=resolved_functions,
+        buckets=resolved_buckets,
+    )
+
+
+def verify_dynamic_agi_supabase_connectivity(
+    *,
+    base_url: str,
+    anon_key: str,
+    timeout: float = 5.0,
+    probe: Callable[[str, Mapping[str, str], float], int] | None = None,
+) -> bool:
+    """Ensure the Dynamic AGI Supabase project is reachable."""
+
+    engine = build_dynamic_agi_supabase_engine()
+    return engine.verify_connectivity(
+        base_url=base_url,
+        anon_key=anon_key,
+        timeout=timeout,
+        probe=probe,
+    )

--- a/dynamic_supabase/__init__.py
+++ b/dynamic_supabase/__init__.py
@@ -1,6 +1,7 @@
 """High-level Supabase orchestration primitives."""
 
 from .engine import (
+    SupabaseConnectivityError,
     SupabaseBucketBlueprint,
     SupabaseFunctionBlueprint,
     SupabaseQueryProfile,
@@ -16,4 +17,5 @@ __all__ = [
     "SupabaseResourceHealth",
     "SupabaseTableBlueprint",
     "DynamicSupabaseEngine",
+    "SupabaseConnectivityError",
 ]

--- a/tests_python/test_dynamic_agi_supabase.py
+++ b/tests_python/test_dynamic_agi_supabase.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Mapping
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from dynamic_agi import (  # noqa: E402 - added after sys.path mutation
+    DYNAMIC_AGI_SUPABASE_BUCKETS,
+    DYNAMIC_AGI_SUPABASE_FUNCTIONS,
+    DYNAMIC_AGI_SUPABASE_TABLES,
+    build_dynamic_agi_supabase_engine,
+    verify_dynamic_agi_supabase_connectivity,
+)
+from dynamic_supabase import SupabaseConnectivityError  # noqa: E402
+
+
+class DynamicAGISupabaseConfigTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = build_dynamic_agi_supabase_engine()
+
+    def test_tables_registered(self) -> None:
+        identifiers = {
+            table.canonical_identifier for table in self.engine.tables
+        }
+        self.assertIn("public.agi_evaluations", identifiers)
+        self.assertIn("public.agi_learning_snapshots", identifiers)
+
+    def test_functions_registered(self) -> None:
+        function_names = {function.canonical_name for function in self.engine.functions}
+        expected = {fn.canonical_name for fn in DYNAMIC_AGI_SUPABASE_FUNCTIONS}
+        self.assertTrue(expected.issubset(function_names))
+
+    def test_bucket_registered(self) -> None:
+        bucket_names = {bucket.canonical_name for bucket in self.engine.buckets}
+        expected = {bucket.canonical_name for bucket in DYNAMIC_AGI_SUPABASE_BUCKETS}
+        self.assertEqual(expected, bucket_names)
+
+    def test_catalogue_contains_metadata(self) -> None:
+        catalogue = self.engine.catalogue()
+        tables = catalogue["tables"]
+        names = {entry["name"] for entry in tables}
+        self.assertIn("agi_evaluations", names)
+        agi_table = next(
+            entry for entry in tables if entry["name"] == "agi_evaluations"
+        )
+        self.assertIn("Dynamic AGI", agi_table["description"] or "")
+
+    def test_health_defaults_without_queries(self) -> None:
+        health = self.engine.resource_health(
+            resource_type="table", resource_name="public.agi_evaluations"
+        )
+        self.assertIn("no telemetry available", health.notes)
+
+    def test_verify_connectivity_success(self) -> None:
+        captured: dict[str, object] = {}
+
+        def probe(url: str, headers: Mapping[str, str], timeout: float) -> int:
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return 204
+
+        result = verify_dynamic_agi_supabase_connectivity(
+            base_url="https://example.supabase.co",
+            anon_key="example-key",
+            timeout=2.5,
+            probe=probe,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            "https://example.supabase.co/rest/v1/",
+            captured["url"],
+        )
+        self.assertEqual("example-key", captured["headers"]["apikey"])
+        self.assertEqual("example-key", captured["headers"]["Authorization"].split()[1])
+        self.assertEqual(2.5, captured["timeout"])
+
+    def test_verify_connectivity_failure(self) -> None:
+        def probe(_: str, __: Mapping[str, str], ___: float) -> int:
+            return 503
+
+        with self.assertRaises(SupabaseConnectivityError):
+            verify_dynamic_agi_supabase_connectivity(
+                base_url="https://example.supabase.co",
+                anon_key="bad-key",
+                probe=probe,
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a connectivity probe API to `DynamicSupabaseEngine` with a dedicated error type
- expose a convenience helper from the Dynamic AGI Supabase module
- extend the Dynamic AGI Supabase tests to cover connectivity success and failure paths

## Testing
- pytest tests_python/test_dynamic_agi_supabase.py
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d920b825f0832296aa3aef73a0032e