### PR TITLE
Add AGI trading integration strategy playbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,7 @@ documenting which assets were consulted.
 | 6.16 | [onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md](./onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md) | Combined logs and model artifacts share metadata for telemetry/model reconciliation. |
 | 6.17 | [onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md](./onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md) | Trading reports share identifiers for ingesting supplemental analytics. |
 | 6.18 | [onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md](./onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md) | Standalone `read_me.md` text share metadata for onboarding notes. |
+| 6.19 | [agi_integration_strategies.md](./agi_integration_strategies.md) | AGI-driven integration plan aligning DTL, DTA, execution, and learning loops. |
 
 ## 7. Operational Runbooks & Launch Phases
 

--- a/docs/agi_integration_strategies.md
+++ b/docs/agi_integration_strategies.md
@@ -1,0 +1,205 @@
+# AGI-Driven Trading Integration Strategy
+
+## Overview
+
+This playbook codifies how Dynamic Capital can fuse Dynamic Trading Logic (DTL),
+the Dynamic Trading Algo (DTA), and emerging AGI agents into a single adaptive
+operating model. The goal is to ship explainable decisions, preserve risk
+discipline, and continuously upgrade performance without interrupting live
+desks. Each section maps the requested capabilities to concrete architecture
+notes, operational checklists, and learning loops that fit the existing
+TradingView → Supabase → MT5 stack.
+
+Use the numbered subsections as implementation trackers. When an initiative
+moves from design to delivery, capture the owner, start date, and completion
+signal directly under the relevant bullet point. This keeps engineering,
+trading, and treasury teams synchronized as AGI scope expands.
+
+## 1. AGI Integration Strategies
+
+### 1.1 Modular Agent Mediation Between DTL and DTA
+
+- **Mediator Layer:** Introduce a lightweight "Strategy Router" agent that
+  consumes DTL hypothesis outputs and DTA execution readiness signals. The
+  router arbitrates conflicts via configurable policies (e.g., risk budget,
+  latency budget) and emits normalized intent envelopes to downstream execution.
+- **Interface Contracts:**
+  - DTL publishes to `signals.hypothesis.v1` with probability, supporting
+    evidence, and required execution window.
+  - DTA responds on `signals.health.v1` with fill confidence, current throttle
+    limits, and outstanding debt to risk.
+  - Mediation logic persists rationale snapshots to Supabase
+    `strategy_rationales` for auditability.
+- **Hot-Swap Capability:** Package mediation logic inside a containerized
+  service (FastAPI or Deno) with feature flags so alternate policies can be
+  shadow-tested alongside production without downtime.
+
+### 1.2 Role-Based AGI Personas
+
+- **Strategy Analyst (DTL Advocate):** Specializes in hypothesis generation,
+  signal clustering, and alignment with Smart Money Concepts (SMC). Runs
+  exploratory notebooks, updates glossary alignment, and proposes mitigation
+  adjustments.
+- **Execution Overseer (DTA Guardian):** Focuses on venue selection, order
+  slicing, and adaptive throttles. Owns latency dashboards, broker KPIs, and
+  slippage simulations.
+- **Risk Sentinel (Policy Authority):** Maintains guardrails across leverage,
+  exposure, and treasury allocations. Approves kill-switch triggers and
+  consensus gating outcomes before live routing.
+- **Coordination Rituals:** Implement weekly persona syncs using the Agent
+  Canvas template (`docs/multi_agent_trading_architecture.md`) to highlight
+  experiments, blocked dependencies, and telemetry observations.
+
+### 1.3 Signal Normalization & Rationale Scoring
+
+- **Normalization Pipeline:**
+  - Step 1: Raw alerts or discretionary notes enter a Kafka topic
+    `signals.raw.v1`.
+  - Step 2: A Deno task cleans timestamps, session tags, and symbol metadata,
+    then stores canonical records in Supabase `signals_normalized`.
+  - Step 3: An AGI "Rationale Scorer" ranks each signal 0–1 across SMC
+    confluence, volatility regime fit, and counter-party flow alignment.
+- **Explainability Artifacts:** Archive rationale vectors alongside textual
+  justifications (top 3 contributing features, conflicting signals, precedent
+  trades) to allow auditors and community members to inspect reasoning quality.
+- **Escalation Hooks:** When rationale confidence drops below configurable
+  thresholds, push notifications to the Strategy Analyst persona and queue the
+  signal for manual review before any order leaves the router.
+
+## 2. Execution Optimization
+
+### 2.1 AGI-Driven Broker Routing
+
+- Build an agent that tracks broker metrics (spread, liquidity depth, rejection
+  rate) in near real time. Feed features into a contextual bandit that selects
+  the optimal venue per symbol while respecting counterparty concentration
+  limits.
+- Integrate slippage prediction models (gradient boosted trees or lightweight
+  transformers) that ingest order book snapshots, historical fills, and latency
+  traces to forecast expected vs. worst-case outcomes.
+
+### 2.2 Latency-Aware Order Placement
+
+- Maintain latency baselines per venue, route, and order type in ClickHouse or
+  TimescaleDB. The Execution Overseer persona tunes timeouts and child order
+  slicing windows using these baselines.
+- Allow AGI to tag each intent with a `latency_class` (e.g., immediate, defer,
+  park) so the router can choose between direct market access, smart order
+  routing, or iceberg style placements.
+
+### 2.3 Adaptive Lot Sizing
+
+- Blend real-time volatility metrics (ATR, realized variance) with AGI-provided
+  confidence intervals to adjust lot sizes dynamically.
+- Impose treasury-aware caps by integrating with the capital allocation service
+  (see Section 4.3) to avoid violating cash buffers or tokenomics triggers.
+
+### 2.4 Shadow Deployments & Consensus Gating
+
+- Deploy new execution policies in "shadow" mode: orders are simulated
+  end-to-end with identical market data but held from live venues. Compare
+  shadow vs. production slippage to determine promotion readiness.
+- Require a quorum (e.g., 2 of 3 personas + automated risk checks) before
+  toggling shadow policies live. Record votes and rationale in Supabase for
+  compliance traceability.
+
+## 3. Logic Enhancement
+
+### 3.1 Multi-LLM Ensemble Benchmarking
+
+- Run ensembles across diverse LLM families (OpenAI, Anthropic, open-weight
+  models) to benchmark SMC interpretations, structural bias calls, and macro
+  overlay commentary.
+- Use evaluation harnesses that score reasoning chains for consistency,
+  factuality, and alignment with glossary definitions. Persist evaluation
+  metrics per model to inform routing.
+
+### 3.2 Smart Money Concepts Validation
+
+- Automate BOS/SMS, liquidity sweep, and mitigation block detection with
+  cross-model voting. Require majority agreement plus quantitative confirmation
+  (volume delta, imbalance thresholds) before flagging high conviction trades.
+- Introduce anomaly detection (e.g., isolation forests) to surface
+  out-of-pattern market structures for human analysts and AGI review.
+
+### 3.3 Feedback Injection
+
+- After every execution cycle, feed realized PnL, slippage, and compliance notes
+  back into the rationale scorer. Update feature weights so recurring execution
+  issues penalize aggressive entries and reward disciplined exits.
+- Maintain a "decision delta" log that pairs predicted outcomes with actual
+  results for reinforcement learning fine-tuning.
+
+## 4. Feedback Loop Design
+
+### 4.1 Closed-Loop Telemetry
+
+- Establish a unified telemetry fabric that mirrors events across TradingView,
+  MT5, Exness, and AGI agent outputs. Utilize OpenTelemetry collectors to
+  fan-out traces into Prometheus (metrics) and ClickHouse (analytics).
+- Normalize identifiers (order ID, signal ID, hypothesis ID) so cross-platform
+  drilldowns remain coherent.
+
+### 4.2 Retrospective Auto-Tuning
+
+- Schedule retrospectives where AGI agents propose modifier adjustments (e.g.,
+  raise mitigation weights, tighten execution throttles) based on telemetry
+  anomalies.
+- Use Supabase stored procedures or Edge Functions to apply approved modifier
+  changes and log before/after configurations for audit.
+
+### 4.3 Treasury Synchronization
+
+- Sync treasury positions, cash buffers, and token issuance windows with
+  execution throttles by subscribing AGI agents to `treasury.status.v1` events.
+- Link DCT pricing levers to strategy conviction: when AGI confidence is high
+  and risk budgets are underutilized, trigger optional buy-back or minting
+  workflows as defined in `docs/dct-dynamic-market-maker.md`.
+
+## 5. Continuous Learning
+
+### 5.1 Reinforcement Learning on Trade Outcomes
+
+- Configure RL pipelines (RLlib or custom PyTorch) that treat strategy intents
+  as actions and realized outcomes as rewards. Incorporate penalty terms for
+  rule breaches, latency overruns, and compliance flags.
+- Run offline training on historical executions before live experimentation;
+  promote policies only after they outperform baselines with statistical
+  confidence.
+
+### 5.2 Mentorship & Community Feedback
+
+- Score mentorship touchpoints and community trade breakdowns using AGI
+  evaluators. Metrics should cover accuracy, conviction clarity, and adherence
+  to approved vocabulary.
+- Feed high-scoring community insights back into DTL backlog grooming to
+  encourage distributed intelligence contributions.
+
+### 5.3 Intelligence Oracle & Tokenomics Triggers
+
+- Integrate with the Intelligence Oracle so that agent-generated insights can
+  nudge tokenomics actions (e.g., staking rate changes, incentive pool unlocks).
+- Define trigger thresholds (confidence %, win-rate delta, treasury coverage)
+  that automatically notify treasury operators when Oracle metrics warrant
+  governance review.
+
+## 6. Implementation Checklist
+
+| Track       | Key Deliverables                                                          | Owner | Status  |
+| ----------- | ------------------------------------------------------------------------- | ----- | ------- |
+| Integration | Strategy Router agent, Supabase rationale store, persona rituals          | TBD   | Planned |
+| Execution   | Broker routing bandit, latency baseline dashboards, shadow deploy tooling | TBD   | Planned |
+| Logic       | Ensemble evaluation harness, SMC anomaly detection, decision delta log    | TBD   | Planned |
+| Feedback    | OpenTelemetry mesh, modifier auto-tuning workflow, treasury event sync    | TBD   | Planned |
+| Learning    | RL training loop, mentorship scoring rubric, Oracle trigger webhooks      | TBD   | Planned |
+
+## 7. Next Actions
+
+1. Stand up the Strategy Router skeleton service with mock DTL/DTA feeds to
+   validate schema alignment.
+2. Draft persona charters and schedule the first cross-role review focused on
+   execution gating and rationale scoring expectations.
+3. Deploy telemetry probes (latency, slippage) into shadow environments so
+   upcoming AGI routing experiments have baseline data.
+4. Outline RL reward functions and guardrails, referencing historical trade
+   outcomes to seed early simulations.


### PR DESCRIPTION
## Summary
- add a dedicated AGI-driven trading integration strategy playbook covering mediation, execution, feedback, and learning loops
- link the new guide from the documentation index for easier discovery

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68d982c20a80832283dccc0a41676777