### PR TITLE
Add Dynamic AGI starter stack reference

### DIFF
--- a/docs/dynamic_agi_starter_stack.md
+++ b/docs/dynamic_agi_starter_stack.md
@@ -1,0 +1,89 @@
+# Dynamic AGI Starter Stack
+
+This document captures the baseline open-source stack that can power the Dynamic
+AGI training pipeline while staying approachable for new contributors and end
+users. The components below balance orchestration, reasoning, quantum
+experimentation, and governance.
+
+## 1. LangChain — Orchestration Layer
+
+- **Role:** Acts as the "nervous system" that chains models, memory, and tools.
+- **Why it matters:** Normalizes incoming signals, manages conversational
+  context, and routes queries between Dynamic Thought Logic (DTL) and Dynamic
+  Task Automation (DTA).
+- **Dynamic Capital use case:** Wrap TradingView alerts and MetaTrader 5 (MT5)
+  logs into structured prompts before handing them to downstream reasoning
+  agents.
+
+## 2. LLM360 / Hugging Face Transformers — Core Reasoning Models
+
+- **Role:** Provide open-source large language models for decision intelligence.
+- **Why it matters:** These models are transparent, fine-tunable, and auditable,
+  avoiding reliance on closed APIs.
+- **Dynamic Capital use case:** Train and adapt models on mentorship
+  transcripts, trade rationales, and localized Maldivian market content.
+
+## 3. SuperAGI — Autonomous Agent Framework
+
+- **Role:** Supplies multi-agent planning, execution, and self-improvement APIs.
+- **Why it matters:** Enables specialized personas such as TradingAgent,
+  TreasuryAgent, and MentorAgent that collaborate and enforce guardrails.
+- **Dynamic Capital use case:** Facilitate agent debates over market signals,
+  apply governance policies, and require consensus before execution.
+
+## 4. PennyLane / TensorFlow Quantum — Quantum Integration
+
+- **Role:** Deliver hybrid quantum-classical machine learning interfaces.
+- **Why it matters:** Supports the "quantum sequences" vision by encoding
+  conviction, risk, and volatility as quantum states.
+- **Dynamic Capital use case:** Optimize lot sizing, slippage prediction, and
+  portfolio allocation with variational quantum circuits.
+
+## 5. SingularityNET — Governance & Marketplace
+
+- **Role:** Offers a decentralized marketplace and governance fabric for AI
+  services.
+- **Why it matters:** Adds blockchain-based provenance, incentive alignment, and
+  transparent governance workflows.
+- **Dynamic Capital use case:** Log AGI rationales on-chain, reward mentors, and
+  enforce DCT tokenomics with auditable trails.
+
+## Integration Flow
+
+```
+TradingView / MT5
+   ↓ (signal normalization via LangChain)
+SuperAGI multi-agent debate
+   ↓ (rationale scoring)
+LLM360 / Hugging Face reasoning
+   ↓ (decision outputs)
+PennyLane / TensorFlow Quantum optimization
+   ↓ (execution modifiers)
+Dynamic Task Automation (order routing)
+   ↓
+SingularityNET / DCT governance + tokenomics synchronization
+```
+
+## Beginner-Friendly Mini App Layer
+
+- **Guided explanations:** LangChain combined with Hugging Face models can
+  answer foundational questions (e.g., "What is a pip?") with analogies and
+  glossary links.
+- **Mentor personas:** SuperAGI's MentorAgent persona tracks user progress,
+  responds to learning queries, and provides scaffolded feedback.
+- **Quantum storytelling:** PennyLane integrations remain abstracted, but user
+  interfaces can celebrate successful "quantum-optimized" trades.
+- **On-chain transparency:** SingularityNET events inform users when their
+  trades trigger DCT burns or governance votes, reinforcing the platform's
+  accountability.
+
+## Next Steps
+
+- Prototype LangChain chains that ingest TradingView webhooks and MT5 logs.
+- Stand up SuperAGI agents with clear guardrails and voting logic.
+- Evaluate LLM360 or Hugging Face checkpoints aligned with Dynamic Capital's
+  domain language.
+- Explore PennyLane tutorials for variational quantum circuit design tailored to
+  trading strategies.
+- Define SingularityNET workflows for recording rationale metadata and
+  distributing DCT incentives.


### PR DESCRIPTION
## Summary
- document the recommended open-source stack for the Dynamic AGI training pipeline
- outline orchestration, reasoning, quantum, and governance components with integration flow
- capture next steps for wiring LangChain, SuperAGI, Hugging Face, PennyLane, and SingularityNET

## Testing
- npx deno fmt docs/dynamic_agi_starter_stack.md

------
https://chatgpt.com/codex/tasks/task_e_68d9904d2bbc8322b6c064045b133c64