### PR TITLE
docs: outline DCT token automation blueprint

### DIFF
--- a/docs/dct-token-automation.md
+++ b/docs/dct-token-automation.md
@@ -1,0 +1,153 @@
+# DCT Token Automation Blueprint
+
+This document captures the automation logic that ties DCT token economics to AGI
+performance, treasury profits, and cross-service pricing. It consolidates
+execution flows, governance touchpoints, and telemetry requirements for future
+smart contract implementations.
+
+## 1. AGI-Driven Burn Mechanics
+
+The burn routine links AGI intelligence growth to DCT supply reductions. The
+pseudocode below assumes a dedicated AGI agent triggers burns when verifiable
+improvements are recorded.
+
+```solidity
+function burnDCT(uint256 intelligenceDelta) external onlyAGI {
+    uint256 burnAmount = intelligenceDelta * burnCoefficient;
+    require(balanceOf(msg.sender) >= burnAmount, "Insufficient DCT");
+    _burn(msg.sender, burnAmount);
+    emit Burned(msg.sender, burnAmount);
+}
+```
+
+**Key inputs**
+
+- `intelligenceDelta` represents the performance increase reported by the AGI
+  intelligence oracle (e.g., mentorship outcomes, trading accuracy, signal
+  reliability).
+- `burnCoefficient` is a governance-controlled multiplier that converts
+  performance delta into a burn amount.
+- The `onlyAGI` modifier restricts who can initiate the burn—only authorized AGI
+  modules can call this function.
+
+**Operational notes**
+
+1. Governance adjusts `burnCoefficient` to modulate deflation intensity as AGI
+   modules mature.
+2. Burn events should be recorded in the treasury ledger alongside the
+   intelligence delta that triggered them for transparent auditing.
+3. If the AGI wallet lacks sufficient DCT, the burn reverts and a shortfall
+   event is logged for remediation.
+
+## 2. Revenue-Backed Buybacks
+
+Treasury profits fuel periodic buybacks that increase price support and add
+additional burn pressure when paired with the AGI routine.
+
+```solidity
+function executeBuyback() external onlyTreasury {
+    uint256 buybackAmount = revenuePool * buybackRatio;
+    swapTONforDCT(buybackAmount);
+    emit BuybackExecuted(buybackAmount);
+}
+```
+
+**Parameters**
+
+- `revenuePool`: Aggregated TON or stablecoin reserves earmarked for market
+  operations.
+- `buybackRatio`: DAO-controlled percentage defining how much of the pool is
+  deployed each cycle.
+- `swapTONforDCT`: Integrates with an on-chain DEX or liquidity pool to
+  repurchase DCT.
+
+**Execution checklist**
+
+1. Treasury automation populates `revenuePool` after settling expenses and
+   buffer allocations.
+2. Governance proposals can raise or lower `buybackRatio` based on runway
+   targets and volatility.
+3. Buybacks route through approved venues and respect per-venue limits defined
+   in treasury policy.
+4. Optional burn hook can retire a portion of acquired DCT immediately after the
+   swap.
+
+## 3. Service Price Synchronisation
+
+Market-maker automation keeps pricing consistent across mentorship, education,
+and signals modules.
+
+```solidity
+function syncServicePrices() external {
+    uint256 avgPrice = getDCTPriceFromOracle();
+    for (uint i = 0; i < services.length; i++) {
+        services[i].updatePrice(avgPrice + volatilityBuffer);
+    }
+    emit PricesSynced(avgPrice);
+}
+```
+
+**Workflow**
+
+1. `getDCTPriceFromOracle()` pulls the current DCT price from approved oracles
+   or VWAP feeds.
+2. A `volatilityBuffer` smooths out rapid swings by adding a governance-tuned
+   spread.
+3. Each registered service contract recalculates its exchange rate or membership
+   fee using the synchronized baseline.
+
+**Risk controls**
+
+- If oracle data lags beyond a defined SLA, the sync is skipped and an alert is
+  raised.
+- Services maintain local caps to prevent sudden price jumps from exceeding user
+  protection thresholds.
+
+## 4. Governance Responsibilities
+
+| Parameter                 | Controller           | Voting method                    |
+| ------------------------- | -------------------- | -------------------------------- |
+| `burnCoefficient`         | DAO token holders    | Staked-weight voting             |
+| `buybackRatio`            | DAO token holders    | Proposal with quorum             |
+| `servicePricingRules`     | Core devs + DAO      | Hybrid (multisig + ratification) |
+| `AGI Intelligence Oracle` | Verified AGI modules | Proof-of-performance attestation |
+
+**Governance considerations**
+
+- All parameter changes should emit events and update an on-chain registry so
+  off-chain dashboards stay aligned.
+- Emergency pause controls allow the DAO multisig to halt burns, buybacks, or
+  price syncs when market anomalies occur.
+
+## 5. Telemetry & Dashboarding
+
+A public dashboard should correlate AGI performance with DCT supply dynamics and
+treasury actions.
+
+| Metric                     | Description                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| **AGI Intelligence Score** | Composite index of mentorship, trading, and feedback performance.            |
+| **DCT Burn Rate**          | Tokens burned per intelligence delta unit.                                   |
+| **Buyback Volume**         | TON deployed for DCT buybacks over the selected period.                      |
+| **Synced Service Price**   | Current cross-service price baseline post-volatility buffer.                 |
+| **Mentorship ROI**         | Comparison of DCT earned by mentors versus DCT burned by AGI-linked actions. |
+
+**Implementation notes**
+
+- Stream oracle updates, burn events, and buyback executions into a unified
+  analytics warehouse (e.g., Supabase or ClickHouse).
+- Surface parameter history and governance outcomes so stakeholders can track
+  how decisions influenced supply dynamics.
+- Provide exportable CSVs or APIs for auditors and quant researchers to validate
+  the burn/buyback cadence.
+
+## 6. Next Steps
+
+1. Formalize smart contract interfaces, including access controls for AGI
+   modules and treasury executors.
+2. Integrate the pseudocode with existing treasury automation pipelines and
+   buyback bots.
+3. Draft security reviews covering oracle manipulation, treasury custody, and
+   governance attack vectors.
+4. Prototype the dashboard using existing analytics infrastructure to test data
+   freshness and completeness.


### PR DESCRIPTION
## Summary
- add documentation that captures AGI-driven burns, treasury-backed buybacks, and synchronized pricing routines for DCT
- outline governance responsibilities and telemetry requirements for the new automation flows

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d97baeb67c8322b10cc47571a31294