### PR TITLE
Document ngrok endpoint identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,9 +913,10 @@ npm run tunnel:functions
 
 Share the resulting HTTPS endpoint with reviewers and map requests to the
 appropriate function path. For instance,
-`https://exosporal-ezequiel-semibiographically.ngrok-free.dev/` has been used
-to proxy the local Telegram webhook during QA sessions—replace it with your own
-ephemeral domain and rotate the tunnel token regularly.
+`https://exosporal-ezequiel-semibiographically.ngrok-free.dev/` (endpoint ID
+`ep_33KMRY2qqYoDugxq8JEyLmOPSqM`) has been used to proxy the local Telegram
+webhook during QA sessions—replace it with your own ephemeral domain and rotate
+the tunnel token regularly.
 
 ## Deployment
 

--- a/docs/ngrok-troubleshooting.md
+++ b/docs/ngrok-troubleshooting.md
@@ -24,7 +24,7 @@ ngrok http --url=exosporal-ezequiel-semibiographically.ngrok-free.dev 80
    - **macOS.** Run `brew install ngrok` (or download the macOS binary from <https://ngrok.com/download>), then ensure `/usr/local/bin` is on your `PATH`.
    - **Windows.** Download and unzip the binary, then add the containing folder to the `Path` environment variable so `ngrok` is invocable from any terminal.
 2. **Authenticate.** Run `ngrok config add-authtoken <token>` with a token from the ngrok dashboard to link the binary to your account. Confirm configuration with `ngrok config check`.
-3. **Reserve or verify the custom domain.** From the ngrok dashboard go to **Domains** and ensure `exosporal-ezequiel-semibiographically.ngrok-free.dev` is reserved for your account. If not, reserve it before starting the tunnel.
+3. **Reserve or verify the custom domain.** From the ngrok dashboard go to **Domains** and ensure `exosporal-ezequiel-semibiographically.ngrok-free.dev` is reserved for your account. Note the endpoint identifier (`ep_33KMRY2qqYoDugxq8JEyLmOPSqM`) listed with the domain so you can confirm you're updating the correct resource. If not reserved, claim it before starting the tunnel.
 4. **Start the tunnel.** Execute the requested command once the CLI is installed and authenticated. If you encounter an error about an unknown flag, upgrade to the latest ngrok v3 release (`ngrok update`) because the `--url` flag is only available in v3.
 
 If you cannot install software on the current machine, run the command from a workstation that already has `ngrok` installed.
@@ -35,7 +35,7 @@ Once the tunnel command is running on a supported machine:
 
 1. **Check the tunnel status locally.** The ngrok console prints the assigned forwarding URL—confirm it matches `https://exosporal-ezequiel-semibiographically.ngrok-free.dev`. You can also visit <http://127.0.0.1:4040/status> to confirm the tunnel is active.
 2. **Test the endpoint.** From another terminal, use `curl https://exosporal-ezequiel-semibiographically.ngrok-free.dev` (or the appropriate path) to ensure you receive the expected response from your local service.
-3. **Inspect the ngrok dashboard.** Visit <https://dashboard.ngrok.com/endpoints/status> to confirm the tunnel is active and requests are flowing. The **Last Connection** timestamp should update when you send traffic.
+3. **Inspect the ngrok dashboard.** Visit <https://dashboard.ngrok.com/endpoints/status> to confirm the tunnel is active and requests are flowing. The **Last Connection** timestamp should update when you send traffic, and the entry should display the endpoint ID `ep_33KMRY2qqYoDugxq8JEyLmOPSqM`.
 4. **Review logs for errors.** In the terminal running ngrok press `Ctrl+L` (or open the **Logs** tab in the dashboard) to reveal connection attempts. Look for TLS handshake failures, 502 responses, or `ERR_NGROK_xxx` codes and resolve them based on the logged guidance.
 
 If any of these verification steps fail, review the ngrok logs (displayed in the tunnel console) for connection errors and ensure the local service on port `80` is reachable. You can test the local service directly with `curl http://localhost:80` to make sure it is serving traffic before exposing it via ngrok.


### PR DESCRIPTION
## Summary
- document the reserved ngrok domain's endpoint ID in the troubleshooting guide
- note the endpoint identifier alongside the example QA tunnel in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92705dc788322818ebe718c132a40