### PR TITLE
Add tunnel smoke test tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,16 @@ curl -s -X POST "$WEBHOOK_BASE" \
   -H 'content-type: application/json' -d '{"test":"ping"}'
 ```
 
+Confirm the tunnel helper wiring before exposing a localhost webhook via ngrok:
+
+```bash
+npm run smoke:tunnel -- --port 54321 --log=stdout
+```
+
+The smoke script runs the helper in dry-run mode, surfaces the resolved binary
+and arguments, and fails fast if overrides (such as `--port` or `--bin`) are not
+applied as expected.
+
 ## Local webhook testing
 
 Run Edge Functions locally without JWT verification to exercise webhooks:
@@ -909,6 +919,13 @@ standard tunnel:
 
 ```bash
 npm run tunnel:functions
+```
+
+If you only need to confirm the ngrok arguments or verify custom flags,
+run the command in dry-run mode:
+
+```bash
+npm run tunnel:functions -- --dry-run
 ```
 
 Share the resulting HTTPS endpoint with reviewers and map requests to the

--- a/docs/ngrok-troubleshooting.md
+++ b/docs/ngrok-troubleshooting.md
@@ -26,6 +26,8 @@ ngrok http --url=exosporal-ezequiel-semibiographically.ngrok-free.dev 80
 2. **Authenticate.** Run `ngrok config add-authtoken <token>` with a token from the ngrok dashboard to link the binary to your account. Confirm configuration with `ngrok config check`.
 3. **Reserve or verify the custom domain.** From the ngrok dashboard go to **Domains** and ensure `exosporal-ezequiel-semibiographically.ngrok-free.dev` is reserved for your account. If not, reserve it before starting the tunnel.
 4. **Start the tunnel.** Execute the requested command once the CLI is installed and authenticated. If you encounter an error about an unknown flag, upgrade to the latest ngrok v3 release (`ngrok update`) because the `--url` flag is only available in v3.
+   - Need to confirm the generated arguments before connecting? Append `-- --dry-run` to the npm script (`npm run tunnel:functions -- --dry-run`) to print the command without launching ngrok. This is helpful when validating custom ports or flags in automation.
+   - For a stricter smoke test that validates overrides, run `npm run smoke:tunnel -- --port 8000 --bin ./bin/ngrok`. The script parses the dry-run JSON, checks that the helper honors each override, and prints the command that would be executed.
 
 If you cannot install software on the current machine, run the command from a workstation that already has `ngrok` installed.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "proj:update-all": "npm run proj:collect && npm run proj:notes && npm run proj:readme && npm run proj:features && npm run proj:projects && npm run proj:announce",
     "test": "node scripts/check-static-homepage.js && deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check",
     "verify": "bash scripts/verify/verify_all.sh",
+    "smoke:tunnel": "node scripts/smoke-tunnel.mjs",
     "audit": "npm audit",
     "audit:fix": "npm audit fix",
     "sync-env": "deno run -A scripts/sync-env.ts",

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -162,6 +162,16 @@ const TASK_LIBRARY = {
       'Executes scripted flows that mirror the production sanity checklist for the Telegram mini app.',
     ],
   },
+  'smoke-tunnel': {
+    id: 'smoke-tunnel',
+    label: 'Run tunnel smoke test (node scripts/smoke-tunnel.mjs)',
+    command: 'node scripts/smoke-tunnel.mjs',
+    optional: true,
+    docs: ['docs/ngrok-troubleshooting.md'],
+    notes: [
+      'Confirms the ngrok helper wiring by inspecting dry-run output and forwarded flags.',
+    ],
+  },
   'supabase-cli-workflow': {
     id: 'supabase-cli-workflow',
     label: 'Run Supabase CLI workflow (bash scripts/supabase-cli-workflow.sh)',
@@ -277,6 +287,11 @@ const CHECKLISTS = {
         optional: true,
         note: 'Complements manual go-live validation with scripted coverage.',
       },
+      {
+        task: 'smoke-tunnel',
+        optional: true,
+        note: 'Verifies tunnel arguments before allowing remote QA access.',
+      },
     ],
   },
   'setup-followups': {
@@ -305,6 +320,7 @@ const CHECKLISTS = {
       'check-linkage',
       'check-webhook',
       { task: 'smoke-miniapp', optional: true },
+      { task: 'smoke-tunnel', optional: true },
     ],
   },
   'nft-collectible': {

--- a/scripts/smoke-tunnel.mjs
+++ b/scripts/smoke-tunnel.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const helperPath = resolve(scriptDir, "ngrok-http.mjs");
+
+function parseCliArgs(args) {
+  const forwardedFlags = [];
+  let expectedPort = process.env.NGROK_PORT ?? "54321";
+  let expectedBin = process.env.NGROK_BIN ?? "ngrok";
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--port") {
+      const next = args[i + 1];
+      if (!next) {
+        throw new Error("Missing value after --port");
+      }
+      expectedPort = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--port=")) {
+      expectedPort = arg.slice("--port=".length);
+      continue;
+    }
+
+    if (arg === "--bin") {
+      const next = args[i + 1];
+      if (!next) {
+        throw new Error("Missing value after --bin");
+      }
+      expectedBin = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--bin=")) {
+      expectedBin = arg.slice("--bin=".length);
+      continue;
+    }
+
+    forwardedFlags.push(arg);
+  }
+
+  return { expectedPort, expectedBin, forwardedFlags };
+}
+
+const cliArgs = process.argv.slice(2);
+let expected;
+try {
+  expected = parseCliArgs(cliArgs);
+} catch (error) {
+  console.error(`❌  ${error.message}`);
+  process.exit(1);
+}
+
+const result = spawnSync(process.execPath, [
+  helperPath,
+  "--dry-run",
+  ...cliArgs,
+], {
+  encoding: "utf8",
+});
+
+if (result.error) {
+  console.error(
+    "❌  Failed to execute ngrok helper dry-run:",
+    result.error.message,
+  );
+  process.exit(1);
+}
+
+if (typeof result.status === "number" && result.status !== 0) {
+  if (result.stdout.trim()) {
+    console.error(result.stdout.trim());
+  }
+  if (result.stderr.trim()) {
+    console.error(result.stderr.trim());
+  }
+  console.error(`❌  ngrok helper exited with status ${result.status}.`);
+  process.exit(result.status || 1);
+}
+
+let payload;
+try {
+  payload = JSON.parse(result.stdout.trim());
+} catch (error) {
+  console.error("❌  Unable to parse ngrok helper output as JSON.");
+  if (result.stdout.trim()) {
+    console.error(result.stdout.trim());
+  }
+  process.exit(1);
+}
+
+const args = Array.isArray(payload.args) ? payload.args : [];
+const [mode, port] = args;
+const forwarded = args.slice(2);
+const issues = [];
+
+if (mode !== "http") {
+  issues.push(`Expected first argument to be \"http\", received \"${mode}\".`);
+}
+
+if (!port) {
+  issues.push("Missing tunnel port in dry-run output.");
+} else if (port !== expected.expectedPort) {
+  issues.push(`Expected port ${expected.expectedPort}, received ${port}.`);
+}
+
+if (payload.bin !== expected.expectedBin) {
+  issues.push(
+    `Expected binary ${expected.expectedBin}, received ${
+      payload.bin || "<empty>"
+    }.`,
+  );
+}
+
+const missingFlags = expected.forwardedFlags.filter((flag) =>
+  !forwarded.includes(flag)
+);
+if (missingFlags.length > 0) {
+  issues.push(`Missing forwarded flags: ${missingFlags.join(", ")}.`);
+}
+
+if (issues.length > 0) {
+  console.error("❌  Tunnel smoke test failed:");
+  issues.forEach((issue) => console.error(`   - ${issue}`));
+  process.exit(1);
+}
+
+console.log("✅  ngrok tunnel helper dry-run looks good.");
+console.log(`    Binary: ${payload.bin}`);
+console.log(`    Command: ${[payload.bin, ...args].join(" ")}`);
+if (forwarded.length > 0) {
+  console.log(`    Forwarded flags: ${forwarded.join(" ")}`);
+} else {
+  console.log("    Forwarded flags: <none>");
+}
+console.log(`    Forwarding to http://localhost:${port}`);

--- a/scripts/verify/tunnel_checks.sh
+++ b/scripts/verify/tunnel_checks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+ensure_out
+
+R=".out/tunnel_checks.txt"
+: > "$R"
+
+DEFAULT_PORT="${NGROK_PORT:-54321}"
+DEFAULT_BIN="${NGROK_BIN:-ngrok}"
+
+say "F) Tunnel CLI Checks"
+
+check_output() {
+  local label="$1"
+  local expected_port="$2"
+  local expected_flag="$3"
+  local expected_bin="$4"
+  shift 4
+
+  local output
+  if ! output=$(node scripts/ngrok-http.mjs --dry-run "$@" 2>/dev/null); then
+    echo "$label=FAIL" >> "$R"
+    warn "Tunnel dry-run command for $label failed to execute."
+    return
+  fi
+
+  if ! node -e "const data = JSON.parse(process.argv[1]); const port = process.argv[2]; const flag = process.argv[3]; const expectedBin = process.argv[4]; if (!Array.isArray(data.args)) process.exit(1); if (data.args[0] !== 'http' || data.args[1] !== port) process.exit(1); if (flag && !data.args.includes(flag)) process.exit(1); if (expectedBin && data.bin !== expectedBin) process.exit(1);" "$output" "$expected_port" "$expected_flag" "$expected_bin"; then
+    echo "$label=FAIL" >> "$R"
+    warn "Tunnel dry-run validation for $label did not match the expected shape."
+    return
+  fi
+
+  echo "$label=PASS" >> "$R"
+}
+
+check_output "default" "$DEFAULT_PORT" "" "$DEFAULT_BIN"
+check_output "custom_port_flag" "8000" "" "$DEFAULT_BIN" --port 8000
+check_output "forward_args" "9000" "--log=stdout" "$DEFAULT_BIN" --port=9000 --log=stdout
+check_output "bin_override" "$DEFAULT_PORT" "" "custom-ngrok" --bin custom-ngrok
+
+say "Tunnel CLI checks complete."

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -13,6 +13,7 @@ bash scripts/verify/deployed_function_checks.sh
 bash scripts/verify/runtime_wiring_checks.sh
 bash scripts/verify/miniapp_safety.sh
 bash scripts/verify/tradingview_webhook.sh
+bash scripts/verify/tunnel_checks.sh
 
 # Build markdown report
 OUT=".out/verify_report.md"
@@ -39,6 +40,7 @@ emit_section "B) Deployed Function Checks" ".out/deployed_checks.txt"
 emit_section "C) Runtime Wiring Checks" ".out/runtime_checks.txt"
 emit_section "D) Mini App Safety" ".out/miniapp_safety.txt"
 emit_section "E) TradingView Webhook" ".out/tradingview_webhook.txt"
+emit_section "F) Tunnel CLI Checks" ".out/tunnel_checks.txt"
 
 echo "Report written to $OUT"
 say "Done."


### PR DESCRIPTION
## Summary
- add a CLI smoke test for the ngrok helper and expose it via npm scripts and the go-live checklist
- tighten the tunnel verification script to validate dry-run output including binary overrides
- document the smoke test workflow in the README and ngrok troubleshooting guide

## Testing
- npm run verify
- npm run smoke:tunnel


------
https://chatgpt.com/codex/tasks/task_e_68d92753e8008322b60044175dab6ae1