### PR TITLE
Add quick reference review for DAI/DAGI/DCT/DTL/DTA checklists

### DIFF
--- a/docs/dai-dagi-dct-dtl-dta-checklist-review.md
+++ b/docs/dai-dagi-dct-dtl-dta-checklist-review.md
@@ -1,0 +1,51 @@
+# DAI, DAGI, DCT, DTL, and DTA Checklist Review
+
+This quick-reference audit links each requested domain to its primary checklist,
+clarifying the operational focus areas that remain active for the Dynamic
+Capital stack.
+
+## Dynamic AI (DAI)
+
+- **Source:** [`docs/dynamic-ai-overview.md`](./dynamic-ai-overview.md)
+- **Operational highlights:**
+  - Validate persona routing, guardrail rehearsals, and replay audits before
+    shipping new orchestration changes.【F:docs/dynamic-ai-overview.md†L57-L85】
+  - Maintain versioning hygiene so prompt templates, lobe parameters, and
+    toggles stay reproducible across environments.【F:docs/dynamic-ai-overview.md†L81-L85】
+
+## Dynamic AGI (DAGI)
+
+- **Source:** [`docs/dynamic-agi-modular-framework.md`](./dynamic-agi-modular-framework.md)
+- **Operational highlights:**
+  - Complete module-specific integrations across science, business, human,
+    security, finance, knowledge, workflow, sustainability, and conceptual
+    domains.【F:docs/dynamic-agi-modular-framework.md†L371-L417】
+  - Harden shared infrastructure by validating telemetry pipelines, symbolic
+    constraint libraries, and security guardrails across the AGI mesh.【F:docs/dynamic-agi-modular-framework.md†L371-L412】
+
+## Dynamic Capital Treasury (DCT)
+
+- **Source:** [`docs/dct-intelligence-driven-tokenomics.md`](./dct-intelligence-driven-tokenomics.md)
+- **Operational highlights:**
+  - Define canonical schemas and monitoring pipelines so intelligence metrics
+    directly inform burn and buyback executors.【F:docs/dct-intelligence-driven-tokenomics.md†L104-L111】
+  - Ship simulation tooling and dashboards to stress test proposals and surface
+    tokenomics deltas for operators.【F:docs/dct-intelligence-driven-tokenomics.md†L111-L113】
+
+## Dynamic Trading Logic (DTL)
+
+- **Source:** [`docs/agi_integration_strategies.md`](./agi_integration_strategies.md)
+- **Operational highlights:**
+  - Progress the implementation table covering integration, execution, logic,
+    feedback, and learning tracks for the Strategy Router and telemetry mesh.【F:docs/agi_integration_strategies.md†L198-L207】
+  - Close mentorship feedback loops and intelligence oracle triggers that feed
+    backlog grooming and treasury coordination.【F:docs/agi_integration_strategies.md†L176-L195】
+
+## Dynamic Trading Algo (DTA)
+
+- **Source:** [`docs/dynamic-trading-algo-improvement-checklist.md`](./dynamic-trading-algo-improvement-checklist.md)
+- **Operational highlights:**
+  - Enforce Smart Money Concepts hygiene across data feeds, analyzer logic, and
+    configuration governance.【F:docs/dynamic-trading-algo-improvement-checklist.md†L8-L55】
+  - Maintain execution discipline, deployment coordination, and retrospective
+    feedback loops after each analyzer update.【F:docs/dynamic-trading-algo-improvement-checklist.md†L57-L96】


### PR DESCRIPTION
## Summary
- add a documentation index that links to the primary DAI, DAGI, DCT, DTL, and DTA checklists
- highlight the operational focus areas that remain active across the automation stack

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68da0cb3912483228410149a69bbb746