### PR TITLE
docs: expand ngrok tunnel verification steps

### DIFF
--- a/docs/ngrok-troubleshooting.md
+++ b/docs/ngrok-troubleshooting.md
@@ -35,7 +35,22 @@ Once the tunnel command is running on a supported machine:
 
 1. **Check the tunnel status locally.** The ngrok console prints the assigned forwarding URL—confirm it matches `https://exosporal-ezequiel-semibiographically.ngrok-free.dev`. You can also visit <http://127.0.0.1:4040/status> to confirm the tunnel is active.
 2. **Test the endpoint.** From another terminal, use `curl https://exosporal-ezequiel-semibiographically.ngrok-free.dev` (or the appropriate path) to ensure you receive the expected response from your local service.
-3. **Inspect the ngrok dashboard.** Visit <https://dashboard.ngrok.com/endpoints/status> to confirm the tunnel is active and requests are flowing. The **Last Connection** timestamp should update when you send traffic.
-4. **Review logs for errors.** In the terminal running ngrok press `Ctrl+L` (or open the **Logs** tab in the dashboard) to reveal connection attempts. Look for TLS handshake failures, 502 responses, or `ERR_NGROK_xxx` codes and resolve them based on the logged guidance.
+3. **Confirm you reached ngrok's edge.** Run `curl -sS -D - https://exosporal-ezequiel-semibiographically.ngrok-free.dev -o /dev/null | grep -i "^x-ngrok"` to verify the response includes ngrok headers. Their presence confirms you're hitting the current tunnel and not a cached or stale DNS entry.
+4. **Inspect the ngrok dashboard.** Visit <https://dashboard.ngrok.com/endpoints/status> to confirm the tunnel is active and requests are flowing. The **Last Connection** timestamp should update when you send traffic.
+5. **Review logs for errors.** In the terminal running ngrok press `Ctrl+L` (or open the **Logs** tab in the dashboard) to reveal connection attempts. Look for TLS handshake failures, 502 responses, or `ERR_NGROK_xxx` codes and resolve them based on the logged guidance.
+6. **List active tunnels via the API (optional).** If you need an automated check, run `ngrok api tunnels list --json` from an authenticated environment and verify that the `public_url` matches the custom domain.
 
 If any of these verification steps fail, review the ngrok logs (displayed in the tunnel console) for connection errors and ensure the local service on port `80` is reachable. You can test the local service directly with `curl http://localhost:80` to make sure it is serving traffic before exposing it via ngrok.
+
+## Coordinating With a Remote Collaborator
+
+When someone else confirms that the tunnel is running on their machine (for example by sharing the ngrok status console), follow these steps before proceeding:
+
+1. **Acknowledge the tunnel status.** Confirm that the forwarding address they shared matches the expected custom domain. If you are on a call or chat, read the domain back to avoid typos.
+2. **Independently test the endpoint.** Run `curl https://exosporal-ezequiel-semibiographically.ngrok-free.dev` (or the relevant path) from your environment to verify that you can reach the service over the tunnel.
+3. **Check the HTTP response.** Look for the status code and payload you expect from the upstream application. A `200` response indicates success; a `4xx/5xx` response means the upstream service is likely misconfigured or offline.
+4. **Match headers with the collaborator.** Ask your collaborator to share the `x-ngrok-trace-id` (or similar) header from their local `curl -i` run and ensure it matches what you see. Matching IDs confirm you are both exercising the same live tunnel instance.
+5. **Confirm dashboard alignment.** Both parties should see the tunnel listed under <https://dashboard.ngrok.com/endpoints/status> with the same `public_url` and a recent **Last Connection** timestamp after your verification curl.
+6. **Share next steps.** Once you confirm the tunnel works, let the collaborator know what actions you will take (for example, running integration tests, triggering a deployment, or browsing the exposed UI). If the curl check fails, report the exact error message so they can diagnose it on their side.
+
+Documenting these checks ensures everyone has a shared understanding of the tunnel's state before moving on to dependent work.


### PR DESCRIPTION
## Summary
- expand the ngrok troubleshooting guide with explicit header checks and API-based validation to confirm an active tunnel
- align the collaborator checklist on shared header IDs and dashboard status so teammates can verify they are exercising the same tunnel

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68d925c341f8832287deede18bb674ea