### PR TITLE
Add helper for building and pushing scout demo image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# Docker Assets
+
+## Scout Demo Image
+
+Use the helper script to build and push the `dynamiccapital/scout-demo` image. You must be logged in to Docker Hub (or the appropria
+te registry) and have [`docker buildx`](https://docs.docker.com/build/install-buildx/) enabled locally.
+
+```bash
+./docker/build_and_push_scout_demo.sh [tag]
+```
+
+By default the script pushes the `v1` tag. Provide a different tag as the first argument to publish another version.

--- a/docker/build_and_push_scout_demo.sh
+++ b/docker/build_and_push_scout_demo.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="dynamiccapital/scout-demo"
+IMAGE_TAG="${1:-v1}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to build the image." >&2
+  exit 1
+fi
+
+if ! docker buildx version >/dev/null 2>&1; then
+  echo "docker buildx is required to push multi-platform images." >&2
+  echo "Install buildx by following https://docs.docker.com/build/install-buildx/" >&2
+  exit 1
+fi
+
+FULL_TAG="${IMAGE_NAME}:${IMAGE_TAG}"
+
+# Build and push the image using buildx so the registry receives the final artifact.
+docker buildx build \
+  --platform linux/amd64 \
+  --push \
+  -t "${FULL_TAG}" \
+  -f docker/Dockerfile \
+  .
+
+echo "Successfully pushed ${FULL_TAG}" 


### PR DESCRIPTION
## Summary
- add a build-and-push helper script for the dynamiccapital/scout-demo image
- document the workflow in a docker README for quick reference

## Testing
- npm run format *(fails in CI due to `deno` not being installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d940b016f0832299a8633e7365e65f