### PR TITLE
Add ASCII to dynamic NFT orchestration pipeline

### DIFF
--- a/dynamic_ascii/__init__.py
+++ b/dynamic_ascii/__init__.py
@@ -10,6 +10,14 @@ from .engine import (
     DynamicAsciiEngine,
     DEFAULT_ASCII_PALETTE,
 )
+from .pipeline import (
+    AsciiDynamicNFTContext,
+    AsciiDynamicNFTPipeline,
+    IntelligenceOracle,
+    MentorshipDashboard,
+    MintPricingEngine,
+    TelegramNotifier,
+)
 
 __all__ = [
     "AsciiCanvas",
@@ -18,4 +26,10 @@ __all__ = [
     "AsciiPalette",
     "DynamicAsciiEngine",
     "DEFAULT_ASCII_PALETTE",
+    "AsciiDynamicNFTContext",
+    "AsciiDynamicNFTPipeline",
+    "IntelligenceOracle",
+    "MentorshipDashboard",
+    "MintPricingEngine",
+    "TelegramNotifier",
 ]

--- a/dynamic_ascii/pipeline.py
+++ b/dynamic_ascii/pipeline.py
@@ -1,0 +1,165 @@
+"""Pipeline that turns imagery into ASCII-driven dynamic NFTs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, Protocol, Sequence
+
+from dynamic_ascii.engine import (
+    AsciiNFT,
+    DynamicAsciiEngine,
+)
+from dynamic_token.nft import DynamicNFTMinter, MintedDynamicNFT
+
+__all__ = [
+    "AsciiDynamicNFTContext",
+    "AsciiDynamicNFTPipeline",
+    "IntelligenceOracle",
+    "MintPricingEngine",
+    "MentorshipDashboard",
+    "TelegramNotifier",
+]
+
+
+class IntelligenceOracle(Protocol):
+    """Produce an intelligence context for an ASCII-derived NFT."""
+
+    def evaluate(self, nft: AsciiNFT) -> Mapping[str, Any]:
+        """Return structured intelligence metadata for *nft*."""
+
+
+class MintPricingEngine(Protocol):
+    """Quote pricing signals for NFT minting flows."""
+
+    def quote(self, intelligence: Mapping[str, Any]) -> float:
+        """Return the mint cost based on *intelligence* context."""
+
+
+class TelegramNotifier(Protocol):
+    """Surface pipeline events to Telegram audiences."""
+
+    def send_ascii_nft(
+        self,
+        chat_id: str,
+        *,
+        ascii_art: str,
+        metadata: Mapping[str, Any],
+    ) -> None:
+        """Notify *chat_id* about a freshly minted ASCII NFT."""
+
+
+class MentorshipDashboard(Protocol):
+    """Persist mentorship achievements linked to NFTs."""
+
+    def record_nft(
+        self,
+        nft: MintedDynamicNFT,
+        *,
+        intelligence: Mapping[str, Any],
+    ) -> None:
+        """Store the minted *nft* details alongside intelligence context."""
+
+
+@dataclass(slots=True)
+class AsciiDynamicNFTContext:
+    """Result payload produced by :class:`AsciiDynamicNFTPipeline`."""
+
+    ascii_nft: AsciiNFT
+    minted: MintedDynamicNFT
+    intelligence: Mapping[str, Any]
+    mint_price: float
+
+
+class AsciiDynamicNFTPipeline:
+    """Co-ordinate ASCII conversion, NFT minting, and ecosystem sync."""
+
+    def __init__(
+        self,
+        *,
+        ascii_engine: DynamicAsciiEngine | None = None,
+        minter: DynamicNFTMinter | None = None,
+        oracle: IntelligenceOracle | None = None,
+        pricing_engine: MintPricingEngine | None = None,
+        telegram_notifier: TelegramNotifier | None = None,
+        mentorship_dashboard: MentorshipDashboard | None = None,
+    ) -> None:
+        self._ascii_engine = ascii_engine or DynamicAsciiEngine()
+        self._minter = minter or DynamicNFTMinter("DCT")
+        self._oracle = oracle
+        self._pricing_engine = pricing_engine
+        self._telegram_notifier = telegram_notifier
+        self._mentorship_dashboard = mentorship_dashboard
+
+    def execute(
+        self,
+        image: Sequence[Sequence[float]]
+        | Sequence[Sequence[int]]
+        | str
+        | bytes
+        | Any,
+        *,
+        owner: str,
+        name: str,
+        description: str,
+        chat_id: str | None = None,
+        width: int | None = None,
+        tags: Sequence[str] | None = None,
+        analysis: Mapping[str, Any] | None = None,
+        extra_attributes: Mapping[str, Any] | None = None,
+    ) -> AsciiDynamicNFTContext:
+        """Run the full pipeline returning minted NFT context."""
+
+        ascii_nft = self._ascii_engine.create_nft(
+            image,
+            name=name,
+            description=description,
+            width=width,
+        )
+
+        intelligence: Mapping[str, Any]
+        if self._oracle is None:
+            intelligence = {}
+        else:
+            intelligence = dict(self._oracle.evaluate(ascii_nft))
+
+        mint_price = (
+            float(self._pricing_engine.quote(intelligence))
+            if self._pricing_engine is not None
+            else 0.0
+        )
+
+        pipeline_metadata: MutableMapping[str, Any] = {
+            "ascii_fingerprint": ascii_nft.fingerprint,
+            "ascii_preview": ascii_nft.ascii_art.as_text(),
+            "intelligence": intelligence,
+            "mint_price": mint_price,
+        }
+        if extra_attributes:
+            pipeline_metadata.update(dict(extra_attributes))
+
+        minted = self._minter.mint(
+            owner,
+            analysis=analysis,
+            tags=tags,
+            extra=pipeline_metadata,
+        )
+
+        if self._mentorship_dashboard is not None:
+            self._mentorship_dashboard.record_nft(
+                minted, intelligence=intelligence
+            )
+
+        if self._telegram_notifier is not None and chat_id:
+            self._telegram_notifier.send_ascii_nft(
+                chat_id,
+                ascii_art=ascii_nft.ascii_art.as_text(),
+                metadata=minted.metadata,
+            )
+
+        return AsciiDynamicNFTContext(
+            ascii_nft=ascii_nft,
+            minted=minted,
+            intelligence=intelligence,
+            mint_price=mint_price,
+        )
+

--- a/tests_python/test_ascii_nft_pipeline.py
+++ b/tests_python/test_ascii_nft_pipeline.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from dynamic_ascii import AsciiDynamicNFTPipeline  # noqa: E402  (import after path setup)
+
+
+class _StubOracle:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def evaluate(self, nft: Any) -> Mapping[str, Any]:
+        self.calls.append(nft.fingerprint)
+        return {"score": 0.87, "band": "Gold"}
+
+
+class _StubPricingEngine:
+    def quote(self, intelligence: Mapping[str, Any]) -> float:
+        assert intelligence.get("score") == pytest.approx(0.87)
+        return 42.0
+
+
+class _StubTelegramNotifier:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str, Mapping[str, Any]]] = []
+
+    def send_ascii_nft(
+        self,
+        chat_id: str,
+        *,
+        ascii_art: str,
+        metadata: Mapping[str, Any],
+    ) -> None:
+        self.messages.append((chat_id, ascii_art, metadata))
+
+
+class _StubDashboard:
+    def __init__(self) -> None:
+        self.entries: list[Mapping[str, Any]] = []
+
+    def record_nft(
+        self,
+        nft,
+        *,
+        intelligence: Mapping[str, Any],
+    ) -> None:
+        self.entries.append({
+            "token_id": nft.token_id,
+            "intelligence": intelligence,
+        })
+
+
+def _matrix() -> list[list[int]]:
+    return [
+        [0, 64, 128, 255],
+        [255, 128, 64, 0],
+        [30, 90, 190, 220],
+        [5, 10, 15, 20],
+    ]
+
+
+def test_pipeline_executes_with_full_integrations() -> None:
+    oracle = _StubOracle()
+    pricing = _StubPricingEngine()
+    telegram = _StubTelegramNotifier()
+    dashboard = _StubDashboard()
+
+    pipeline = AsciiDynamicNFTPipeline(
+        oracle=oracle,
+        pricing_engine=pricing,
+        telegram_notifier=telegram,
+        mentorship_dashboard=dashboard,
+    )
+
+    context = pipeline.execute(
+        _matrix(),
+        owner="0xABC",
+        name="Aurora",
+        description="Mentorship milestone",
+        chat_id="12345",
+        tags=("mentorship",),
+        analysis={"action": "buy", "confidence": 0.91},
+        extra_attributes={"impact_points": 7},
+    )
+
+    assert context.minted.owner == "0xABC"
+    assert context.mint_price == pytest.approx(42.0)
+    assert context.intelligence == {"score": 0.87, "band": "Gold"}
+    assert "ascii_fingerprint" in context.minted.metadata
+    assert context.minted.metadata["impact_points"] == 7
+    assert context.minted.metadata["mint_price"] == pytest.approx(42.0)
+    assert telegram.messages and telegram.messages[0][0] == "12345"
+    assert dashboard.entries[0]["token_id"] == context.minted.token_id
+    assert dashboard.entries[0]["intelligence"] == context.intelligence
+    assert oracle.calls[0] == context.ascii_nft.fingerprint
+
+
+def test_pipeline_handles_optional_dependencies() -> None:
+    pipeline = AsciiDynamicNFTPipeline()
+
+    context = pipeline.execute(
+        _matrix(),
+        owner="0xDEF",
+        name="Nebula",
+        description="Autonomous wisdom badge",
+    )
+
+    assert context.mint_price == 0.0
+    assert context.intelligence == {}
+    assert context.minted.metadata["mint_price"] == 0.0
+    assert context.minted.owner == "0xDEF"


### PR DESCRIPTION
## Summary
- add a reusable pipeline that transforms imagery into ASCII art, mints dynamic NFTs, and syncs ecosystem integrations
- expose the pipeline interfaces via the dynamic_ascii package for downstream consumers
- cover the pipeline with tests that validate integrations, pricing, and optional dependency handling

## Testing
- pytest tests_python/test_ascii_nft_pipeline.py tests_python/test_dynamic_ascii.py

------
https://chatgpt.com/codex/tasks/task_e_68d9825caa24832299e85fa9ad4868c3