### PR TITLE
Enhance training model generator with back-to-back transitions

### DIFF
--- a/dynamic_agi/__init__.py
+++ b/dynamic_agi/__init__.py
@@ -13,6 +13,12 @@ from .local_machine import (
     build_local_machine_plan_from_output,
     __all__ as _local_machine_all,
 )
+from .training_models import (
+    AGITrainingExample,
+    DynamicAGITrainingModel,
+    DynamicAGITrainingModelGenerator,
+    __all__ as _training_models_all,
+)
 from .model import (
     AGIDiagnostics,
     AGIOutput,
@@ -37,4 +43,5 @@ __all__ = [
     *_self_improvement_all,
     *_fine_tune_all,
     *_local_machine_all,
+    *_training_models_all,
 ]

--- a/dynamic_agi/training_models.py
+++ b/dynamic_agi/training_models.py
@@ -1,0 +1,380 @@
+"""Training model generation utilities for Dynamic AGI."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+from .self_improvement import ImprovementSignal, LearningSnapshot
+
+__all__ = [
+    "AGITrainingExample",
+    "DynamicAGITrainingModel",
+    "DynamicAGITrainingModelGenerator",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if math.isfinite(number):
+        return number
+    return default
+
+
+def _direction_score(direction: str) -> float:
+    if direction == "positive":
+        return 1.0
+    if direction == "negative":
+        return -1.0
+    return 0.0
+
+
+def _normalise_feedback(feedback: Sequence[str]) -> Tuple[str, ...]:
+    cleaned: list[str] = []
+    for item in feedback:
+        text = str(item).strip()
+        if text:
+            cleaned.append(text)
+    return tuple(cleaned)
+
+
+def _average(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return fmean(values)
+
+
+def _clone_mapping(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    cloned: Dict[str, Any] = {}
+    for key, value in payload.items():
+        key_text = str(key)
+        if isinstance(value, Mapping):
+            cloned[key_text] = _clone_mapping(value)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            cloned[key_text] = [
+                _clone_mapping(item) if isinstance(item, Mapping) else item
+                for item in value
+            ]
+        else:
+            cloned[key_text] = value
+    return cloned
+
+
+def _normalise_metric_key(
+    metric: str,
+    *,
+    index: int,
+    seen: Dict[str, int],
+) -> str:
+    base = metric.strip().lower()
+    if not base:
+        base = f"metric_{index}"
+    occurrence = seen.get(base, 0)
+    seen[base] = occurrence + 1
+    if occurrence:
+        return f"{base}#{occurrence + 1}"
+    return base
+
+
+def _summarise_signals(
+    signals: Sequence[ImprovementSignal],
+) -> Dict[str, Dict[str, float]]:
+    summary: Dict[str, Dict[str, float]] = {}
+    counts: Counter[str] = Counter()
+    for signal in signals:
+        metric = signal.metric.strip().lower() or "general"
+        stats = summary.setdefault(
+            metric,
+            {"value": 0.0, "direction": 0.0, "weight": 0.0},
+        )
+        stats["value"] += _safe_float(signal.value)
+        stats["direction"] += _direction_score(signal.direction)
+        stats["weight"] += _safe_float(signal.weight, default=1.0)
+        counts[metric] += 1
+
+    for metric, count in counts.items():
+        if count <= 1:
+            continue
+        stats = summary[metric]
+        stats["value"] /= count
+        stats["direction"] /= count
+        stats["weight"] /= count
+    return summary
+
+
+def _derive_back_to_back_features(
+    current: LearningSnapshot,
+    previous: LearningSnapshot,
+) -> Tuple[Dict[str, float], Dict[str, Any], float]:
+    features: Dict[str, float] = {}
+    metadata: Dict[str, Any] = {
+        "delta_seconds": (
+            current.timestamp - previous.timestamp
+        ).total_seconds(),
+    }
+    magnitude_components: list[float] = []
+
+    performance_keys = set(current.performance) | set(previous.performance)
+    performance_changes: Dict[str, float] = {}
+    for key in sorted(performance_keys):
+        current_value = _safe_float(current.performance.get(key))
+        previous_value = _safe_float(previous.performance.get(key))
+        delta = current_value - previous_value
+        features[f"delta::performance::{key}"] = delta
+        if delta:
+            performance_changes[key] = delta
+            magnitude_components.append(abs(delta))
+
+    current_signals = _summarise_signals(current.signals)
+    previous_signals = _summarise_signals(previous.signals)
+    signal_keys = set(current_signals) | set(previous_signals)
+    value_changes: Dict[str, float] = {}
+    direction_changes: Dict[str, float] = {}
+    weight_changes: Dict[str, float] = {}
+
+    for key in sorted(signal_keys):
+        current_stats = current_signals.get(
+            key, {"value": 0.0, "direction": 0.0, "weight": 0.0}
+        )
+        previous_stats = previous_signals.get(
+            key, {"value": 0.0, "direction": 0.0, "weight": 0.0}
+        )
+        delta_value = current_stats["value"] - previous_stats["value"]
+        delta_direction = current_stats["direction"] - previous_stats["direction"]
+        delta_weight = current_stats["weight"] - previous_stats["weight"]
+
+        features[f"delta::signal::{key}::value"] = delta_value
+        features[f"delta::signal::{key}::direction"] = delta_direction
+        features[f"delta::signal::{key}::weight"] = delta_weight
+
+        if delta_value:
+            value_changes[key] = delta_value
+            magnitude_components.append(abs(delta_value))
+        if delta_direction:
+            direction_changes[key] = delta_direction
+            magnitude_components.append(abs(delta_direction))
+        if delta_weight:
+            weight_changes[key] = delta_weight
+            magnitude_components.append(abs(delta_weight))
+
+    magnitude = _average(magnitude_components)
+    metadata.update(
+        {
+            "performance_changes": performance_changes,
+            "signal_value_changes": value_changes,
+            "signal_direction_changes": direction_changes,
+            "signal_weight_changes": weight_changes,
+            "magnitude": magnitude,
+        }
+    )
+
+    return features, metadata, magnitude
+
+
+@dataclass(slots=True)
+class AGITrainingExample:
+    """Normalised features and labels derived from a learning snapshot."""
+
+    features: Dict[str, float]
+    labels: Dict[str, float]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "features": dict(self.features),
+            "labels": dict(self.labels),
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class DynamicAGITrainingModel:
+    """Container describing a generated Dynamic AGI training dataset."""
+
+    examples: Tuple[AGITrainingExample, ...]
+    feature_names: Tuple[str, ...]
+    label_names: Tuple[str, ...]
+    summary: Dict[str, Any]
+    notes: Optional[str] = None
+    generated_at: datetime = field(default_factory=_utcnow)
+
+    def __post_init__(self) -> None:
+        if self.generated_at.tzinfo is None:
+            self.generated_at = self.generated_at.replace(tzinfo=timezone.utc)
+        else:
+            self.generated_at = self.generated_at.astimezone(timezone.utc)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "generated_at": self.generated_at.isoformat(),
+            "examples": [example.to_dict() for example in self.examples],
+            "feature_names": list(self.feature_names),
+            "label_names": list(self.label_names),
+            "summary": dict(self.summary),
+        }
+        if self.notes:
+            payload["notes"] = self.notes
+        return payload
+
+
+class DynamicAGITrainingModelGenerator:
+    """Generate structured training models from learning snapshots."""
+
+    def __init__(
+        self,
+        *,
+        include_feedback: bool = True,
+        derive_back_to_back: bool = False,
+    ) -> None:
+        self.include_feedback = include_feedback
+        self.derive_back_to_back = derive_back_to_back
+
+    def generate(
+        self,
+        snapshots: Iterable[LearningSnapshot],
+        *,
+        notes: Optional[str] = None,
+    ) -> DynamicAGITrainingModel:
+        examples: list[AGITrainingExample] = []
+        feature_names: set[str] = set()
+        label_names: set[str] = set()
+        performance_scores: list[float] = []
+        direction_histogram: Counter[str] = Counter()
+        transition_magnitudes: list[float] = []
+        back_to_back_pairs = 0
+        previous_snapshot: Optional[LearningSnapshot] = None
+
+        for snapshot in snapshots:
+            example = self._example_from_snapshot(
+                snapshot,
+                previous_snapshot=previous_snapshot,
+            )
+            examples.append(example)
+            feature_names.update(example.features.keys())
+            label_names.update(example.labels.keys())
+            score = example.metadata.get("performance_score")
+            if isinstance(score, (int, float)):
+                performance_scores.append(float(score))
+            for label_value in example.labels.values():
+                if label_value > 0:
+                    direction_histogram["positive"] += 1
+                elif label_value < 0:
+                    direction_histogram["negative"] += 1
+                else:
+                    direction_histogram["neutral"] += 1
+
+            if self.derive_back_to_back and previous_snapshot is not None:
+                back_to_back_pairs += 1
+                transition = example.metadata.get("transition_magnitude")
+                if isinstance(transition, (int, float)):
+                    transition_magnitudes.append(float(transition))
+
+            previous_snapshot = snapshot
+
+        summary = {
+            "example_count": len(examples),
+            "feature_count": len(feature_names),
+            "label_count": len(label_names),
+            "average_performance_score": _average(performance_scores),
+            "direction_histogram": dict(direction_histogram),
+        }
+
+        if self.derive_back_to_back:
+            if not back_to_back_pairs and len(examples) > 1:
+                back_to_back_pairs = len(examples) - 1
+            summary["back_to_back_pairs"] = back_to_back_pairs
+            summary["average_back_to_back_magnitude"] = _average(
+                transition_magnitudes
+            )
+        else:
+            summary["back_to_back_pairs"] = 0
+            summary["average_back_to_back_magnitude"] = 0.0
+
+        return DynamicAGITrainingModel(
+            examples=tuple(examples),
+            feature_names=tuple(sorted(feature_names)),
+            label_names=tuple(sorted(label_names)),
+            summary=summary,
+            notes=notes,
+        )
+
+    def _example_from_snapshot(
+        self,
+        snapshot: LearningSnapshot,
+        *,
+        previous_snapshot: Optional[LearningSnapshot] = None,
+    ) -> AGITrainingExample:
+        features: Dict[str, float] = {}
+        labels: Dict[str, float] = {}
+        seen_metrics: Dict[str, int] = {}
+
+        for key, value in snapshot.performance.items():
+            feature_key = f"performance::{str(key)}"
+            features[feature_key] = _safe_float(value)
+
+        average_performance = _average(
+            [_safe_float(value) for value in snapshot.performance.values()]
+        )
+
+        for index, signal in enumerate(snapshot.signals, start=1):
+            metric_key = _normalise_metric_key(
+                signal.metric,
+                index=index,
+                seen=seen_metrics,
+            )
+            features[f"signal::{metric_key}::value"] = _safe_float(signal.value)
+            features[f"signal::{metric_key}::weight"] = _safe_float(
+                signal.weight,
+                default=1.0,
+            )
+            direction_key = f"signal::{metric_key}::direction"
+            score = _direction_score(signal.direction)
+            features[direction_key] = score
+            labels[direction_key] = score
+
+        metadata: Dict[str, Any] = {
+            "timestamp": snapshot.timestamp.astimezone(timezone.utc).isoformat(),
+            "performance_score": average_performance,
+            "feedback_count": len(snapshot.feedback),
+            "signals_observed": [signal.metric for signal in snapshot.signals],
+        }
+
+        if self.include_feedback:
+            metadata["feedback"] = list(_normalise_feedback(snapshot.feedback))
+
+        if snapshot.awareness_report is not None:
+            metadata["awareness_report"] = _clone_mapping(snapshot.awareness_report)
+        if snapshot.metacognition_report is not None:
+            metadata["metacognition_report"] = _clone_mapping(snapshot.metacognition_report)
+
+        if self.derive_back_to_back and previous_snapshot is not None:
+            (
+                delta_features,
+                transition_metadata,
+                magnitude,
+            ) = _derive_back_to_back_features(snapshot, previous_snapshot)
+            features.update(delta_features)
+            if transition_metadata:
+                metadata["back_to_back"] = transition_metadata
+            metadata["transition_magnitude"] = magnitude
+        elif self.derive_back_to_back:
+            metadata["transition_magnitude"] = 0.0
+
+        return AGITrainingExample(
+            features=features,
+            labels=labels,
+            metadata=metadata,
+        )

--- a/tests/dynamic_agi/test_training_models.py
+++ b/tests/dynamic_agi/test_training_models.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from dynamic_agi.self_improvement import ImprovementSignal, LearningSnapshot
+from dynamic_agi.training_models import (
+    DynamicAGITrainingModelGenerator,
+)
+
+
+def _build_snapshot(
+    *,
+    performance: dict[str, float],
+    feedback: tuple[str, ...],
+    signals: tuple[ImprovementSignal, ...],
+) -> LearningSnapshot:
+    return LearningSnapshot(
+        output={"status": "ok"},
+        performance=performance,
+        feedback=feedback,
+        signals=signals,
+    )
+
+
+def test_generate_training_model_produces_expected_features() -> None:
+    generator = DynamicAGITrainingModelGenerator()
+    snapshot = _build_snapshot(
+        performance={"sharpe": 1.5, "drawdown": -0.02},
+        feedback=("Focus risk control", "Nice work"),
+        signals=(
+            ImprovementSignal(metric="PnL", value=1.2, direction="positive", weight=0.8),
+            ImprovementSignal(metric="Drawdown", value=0.5, direction="negative", weight=1.4),
+        ),
+    )
+
+    model = generator.generate([snapshot], notes="session-1")
+
+    assert model.summary["example_count"] == 1
+    assert model.notes == "session-1"
+
+    example = model.examples[0]
+    assert example.features["performance::sharpe"] == pytest.approx(1.5)
+    assert example.features["performance::drawdown"] == pytest.approx(-0.02)
+    assert example.features["signal::pnl::value"] == pytest.approx(1.2)
+    assert example.features["signal::drawdown::weight"] == pytest.approx(1.4)
+    assert example.labels["signal::pnl::direction"] == pytest.approx(1.0)
+    assert example.labels["signal::drawdown::direction"] == pytest.approx(-1.0)
+
+    assert "feedback" in example.metadata
+    assert example.metadata["feedback"] == ["Focus risk control", "Nice work"]
+    assert model.summary["direction_histogram"].get("positive", 0) == 1
+    assert model.summary["direction_histogram"].get("negative", 0) == 1
+    assert model.summary["back_to_back_pairs"] == 0
+    assert model.summary["average_back_to_back_magnitude"] == pytest.approx(0.0)
+
+    assert set(model.feature_names) >= {
+        "performance::sharpe",
+        "performance::drawdown",
+        "signal::pnl::value",
+        "signal::pnl::direction",
+        "signal::drawdown::weight",
+        "signal::drawdown::direction",
+    }
+
+
+def test_generator_respects_feedback_flag_and_counts_directions() -> None:
+    generator = DynamicAGITrainingModelGenerator(include_feedback=False)
+    snapshot_positive = _build_snapshot(
+        performance={"alpha": 0.2},
+        feedback=("Keep scaling",),
+        signals=(
+            ImprovementSignal(metric="Momentum", value=0.9, direction="positive"),
+        ),
+    )
+    snapshot_neutral = _build_snapshot(
+        performance={},
+        feedback=("Neutral",),
+        signals=(
+            ImprovementSignal(metric="Risk", value=0.0, direction="neutral"),
+        ),
+    )
+
+    model = generator.generate([snapshot_positive, snapshot_neutral])
+
+    assert model.summary["example_count"] == 2
+    histogram = model.summary["direction_histogram"]
+    assert histogram.get("positive", 0) == 1
+    assert histogram.get("neutral", 0) == 1
+
+    first_example = model.examples[0]
+    assert "feedback" not in first_example.metadata
+    assert model.summary["back_to_back_pairs"] == 0
+    assert model.summary["average_back_to_back_magnitude"] == pytest.approx(0.0)
+
+
+def test_back_to_back_transitions_add_delta_features() -> None:
+    generator = DynamicAGITrainingModelGenerator(
+        derive_back_to_back=True,
+    )
+
+    first_snapshot = _build_snapshot(
+        performance={"alpha": 0.1, "beta": 0.5},
+        feedback=("Steady",),
+        signals=(
+            ImprovementSignal(metric="PnL", value=1.0, direction="neutral"),
+            ImprovementSignal(metric="Risk", value=0.2, direction="negative"),
+        ),
+    )
+    second_snapshot = _build_snapshot(
+        performance={"alpha": 0.4, "beta": 0.3},
+        feedback=("Accelerate",),
+        signals=(
+            ImprovementSignal(metric="PnL", value=1.4, direction="positive"),
+            ImprovementSignal(metric="Risk", value=0.1, direction="neutral"),
+        ),
+    )
+
+    model = generator.generate([first_snapshot, second_snapshot])
+
+    assert model.summary["back_to_back_pairs"] == 1
+    assert model.summary["average_back_to_back_magnitude"] > 0
+
+    second_example = model.examples[1]
+    assert second_example.metadata.get("transition_magnitude", 0.0) > 0
+    back_to_back_meta = second_example.metadata.get("back_to_back")
+    assert isinstance(back_to_back_meta, dict)
+    assert back_to_back_meta["performance_changes"]["alpha"] == pytest.approx(0.3)
+    assert back_to_back_meta["signal_direction_changes"]["pnl"] > 0
+    assert "delta::performance::alpha" in second_example.features
+    assert "delta::signal::pnl::value" in second_example.features


### PR DESCRIPTION
## Summary
- extend the Dynamic AGI training model generator with optional back-to-back transition features and metadata
- normalise signal feature keys to prevent collisions and expose aggregated direction/value deltas in summaries
- expand the training model tests to cover transition mode behaviour and updated summaries

## Testing
- pytest tests/dynamic_agi/test_training_models.py tests/dynamic_agi/test_dynamic_fine_tune.py

------
https://chatgpt.com/codex/tasks/task_e_68d942ee6b988322843032707b44d93c