### PR TITLE
Update dynamic inventory documentation with new modules

### DIFF
--- a/docs/dynamic_inventory.md
+++ b/docs/dynamic_inventory.md
@@ -2,7 +2,8 @@
 
 _Last updated: 2025-09-28 (UTC)_
 
-This catalog summarizes the repository's `dynamic_` directories so you can explore related knowledge modules at a glance.
+This catalog summarizes the repository's `dynamic_` directories so you can
+explore related knowledge modules at a glance.
 
 ## Quick navigation
 
@@ -15,31 +16,34 @@ This catalog summarizes the repository's `dynamic_` directories so you can explo
 
 ## Snapshot metrics
 
-- Total directories: 154
-- Domain groups: 11 (largest: Technology & Infrastructure with 51 modules)
+- Total directories: 161
+- Domain groups: 11 (largest: Technology & Infrastructure with 54 modules)
 - Generation command: `ls -d dynamic_* | sort`
 
 ## Domain overview
 
+<!-- deno-fmt-ignore -->
 | Domain | Modules | Focus |
 | --- | ---: | --- |
-| Technology & Infrastructure | 51 | Core engineering building blocks for compute, storage, networking, and orchestration. |
-| AI, Agents & Cognition | 13 | Intelligent systems, agentic behaviors, and cognitive capabilities. |
-| Science & Space | 19 | Scientific foundations spanning physics, astronomy, and multi-layer space environments. |
+| Technology & Infrastructure | 54 | Core engineering building blocks for compute, storage, networking, and orchestration. |
+| AI, Agents & Cognition | 14 | Intelligent systems, agentic behaviors, and cognitive capabilities. |
+| Science & Space | 20 | Scientific foundations spanning physics, astronomy, and multi-layer space environments. |
 | Business & Operations | 12 | Operational excellence, planning, and delivery disciplines for teams and initiatives. |
 | Human & Creative Dimensions | 12 | People-centered growth including mindset, skills, mentorship, and expression. |
 | Security & Governance | 14 | Trust, compliance, and protective controls for resilient systems and organizations. |
 | Finance & Markets | 4 | Market structure, analytics, and trading intelligence modules. |
-| Knowledge Systems & Communication | 12 | Information architecture, indexing, and shared language assets. |
-| Process & Workflow Tooling | 8 | Frameworks for orchestrating routines, bridges, and continuous cycles. |
+| Knowledge Systems & Communication | 13 | Information architecture, indexing, and shared language assets. |
+| Process & Workflow Tooling | 9 | Frameworks for orchestrating routines, bridges, and continuous cycles. |
 | Natural Systems & Sustainability | 5 | Biological and energy-oriented systems thinking. |
 | Conceptual & Experimental Frameworks | 4 | Abstract models, pillars, and exploratory mental scaffolds. |
+
 
 ## Domain-based catalog
 
 ### Technology & Infrastructure
 
-Foundational engineering modules spanning compute, networking, runtimes, and operational tooling.
+Foundational engineering modules spanning compute, networking, runtimes, and
+operational tooling.
 
 - `dynamic_algo`
 - `dynamic_architect`
@@ -56,6 +60,7 @@ Foundational engineering modules spanning compute, networking, runtimes, and ope
 - `dynamic_clusters`
 - `dynamic_database`
 - `dynamic_dependency`
+- `dynamic_dockerfile`
 - `dynamic_domain`
 - `dynamic_domain_name_system`
 - `dynamic_domain_names`
@@ -70,6 +75,7 @@ Foundational engineering modules spanning compute, networking, runtimes, and ope
 - `dynamic_index`
 - `dynamic_ip_address`
 - `dynamic_load_balancer`
+- `dynamic_local_machine`
 - `dynamic_logging`
 - `dynamic_loop`
 - `dynamic_mapping`
@@ -83,6 +89,7 @@ Foundational engineering modules spanning compute, networking, runtimes, and ope
 - `dynamic_skeleton`
 - `dynamic_source`
 - `dynamic_states`
+- `dynamic_supabase`
 - `dynamic_syncronization`
 - `dynamic_token`
 - `dynamic_ton`
@@ -95,7 +102,8 @@ Foundational engineering modules spanning compute, networking, runtimes, and ope
 
 ### AI, Agents & Cognition
 
-Intelligence-focused modules covering cognition, memory, and autonomous behaviors.
+Intelligence-focused modules covering cognition, memory, and autonomous
+behaviors.
 
 - `dynamic_agents`
 - `dynamic_agi`
@@ -110,10 +118,12 @@ Intelligence-focused modules covering cognition, memory, and autonomous behavior
 - `dynamic_predictive`
 - `dynamic_self_awareness`
 - `dynamic_thinking`
+- `dynamic_trainer`
 
 ### Science & Space
 
-Scientific and astrophysical modules mapping layered environments from atoms to interstellar systems.
+Scientific and astrophysical modules mapping layered environments from atoms to
+interstellar systems.
 
 - `dynamic_astronomy`
 - `dynamic_atmosphere`
@@ -124,6 +134,7 @@ Scientific and astrophysical modules mapping layered environments from atoms to 
 - `dynamic_intergalactic_space`
 - `dynamic_interplanetary_space`
 - `dynamic_interstellar_space`
+- `dynamic_mass`
 - `dynamic_mesosphere`
 - `dynamic_ocean`
 - `dynamic_physics`
@@ -154,7 +165,8 @@ Modules for planning, execution, forecasting, and delivery excellence.
 
 ### Human & Creative Dimensions
 
-People-centered capabilities that cultivate skills, wisdom, and supportive cultures.
+People-centered capabilities that cultivate skills, wisdom, and supportive
+cultures.
 
 - `dynamic_analytical_thinking`
 - `dynamic_creative_thinking`
@@ -203,6 +215,7 @@ Knowledge-management assets that organize language, references, and indexes.
 
 - `dynamic_acronym`
 - `dynamic_glossary`
+- `dynamic_grammar`
 - `dynamic_hashtag`
 - `dynamic_letter_index`
 - `dynamic_library`
@@ -222,6 +235,7 @@ Patterns and routines that keep projects synchronized and adaptive.
 - `dynamic_bridge`
 - `dynamic_cycle`
 - `dynamic_effect`
+- `dynamic_hierarchy`
 - `dynamic_mantra`
 - `dynamic_method`
 - `dynamic_playbook`
@@ -248,26 +262,31 @@ Exploratory constructs for first-principles thinking and hypothesis building.
 
 ## Potential uses for each module
 
-Treat every directory as a modular knowledge pack that can collect the following assets:
+Treat every directory as a modular knowledge pack that can collect the following
+assets:
 
-| Focus | How it helps |
-| --- | --- |
-| Definitions and glossaries | Establish shared vocabulary across teams. |
-| Equations, algorithms, or models | Anchor the concept with computational or analytical tooling. |
-| Playbooks and workflows | Document repeatable delivery patterns and decision paths. |
-| Diagrams or architectures | Visualize relationships, dependencies, and flows. |
-| Code snippets or configuration templates | Accelerate implementation with ready-to-adapt assets. |
+| Focus                                    | How it helps                                                 |
+| ---------------------------------------- | ------------------------------------------------------------ |
+| Definitions and glossaries               | Establish shared vocabulary across teams.                    |
+| Equations, algorithms, or models         | Anchor the concept with computational or analytical tooling. |
+| Playbooks and workflows                  | Document repeatable delivery patterns and decision paths.    |
+| Diagrams or architectures                | Visualize relationships, dependencies, and flows.            |
+| Code snippets or configuration templates | Accelerate implementation with ready-to-adapt assets.        |
 
 ## Next steps to enrich the knowledge base
 
-1. Map relationships across domains (e.g., `dynamic_ai` → `dynamic_agents` → `dynamic_task_manager`).
-2. Standardize a reusable playbook template covering overview, principles, use cases, examples, and links.
-3. Build navigational indices such as a table of contents or a search-friendly glossary for quick lookup.
+1. Map relationships across domains (e.g., `dynamic_ai` → `dynamic_agents` →
+   `dynamic_task_manager`).
+2. Standardize a reusable playbook template covering overview, principles, use
+   cases, examples, and links.
+3. Build navigational indices such as a table of contents or a search-friendly
+   glossary for quick lookup.
 
 ## Complete alphabetical index
 
 The table below is sorted alphabetically from left to right for quick scanning.
 
+<!-- deno-fmt-ignore -->
 | A | B | C | D |
 | --- | --- | --- | --- |
 | `dynamic_accounting` | `dynamic_acronym` | `dynamic_agents` | `dynamic_agi` |
@@ -280,32 +299,35 @@ The table below is sorted alphabetically from left to right for quick scanning.
 | `dynamic_cislunar_space` | `dynamic_client_server` | `dynamic_clusters` | `dynamic_consciousness` |
 | `dynamic_contracts` | `dynamic_cosmic` | `dynamic_creative_thinking` | `dynamic_critical_thinking` |
 | `dynamic_cycle` | `dynamic_database` | `dynamic_demand` | `dynamic_dependency` |
-| `dynamic_development_team` | `dynamic_dimensions` | `dynamic_domain` | `dynamic_domain_name_system` |
-| `dynamic_domain_names` | `dynamic_effect` | `dynamic_emoticon` | `dynamic_encryption` |
-| `dynamic_energy` | `dynamic_engineer` | `dynamic_engines` | `dynamic_event` |
-| `dynamic_exosphere` | `dynamic_expressions` | `dynamic_firewall` | `dynamic_forecast` |
-| `dynamic_framework` | `dynamic_fuel` | `dynamic_generator` | `dynamic_glossary` |
-| `dynamic_graphql` | `dynamic_hashtag` | `dynamic_heal` | `dynamic_helpers` |
-| `dynamic_http` | `dynamic_human_resources` | `dynamic_idempotency` | `dynamic_implicit_memory` |
-| `dynamic_index` | `dynamic_indicators` | `dynamic_intergalactic_space` | `dynamic_interplanetary_space` |
-| `dynamic_interstellar_space` | `dynamic_ip_address` | `dynamic_keepers` | `dynamic_kyc` |
-| `dynamic_letter_index` | `dynamic_library` | `dynamic_load_balancer` | `dynamic_logging` |
-| `dynamic_loop` | `dynamic_mantra` | `dynamic_mapping` | `dynamic_memory` |
-| `dynamic_memory_reconsolidation` | `dynamic_mentorship` | `dynamic_mesosphere` | `dynamic_message_queue` |
-| `dynamic_metacognition` | `dynamic_metadata` | `dynamic_method` | `dynamic_microservices` |
-| `dynamic_mindset` | `dynamic_numbers` | `dynamic_ocean` | `dynamic_package` |
-| `dynamic_physics` | `dynamic_pillars` | `dynamic_playbook` | `dynamic_point_in_time` |
-| `dynamic_predictive` | `dynamic_proof` | `dynamic_proof_of_authority` | `dynamic_proof_of_burn` |
-| `dynamic_proof_of_history` | `dynamic_proof_of_reputation` | `dynamic_proof_of_space` | `dynamic_proof_of_stake` |
-| `dynamic_proof_of_work` | `dynamic_proxy` | `dynamic_quote` | `dynamic_recycling` |
-| `dynamic_reference` | `dynamic_review` | `dynamic_routine` | `dynamic_script` |
-| `dynamic_self_awareness` | `dynamic_skeleton` | `dynamic_skills` | `dynamic_source` |
-| `dynamic_space` | `dynamic_spheres` | `dynamic_stake` | `dynamic_states` |
-| `dynamic_stem_cell` | `dynamic_stratosphere` | `dynamic_suites` | `dynamic_summary` |
-| `dynamic_superclusters` | `dynamic_supply` | `dynamic_syncronization` | `dynamic_synonym` |
-| `dynamic_tag` | `dynamic_task_manager` | `dynamic_teaching` | `dynamic_team` |
-| `dynamic_text` | `dynamic_thermosphere` | `dynamic_thinking` | `dynamic_token` |
-| `dynamic_ton` | `dynamic_tool_kits` | `dynamic_troposphere` | `dynamic_ultimate_reality` |
-| `dynamic_validator` | `dynamic_version` | `dynamic_vocabulary` | `dynamic_volume` |
-| `dynamic_wallet` | `dynamic_wave` | `dynamic_web` | `dynamic_web3` |
-| `dynamic_wisdom` | `dynamic_zone` |  |  |
+| `dynamic_development_team` | `dynamic_dimensions` | `dynamic_dockerfile` | `dynamic_domain` |
+| `dynamic_domain_name_system` | `dynamic_domain_names` | `dynamic_effect` | `dynamic_emoticon` |
+| `dynamic_encryption` | `dynamic_energy` | `dynamic_engineer` | `dynamic_engines` |
+| `dynamic_event` | `dynamic_exosphere` | `dynamic_expressions` | `dynamic_firewall` |
+| `dynamic_forecast` | `dynamic_framework` | `dynamic_fuel` | `dynamic_generator` |
+| `dynamic_glossary` | `dynamic_grammar` | `dynamic_graphql` | `dynamic_hashtag` |
+| `dynamic_heal` | `dynamic_helpers` | `dynamic_hierarchy` | `dynamic_http` |
+| `dynamic_human_resources` | `dynamic_idempotency` | `dynamic_implicit_memory` | `dynamic_index` |
+| `dynamic_indicators` | `dynamic_intergalactic_space` | `dynamic_interplanetary_space` | `dynamic_interstellar_space` |
+| `dynamic_ip_address` | `dynamic_keepers` | `dynamic_kyc` | `dynamic_letter_index` |
+| `dynamic_library` | `dynamic_load_balancer` | `dynamic_local_machine` | `dynamic_logging` |
+| `dynamic_loop` | `dynamic_mantra` | `dynamic_mapping` | `dynamic_mass` |
+| `dynamic_memory` | `dynamic_memory_reconsolidation` | `dynamic_mentorship` | `dynamic_mesosphere` |
+| `dynamic_message_queue` | `dynamic_metacognition` | `dynamic_metadata` | `dynamic_method` |
+| `dynamic_microservices` | `dynamic_mindset` | `dynamic_numbers` | `dynamic_ocean` |
+| `dynamic_package` | `dynamic_physics` | `dynamic_pillars` | `dynamic_playbook` |
+| `dynamic_point_in_time` | `dynamic_predictive` | `dynamic_proof` | `dynamic_proof_of_authority` |
+| `dynamic_proof_of_burn` | `dynamic_proof_of_history` | `dynamic_proof_of_reputation` | `dynamic_proof_of_space` |
+| `dynamic_proof_of_stake` | `dynamic_proof_of_work` | `dynamic_proxy` | `dynamic_quote` |
+| `dynamic_recycling` | `dynamic_reference` | `dynamic_review` | `dynamic_routine` |
+| `dynamic_script` | `dynamic_self_awareness` | `dynamic_skeleton` | `dynamic_skills` |
+| `dynamic_source` | `dynamic_space` | `dynamic_spheres` | `dynamic_stake` |
+| `dynamic_states` | `dynamic_stem_cell` | `dynamic_stratosphere` | `dynamic_suites` |
+| `dynamic_summary` | `dynamic_supabase` | `dynamic_superclusters` | `dynamic_supply` |
+| `dynamic_syncronization` | `dynamic_synonym` | `dynamic_tag` | `dynamic_task_manager` |
+| `dynamic_teaching` | `dynamic_team` | `dynamic_text` | `dynamic_thermosphere` |
+| `dynamic_thinking` | `dynamic_token` | `dynamic_ton` | `dynamic_tool_kits` |
+| `dynamic_trainer` | `dynamic_troposphere` | `dynamic_ultimate_reality` | `dynamic_validator` |
+| `dynamic_version` | `dynamic_vocabulary` | `dynamic_volume` | `dynamic_wallet` |
+| `dynamic_wave` | `dynamic_web` | `dynamic_web3` | `dynamic_wisdom` |
+| `dynamic_zone` |  |  |  |
+


### PR DESCRIPTION
## Summary
- refresh the snapshot metrics to reflect 161 `dynamic_*` directories and updated domain counts
- add the previously missing modules to the domain catalog listings, including infrastructure, science, AI, knowledge, and workflow entries
- regenerate the alphabetical index so every `dynamic_*` directory now appears

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d96f13a05c8322b1bd4fb0e4f5d086