### PR TITLE
Document MT5 bridge checklist cross-links and secrets

### DIFF
--- a/docs/LAUNCH_CHECKLIST.md
+++ b/docs/LAUNCH_CHECKLIST.md
@@ -2,19 +2,21 @@
 
 ## Required Secrets
 
-| Name | Purpose |
-| --- | --- |
-| SUPABASE_URL | Supabase project URL |
-| SUPABASE_SERVICE_ROLE_KEY | Service role key for full access |
-| TELEGRAM_BOT_TOKEN | Bot token from BotFather |
-| TELEGRAM_WEBHOOK_SECRET | Secret for webhook validation |
-| MINI_APP_URL | Full URL to hosted Mini App (fallback) |
-| MINI_APP_SHORT_NAME | BotFather short name launching the Mini App |
-| ADMIN_API_SECRET | Header secret for admin-only endpoints |
-| SUPABASE_ANON_KEY | Public anon key for client access |
-| SUPABASE_PROJECT_ID | Supabase project reference |
-| SUPABASE_ACCESS_TOKEN | Personal access token for CLI tasks |
-| SUPABASE_DB_PASSWORD | Database password used by migrations |
+| Name                           | Purpose                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------- |
+| SUPABASE_URL                   | Supabase project URL                                                             |
+| SUPABASE_SERVICE_ROLE_KEY      | Service role key for full access                                                 |
+| TELEGRAM_BOT_TOKEN             | Bot token from BotFather                                                         |
+| TELEGRAM_WEBHOOK_SECRET        | Secret for webhook validation                                                    |
+| TRADING_SIGNALS_WEBHOOK_SECRET | Shared secret that authenticates TradingView → Supabase alert posts              |
+| MT5_BRIDGE_WORKER_ID           | Identifier the Supabase listener/EAs use when recording fills and status updates |
+| MINI_APP_URL                   | Full URL to hosted Mini App (fallback)                                           |
+| MINI_APP_SHORT_NAME            | BotFather short name launching the Mini App                                      |
+| ADMIN_API_SECRET               | Header secret for admin-only endpoints                                           |
+| SUPABASE_ANON_KEY              | Public anon key for client access                                                |
+| SUPABASE_PROJECT_ID            | Supabase project reference                                                       |
+| SUPABASE_ACCESS_TOKEN          | Personal access token for CLI tasks                                              |
+| SUPABASE_DB_PASSWORD           | Database password used by migrations                                             |
 
 Set each value in **Supabase Edge → Functions → Secrets** before deploying.
 
@@ -22,7 +24,8 @@ Set each value in **Supabase Edge → Functions → Secrets** before deploying.
 
 ### Run linkage audit
 
-Use the `sync-audit` function to verify secrets and Telegram linkage. Passing `fix:true` attempts to repair drift:
+Use the `sync-audit` function to verify secrets and Telegram linkage. Passing
+`fix:true` attempts to repair drift:
 
 ```bash
 curl -s https://<PROJECT_REF>.functions.supabase.co/sync-audit \
@@ -44,14 +47,18 @@ The keeper re-applies the expected webhook and menu URL if Telegram resets them.
 
 ## BotFather vs `MINI_APP_URL`
 
-- `MINI_APP_SHORT_NAME` comes from BotFather and produces `https://t.me/<bot>/<short_name>`; this is the preferred launch path.
-- `MINI_APP_URL` is a full URL fallback used when the short name is missing or during migrations.
+- `MINI_APP_SHORT_NAME` comes from BotFather and produces
+  `https://t.me/<bot>/<short_name>`; this is the preferred launch path.
+- `MINI_APP_URL` is a full URL fallback used when the short name is missing or
+  during migrations.
 
 ### Safe roll-forward
 
 1. Set `MINI_APP_URL` to the new location and redeploy the bot.
 2. Run `sync-audit` with `fix:true` to push the menu and webhook updates.
 3. Configure `MINI_APP_SHORT_NAME` in BotFather pointing to the new Mini App.
-4. After verifying, remove `MINI_APP_URL` so the short name becomes authoritative.
+4. After verifying, remove `MINI_APP_URL` so the short name becomes
+   authoritative.
 
-This sequence avoids downtime while transitioning between URL and BotFather configurations.
+This sequence avoids downtime while transitioning between URL and BotFather
+configurations.

--- a/docs/TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md
+++ b/docs/TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md
@@ -1,58 +1,105 @@
 # TradingView → MT5 Onboarding Checklist
 
-Use this list when spinning up the TradingView webhook to MetaTrader 5 automation flow. It mirrors the onboarding roadmap so cross-functional contributors can work in parallel while keeping hand-offs explicit. When reusing the `tradingview-to-metatrader5` bridge, pair this guide with the dedicated [TradingView→MT5 Bridge Integration Checklist](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md).
+Use this list when spinning up the TradingView webhook to MetaTrader 5
+automation flow. It mirrors the onboarding roadmap so cross-functional
+contributors can work in parallel while keeping hand-offs explicit. When reusing
+the `tradingview-to-metatrader5` bridge, pair this guide with the dedicated
+[TradingView→MT5 Bridge Integration Checklist](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md).
 
 ## 1. Align scope & shared artifacts
-- [ ] Document the end-to-end architecture (TradingView → webhook → Supabase → MT5 EA) in the project tracker (see [Unified Webhook Sync Architecture](./unified-webhook-sync.md)).
-- [ ] Inventory existing Pine Script, webhook handlers, Supabase schema, and EA code so owners know baseline maturity.
-- [ ] Capture sample TradingView alert payloads (JSON) and share with downstream teams.
-- [ ] Centralize documentation in the `algorithms/` workspace to keep scripts, webhook logic, and EA tasks discoverable.
+
+- [ ] Document the end-to-end architecture (TradingView → webhook → Supabase →
+      MT5 EA) in the project tracker (see
+      [Unified Webhook Sync Architecture](./unified-webhook-sync.md)).
+- [ ] Inventory existing Pine Script, webhook handlers, Supabase schema, and EA
+      code so owners know baseline maturity.
+- [ ] Capture sample TradingView alert payloads (JSON) and share with downstream
+      teams.
+- [ ] Centralize documentation in the `algorithms/` workspace to keep scripts,
+      webhook logic, and EA tasks discoverable.
 
 ## 2. TradingView & Pine Script readiness
-- [ ] Finalize or update Pine Script strategies/indicators tied to the automation effort.
-- [ ] Embed `alert()` calls that emit normalized JSON (symbol, direction, sizing, identifiers).
-- [ ] Confirm TradingView plan tier supports webhooks and has capacity for required alerts.
-- [ ] Stand up alerts with webhook delivery enabled and validated against the staging endpoint.
-- [ ] Record alert configuration details and any throttling limits in documentation.
+
+- [ ] Finalize or update Pine Script strategies/indicators tied to the
+      automation effort.
+- [ ] Embed `alert()` calls that emit normalized JSON (symbol, direction,
+      sizing, identifiers).
+- [ ] Confirm TradingView plan tier supports webhooks and has capacity for
+      required alerts.
+- [ ] Stand up alerts with webhook delivery enabled and validated against the
+      staging endpoint.
+- [ ] Record alert configuration details and any throttling limits in
+      documentation.
 
 ## 3. Webhook ingestion service
-- [ ] Stand up the webhook receiver (Vercel serverless function or Python service) following repo conventions.
-- [ ] Implement authentication (shared secret, signature) and reject unauthorized payloads.
-- [ ] Record shared secrets such as `TRADING_SIGNALS_WEBHOOK_SECRET` and `MT5_BRIDGE_WORKER_ID` in the deployment checklist so they map cleanly to Supabase.
-- [ ] Normalize symbols, timestamps, and payload shape to match Supabase expectations.
+
+- [ ] Stand up the webhook receiver (Vercel serverless function or Python
+      service) following repo conventions.
+- [ ] Implement authentication (shared secret, signature) and reject
+      unauthorized payloads.
+- [x] Record shared secrets such as `TRADING_SIGNALS_WEBHOOK_SECRET` and
+      `MT5_BRIDGE_WORKER_ID` in the deployment checklist so they map cleanly to
+      Supabase. _Documented in the
+      [Launch Checklist](./LAUNCH_CHECKLIST.md#required-secrets) table so ops
+      can provision them alongside existing Telegram keys._
+- [ ] Normalize symbols, timestamps, and payload shape to match Supabase
+      expectations.
 - [ ] Add idempotency or deduplication to prevent duplicate trade executions.
-- [ ] Emit structured logs and capture metrics for received, processed, and failed alerts.
+- [ ] Emit structured logs and capture metrics for received, processed, and
+      failed alerts.
 - [ ] Write unit/integration tests covering happy-path and malformed payloads.
 
 ## 4. Supabase backend enablement
-- [ ] Design and migrate tables such as `signals`, `trades`, `positions`, and configuration stores.
-- [ ] Apply the `20250920000000_trading_signals_pipeline.sql` migration so `trading_accounts`, `signals`, `signal_dispatches`, and `trades` exist with polling indexes.
-- [ ] Define RLS policies or restrict access via service-role keys for automation components.
-- [ ] Enable Realtime channels or RPC endpoints that the EA/process will consume.
-- [ ] Run manual inserts from the webhook service to confirm database connectivity.
-- [ ] Document REST/RPC usage patterns and share connection credentials securely.
+
+- [ ] Design and migrate tables such as `signals`, `trades`, `positions`, and
+      configuration stores.
+- [ ] Apply the `20250920000000_trading_signals_pipeline.sql` migration so
+      `trading_accounts`, `signals`, `signal_dispatches`, and `trades` exist
+      with polling indexes.
+- [ ] Define RLS policies or restrict access via service-role keys for
+      automation components.
+- [ ] Enable Realtime channels or RPC endpoints that the EA/process will
+      consume.
+- [ ] Run manual inserts from the webhook service to confirm database
+      connectivity.
+- [ ] Document REST/RPC usage patterns and share connection credentials
+      securely.
 
 ## 5. MetaTrader 5 Expert Advisor integration
-- [ ] Decide on connectivity (Supabase polling/realtime vs. socket bridge) and implement the adapter layer.
+
+- [ ] Decide on connectivity (Supabase polling/realtime vs. socket bridge) and
+      implement the adapter layer.
 - [ ] Parse incoming payloads and map to MT5 trade parameters with validation.
 - [ ] Implement execution logic, risk management, and post-trade reconciliation.
-- [ ] Forward execution status, fills, and error states back to Supabase for observability.
-- [ ] Exercise the `claim_trading_signal`, `mark_trading_signal_status`, and `record_trade_update` RPC helpers before wiring production order flow.
+- [ ] Forward execution status, fills, and error states back to Supabase for
+      observability.
+- [ ] Exercise the `claim_trading_signal`, `mark_trading_signal_status`, and
+      `record_trade_update` RPC helpers before wiring production order flow.
 - [ ] Add robust logging, retries, and fail-safes for network or broker issues.
 - [ ] Backtest and forward-test with demo accounts using staged signals.
 
 ## 6. Infrastructure, CI/CD & operations
-- [ ] Provision and harden a VPS (e.g., DigitalOcean) to host MT5 and supporting services 24/7.
-- [ ] Configure MT5 auto-start, EA deployment, and monitoring/alerting for crashes or disconnects.
-- [ ] Centralize secret management for TradingView, Supabase, and broker credentials.
-- [ ] Extend CI/CD pipelines to lint/test Pine Script, webhook code, and EA builds.
+
+- [ ] Provision and harden a VPS (e.g., DigitalOcean) to host MT5 and supporting
+      services 24/7.
+- [ ] Configure MT5 auto-start, EA deployment, and monitoring/alerting for
+      crashes or disconnects.
+- [ ] Centralize secret management for TradingView, Supabase, and broker
+      credentials.
+- [ ] Extend CI/CD pipelines to lint/test Pine Script, webhook code, and EA
+      builds.
 - [ ] Add deployment automation for Vercel functions and Supabase migrations.
 - [ ] Document operational runbooks, escalation paths, and rollback procedures.
 
 ## 7. Security, validation & go-live
+
 - [ ] Lock down webhook endpoints (IP allowlists, TLS verification, API keys).
-- [ ] Run end-to-end dry runs from TradingView alert to MT5 execution on a demo account.
+- [ ] Run end-to-end dry runs from TradingView alert to MT5 execution on a demo
+      account.
 - [ ] Measure latency at each hop and tune alerts or infrastructure as needed.
-- [ ] Set up observability dashboards/alerts for webhook failures, Supabase errors, and EA exceptions.
-- [ ] Perform go-live review with stakeholders, including risk/compliance sign-off.
-- [ ] Schedule ongoing audits of trading performance, system health, and credential hygiene.
+- [ ] Set up observability dashboards/alerts for webhook failures, Supabase
+      errors, and EA exceptions.
+- [ ] Perform go-live review with stakeholders, including risk/compliance
+      sign-off.
+- [ ] Schedule ongoing audits of trading performance, system health, and
+      credential hygiene.

--- a/docs/TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md
+++ b/docs/TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md
@@ -1,50 +1,121 @@
 # TradingView→MT5 Bridge Integration Checklist
 
-Use this list when adapting the [`abhidp/tradingview-to-metatrader5`](https://github.com/abhidp/tradingview-to-metatrader5) copier for Dynamic Capital’s TradingView → Supabase → MT5 pipeline. It pulls concrete tasks out of the upstream repo so the bridge can be vendored, Supabase-enabled, and productionized on the Windows host that runs MT5.
+Use this list when adapting the
+[`abhidp/tradingview-to-metatrader5`](https://github.com/abhidp/tradingview-to-metatrader5)
+copier for Dynamic Capital’s TradingView → Supabase → MT5 pipeline. It pulls
+concrete tasks out of the upstream repo so the bridge can be vendored,
+Supabase-enabled, and productionized on the Windows host that runs MT5.
+
+> [!TIP] **Quick navigation**
+>
+> - [TradingView → MT5 Onboarding Checklist](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md)
+> - [Supabase trading signals migration](../supabase/migrations/20250920000000_trading_signals_pipeline.sql)
+> - [Automated Trading Checklist](./automated-trading-checklist.md)
 
 ## 1. Vendor the upstream project into the algorithms workspace
-- [ ] Copy the repo into `algorithms/mql5/tradingview_to_mt5_bridge/` so `run.py`, `docker-compose.yml`, `start.bat`, and the `src/` tree keep their relative paths.
-- [ ] Add `algorithms/mql5/tradingview_to_mt5_bridge/THIRD_PARTY.md` that records the upstream commit hash, license (MIT), and any local modifications.
-- [ ] Promote `.env.template` to `.env.example`, replacing TradingView-only secrets with Supabase + MT5 keys (`SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `MT5_SERVER`, etc.).
-- [ ] Mirror Python 3.11 requirements by pinning dependencies in `algorithms/mql5/tradingview_to_mt5_bridge/requirements.txt` and documenting the `python -m venv .venv` bootstrap in the local README.
-- [ ] Evaluate whether `docker-compose.yml` should stay (for Redis) or be replaced with Supabase-native services; flag follow-up tasks in the vendored README.
+
+- [ ] Copy the repo into `algorithms/mql5/tradingview_to_mt5_bridge/` so
+      `run.py`, `docker-compose.yml`, `start.bat`, and the `src/` tree keep
+      their relative paths.
+- [ ] Add `algorithms/mql5/tradingview_to_mt5_bridge/THIRD_PARTY.md` that
+      records the upstream commit hash, license (MIT), and any local
+      modifications.
+- [ ] Promote `.env.template` to `.env.example`, replacing TradingView-only
+      secrets with Supabase + MT5 keys (`SUPABASE_URL`, `SUPABASE_SERVICE_KEY`,
+      `MT5_SERVER`, etc.).
+- [ ] Mirror Python 3.11 requirements by pinning dependencies in
+      `algorithms/mql5/tradingview_to_mt5_bridge/requirements.txt` and
+      documenting the `python -m venv .venv` bootstrap in the local README.
+- [ ] Evaluate whether `docker-compose.yml` should stay (for Redis) or be
+      replaced with Supabase-native services; flag follow-up tasks in the
+      vendored README.
 
 ## 2. Point the bridge at Dynamic Capital data sources
-- [ ] Wire `src/config/database.py` to accept a Supabase/Postgres connection string and CA bundle instead of the local `init.sql` bootstrap.
-- [ ] Remove or retire the upstream `src/scripts/init_db.py` workflow so migrations originate from the Dynamic Capital Supabase schema repo.
-- [ ] Map Supabase `signals` columns to the copier’s models (`models/database.py`) and trim unused tables/fields that Supabase will not expose.
-- [ ] Use the new `trading_accounts`, `signals`, `signal_dispatches`, and `trades` tables from `20250920000000_trading_signals_pipeline.sql` as the source of truth (alert IDs remain unique).
-- [ ] Configure Redis credentials/hostnames via `.env.example` so the Windows host can talk to Dynamic Capital’s managed queue (or confirm the local Docker Redis remains the source of truth).
+
+- [ ] Wire `src/config/database.py` to accept a Supabase/Postgres connection
+      string and CA bundle instead of the local `init.sql` bootstrap.
+- [ ] Remove or retire the upstream `src/scripts/init_db.py` workflow so
+      migrations originate from the Dynamic Capital Supabase schema repo.
+- [ ] Map Supabase `signals` columns to the copier’s models
+      (`models/database.py`) and trim unused tables/fields that Supabase will
+      not expose.
+- [ ] Use the new `trading_accounts`, `signals`, `signal_dispatches`, and
+      `trades` tables from `20250920000000_trading_signals_pipeline.sql` as the
+      source of truth (alert IDs remain unique).
+- [ ] Configure Redis credentials/hostnames via `.env.example` so the Windows
+      host can talk to Dynamic Capital’s managed queue (or confirm the local
+      Docker Redis remains the source of truth).
 
 ## 3. Replace the mitmproxy ingestion path with a Supabase listener
-- [ ] Add `src/workers/supabase_listener.py` that polls or subscribes to Supabase Realtime for `signals` rows in an actionable status.
-- [ ] Register a CLI entry point (e.g., `python run.py supabase-listener`) mirroring how `run.py proxy` and `run.py worker` are exposed upstream.
-- [ ] Reuse `utils/queue_handler.RedisQueue.push_trade` to enqueue Supabase payloads so `workers/mt5_worker.py` and `services/mt5_service.py` stay untouched.
-- [ ] Implement optimistic locking or status transitions (`pending → in_progress`) when publishing a Supabase signal to Redis to avoid double execution.
-- [ ] Invoke the RPC helpers (`claim_trading_signal`, `mark_trading_signal_status`, `record_trade_update`) rather than raw table writes to keep dispatch counters and timestamps consistent.
-- [ ] Capture Supabase credentials via Windows Credential Manager or encrypted `.env` values and load them in the new listener.
+
+- [ ] Add `src/workers/supabase_listener.py` that polls or subscribes to
+      Supabase Realtime for `signals` rows in an actionable status.
+- [ ] Register a CLI entry point (e.g., `python run.py supabase-listener`)
+      mirroring how `run.py proxy` and `run.py worker` are exposed upstream.
+- [ ] Reuse `utils/queue_handler.RedisQueue.push_trade` to enqueue Supabase
+      payloads so `workers/mt5_worker.py` and `services/mt5_service.py` stay
+      untouched.
+- [ ] Implement optimistic locking or status transitions
+      (`pending → in_progress`) when publishing a Supabase signal to Redis to
+      avoid double execution.
+- [ ] Invoke the RPC helpers (`claim_trading_signal`,
+      `mark_trading_signal_status`, `record_trade_update`) rather than raw table
+      writes to keep dispatch counters and timestamps consistent.
+- [ ] Capture Supabase credentials via Windows Credential Manager or encrypted
+      `.env` values and load them in the new listener.
 
 ## 4. Propagate execution results back into Supabase
-- [ ] Extend `services/mt5_service.MT5Service` (or wrap `workers/mt5_worker`) to call Supabase REST/RPC endpoints once an order fills, partially fills, or errors.
-- [ ] Persist MT5 ticket IDs, fill prices, and error messages onto the originating Supabase record so downstream dashboards stay accurate.
-- [ ] Subscribe to the `SUPABASE_SIGNALS_CHANNEL` (default `realtime:public:signals`) so the bridge can react to new rows without busy polling.
-- [ ] Ensure Supabase updates occur atomically (`status`, `filled_at`, `mt5_ticket_id`) and implement retry/backoff helpers in case the REST call fails.
-- [ ] Publish health metrics (last fill timestamp, outstanding in-flight trades) into Supabase or another telemetry sink so ops can monitor the copier.
+
+- [ ] Extend `services/mt5_service.MT5Service` (or wrap `workers/mt5_worker`) to
+      call Supabase REST/RPC endpoints once an order fills, partially fills, or
+      errors.
+- [ ] Persist MT5 ticket IDs, fill prices, and error messages onto the
+      originating Supabase record so downstream dashboards stay accurate.
+- [ ] Subscribe to the `SUPABASE_SIGNALS_CHANNEL` (default
+      `realtime:public:signals`) so the bridge can react to new rows without
+      busy polling.
+- [ ] Ensure Supabase updates occur atomically (`status`, `filled_at`,
+      `mt5_ticket_id`) and implement retry/backoff helpers in case the REST call
+      fails.
+- [ ] Publish health metrics (last fill timestamp, outstanding in-flight trades)
+      into Supabase or another telemetry sink so ops can monitor the copier.
 
 ## 5. Harden the Windows runtime and services
-- [ ] Restrict Redis/Postgres listeners to `127.0.0.1` or a private interface; enforce Windows Firewall rules that mirror `docs/PHASE_6_OPS.md` controls.
-- [ ] Create Windows Task Scheduler or NSSM services that start `python run.py supabase-listener` and `python run.py worker` automatically on boot.
-- [ ] Reuse upstream logging (`logs/` folder) but ship copies to Dynamic Capital’s centralized log store (e.g., Supabase storage or Loki).
-- [ ] Confirm mitmproxy binaries and certificates are no longer required; uninstall or archive them so only the Supabase pathway stays active.
+
+- [ ] Restrict Redis/Postgres listeners to `127.0.0.1` or a private interface;
+      enforce Windows Firewall rules that mirror `docs/PHASE_6_OPS.md` controls.
+- [ ] Create Windows Task Scheduler or NSSM services that start
+      `python run.py supabase-listener` and `python run.py worker` automatically
+      on boot.
+- [ ] Reuse upstream logging (`logs/` folder) but ship copies to Dynamic
+      Capital’s centralized log store (e.g., Supabase storage or Loki).
+- [ ] Confirm mitmproxy binaries and certificates are no longer required;
+      uninstall or archive them so only the Supabase pathway stays active.
 
 ## 6. Document runbooks and onboarding steps
-- [ ] Update or create `algorithms/mql5/tradingview_to_mt5_bridge/README.md` with Dynamic Capital-specific bootstrapping (venv activation, `.env` keys, CLI commands, Supabase dependency).
-- [ ] Capture a fresh Windows VPS bring-up sequence: install Python 3.11, Git, MT5 terminal, Redis (if kept), and configure timezone/NTP per trading ops standards.
-- [ ] Document troubleshooting recipes for Supabase authentication failures, Redis connectivity, MT5 login/auth issues, and Windows service restarts.
-- [ ] Cross-link this checklist, the onboarding checklist, and any Supabase schema docs so contributors can navigate between repo pieces quickly.
+
+- [ ] Update or create `algorithms/mql5/tradingview_to_mt5_bridge/README.md`
+      with Dynamic Capital-specific bootstrapping (venv activation, `.env` keys,
+      CLI commands, Supabase dependency).
+- [ ] Capture a fresh Windows VPS bring-up sequence: install Python 3.11, Git,
+      MT5 terminal, Redis (if kept), and configure timezone/NTP per trading ops
+      standards.
+- [ ] Document troubleshooting recipes for Supabase authentication failures,
+      Redis connectivity, MT5 login/auth issues, and Windows service restarts.
+- [x] Cross-link this checklist, the onboarding checklist, and any Supabase
+      schema docs so contributors can navigate between repo pieces quickly.
+      _Quick navigation callout above now links the three core resources so
+      operators can pivot between docs without hunting through the tree._
 
 ## 7. Validate the end-to-end signal flow
-- [ ] Dry-run the full TradingView alert → Vercel webhook → Supabase → Supabase listener → Redis queue → MT5 worker path against a demo account and confirm Supabase status updates.
-- [ ] Inject failure scenarios (network drop, Supabase outage, MT5 rejection) and verify retries, alerts, and Supabase status transitions behave as expected.
-- [ ] Benchmark latency between signal ingestion and MT5 fill; record acceptable thresholds in the runbook.
-- [ ] Obtain sign-off from engineering, trading, ops, and compliance once documentation and controls meet Dynamic Capital standards.
+
+- [ ] Dry-run the full TradingView alert → Vercel webhook → Supabase → Supabase
+      listener → Redis queue → MT5 worker path against a demo account and
+      confirm Supabase status updates.
+- [ ] Inject failure scenarios (network drop, Supabase outage, MT5 rejection)
+      and verify retries, alerts, and Supabase status transitions behave as
+      expected.
+- [ ] Benchmark latency between signal ingestion and MT5 fill; record acceptable
+      thresholds in the runbook.
+- [ ] Obtain sign-off from engineering, trading, ops, and compliance once
+      documentation and controls meet Dynamic Capital standards.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "env:validate": "tsx scripts/env/validate.ts",
     "env:sync": "tsx scripts/env/sync.ts",
     "env:report": "tsx scripts/env/report.ts",
+    "scan:checklists": "tsx scripts/scan-checklists.ts",
     "do:sync-site": "node scripts/digitalocean/sync-site-config.mjs",
     "do:sync-cdn": "node scripts/digitalocean/sync-cdn-config.mjs",
     "doctl:sync-site": "node scripts/doctl/sync-site-config.mjs",

--- a/scripts/scan-checklists.ts
+++ b/scripts/scan-checklists.ts
@@ -1,0 +1,186 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { extname, relative, resolve } from "node:path";
+import process from "node:process";
+
+process.stdout.on("error", (error) => {
+  const nodeError = error as NodeJS.ErrnoException;
+  if (nodeError.code === "EPIPE") {
+    process.exit(0);
+  }
+  throw error;
+});
+
+/**
+ * Recursively scans the repository for lines that mention "checklist".
+ *
+ * This helps the Dynamic Capital execution agents surface compliance and risk
+ * guardrails encoded as checklist tasks across the stack. The output feeds
+ * Dynamic AGI feedback loops by highlighting modules that require governance
+ * attention, ensuring execution integrity.
+ */
+interface ChecklistHit {
+  file: string;
+  line: number;
+  text: string;
+}
+
+const DEFAULT_EXTENSIONS = new Set([
+  ".md",
+  ".mdx",
+  ".py",
+  ".ts",
+  ".tsx",
+  ".json",
+  ".yaml",
+  ".yml",
+]);
+
+const SKIP_DIRECTORIES = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  "vendor",
+  "__pycache__",
+  ".venv",
+]);
+
+function shouldSkipDir(name: string): boolean {
+  return SKIP_DIRECTORIES.has(name);
+}
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (shouldSkipDir(entry.name)) {
+        continue;
+      }
+      const nested = await collectFiles(resolve(dir, entry.name));
+      files.push(...nested);
+    } else if (entry.isFile()) {
+      const extension = extname(entry.name).toLowerCase();
+      if (DEFAULT_EXTENSIONS.has(extension)) {
+        files.push(resolve(dir, entry.name));
+      }
+    }
+  }
+
+  return files;
+}
+
+function extractHits(file: string, contents: string): ChecklistHit[] {
+  const hits: ChecklistHit[] = [];
+  const lines = contents.split(/\r?\n/);
+  const checklistPattern = /checklist/i;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!checklistPattern.test(line)) {
+      continue;
+    }
+
+    const trimmed = line.trim();
+    const snippet = trimmed.length > 160
+      ? `${trimmed.slice(0, 157)}...`
+      : trimmed;
+
+    hits.push({
+      file,
+      line: index + 1,
+      text: snippet,
+    });
+  }
+
+  return hits;
+}
+
+async function scan(root: string): Promise<Map<string, ChecklistHit[]>> {
+  const normalizedRoot = resolve(root);
+  const files = await collectFiles(normalizedRoot);
+  const hitsByFile = new Map<string, ChecklistHit[]>();
+
+  await Promise.all(
+    files.map(async (absolutePath) => {
+      try {
+        const fileStats = await stat(absolutePath);
+        if (!fileStats.isFile()) {
+          return;
+        }
+
+        const contents = await readFile(absolutePath, "utf8");
+        const hits = extractHits(
+          relative(normalizedRoot, absolutePath),
+          contents,
+        );
+        if (hits.length > 0) {
+          hitsByFile.set(absolutePath, hits);
+        }
+      } catch (error) {
+        console.warn(`Unable to scan ${absolutePath}:`, error);
+      }
+    }),
+  );
+
+  return hitsByFile;
+}
+
+function printReport(
+  hitsByFile: Map<string, ChecklistHit[]>,
+  root: string,
+): void {
+  if (hitsByFile.size === 0) {
+    console.log("No checklist references detected in the target scope.");
+    return;
+  }
+
+  console.log("Checklist scan report");
+  console.log(`Root: ${root}`);
+  console.log("");
+
+  const sortedEntries = Array.from(hitsByFile.entries()).sort((a, b) =>
+    a[0].localeCompare(b[0])
+  );
+
+  for (const [absolutePath, hits] of sortedEntries) {
+    const relativePath = relative(root, absolutePath);
+    console.log(relativePath);
+    for (const hit of hits) {
+      console.log(`  [${hit.line}] ${hit.text}`);
+    }
+    console.log("");
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const rootArg = args.find((value) => !value.startsWith("--"));
+  const jsonOutput = args.includes("--json");
+  const root = resolve(rootArg ?? process.cwd());
+
+  const hitsByFile = await scan(root);
+
+  if (jsonOutput) {
+    const payload = Array.from(hitsByFile.entries()).map((
+      [absolutePath, hits],
+    ) => ({
+      file: relative(root, absolutePath),
+      hits: hits.map((hit) => ({
+        line: hit.line,
+        text: hit.text,
+      })),
+    }));
+
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  printReport(hitsByFile, root);
+}
+
+main().catch((error) => {
+  console.error("Checklist scan failed:", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- document TradingView-to-Supabase secrets in the Launch Checklist so bridge services share deployment keys
- mark the MT5 onboarding checklist secret-tracking item complete with a pointer to the updated launch documentation
- add quick navigation links across the MT5 bridge checklist, onboarding checklist, and Supabase migration reference

## Testing
- bash -lc '$(bash scripts/deno_bin.sh) fmt docs/LAUNCH_CHECKLIST.md docs/TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md docs/TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md'


------
https://chatgpt.com/codex/tasks/task_e_68d9909c3d1c8322a5f60f57f3f53d15