### PR TITLE
docs: summarize pending checklist tasks

### DIFF
--- a/docs/pending-tasks-summary.md
+++ b/docs/pending-tasks-summary.md
@@ -1,0 +1,67 @@
+# Pending Documentation Tasks
+
+This report aggregates unchecked checklist items across `docs/*.md` files. Use it to prioritize follow-up work or audits on the listed guides and playbooks.
+
+## Incomplete Checklists by Document
+
+| Document | Outstanding Tasks |
+| --- | ---: |
+| [docs/automated-trading-checklist.md](./automated-trading-checklist.md) | 44 |
+| [docs/nft-collectible-launch-checklist.md](./nft-collectible-launch-checklist.md) | 42 |
+| [docs/chatagent-blueprint.md](./chatagent-blueprint.md) | 41 |
+| [docs/TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | 40 |
+| [docs/coding-efficiency-checklist.md](./coding-efficiency-checklist.md) | 39 |
+| [docs/VERCEL_PRODUCTION_CHECKLIST.md](./VERCEL_PRODUCTION_CHECKLIST.md) | 37 |
+| [docs/desk-hub-mini-app-token-hub-checklist.md](./desk-hub-mini-app-token-hub-checklist.md) | 36 |
+| [docs/ui/unification-optimization-checklist.md](./ui/unification-optimization-checklist.md) | 35 |
+| [docs/TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md) | 32 |
+| [docs/dynamic-ui-development-checklist.md](./dynamic-ui-development-checklist.md) | 32 |
+| [docs/investing-com-candlestick-checklist.md](./investing-com-candlestick-checklist.md) | 32 |
+| [docs/dynamic_app_launch_workflow.md](./dynamic_app_launch_workflow.md) | 30 |
+| [docs/dynamic-trading-algo-improvement-checklist.md](./dynamic-trading-algo-improvement-checklist.md) | 29 |
+| [docs/dynamic-agi-modular-framework.md](./dynamic-agi-modular-framework.md) | 27 |
+| [docs/grok-1-integration-checklist.md](./grok-1-integration-checklist.md) | 27 |
+| [docs/git-branch-organization-checklist.md](./git-branch-organization-checklist.md) | 25 |
+| [docs/dynamic-capital-future-proofing-blueprint.md](./dynamic-capital-future-proofing-blueprint.md) | 24 |
+| [docs/tribute-integration-checklist.md](./tribute-integration-checklist.md) | 21 |
+| [docs/dct-jetton-starter-kit.md](./dct-jetton-starter-kit.md) | 20 |
+| [docs/human-resources/trading-compensation.md](./human-resources/trading-compensation.md) | 17 |
+| [docs/AGI_INTELLIGENCE_ORACLE.md](./AGI_INTELLIGENCE_ORACLE.md) | 15 |
+| [docs/cosmic-recycling-lifecycle.md](./cosmic-recycling-lifecycle.md) | 15 |
+| [docs/dct-fiat-minting-plan.md](./dct-fiat-minting-plan.md) | 15 |
+| [docs/dynamic-capital-checklist.md](./dynamic-capital-checklist.md) | 15 |
+| [docs/stellar-element-composition.md](./stellar-element-composition.md) | 15 |
+| [docs/dynamic_ascii_nft_pipeline.md](./dynamic_ascii_nft_pipeline.md) | 13 |
+| [docs/REPO_MAP_OPTIMIZATION.md](./REPO_MAP_OPTIMIZATION.md) | 12 |
+| [docs/ci_cd_maturity_plan.md](./ci_cd_maturity_plan.md) | 12 |
+| [docs/credit_pricing_strategy.md](./credit_pricing_strategy.md) | 12 |
+| [docs/dct-algo-dynamic-pricing.md](./dct-algo-dynamic-pricing.md) | 12 |
+| [docs/dynamic-agi-quantum-native-training.md](./dynamic-agi-quantum-native-training.md) | 12 |
+| [docs/dynamic-consensus-mechanism-playbook.md](./dynamic-consensus-mechanism-playbook.md) | 12 |
+| [docs/dynamic-market-notes.md](./dynamic-market-notes.md) | 12 |
+| [docs/intelligence-resonance-spectrum.md](./intelligence-resonance-spectrum.md) | 12 |
+| [docs/iso9241_environment_checklist.md](./iso9241_environment_checklist.md) | 12 |
+| [docs/market-structure-study-notes.md](./market-structure-study-notes.md) | 11 |
+| [docs/dynamic-telegram-nextjs-gui-architecture.md](./dynamic-telegram-nextjs-gui-architecture.md) | 10 |
+| [docs/dynamic-agi-agent-assignment-process.md](./dynamic-agi-agent-assignment-process.md) | 9 |
+| [docs/VARIABLES_AND_LINKS_CHECKLIST.md](./VARIABLES_AND_LINKS_CHECKLIST.md) | 8 |
+| [docs/dynamic-mental-operating-system.md](./dynamic-mental-operating-system.md) | 8 |
+| [docs/education/grading-and-scoring.md](./education/grading-and-scoring.md) | 8 |
+| [docs/open_source_dictionary_apis.md](./open_source_dictionary_apis.md) | 8 |
+| [docs/dynamic-capital-extended-integration-playbook.md](./dynamic-capital-extended-integration-playbook.md) | 7 |
+| [docs/dynamic-capital-model-context-protocol.md](./dynamic-capital-model-context-protocol.md) | 7 |
+| [docs/dynamic-capital-wisdom-playbook.md](./dynamic-capital-wisdom-playbook.md) | 7 |
+| [docs/GO_LIVE_CHECKLIST.md](./GO_LIVE_CHECKLIST.md) | 6 |
+| [docs/dynamic-capital-playbook.md](./dynamic-capital-playbook.md) | 6 |
+| [docs/dynamic_agi_starter_stack.md](./dynamic_agi_starter_stack.md) | 5 |
+| [docs/dynamic_engines_usage.md](./dynamic_engines_usage.md) | 5 |
+| [docs/summary_types.md](./summary_types.md) | 5 |
+| [docs/unified-webhook-sync.md](./unified-webhook-sync.md) | 5 |
+| [docs/REPO_SUMMARY.md](./REPO_SUMMARY.md) | 3 |
+| [docs/ton-ide-plugins.md](./ton-ide-plugins.md) | 3 |
+
+## How to Use This List
+
+- Prioritize documents with the highest outstanding counts to retire major checklist gaps quickly.
+- Update the originating documents as tasks are completed; regenerate this summary to keep stakeholders informed.
+- Consider automating this report (e.g., a CI job) if checklist tracking becomes part of regular governance.


### PR DESCRIPTION
## Summary
- add a `pending-tasks-summary.md` report under `docs/`
- aggregate unchecked checklist counts across documentation checklists to highlight outstanding work

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da03e655688322ae9d93e00c3c2a24