### PR TITLE
Clarify quantum expansion documentation

### DIFF
--- a/docs/quantum_expansion_equation.md
+++ b/docs/quantum_expansion_equation.md
@@ -1,0 +1,157 @@
+# Quantum Expansion Equation
+
+## Overview
+
+The quantum expansion equation models how a particle's effective spatial spread
+evolves over time when quantum uncertainty, thermal agitation, and the
+large-scale expansion of spacetime all contribute simultaneously. It extends
+classical diffusion by embedding the dynamics in an expanding cosmological
+background while preserving micro-scale thermal and quantum effects.
+
+## Assumptions and Validity
+
+- \(D_t\) represents a characteristic length scale (e.g., standard deviation of
+  a Gaussian wave packet). The recurrence assumes this scale remains positive
+  and differentiable over the integration window.
+- Temperature perturbations are encoded through a lumped coefficient \(\beta\)
+  and discrete increment \(\Delta T_t\); latent heat or phase-transition
+  effects are abstracted into the choice of \(\beta\).
+- The scale factor \(a(t)\) is supplied exogenously—typically from a
+  cosmological solver or prescribed laboratory control—and is sufficiently
+  smooth that \(a(t+1)\) is well approximated at the discrete time resolution.
+- Quantum diffusion enters via a lowest-order semiclassical correction; higher
+  order tunneling or interaction terms are aggregated into an optional
+  extension \(f_q\).
+
+## Core Recurrence
+
+\[ D_{t+1} = a(t+1) \cdot \Big[ D_t + \beta D_t \Delta T_t + \hbar \frac{\Delta
+t}{m D_t} \Big] \]
+
+Where:
+
+- \(D_{t+1}\) – effective spread (e.g., wave packet width) at the next state.
+- \(a(t+1)\) – cosmic scale factor describing the macroscopic expansion of
+  spacetime.
+- \(\beta D_t \Delta T_t\) – thermally driven change in spread from local
+  vibrations or heat exchange.
+- \(\hbar\) – reduced Planck constant introducing Heisenberg uncertainty.
+- \(m\) – particle mass.
+- \(\frac{\hbar \Delta t}{m D_t}\) – diffusion term associated with free
+  wavefunction spreading.
+
+## Term Breakdown
+
+1. **Thermal contribution (\(\beta D_t \Delta T_t\))**
+   - Captures stochastic spread induced by temperature gradients and collisions.
+   - Dominant for mesoscopic systems where thermal agitation overwhelms quantum
+     or cosmological effects.
+2. **Cosmic expansion (\(a(t+1)\))**
+   - Scales the entire bracketed micro-state update by the background expansion
+     of spacetime.
+   - Relevant for astrophysical or cosmological simulations that track particles
+     over cosmological timescales.
+3. **Quantum diffusion (\(\hbar \frac{\Delta t}{m D_t}\))**
+   - Represents intrinsic wave packet spreading.
+   - Mirrors the free-particle variance evolution \(\sigma(t) = \sqrt{
+     \sigma_0^2 + \frac{\hbar^2 t^2}{m^2 \sigma_0^2} }\).
+   - Dominant for light particles (e.g., electrons, photons) or ultra-cold
+     regimes where thermal agitation is suppressed.
+
+## Multi-scale Interpretation
+
+| Regime | Dominant Terms | Typical Diagnostics |
+| --- | --- | --- |
+| Everyday matter | Thermal | Compare against diffusion coefficients, phonon spectra |
+| Astrophysical bodies | Cosmic | Track coherence lengths across Hubble times |
+| Quantum systems | Quantum diffusion | Monitor uncertainty-product saturation |
+| Extreme environments | Thermal + cosmic + quantum | Evaluate curvature coupling, entropy flux |
+
+The table highlights how the weighting between contributions informs which
+observables should be monitored during simulation or experimentation.
+
+## Simulation Workflow
+
+1. Initialize \(D_0\) from experimental or theoretical priors (e.g., ground-state
+   widths, thermal de Broglie wavelengths).
+2. Choose a cosmological model to supply \(a(t)\); for astrophysical contexts
+   this may be a Friedmann–Lemaître–Robertson–Walker (FLRW) solution, while
+   laboratory systems typically fix \(a(t) = 1\).
+3. Select thermodynamic and quantum parameters \(\beta, \Delta T_t, m\) and
+   time-step size \(\Delta t\).
+4. Iterate the recurrence, updating \(D_t\) and recording observables such as
+   variance, entropy, or decoherence metrics.
+5. Calibrate model coefficients by comparing simulated spreads with empirical
+   measurements (e.g., diffraction data, cosmological surveys).
+
+### Reference Implementation Skeleton
+
+```python
+for step in range(num_steps):
+    thermal = beta * D[step] * delta_T[step]
+    quantum = hbar * dt / (mass * D[step])
+    micro_update = D[step] + thermal + quantum + f_q_extra(step)
+    D[step + 1] = scale_factor(step + 1) * micro_update
+    enforce_bounds(D, step + 1)
+    log_observables(D, step + 1)
+```
+
+Supplement the skeleton with adaptive-stepping logic and robust boundary guards
+for \(D_t\) as discussed below.
+
+## Optimization Strategies
+
+### Adaptive Time-stepping
+
+- Vary \(\Delta t\) based on a local truncation error estimate to maintain
+  accuracy near stiff regimes (e.g., \(D_t \to 0\)).
+- Couple adaptive stepping with reject/redo logic to prevent divergence when the
+  quantum diffusion term spikes.
+
+### Constraint Enforcement
+
+- Enforce lower bounds \(D_t \geq D_{\min}\) derived from physical priors or
+  experimental resolution to avoid singular denominators.
+- Apply projection methods that rescale \(D_t\) back onto feasible manifolds if
+  large fluctuations violate conservation laws or known asymptotics.
+
+### Precomputation and Parallelism
+
+- Precompute temperature and scale-factor schedules when they evolve slowly to
+  reduce per-step overhead.
+- Vectorize the recurrence across particle ensembles and distribute workloads on
+  GPUs or multi-node clusters for Monte Carlo studies.
+
+### Model Reduction and Surrogates
+
+- Fit surrogate models (e.g., neural operators, reduced-order bases) to the
+  high-fidelity recurrence outputs for rapid parameter sweeps.
+- Use sensitivity analysis or automatic differentiation to identify dominant
+  parameters and prune negligible interactions in \(f_q\).
+
+### Dimensionless Formulation
+
+- Introduce a characteristic scale \(D_*\) (e.g., initial spread) and time scale
+  \(t_*\) to construct \(\hat{D}_t = D_t / D_*\) and \(\hat{t} = t / t_*\).
+- The recurrence becomes
+  \[
+  \hat{D}_{t+1} = a(t+1) \Big[ \hat{D}_t + \hat{\beta} \hat{D}_t \Delta \hat{T}_t
+  + \frac{\epsilon}{\hat{D}_t} \Big],
+  \]
+  where \(\hat{\beta} = \beta \Delta T_t\) and \(\epsilon = \hbar \Delta t /
+  (m D_*^2)\).
+- Working with dimensionless groups stabilizes numerical ranges, clarifies
+  parameter sensitivity, and facilitates cross-system comparisons.
+
+## Implementation Notes
+
+- Embed the recurrence inside integrators that exploit sparsity patterns from
+  the thermal or cosmological submodels to minimize memory traffic.
+- Couple with energy-density or field-theory models to extend the quantum term
+  \(f_q(\hbar, m, \Delta t)\) toward interaction-aware diffusion or tunneling
+  corrections.
+- Store logarithms of \(D_t\) when dynamic range is extreme to preserve numeric
+  precision.
+- Validate against analytic limits (e.g., \(a(t)=1\) reduces to pure diffusion)
+  and monitor conserved invariants where applicable (entropy production,
+  uncertainty bounds) to detect integration drift.


### PR DESCRIPTION
## Summary
- document modeling assumptions and applicability limits for the quantum expansion recurrence
- restructure the multi-scale interpretation into a diagnostic table and add implementation pseudocode
- add a dimensionless reformulation and validation guidance for numerical stability

## Testing
- ⚠️ `npm run format` *(introduces repository-wide churn; reverted non-target changes after confirming formatter ran)*

------
https://chatgpt.com/codex/tasks/task_e_68d951ef42c88322a0fe6b2a932b4691