### PR TITLE
Add Docker smoke test workflow

### DIFF
--- a/.github/workflows/docker-local-smoke.yml
+++ b/.github/workflows/docker-local-smoke.yml
@@ -1,0 +1,48 @@
+name: Docker local smoke test
+
+on:
+  push:
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-local-smoke.yml'
+  pull_request:
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-local-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  compose-smoke:
+    name: Build Docker image and run smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DOCKER_BUILDKIT: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Show Docker info
+        run: |
+          docker version
+          docker info
+
+      - name: Build app service image
+        run: docker compose -f docker/docker-compose.yml build app
+
+      - name: Smoke test container startup
+        run: docker compose -f docker/docker-compose.yml run --rm --entrypoint node app --version
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker/docker-compose.yml down --volumes --remove-orphans

--- a/README.md
+++ b/README.md
@@ -822,6 +822,18 @@ on images.
    - Ensure required environment variables are present; missing values may cause
      runtime errors.
 
+### GitHub Actions Docker smoke test
+
+- The `Docker local smoke test` workflow builds the Compose `app` service image
+  and runs a lightweight command inside the resulting container to ensure Docker
+  remains functional in CI.
+- It runs automatically for pull requests or pushes that touch the `docker/`
+  directory (or the workflow file itself) and is also available through the
+  **Run workflow** button on the Actions tab for ad-hoc verification.
+- To reproduce the same check locally, run `docker compose -f
+  docker/docker-compose.yml build app` followed by `docker compose -f
+  docker/docker-compose.yml run --rm --entrypoint node app --version`.
+
 ## Mini App
 
 - Set `MINI_APP_URL` in env (example domain only, do not hardcode).


### PR DESCRIPTION
## Summary
- add a Docker-focused GitHub Actions workflow that builds the Compose app image and runs a node version smoke test inside the container
- document the new workflow and provide equivalent local commands in the README

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d954779d188322bc13e833d8a9e27f