### PR TITLE
Add documentation for DCT intelligence-driven tokenomics

### DIFF
--- a/docs/dct-intelligence-driven-tokenomics.md
+++ b/docs/dct-intelligence-driven-tokenomics.md
@@ -1,0 +1,112 @@
+# Dynamic Capital Token (DCT) Intelligence-Driven Tokenomics
+
+## Overview
+
+Dynamic Capital Token (DCT) introduces feedback loops between protocol
+intelligence, service performance, and token supply mechanics. The architecture
+below formalizes how gains in artificial general intelligence (AGI) or network
+revenue translate into on-chain token flows.
+
+## 1. Intelligence-Linked Burning Algorithm
+
+The burn module retires DCT whenever the protocol's AGI achieves measurable
+gains.
+
+- **Formula**: $B = \lambda \cdot \Delta I$
+- **Variables**:
+  - $B$: total DCT to burn for the epoch
+  - $\Delta I$: intelligence delta derived from model evaluations, user
+    sentiment, or trading accuracy
+  - $\lambda$: governance-defined burn coefficient that scales sensitivity to
+    intelligence changes
+- **Trigger Events**:
+  - Production deployment of improved AGI models
+  - Completion of mentorship or training milestones that increase composite
+    intelligence scores
+  - Positive user feedback loops or benchmark uplifts recorded by monitoring
+    oracles
+- **Process Flow**:
+  1. Intelligence oracle aggregates metrics and calculates $\Delta I$.
+  2. Governance contract provides the current $\lambda$ parameter.
+  3. Burn executor retires $B$ DCT from treasury or supply, emitting events for
+     transparency.
+
+## 2. Revenue-Driven Buyback Algorithm
+
+Protocol revenues are recycled into DCT to reinforce price support and reward
+productive contributors.
+
+- **Formula**: $BB = \phi \cdot R$
+- **Variables**:
+  - $BB$: total DCT purchased via buyback
+  - $R$: net revenue from subscriptions, strategy fees, or liquidity pool
+    spreads
+  - $\phi$: buyback ratio adjustable through governance votes
+- **Execution Cycle**:
+  1. Revenue router batches net inflows per epoch.
+  2. Treasury contract calculates the buyback budget $BB$.
+  3. Automated market operations acquire DCT from designated DEX pools.
+  4. Purchased tokens are redistributed to staking vaults, mentorship rewards,
+     or AGI training bounties as configured.
+
+## 3. Market Maker Coordination Algorithm
+
+A liquidity coordination layer synchronizes service pricing with market dynamics
+while buffering volatility.
+
+- **Formula**: $P_s = \frac{P_{avg} + \sigma}{n}$
+- **Variables**:
+  - $P_s$: adjusted service price for a given product line
+  - $P_{avg}$: volume-weighted average DCT price across venues
+  - $\sigma$: volatility buffer derived from on-chain order book variance
+  - $n$: number of active services requiring synchronized pricing
+- **Responsibilities**:
+  - Maintain target spreads and depth across mentorship, signals, and pooled
+    strategies.
+  - Dynamically rebalance liquidity using treasury reserves when volatility
+    spikes.
+  - Signal pricing updates to downstream service modules to keep UX consistent.
+
+## 4. Synced Pricing Engine
+
+A unified oracle layer translates live DCT valuations into service access costs.
+
+- **Mechanism**:
+  1. Oracle fetches DCT price feeds from TON-native data sources.
+  2. Pricing engine refreshes service tariffs on a block cadence or on-demand
+     triggers.
+  3. Discount or boost factors are applied based on AGI performance tiers or
+     user status.
+  4. Updated prices propagate to mentorship, VIP signals, education, and trading
+     pools.
+
+## Intelligence-Driven Tokenomics Matrix
+
+| Component          | Linked Behavior                                                       |
+| ------------------ | --------------------------------------------------------------------- |
+| AGI Growth         | Triggers DCT burn and elevates perceived service value                |
+| Mentorship Success | Unlocks staking rewards and increases aggregated intelligence scores  |
+| Trading Accuracy   | Improves $\Delta I$ inputs and refines market making heuristics       |
+| User Engagement    | Scales revenue $R$, driving higher buyback volumes and token velocity |
+
+## Governance Considerations
+
+- **Parameter Management**: $\lambda$ and $\phi$ should support time-weighted
+  adjustments to smooth sudden metric swings.
+- **Transparency**: Publish burn and buyback events with metric snapshots so
+  stakeholders can audit the intelligence-to-tokenomics linkage.
+- **Fail Safes**: Introduce guardrails that cap $B$ and $BB$ per epoch to avoid
+  treasury depletion during anomalous data spikes.
+- **Review Cadence**: Conduct quarterly parameter reviews that incorporate AGI
+  roadmap progress, liquidity health, and community feedback.
+
+## Integration Checklist
+
+- Define canonical data schemas for intelligence metrics, revenue streams, and
+  service inventories.
+- Connect monitoring pipelines that feed oracle updates to the burn and buyback
+  executors.
+- Implement simulation tooling to stress test parameter changes before
+  governance proposals go live.
+- Provide dashboards that visualize intelligence deltas, burn history, buyback
+  cadence, and service price adjustments.


### PR DESCRIPTION
## Summary
- document the intelligence-driven burn, buyback, and market maker algorithms that govern DCT supply dynamics
- outline governance safeguards and integration steps for rolling out intelligence-linked tokenomics

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d97b768c148322893962c08ae2bf20