### PR TITLE
Add Dynamic AGI TON ecosystem overview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,20 @@
 ## What's New
 
 <!-- WHATS_NEW:START -->
-- Dynamic AI multi-lobe fusion engine now powers adaptive trade orchestration with a Supabase-backed hedging service for real-time guardrails.
-- Multi-LLM Studio workspace enables cross-provider strategy design with shared prompts, benchmarks, and deployment presets.
-- Enhanced Telegram bot console delivers richer admin telemetry, escalation tooling, and instant Mini App synchronization.
+
+- Dynamic AI multi-lobe fusion engine now powers adaptive trade orchestration
+  with a Supabase-backed hedging service for real-time guardrails.
+- Multi-LLM Studio workspace enables cross-provider strategy design with shared
+  prompts, benchmarks, and deployment presets.
+- Enhanced Telegram bot console delivers richer admin telemetry, escalation
+  tooling, and instant Mini App synchronization.
+
 <!-- WHATS_NEW:END -->
 
 ## Table of Contents
 
 <!-- TOC:START -->
+
 - [What's New](#whats-new)
 - [Shortcuts](#shortcuts)
   - [Saved GitHub queries](#saved-github-queries)
@@ -80,6 +86,7 @@
 - [Hybrid Development Workflow](#hybrid-development-workflow)
 - [License / contributions](#license--contributions)
 - [Notes](#notes)
+
 <!-- TOC:END -->
 
 ## Shortcuts
@@ -162,54 +169,67 @@ import { FiActivity, FiHome, FiUser } from "react-icons/fi";
 - **Multi-LLM Studio tool** (`apps/web/app/tools/multi-llm`) for comparing
   OpenAI, Anthropic, and Groq chat completions side by side with configurable
   temperature and token limits directly inside the main Next.js app.
-- **Market Intelligence Workspace** with curated data rooms, model outputs, and deal pipelines for investor-ready insights.
-- **Dynamic Market Review automation** that aggregates TradingView signals, Telegram alerts, and Supabase events into actionable hedging triggers.
-- **`economic-calendar` edge function** streaming macro events into the signal bus for instant bot and dashboard consumption.
+- **Market Intelligence Workspace** with curated data rooms, model outputs, and
+  deal pipelines for investor-ready insights.
+- **Dynamic Market Review automation** that aggregates TradingView signals,
+  Telegram alerts, and Supabase events into actionable hedging triggers.
+- **`economic-calendar` edge function** streaming macro events into the signal
+  bus for instant bot and dashboard consumption.
 - Step through the
   [Dynamic AI & Dynamic Trading Algo Enhancement Roadmap](docs/multi-llm-algo-enhancement-roadmap.md)
   to align provider orchestration with the trading automation stack.
-- Onboard fast with the
-  [Dynamic AI Overview](docs/dynamic-ai-overview.md) summarising the Brain layer,
-  lobe fusion model, and operational guardrails that keep automation governed.
+- Onboard fast with the [Dynamic AI Overview](docs/dynamic-ai-overview.md)
+  summarising the Brain layer, lobe fusion model, and operational guardrails
+  that keep automation governed.
 
 ## Investor Experience
 
-- **TonConnect onboarding flow** delivers deep links from Telegram, QR fallback, and guarded session handshakes so traders can authenticate once and rejoin across devices.
-- **Automation guardrails** enforce per-user hedging limits, circuit breakers, and operator approval queues before new strategies reach production.
-- **Supported wallets** include Tonkeeper, OpenMask, and MyTonWallet with dynamic capability negotiation for staking, swaps, and signature payloads.
+- **TonConnect onboarding flow** delivers deep links from Telegram, QR fallback,
+  and guarded session handshakes so traders can authenticate once and rejoin
+  across devices.
+- **Automation guardrails** enforce per-user hedging limits, circuit breakers,
+  and operator approval queues before new strategies reach production.
+- **Supported wallets** include Tonkeeper, OpenMask, and MyTonWallet with
+  dynamic capability negotiation for staking, swaps, and signature payloads.
 
 ## Treasury & Token
 
-- **Dynamic Capital Token (DCT)** anchors treasury governance with transparent supply, vesting cliffs, and fee routing published in the [DCT whitepaper](docs/dynamic-capital-ton-whitepaper.md).
-- **Live DEX references**: monitor liquidity and pricing on [STON.fi](https://app.ston.fi) and [DeDust](https://dedust.io) pairs, with hedging hooks synced to the Supabase ledger service.
+- **Dynamic Capital Token (DCT)** anchors treasury governance with transparent
+  supply, vesting cliffs, and fee routing published in the
+  [DCT whitepaper](docs/dynamic-capital-ton-whitepaper.md).
+- **Live DEX references**: monitor liquidity and pricing on
+  [STON.fi](https://app.ston.fi) and [DeDust](https://dedust.io) pairs, with
+  hedging hooks synced to the Supabase ledger service.
 
 ## Architecture & Docs
 
 Explore the broader platform anatomy and contributor guides:
 
-- [Master meta-model reference](models/meta_model.md) — shared state/control/dynamics grammar with module index.
+- [Master meta-model reference](models/meta_model.md) — shared
+  state/control/dynamics grammar with module index.
 - [Dynamic Capital ecosystem anatomy](docs/dynamic-capital-ecosystem-anatomy.md)
 - [Dynamic AI overview](docs/dynamic-ai-overview.md)
 - [Dynamic Trading ALGO vs LOGIC](docs/dynamic-trading-algo-vs-logic.md)
+- [Dynamic AGI x TON ecosystem overview](docs/dynamic-agi-ton-overview.md)
 
 ### Dynamic AGI self-improvement loop
 
-`dynamic_agi.DynamicAGIModel` now accepts an optional
-`DynamicSelfImprovement` manager that records each evaluation and emits an
-iterative improvement plan. Provide realised performance telemetry or human
-feedback when calling `evaluate()` so the manager can accumulate session
-snapshots. The returned `AGIOutput` includes an `improvement` payload with
-ranked focus areas, aggregated metrics, and the latest introspection reports.
-See `tests/dynamic_agi/test_dynamic_self_improvement.py` for an end-to-end
-example.
+`dynamic_agi.DynamicAGIModel` now accepts an optional `DynamicSelfImprovement`
+manager that records each evaluation and emits an iterative improvement plan.
+Provide realised performance telemetry or human feedback when calling
+`evaluate()` so the manager can accumulate session snapshots. The returned
+`AGIOutput` includes an `improvement` payload with ranked focus areas,
+aggregated metrics, and the latest introspection reports. See
+`tests/dynamic_agi/test_dynamic_self_improvement.py` for an end-to-end example.
 
 **Dynamic AGI** abbreviates **Driving Yield of New Advancements in Minds,
 Intelligence & Creation — Adapting Global Intelligence**. The
 `dynamic_agi.DynamicAGIModel.identity` helper exposes this expansion and its
-three pillars (`Driving Yield of New Advancements in Minds`, `Intelligence &
-Creation`, `Adapting Global Intelligence`) so downstream services can surface
-consistent branding while reinforcing the platform's mandate to compound
-innovation under adaptive intelligence safeguards.
+three pillars (`Driving Yield of New Advancements in Minds`,
+`Intelligence &
+Creation`, `Adapting Global Intelligence`) so downstream
+services can surface consistent branding while reinforcing the platform's
+mandate to compound innovation under adaptive intelligence safeguards.
 
 ## Dynamic Theme System
 
@@ -830,8 +850,10 @@ on images.
 - It runs automatically for pull requests or pushes that touch the `docker/`
   directory (or the workflow file itself) and is also available through the
   **Run workflow** button on the Actions tab for ad-hoc verification.
-- To reproduce the same check locally, run `docker compose -f
-  docker/docker-compose.yml build app` followed by `docker compose -f
+- To reproduce the same check locally, run
+  `docker compose -f
+  docker/docker-compose.yml build app` followed by
+  `docker compose -f
   docker/docker-compose.yml run --rm --entrypoint node app --version`.
 
 ## Mini App
@@ -924,17 +946,16 @@ Then POST to `http://localhost:54321/functions/v1/telegram-webhook` with
 
 ### Public tunnel for remote QA
 
-If teammates need to validate the webhook or Mini App from outside your
-network, expose the local Supabase functions port through a trusted tunnel
-provider such as ngrok. A convenience script is available to start the
-standard tunnel:
+If teammates need to validate the webhook or Mini App from outside your network,
+expose the local Supabase functions port through a trusted tunnel provider such
+as ngrok. A convenience script is available to start the standard tunnel:
 
 ```bash
 npm run tunnel:functions
 ```
 
-If you only need to confirm the ngrok arguments or verify custom flags,
-run the command in dry-run mode:
+If you only need to confirm the ngrok arguments or verify custom flags, run the
+command in dry-run mode:
 
 ```bash
 npm run tunnel:functions -- --dry-run
@@ -942,8 +963,8 @@ npm run tunnel:functions -- --dry-run
 
 Share the resulting HTTPS endpoint with reviewers and map requests to the
 appropriate function path. For instance,
-`https://exosporal-ezequiel-semibiographically.ngrok-free.dev/` has been used
-to proxy the local Telegram webhook during QA sessions—replace it with your own
+`https://exosporal-ezequiel-semibiographically.ngrok-free.dev/` has been used to
+proxy the local Telegram webhook during QA sessions—replace it with your own
 ephemeral domain and rotate the tunnel token regularly.
 
 ## Deployment
@@ -1008,8 +1029,8 @@ troubleshooting.
 The automated hedge engine now complements the directional trading pipeline:
 
 - **Database schema** – `public.hedge_actions` records every hedge lifecycle
-  event with enums for side, reason, and status so dashboards and bots can
-  track volatility offsets alongside standard trades.
+  event with enums for side, reason, and status so dashboards and bots can track
+  volatility offsets alongside standard trades.
 - **Policy node** – the `dynamic-hedge` entry in `public.node_configs` runs
   every five minutes, watching trades, correlations, and risk settings before
   persisting new hedges and emitting MT5-ready signals.

--- a/docs/dynamic-agi-ton-overview.md
+++ b/docs/dynamic-agi-ton-overview.md
@@ -1,0 +1,68 @@
+# Dynamic AGI x TON Ecosystem Overview
+
+## Project Overview
+
+- **Dynamic Capital** fuses an adaptive AGI research stack with TON-native Web3
+  infrastructure to serve Maldivian traders through a Telegram-first experience.
+- The platform orchestrates trading insights, pooled mentorship, and tokenized
+  access from a single Dynamic Capital Token (DCT) economy.
+- Every surface — Telegram bot, Mini App, smart contracts, and analytics engines
+  — is designed for rapid iteration while preserving compliance and risk
+  controls.
+
+## Core Components
+
+- **Dynamic Capital Token (DCT):** Utility token that unlocks premium
+  intelligence feeds, governance votes, and staking programs linked to
+  mentorship pools.
+- **Telegram Bot & Mini App:** Front-line trader interface delivering onboarding
+  flows, actionable signals, and direct access to staking or liquidity programs.
+- **Supabase & Data Infrastructure:** Unified telemetry, user state, and risk
+  metrics powering personalized recommendations and compliance checkpoints.
+- **Dynamic Intelligence Layer:** Multi-model orchestration framework combining
+  LLM strategy generation, historical market memory, and guardrail policies.
+- **Automation & Ops Fabric:** Workflow engines, observability pipelines, and
+  compliance automation that keep on-chain and off-chain actions synchronized.
+
+## Telegram Mini App Features
+
+- **Onboarding & Identity:** Embedded KYC capture, wallet linking, and
+  fiat/crypto deposit verification optimized for mobile bandwidth.
+- **Trading Dashboards:** Market sentiment heatmaps, curated signal feeds, and
+  performance analytics driven by the Dynamic Intelligence Layer.
+- **Staking & Pool Access:** Seamless entry into DCT staking, mentorship pools,
+  and social trading cohorts with real-time TVL updates.
+- **Notifications & Support:** Event-driven alerts for trade execution, pool
+  status, and governance proposals plus direct access to support agents.
+
+## Intelligence Stack
+
+- **Cognitive Memory Mesh:** Long-term knowledge base that blends market
+  archives, mentorship playbooks, and regulatory notes into retrievable context.
+- **Adaptive Strategy Engine:** Ensemble of LLMs and quantitative models tuned
+  for Maldivian liquidity patterns and trader profiles.
+- **Risk Sentinel:** Guardrail subsystem enforcing stop-loss policies, treasury
+  exposure limits, and AML/CTF heuristics before orders are released.
+- **Mentorship Copilot:** Agentic workflow pairing mentors with mentees,
+  summarizing sessions, and feeding anonymized insights back into the strategy
+  engine.
+
+## Web3 & TON Integration
+
+- **TON Smart Contracts:** DCT-powered contracts manage staking pools, automated
+  liquidity rotation, NFT access badges, and token-gated governance modules.
+- **Wallet & Payment Bridges:** Native TON wallet support plus fiat settlement
+  bridges that reconcile deposits with on-chain activity.
+- **Analytics & Compliance:** Transaction indexing, real-time proof-of-reserve
+  attestations, and anomaly detection across TON-ledger interactions.
+- **Ecosystem Partnerships:** Integrations with TON DeFi pools, NFT
+  marketplaces, and oracle providers to extend liquidity and data surface area.
+
+## Next Steps
+
+- Formalize mentorship pool tokenomics and publish staking APR models aligned
+  with TON yield curves.
+- Expand Mini App roadmap with localized payment options, Malayalam-language
+  support, and mentor discovery UX.
+- Harden on-chain monitoring by instrumenting proof-of-reserve attestations and
+  anomaly alerts for treasury operations.


### PR DESCRIPTION
## Summary
- add a focused overview document describing the Dynamic AGI x TON ecosystem
- link the new reference from the Architecture & Docs section of the root README

## Testing
- $(bash scripts/deno_bin.sh) fmt README.md docs/dynamic-agi-ton-overview.md

------
https://chatgpt.com/codex/tasks/task_e_68d97a90dfbc8322ac5f5c6ee3882f4c