### PR TITLE
Refine Phase 4 governance router safeguards

### DIFF
--- a/dai_architecture/__init__.py
+++ b/dai_architecture/__init__.py
@@ -5,6 +5,15 @@ from .io_bus.message_bus import TaskBus
 from .memory.l0_context import L0ContextManager
 from .orchestrator.router import MinimalRouter
 from .orchestrator.validator import BaselineValidator, TaskValidationError
+from .orchestrator.phase4_router import (
+    AuditTrailLogger,
+    DataResidencyPolicy,
+    GovernanceError,
+    ObservabilityCollector,
+    Phase4Router,
+    SafetyHarness,
+    SafetyViolation,
+)
 from .core_adapters import (
     BaseCoreAdapter,
     CoreDecision,
@@ -22,6 +31,13 @@ __all__ = [
     "MinimalRouter",
     "BaselineValidator",
     "TaskValidationError",
+    "AuditTrailLogger",
+    "DataResidencyPolicy",
+    "GovernanceError",
+    "ObservabilityCollector",
+    "Phase4Router",
+    "SafetyHarness",
+    "SafetyViolation",
     "BaseCoreAdapter",
     "CoreDecision",
     "ChatCPT2Adapter",

--- a/dai_architecture/core_adapters/base.py
+++ b/dai_architecture/core_adapters/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Mapping, MutableMapping
+from typing import Any, Iterable, Mapping, MutableMapping, Tuple
 
 from ..io_bus.schema import TaskEnvelope
 
@@ -31,9 +31,26 @@ class BaseCoreAdapter(ABC):
     """Minimal interface shared by all Phase 1 adapters."""
 
     name: str
+    data_zones: Tuple[str, ...]
+    privacy: str
 
-    def __init__(self, name: str) -> None:
+    def __init__(
+        self,
+        name: str,
+        *,
+        data_zones: Iterable[str] | None = None,
+        privacy: str = "standard",
+    ) -> None:
         self.name = name
+        zones = tuple(zone.lower() for zone in (data_zones or ("global",)))
+        self.data_zones = zones or ("global",)
+        self.privacy = privacy
+
+    def supports_zone(self, zone: str) -> bool:
+        """Return ``True`` when the adapter can operate in ``zone``."""
+
+        zone = zone.lower()
+        return zone in self.data_zones or "global" in self.data_zones
 
     @abstractmethod
     def score_task(self, envelope: TaskEnvelope, context: Mapping[str, Any]) -> float:

--- a/dai_architecture/orchestrator/__init__.py
+++ b/dai_architecture/orchestrator/__init__.py
@@ -1,6 +1,26 @@
-"""Orchestration primitives used in Build Phase 1."""
+"""Orchestration primitives across Build Phases."""
 
 from .router import MinimalRouter
 from .validator import BaselineValidator, TaskValidationError
+from .phase4_router import (
+    AuditTrailLogger,
+    DataResidencyPolicy,
+    GovernanceError,
+    ObservabilityCollector,
+    Phase4Router,
+    SafetyHarness,
+    SafetyViolation,
+)
 
-__all__ = ["MinimalRouter", "BaselineValidator", "TaskValidationError"]
+__all__ = [
+    "MinimalRouter",
+    "BaselineValidator",
+    "TaskValidationError",
+    "AuditTrailLogger",
+    "DataResidencyPolicy",
+    "GovernanceError",
+    "ObservabilityCollector",
+    "Phase4Router",
+    "SafetyHarness",
+    "SafetyViolation",
+]

--- a/dai_architecture/orchestrator/phase4_router.py
+++ b/dai_architecture/orchestrator/phase4_router.py
@@ -1,0 +1,302 @@
+"""Operations & governance orchestration components for Build Phase 4."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+from ..core_adapters import BaseCoreAdapter, CoreDecision
+from ..io_bus.message_bus import TaskBus
+from ..io_bus.schema import ResultEnvelope, TaskEnvelope
+from ..memory.l0_context import L0ContextManager
+from .router import MinimalRouter
+from .validator import BaselineValidator, TaskValidationError
+
+
+class GovernanceError(TaskValidationError):
+    """Raised when governance policies block adapter execution."""
+
+
+class SafetyViolation(TaskValidationError):
+    """Raised when a decision breaches safety guardrails."""
+
+
+@dataclass(slots=True)
+class AuditTrailLogger:
+    """Collects audit entries for downstream governance review."""
+
+    validator: BaselineValidator
+    entries: List[MutableMapping[str, Any]] = field(default_factory=list)
+
+    def record(
+        self,
+        *,
+        envelope: TaskEnvelope,
+        decision: CoreDecision,
+        adapter: BaseCoreAdapter,
+        context_snapshot: Mapping[str, Any],
+    ) -> None:
+        """Persist an audit entry after successful orchestration."""
+
+        entry: MutableMapping[str, Any] = {
+            "task_id": envelope.task_id,
+            "decision": decision.action,
+            "confidence": round(decision.confidence, 4),
+            "adapter": adapter.name,
+            "data_zone": context_snapshot.get("governance", {}).get("data_zone")
+            if isinstance(context_snapshot.get("governance"), Mapping)
+            else context_snapshot.get("data_residency", "global"),
+            "context_snapshot": dict(context_snapshot),
+            "rationale": decision.rationale,
+        }
+        self.validator.validate_audit_trail([entry])
+        self.entries.append(entry)
+
+    def export(self) -> List[MutableMapping[str, Any]]:
+        """Return accumulated audit entries."""
+
+        return [dict(entry) for entry in self.entries]
+
+
+@dataclass(slots=True)
+class ObservabilityCollector:
+    """Tracks orchestration events for latency and confidence monitoring."""
+
+    _starts: MutableMapping[str, float] = field(default_factory=dict)
+    events: List[MutableMapping[str, Any]] = field(default_factory=list)
+
+    def start(self, task_id: str) -> None:
+        self._starts[task_id] = time.perf_counter()
+
+    def record_success(
+        self,
+        task_id: str,
+        *,
+        adapter: BaseCoreAdapter,
+        decision: CoreDecision,
+    ) -> None:
+        started = self._starts.pop(task_id, None)
+        latency_ms = ((time.perf_counter() - started) * 1000.0) if started else None
+        entry: MutableMapping[str, Any] = {
+            "task_id": task_id,
+            "adapter": adapter.name,
+            "status": "completed",
+            "latency_ms": latency_ms,
+            "confidence": decision.confidence,
+        }
+        self.events.append(entry)
+
+    def record_failure(
+        self,
+        task_id: str,
+        *,
+        adapter: BaseCoreAdapter,
+        reason: str,
+    ) -> None:
+        started = self._starts.pop(task_id, None)
+        latency_ms = ((time.perf_counter() - started) * 1000.0) if started else None
+        entry: MutableMapping[str, Any] = {
+            "task_id": task_id,
+            "adapter": adapter.name,
+            "status": "failed",
+            "latency_ms": latency_ms,
+            "reason": reason,
+        }
+        self.events.append(entry)
+
+    def summary(self) -> MutableMapping[str, Any]:
+        """Return aggregate metrics for completed events."""
+
+        completed = [event for event in self.events if event.get("status") == "completed"]
+        if not completed:
+            return {"count": 0, "avg_latency_ms": 0.0, "avg_confidence": 0.0, "failures": self.failure_count}
+        latencies = [event.get("latency_ms") for event in completed if event.get("latency_ms") is not None]
+        average_latency = sum(latencies) / len(latencies) if latencies else 0.0
+        average_confidence = sum(event.get("confidence", 0.0) for event in completed) / len(completed)
+        return {
+            "count": len(completed),
+            "avg_latency_ms": round(average_latency, 3),
+            "avg_confidence": round(average_confidence, 3),
+            "failures": self.failure_count,
+        }
+
+    @property
+    def failure_count(self) -> int:
+        return sum(1 for event in self.events if event.get("status") == "failed")
+
+
+@dataclass(slots=True)
+class DataResidencyPolicy:
+    """Filters adapters so decisions respect data locality policies."""
+
+    default_zone: str = "global"
+    adapter_overrides: Mapping[str, Sequence[str]] = field(default_factory=dict)
+
+    def _adapter_zones(self, adapter: BaseCoreAdapter) -> Tuple[str, ...]:
+        override = self.adapter_overrides.get(adapter.name)
+        if override:
+            return tuple(zone.lower() for zone in override)
+        return adapter.data_zones
+
+    def filter_adapters(
+        self, envelope: TaskEnvelope, adapters: Iterable[BaseCoreAdapter]
+    ) -> List[BaseCoreAdapter]:
+        zone = self._resolve_zone(envelope)
+        allowed: List[BaseCoreAdapter] = []
+        for adapter in adapters:
+            zones = self._adapter_zones(adapter)
+            if zones:
+                if zone in zones or "global" in zones:
+                    allowed.append(adapter)
+                    continue
+            if adapter.supports_zone(zone):
+                allowed.append(adapter)
+        if not allowed:
+            raise GovernanceError(f"No adapters available for data zone '{zone}'")
+        return allowed
+
+    def _resolve_zone(self, envelope: TaskEnvelope) -> str:
+        governance = envelope.context.get("governance")
+        if isinstance(governance, Mapping):
+            zone = governance.get("data_zone")
+            if isinstance(zone, str) and zone.strip():
+                return zone.lower()
+        zone = envelope.context.get("data_residency")
+        if isinstance(zone, str) and zone.strip():
+            return zone.lower()
+        return self.default_zone
+
+
+@dataclass(slots=True)
+class SafetyHarness:
+    """Enforces guardrails before results are accepted."""
+
+    banned_actions: Sequence[str] = field(default_factory=tuple)
+    max_drawdown: float | None = None
+    max_volatility: float | None = None
+    _banned_cache: set[str] = field(init=False, repr=False, default_factory=set)
+
+    def __post_init__(self) -> None:
+        self._banned_cache = {item.upper() for item in self.banned_actions}
+
+    def enforce(self, envelope: TaskEnvelope, decision: CoreDecision) -> None:
+        action = decision.action.upper()
+        if action in self._banned_cache:
+            raise SafetyViolation(f"Action '{action}' blocked by safety policy")
+        drawdown = self._safe_float(envelope.context.get("drawdown", 0.0))
+        if self.max_drawdown is not None and drawdown > self.max_drawdown:
+            raise SafetyViolation(
+                f"Drawdown {drawdown:.2f} exceeds maximum {self.max_drawdown:.2f}"
+            )
+        volatility = self._safe_float(envelope.context.get("volatility", 0.0))
+        if self.max_volatility is not None and volatility > self.max_volatility:
+            raise SafetyViolation(
+                f"Volatility {volatility:.2f} exceeds maximum {self.max_volatility:.2f}"
+            )
+
+    @staticmethod
+    def _safe_float(value: Any) -> float:
+        try:
+            return float(value or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+
+class Phase4Router(MinimalRouter):
+    """Extends the minimal router with ops, audit, and governance controls."""
+
+    def __init__(
+        self,
+        *,
+        adapters: Iterable[BaseCoreAdapter],
+        validator: BaselineValidator,
+        context_manager: L0ContextManager,
+        bus: TaskBus,
+        audit_logger: AuditTrailLogger | None = None,
+        observability: ObservabilityCollector | None = None,
+        residency_policy: DataResidencyPolicy | None = None,
+        safety_harness: SafetyHarness | None = None,
+    ) -> None:
+        super().__init__(
+            adapters=adapters,
+            validator=validator,
+            context_manager=context_manager,
+            bus=bus,
+        )
+        self.audit_logger = audit_logger or AuditTrailLogger(validator=validator)
+        self.observability = observability or ObservabilityCollector()
+        self.residency_policy = residency_policy or DataResidencyPolicy()
+        self.safety_harness = safety_harness or SafetyHarness()
+
+    def process_next(self) -> ResultEnvelope | None:  # type: ignore[override]
+        envelope = self.bus.dequeue_task()
+        if not envelope:
+            return None
+        self.validator.validate_task(envelope)
+        context = self.context_manager.prepare(envelope)
+        self.observability.start(envelope.task_id)
+
+        filtered = self.residency_policy.filter_adapters(envelope, self._adapters)
+        ranked = self._rank_with_candidates(envelope, context, filtered)
+
+        adapter, decision = self._attempt_execution(ranked, envelope, context)
+
+        result = ResultEnvelope(
+            task_id=envelope.task_id,
+            status="completed",
+            payload=decision.as_payload(),
+        )
+        self.validator.validate_result(result, envelope.constraints)
+        self.bus.publish_result(result)
+        self.context_manager.update(
+            envelope.task_id,
+            last_adapter=adapter.name,
+            confidence=decision.confidence,
+            last_action=decision.action,
+        )
+        self.audit_logger.record(
+            envelope=envelope,
+            decision=decision,
+            adapter=adapter,
+            context_snapshot=context,
+        )
+        self.observability.record_success(envelope.task_id, adapter=adapter, decision=decision)
+        return result
+
+    def _rank_with_candidates(
+        self,
+        envelope: TaskEnvelope,
+        context: Mapping[str, Any],
+        candidates: Sequence[BaseCoreAdapter],
+    ) -> List[BaseCoreAdapter]:
+        return super()._rank_adapters_for(envelope, context, candidates)
+
+    def _attempt_execution(
+        self,
+        ranked: Sequence[BaseCoreAdapter],
+        envelope: TaskEnvelope,
+        context: Mapping[str, Any],
+    ) -> Tuple[BaseCoreAdapter, CoreDecision]:
+        failures: List[str] = []
+        for adapter in ranked:
+            try:
+                decision = adapter.run(envelope, context)
+                self.safety_harness.enforce(envelope, decision)
+                return adapter, decision
+            except SafetyViolation as exc:
+                failures.append(str(exc))
+                self.observability.record_failure(
+                    envelope.task_id,
+                    adapter=adapter,
+                    reason=str(exc),
+                )
+            except Exception as exc:  # pragma: no cover - defensive guard
+                failures.append(f"{adapter.name} raised: {exc}")
+                self.observability.record_failure(
+                    envelope.task_id,
+                    adapter=adapter,
+                    reason="exception",
+                )
+        message = "+ ".join(failures) if failures else "no adapters executed"
+        raise SafetyViolation(f"All adapters failed safety checks: {message}")

--- a/dai_architecture/orchestrator/router.py
+++ b/dai_architecture/orchestrator/router.py
@@ -64,8 +64,16 @@ class MinimalRouter:
         envelope: TaskEnvelope,
         context: Mapping[str, Any],
     ) -> List[BaseCoreAdapter]:
+        return self._rank_adapters_for(envelope, context, self._adapters)
+
+    def _rank_adapters_for(
+        self,
+        envelope: TaskEnvelope,
+        context: Mapping[str, Any],
+        adapters: Iterable[BaseCoreAdapter],
+    ) -> List[BaseCoreAdapter]:
         scored: List[Tuple[float, BaseCoreAdapter]] = []
-        for adapter in self._adapters:
+        for adapter in adapters:
             score = adapter.score_task(envelope, context)
             scored.append((score, adapter))
         scored.sort(key=lambda item: item[0], reverse=True)

--- a/dai_architecture/tests/test_phase4_ops_governance.py
+++ b/dai_architecture/tests/test_phase4_ops_governance.py
@@ -1,0 +1,224 @@
+"""Tests for Build Phase 4 orchestration features."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dai_architecture import (  # noqa: E402 - configured sys.path above
+    AuditTrailLogger,
+    BaselineValidator,
+    DataResidencyPolicy,
+    GovernanceError,
+    L0ContextManager,
+    ObservabilityCollector,
+    Phase4Router,
+    SafetyHarness,
+    SafetyViolation,
+    TaskBus,
+    TaskEnvelope,
+    ConstraintSet,
+)
+from dai_architecture.core_adapters import BaseCoreAdapter, CoreDecision
+
+
+class _DummyAdapter(BaseCoreAdapter):
+    def __init__(
+        self,
+        name: str,
+        *,
+        action: str,
+        confidence: float,
+        score: float,
+        data_zones: tuple[str, ...] = ("global",),
+    ) -> None:
+        super().__init__(name=name, data_zones=data_zones)
+        self._action = action
+        self._confidence = confidence
+        self._score = score
+
+    def score_task(self, envelope: TaskEnvelope, context: Mapping[str, Any]) -> float:
+        return self._score
+
+    def run(self, envelope: TaskEnvelope, context: Mapping[str, Any]) -> CoreDecision:
+        rationale = "Governed decision rationale"
+        return CoreDecision(action=self._action, confidence=self._confidence, rationale=rationale)
+
+
+def _make_envelope(zone: str | None = None, *, intent: str = "accumulate") -> TaskEnvelope:
+    context: dict[str, Any] = {
+        "market": {"direction": "bullish", "momentum": 0.6},
+        "confidence_hint": 0.6,
+        "volatility": 0.3,
+        "drawdown": 0.05,
+    }
+    if zone:
+        context["governance"] = {"data_zone": zone}
+    constraints = ConstraintSet(min_confidence=0.4)
+    return TaskEnvelope(task_id="task-phase4", intent=intent, context=context, constraints=constraints)
+
+
+def test_phase4_router_enforces_data_locality() -> None:
+    adapters = (
+        _DummyAdapter("us_adapter", action="BUY", confidence=0.7, score=0.9, data_zones=("us",)),
+        _DummyAdapter("eu_adapter", action="BUY", confidence=0.72, score=0.8, data_zones=("eu",)),
+    )
+    bus = TaskBus()
+    validator = BaselineValidator()
+    audit = AuditTrailLogger(validator)
+    observability = ObservabilityCollector()
+    policy = DataResidencyPolicy()
+    router = Phase4Router(
+        adapters=adapters,
+        validator=validator,
+        context_manager=L0ContextManager(),
+        bus=bus,
+        audit_logger=audit,
+        observability=observability,
+        residency_policy=policy,
+    )
+
+    bus.publish_task(_make_envelope("eu"))
+    result = router.process_next()
+    assert result is not None
+    assert result.payload["action"] == "BUY"
+    assert audit.entries[0]["adapter"] == "eu_adapter"
+    assert all(event["adapter"] == "eu_adapter" for event in observability.events if event["status"] == "completed")
+
+
+def test_phase4_router_records_audit_and_summary() -> None:
+    adapter = _DummyAdapter("global", action="BUY", confidence=0.65, score=1.0)
+    bus = TaskBus()
+    validator = BaselineValidator()
+    audit = AuditTrailLogger(validator)
+    observability = ObservabilityCollector()
+    router = Phase4Router(
+        adapters=(adapter,),
+        validator=validator,
+        context_manager=L0ContextManager(),
+        bus=bus,
+        audit_logger=audit,
+        observability=observability,
+    )
+
+    bus.publish_task(_make_envelope())
+    result = router.process_next()
+    assert result is not None
+    assert len(audit.entries) == 1
+    exported = audit.export()
+    assert exported[0]["task_id"] == "task-phase4"
+    summary = observability.summary()
+    assert summary["count"] == 1
+    assert summary["failures"] == 0
+    assert pytest.approx(summary["avg_confidence"], rel=1e-3) == 0.65
+
+
+def test_phase4_router_applies_safety_harness() -> None:
+    banned_adapter = _DummyAdapter("risk_adapter", action="SELL", confidence=0.7, score=0.95)
+    safe_adapter = _DummyAdapter("safe_adapter", action="HOLD", confidence=0.6, score=0.9)
+    bus = TaskBus()
+    validator = BaselineValidator()
+    audit = AuditTrailLogger(validator)
+    observability = ObservabilityCollector()
+    safety = SafetyHarness(banned_actions=("SELL",))
+    router = Phase4Router(
+        adapters=(banned_adapter, safe_adapter),
+        validator=validator,
+        context_manager=L0ContextManager(),
+        bus=bus,
+        audit_logger=audit,
+        observability=observability,
+        safety_harness=safety,
+    )
+
+    bus.publish_task(_make_envelope())
+    result = router.process_next()
+    assert result is not None
+    assert result.payload["action"] == "HOLD"
+    assert audit.entries[0]["adapter"] == "safe_adapter"
+    assert observability.failure_count == 1
+
+
+def test_phase4_router_raises_when_no_zone_available() -> None:
+    adapters = (
+        _DummyAdapter("us_adapter", action="BUY", confidence=0.7, score=0.9, data_zones=("us",)),
+    )
+    bus = TaskBus()
+    validator = BaselineValidator()
+    router = Phase4Router(
+        adapters=adapters,
+        validator=validator,
+        context_manager=L0ContextManager(),
+        bus=bus,
+    )
+    bus.publish_task(_make_envelope("eu"))
+    with pytest.raises(GovernanceError):
+        router.process_next()
+
+
+def test_safety_harness_handles_non_numeric_risk() -> None:
+    adapter = _DummyAdapter("mixed", action="HOLD", confidence=0.5, score=1.0)
+    bus = TaskBus()
+    validator = BaselineValidator()
+    audit = AuditTrailLogger(validator)
+    observability = ObservabilityCollector()
+    safety = SafetyHarness(max_drawdown=0.2, max_volatility=0.5)
+    router = Phase4Router(
+        adapters=(adapter,),
+        validator=validator,
+        context_manager=L0ContextManager(),
+        bus=bus,
+        audit_logger=audit,
+        observability=observability,
+        safety_harness=safety,
+    )
+
+    envelope = _make_envelope()
+    envelope.context["drawdown"] = "not-a-number"
+    envelope.context["volatility"] = None
+    bus.publish_task(envelope)
+    assert router.process_next() is not None
+
+
+def test_observability_drops_timer_on_failures() -> None:
+    adapter = _DummyAdapter("unstable", action="SELL", confidence=0.7, score=1.0)
+    bus = TaskBus()
+    validator = BaselineValidator()
+    audit = AuditTrailLogger(validator)
+    observability = ObservabilityCollector()
+    safety = SafetyHarness(banned_actions=("SELL",))
+    router = Phase4Router(
+        adapters=(adapter,),
+        validator=validator,
+        context_manager=L0ContextManager(),
+        bus=bus,
+        audit_logger=audit,
+        observability=observability,
+        safety_harness=safety,
+    )
+
+    bus.publish_task(_make_envelope())
+    with pytest.raises(SafetyViolation):
+        router.process_next()
+    assert not observability._starts  # type: ignore[attr-defined]
+
+
+def test_residency_policy_respects_overrides_with_supports_fallback() -> None:
+    adapter = _DummyAdapter(
+        "regional",
+        action="BUY",
+        confidence=0.6,
+        score=0.8,
+        data_zones=("eu",),
+    )
+    policy = DataResidencyPolicy(adapter_overrides={"regional": ()})
+    envelope = _make_envelope("EU")
+    allowed = policy.filter_adapters(envelope, (adapter,))
+    assert allowed == [adapter]


### PR DESCRIPTION
## Summary
- stop mutating the adapter registry when ranking candidates by exposing a shared helper on the minimal router
- harden governance controls with cached banned-action checks, resilient risk parsing, and observability cleanup on failures
- expand the Phase 4 governance tests to exercise the new failure timing, override behaviour, and numeric fallbacks

## Testing
- pytest dai_architecture/tests/test_phase4_ops_governance.py

------
https://chatgpt.com/codex/tasks/task_e_68da1faf2aec83228a4022bacab9a2e7