### PR TITLE
Add Deno proxy for Docker builds

### DIFF
--- a/scripts/docker.ts
+++ b/scripts/docker.ts
@@ -1,0 +1,44 @@
+/**
+ * Lightweight proxy script that forwards commands to the local Docker CLI.
+ *
+ * This allows running Docker commands through `deno run docker ...` so we
+ * benefit from Deno's permission model and consistent tooling. The script
+ * simply hands through any CLI arguments to the `docker` binary and mirrors
+ * its exit code.
+ */
+
+if (import.meta.main) {
+  if (Deno.args.length === 0) {
+    console.error("Usage: deno run docker <docker arguments...>");
+    console.error(
+      "Example: deno run docker build --push -t dynamiccapital/scout-demo:v1",
+    );
+    Deno.exit(1);
+  }
+
+  try {
+    const command = new Deno.Command("docker", {
+      args: Deno.args,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const child = command.spawn();
+    const status = await child.status;
+
+    if (!status.success) {
+      Deno.exit(status.code ?? 1);
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      console.error(
+        "Docker CLI not found. Please install Docker and ensure it is in your PATH.",
+      );
+      Deno.exit(127);
+    }
+
+    console.error("Failed to execute docker:", error);
+    Deno.exit(1);
+  }
+}

--- a/supabase/functions/telegram-bot/vendor/import_map.json
+++ b/supabase/functions/telegram-bot/vendor/import_map.json
@@ -6,6 +6,7 @@
     "https://esm.sh/": "./esm.sh/",
     "@supabase/supabase-js": "./esm.sh/@supabase/supabase-js@2.js",
     "mime-types": "./esm.sh/mime-types@3.0.1.js",
+    "docker": "../../../../scripts/docker.ts",
     "@/": "../../../../apps/web/",
     "zod": "https://deno.land/x/zod@v3.22.4/mod.ts",
     "@opentelemetry/api": "../../../../tests/stubs/opentelemetry-api.ts",


### PR DESCRIPTION
## Summary
- add a lightweight Deno script that forwards invocations to the local Docker CLI
- register the script in the import map so it can be executed via `deno run docker`

## Testing
- not run (not applicable for introducing a thin command wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68d9427c70bc83229279ce85020d8db4