### PR TITLE
Optimize self-improvement recurrence computations

### DIFF
--- a/docs/self-improvement-equation.md
+++ b/docs/self-improvement-equation.md
@@ -1,0 +1,51 @@
+# The Self-Improvement Equation
+
+This note captures the intuition behind the cyclical improvement rule
+
+$$
+S_{t+1} = (S_t + A_t) \cdot (1 + R_t + L_t)
+$$
+
+where:
+
+- $S_t$ represents the current state of the self.
+- $A_t$ bundles the concrete actions chosen through a What + How framing.
+- $R_t$ denotes reflective depth, the renewed Why + Who inquiry for the next
+  loop.
+- $L_t$ encodes the new learning extracted from Which + Where + When
+  exploration.
+
+## How the Update Works
+
+1. **Identity-first expansion** – Begin each cycle by revisiting Why you are in
+   the process and Who you are becoming. This keeps the identity anchor grounded
+   before tactical choices are made.
+2. **Action injection** – Integrate the best available What and How responses as
+   the additive term $A_t$. These drive direct movement in the state without yet
+   compounding the loop.
+3. **Compounding reflection and learning** – Scale the state-plus-action bundle
+   by $(1 + R_t + L_t)$. Reflection $R_t$ deepens alignment, while learning
+   $L_t$ widens the possibility space through Which, Where, and When
+   experimentation.
+
+## Practical Interpretation
+
+- **Identity → goals → execution sequencing** – Moving from internal anchors
+  (Why, Who, What) to external logistics (Which, How, When, Where) ensures that
+  each loop is coherent with long-term identity while still producing measurable
+  outputs.
+- **Compounding loops** – Reflection and learning act multiplicatively, so even
+  modest gains in $R_t$ or $L_t$ compound prior progress. Skipping these phases
+  collapses the loop back to incremental action without reinforcement.
+- **Adaptive calibration** – Track $A_t$, $R_t$, and $L_t$ explicitly to
+  diagnose whether progress stalls from insufficient action, shallow reflection,
+  or weak learning inputs. Adjust the corresponding practice to restore
+  momentum.
+- **Deepening cycles** – Repeated passes through the loop should sharpen
+  identity, refine goals, and accelerate progress. The model highlights how
+  qualitative insights (reflection, learning) quantitatively amplify tangible
+  actions.
+
+Use the equation as a weekly or monthly retrospective tool: score each
+component, estimate its impact on the next state, and plan interventions that
+raise the multiplicative terms rather than chasing more actions alone.

--- a/src/lib/self-improvement.ts
+++ b/src/lib/self-improvement.ts
@@ -1,0 +1,83 @@
+export interface SelfImprovementInputs {
+  /**
+   * The current state of the self before the update (S_t).
+   */
+  currentState: number;
+  /**
+   * The direct contribution from actions chosen this cycle (A_t).
+   */
+  actionDelta: number;
+  /**
+   * Reflection coefficient that compounds the state for the next loop (R_t).
+   */
+  reflectionGain: number;
+  /**
+   * Learning coefficient representing new insights for the next loop (L_t).
+   */
+  learningGain: number;
+}
+
+export interface SelfImprovementCycle
+  extends Omit<SelfImprovementInputs, "currentState"> {}
+
+const FINITE_ERROR_MESSAGE = "Self-improvement inputs must be finite numbers.";
+
+/**
+ * Computes the next self state using the self-improvement recurrence:
+ *
+ * S_{t+1} = (S_t + A_t) * (1 + R_t + L_t)
+ */
+export function computeNextSelfState({
+  currentState,
+  actionDelta,
+  reflectionGain,
+  learningGain,
+}: SelfImprovementInputs): number {
+  validateFinite(currentState, actionDelta, reflectionGain, learningGain);
+
+  const base = currentState + actionDelta;
+  const compoundedGain = reflectionGain + learningGain;
+
+  return base + base * compoundedGain;
+}
+
+/**
+ * Runs a sequence of self-improvement cycles, returning the state after each
+ * update (including the initial state).
+ */
+export function simulateSelfImprovement(
+  initialState: number,
+  cycles: readonly SelfImprovementCycle[],
+): number[] {
+  validateFinite(initialState);
+
+  const cycleCount = cycles.length;
+  const states = new Array<number>(cycleCount + 1);
+  states[0] = initialState;
+
+  let currentState = initialState;
+
+  for (let index = 0; index < cycleCount; index += 1) {
+    const cycle = cycles[index];
+    const { actionDelta, reflectionGain, learningGain } = cycle;
+
+    validateFinite(actionDelta, reflectionGain, learningGain);
+
+    const base = currentState + actionDelta;
+    const compoundedGain = reflectionGain + learningGain;
+    const nextState = base + base * compoundedGain;
+
+    currentState = nextState;
+    states[index + 1] = nextState;
+  }
+
+  return states;
+}
+
+function validateFinite(...values: number[]): void {
+  for (let index = 0; index < values.length; index += 1) {
+    if (!Number.isFinite(values[index])) {
+      throw new TypeError(FINITE_ERROR_MESSAGE);
+    }
+  }
+}

--- a/tests/self-improvement-equation.spec.ts
+++ b/tests/self-improvement-equation.spec.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from "node:assert";
+
+import {
+  computeNextSelfState,
+  simulateSelfImprovement,
+} from "../src/lib/self-improvement.ts";
+
+const nextState = computeNextSelfState({
+  currentState: 10,
+  actionDelta: 2,
+  reflectionGain: 0.3,
+  learningGain: 0.2,
+});
+
+assert.equal(nextState, (10 + 2) * (1 + 0.3 + 0.2));
+
+const trajectory = simulateSelfImprovement(5, [
+  {
+    actionDelta: 1,
+    reflectionGain: 0,
+    learningGain: 0,
+  },
+  {
+    actionDelta: 2,
+    reflectionGain: 0.1,
+    learningGain: 0.1,
+  },
+]);
+
+const expected = [5, 6, (6 + 2) * 1.2];
+trajectory.forEach((value, index) => {
+  const diff = Math.abs(value - expected[index]);
+  assert.ok(diff < 1e-9, `trajectory mismatch at index ${index}`);
+});
+
+let errorThrown = false;
+try {
+  computeNextSelfState({
+    currentState: Number.NaN,
+    actionDelta: 0,
+    reflectionGain: 0,
+    learningGain: 0,
+  });
+} catch (error) {
+  errorThrown = error instanceof TypeError;
+}
+
+assert.equal(errorThrown, true, "non-finite inputs should throw TypeError");
+
+console.log("Self-improvement equation checks passed");


### PR DESCRIPTION
## Summary
- preallocate the self-improvement simulation buffer and inline recurrence math to avoid redundant work in tight loops
- streamline finite-value validation to remove intermediate allocations while keeping safety guarantees

## Testing
- npm run lint
- npm run typecheck
- npx tsx tests/self-improvement-equation.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9508c01ec8322b7f0f0f340eb3d98