### PR TITLE
Fix Radix Slot usage in button components

### DIFF
--- a/apps/web/components/dynamic-portfolio/mdx.tsx
+++ b/apps/web/components/dynamic-portfolio/mdx.tsx
@@ -26,6 +26,7 @@ import {
   Text,
   TextProps,
 } from "@/components/dynamic-ui-system";
+import { SchoolCourseList } from "@/components/school/SchoolCourseList";
 
 type CustomLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string;
@@ -210,6 +211,7 @@ const components = {
   Icon,
   Media,
   SmartLink,
+  SchoolCourseList,
 };
 
 type CustomMDXProps = MDXRemoteProps & {

--- a/apps/web/components/school/SchoolCourseList.tsx
+++ b/apps/web/components/school/SchoolCourseList.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/utils";
 import { CourseCard } from "./CourseCard";
 import { SignInPromptCard } from "./SignInPromptCard";
 
-interface SchoolCourseListProps {
+export interface SchoolCourseListProps {
   variant?: "full" | "compact";
   className?: string;
 }


### PR DESCRIPTION
## Summary
- guard Radix Slot usage in button and enhanced-button to ensure a single cloned child while preserving loading indicators
- export SchoolCourseListProps and register SchoolCourseList in the MDX component map so MDX content can render the client list

## Testing
- npm run lint
- npm run typecheck
- npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68d92ee210708322ad74e8c43bd05d77