### PR TITLE
Add Docker build assets for trainer service

### DIFF
--- a/trainer/Dockerfile
+++ b/trainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+
+RUN python3 -m pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/trainer/requirements.txt
+++ b/trainer/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn[standard]
+requests
+--extra-index-url https://download.pytorch.org/whl/cu118
+torch
+torchvision
+torchaudio
+transformers
+datasets
+peft


### PR DESCRIPTION
## Summary
- add a CUDA-based Dockerfile for the trainer service that installs Python dependencies and launches uvicorn
- provide a requirements file including FastAPI, PyTorch CUDA wheels, and supporting ML libraries

## Testing
- `docker build -t trainer .` *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93b33696483228a2382ef58cc119d