### PR TITLE
Ensure DigitalOcean health check routes bypass redirects

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -82,7 +82,7 @@ spec:
       routes:
         - path: /
       health_check:
-        http_path: /
+        http_path: /healthz
       envs:
         - key: SITE_URL
           value: https://dynamic-capital-qazf2.ondigitalocean.app

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -226,13 +226,22 @@ if (nextConfig.output !== 'export') {
     if (process.env.DISABLE_HTTP_REDIRECTS === 'true') {
       return [];
     }
+    const httpProtoHeader = {
+      type: 'header',
+      key: 'x-forwarded-proto',
+      value: 'http',
+    };
     return [
       {
-        source: '/:path*',
-        has: [
-          { type: 'header', key: 'x-forwarded-proto', value: 'http' },
-        ],
-        destination: `https://${CANONICAL_HOST}/:path*`,
+        source: '/',
+        has: [httpProtoHeader],
+        destination: `https://${CANONICAL_HOST}`,
+        permanent: true,
+      },
+      {
+        source: '/:path((?!healthz$).+)',
+        has: [httpProtoHeader],
+        destination: `https://${CANONICAL_HOST}/:path`,
         permanent: true,
       },
       ...(process.env.LEGACY_HOST


### PR DESCRIPTION
## Summary
- stop redirecting the /healthz probe to HTTPS so DigitalOcean health checks resolve successfully
- point the DigitalOcean app spec and sync tooling at /healthz to keep infrastructure in sync

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d9532ec6048322a4e854738f0cf0d9