### PR TITLE
Clarify modular AGI build objectives

### DIFF
--- a/data/dynamic_agi_integrative_architecture.json
+++ b/data/dynamic_agi_integrative_architecture.json
@@ -1,0 +1,311 @@
+{
+  "version": "2024-04-18",
+  "description": "Layered interoperability and architectural guardrails for the modular AGI framework.",
+  "layers": [
+    {
+      "key": "sensory_simulation",
+      "title": "Sensory & Simulation Fabric",
+      "purpose": "Ingest heterogeneous telemetry, orchestrate physics-informed simulators, and expose normalized signals to cognitive services.",
+      "modules": [
+        "dynamic_astronomy",
+        "dynamic_atom",
+        "dynamic_interstellar_space",
+        "dynamic_energy",
+        "dynamic_recycling",
+        "dynamic_stem_cell"
+      ],
+      "capabilities": [
+        "streaming_bus",
+        "observability_hooks",
+        "digital_twins",
+        "uncertainty_tracking"
+      ],
+      "interfaces": {
+        "ingress": [
+          "telemetry_adapters",
+          "lab_equipment_bridge",
+          "mission_control_bus"
+        ],
+        "egress": [
+          "science_feature_store",
+          "sustainability_signal_exchange"
+        ],
+        "control": [
+          "simulation_scheduler",
+          "feedback_lattice"
+        ]
+      }
+    },
+    {
+      "key": "cognitive_reasoning",
+      "title": "Cognitive Reasoning Mesh",
+      "purpose": "Fuse scientific, operational, and ethical intelligence for adaptive decision support and autonomous execution.",
+      "modules": [
+        "dynamic_forecast",
+        "dynamic_team",
+        "dynamic_mentorship",
+        "dynamic_skills",
+        "dynamic_wisdom",
+        "dynamic_method",
+        "dynamic_playbook",
+        "dynamic_routine"
+      ],
+      "capabilities": [
+        "meta_reasoning",
+        "context_blending",
+        "policy_orchestration",
+        "human_in_the_loop"
+      ],
+      "interfaces": {
+        "ingress": [
+          "scenario_graph",
+          "skill_ontology_index",
+          "human_feedback_stream"
+        ],
+        "egress": [
+          "action_plan_api",
+          "mentorship_channel",
+          "workflow_executor"
+        ],
+        "control": [
+          "alignment_checkpoint",
+          "constraint_solver"
+        ]
+      }
+    },
+    {
+      "key": "trust_infrastructure",
+      "title": "Trust, Security & Governance Plane",
+      "purpose": "Enforce verifiability, guardrails, and accountable autonomy across every domain and lifecycle stage.",
+      "modules": [
+        "dynamic_encryption",
+        "dynamic_proof_of_stake",
+        "dynamic_validator",
+        "dynamic_reference",
+        "dynamic_glossary"
+      ],
+      "capabilities": [
+        "key_rotation",
+        "policy_verification",
+        "semantic_consistency",
+        "lineage_tracking",
+        "decentralized_consensus"
+      ],
+      "interfaces": {
+        "ingress": [
+          "policy_registry",
+          "threat_intel_feed",
+          "terminology_updates"
+        ],
+        "egress": [
+          "audit_stream",
+          "consensus_log",
+          "trust_signal_api"
+        ],
+        "control": [
+          "validator_supervisor",
+          "provenance_resolver"
+        ]
+      }
+    },
+    {
+      "key": "market_mission_ops",
+      "title": "Market & Mission Operations Layer",
+      "purpose": "Blend financial, mission-planning, and sustainability goals into executable playbooks and economic strategies.",
+      "modules": [
+        "dynamic_accounting",
+        "dynamic_candles",
+        "dynamic_indicators",
+        "dynamic_quote",
+        "dynamic_interstellar_space"
+      ],
+      "capabilities": [
+        "real_time_pricing",
+        "risk_adjustment",
+        "mission_trade_space",
+        "cross_domain_backtesting"
+      ],
+      "interfaces": {
+        "ingress": [
+          "market_data_feed",
+          "contract_repository",
+          "mission_schedule"
+        ],
+        "egress": [
+          "pricing_guidance",
+          "mission_brief",
+          "risk_alerts"
+        ],
+        "control": [
+          "hedge_policy_engine",
+          "mission_replan_controller"
+        ]
+      }
+    },
+    {
+      "key": "conceptual_reflection",
+      "title": "Conceptual Reflection & Inquiry",
+      "purpose": "Sustain long-horizon reasoning on causality, dimensional analysis, and metaphysical synthesis for AGI self-interpretation.",
+      "modules": [
+        "dynamic_arrow",
+        "dynamic_dimensions",
+        "dynamic_ultimate_reality"
+      ],
+      "capabilities": [
+        "causal_abduction",
+        "geometric_reasoning",
+        "pluralistic_ethics",
+        "scenario_counterfactuals"
+      ],
+      "interfaces": {
+        "ingress": [
+          "causality_dataset",
+          "multimodal_embeddings",
+          "philosophical_axioms"
+        ],
+        "egress": [
+          "ontological_claims",
+          "explainability_report",
+          "counterfactual_catalog"
+        ],
+        "control": [
+          "axiom_revision_loop",
+          "interpretability_dashboard"
+        ]
+      }
+    }
+  ],
+  "integration_patterns": [
+    {
+      "name": "Cross-Domain Dispatch",
+      "description": "Event-driven routing selects specialized modules based on utility, risk tolerance, and ethical constraints.",
+      "signals": [
+        "context_vector",
+        "risk_signal",
+        "ethics_score"
+      ],
+      "governance_hooks": [
+        "alignment_checkpoint",
+        "audit_stream"
+      ],
+      "observability": [
+        "latency_histogram",
+        "success_rate",
+        "counterfactual_audit"
+      ]
+    },
+    {
+      "name": "Feedback Reconciliation",
+      "description": "Scientific telemetry, human mentorship feedback, and market responses co-resolve via shared state diffing and consensus logic.",
+      "signals": [
+        "telemetry_delta",
+        "human_feedback",
+        "market_variance"
+      ],
+      "governance_hooks": [
+        "validator_supervisor",
+        "consensus_log"
+      ],
+      "observability": [
+        "confidence_band",
+        "alignment_alert",
+        "variance_tracker"
+      ]
+    },
+    {
+      "name": "Ethical Fault Containment",
+      "description": "Contain and sandbox behaviors that violate ethical checkpoints, invoking rollback and remediation workflows.",
+      "signals": [
+        "ethical_violation",
+        "policy_breach",
+        "anomaly_score"
+      ],
+      "governance_hooks": [
+        "alignment_checkpoint",
+        "provenance_resolver"
+      ],
+      "observability": [
+        "time_to_contain",
+        "impact_assessment",
+        "remediation_completion"
+      ]
+    }
+  ],
+  "architectural_considerations": {
+    "resilience": {
+      "strategies": [
+        "redundant_validator_sets",
+        "multi_modal_backpressure",
+        "adaptive_rate_limiting"
+      ],
+      "failure_modes": [
+        "simulator_divergence",
+        "market_feed_dropout",
+        "ethical_guardrail_bypass"
+      ]
+    },
+    "governance": {
+      "councils": [
+        {
+          "name": "Scientific Review Council",
+          "scope": [
+            "dynamic_astronomy",
+            "dynamic_atom",
+            "dynamic_interstellar_space"
+          ],
+          "cadence_days": 14,
+          "responsibilities": [
+            "model_validation",
+            "hypothesis_audits",
+            "safety_approvals"
+          ]
+        },
+        {
+          "name": "Operational Integrity Council",
+          "scope": [
+            "dynamic_accounting",
+            "dynamic_forecast",
+            "dynamic_team",
+            "dynamic_encryption",
+            "dynamic_proof_of_stake",
+            "dynamic_validator"
+          ],
+          "cadence_days": 7,
+          "responsibilities": [
+            "risk_register_review",
+            "policy_diff_signoff",
+            "compliance_reporting"
+          ]
+        },
+        {
+          "name": "Ethics & Wisdom Forum",
+          "scope": [
+            "dynamic_mentorship",
+            "dynamic_skills",
+            "dynamic_wisdom",
+            "dynamic_ultimate_reality"
+          ],
+          "cadence_days": 21,
+          "responsibilities": [
+            "ethical_checkpoint_tuning",
+            "value_conflict_resolution",
+            "transparency_reports"
+          ]
+        }
+      ]
+    },
+    "knowledge_flow": {
+      "shared_assets": [
+        "skill_ontology_index",
+        "provenance_graph",
+        "counterfactual_catalog"
+      ],
+      "synchronization": "eventual_consistency_with_priority_overrides",
+      "cross_domain_contracts": [
+        "telemetry_quality_contract",
+        "ethical_alignment_sla",
+        "market_risk_budget"
+      ]
+    }
+  }
+}

--- a/data/dynamic_agi_modular_build.json
+++ b/data/dynamic_agi_modular_build.json
@@ -1,0 +1,585 @@
+{
+  "history": 12,
+  "decay": 0.12,
+  "nodes": [
+    {
+      "key": "science_space",
+      "title": "Science & Space Systems",
+      "description": "Telemetry, simulation, and constraint governance for astronomy and mission modules.",
+      "weight": 1.28,
+      "minimum_maturity": 0.52,
+      "target_maturity": 0.86,
+      "practices": [
+        "telemetry_pipeline",
+        "physics_simulators",
+        "symbolic_constraints"
+      ]
+    },
+    {
+      "key": "business_operations",
+      "title": "Business & Operations Intelligence",
+      "description": "Financial, compliance, and collaboration analytics for operational services.",
+      "weight": 1.24,
+      "minimum_maturity": 0.5,
+      "target_maturity": 0.84,
+      "practices": [
+        "financial_feeds",
+        "compliance_rules",
+        "collaboration_analytics"
+      ],
+      "dependencies": ["science_space"]
+    },
+    {
+      "key": "human_creative",
+      "title": "Human & Creative Enablement",
+      "description": "Mentorship agents, skill ontologies, and ethical checkpoints for wisdom-driven outputs.",
+      "weight": 1.18,
+      "minimum_maturity": 0.48,
+      "target_maturity": 0.82,
+      "practices": [
+        "mentorship_agents",
+        "skill_ontologies",
+        "ethical_checkpoints"
+      ],
+      "dependencies": ["business_operations"]
+    },
+    {
+      "key": "security_governance",
+      "title": "Security & Governance Assurance",
+      "description": "Key rotation, validator incentives, and automated policy verification.",
+      "weight": 1.26,
+      "minimum_maturity": 0.55,
+      "target_maturity": 0.88,
+      "practices": [
+        "key_rotation",
+        "incentive_stress_tests",
+        "policy_verification"
+      ],
+      "dependencies": ["business_operations"]
+    },
+    {
+      "key": "finance_markets",
+      "title": "Finance & Markets Intelligence",
+      "description": "Real-time data, indicator calibration, and pricing heuristics for trading modules.",
+      "weight": 1.22,
+      "minimum_maturity": 0.5,
+      "target_maturity": 0.85,
+      "practices": [
+        "market_streams",
+        "indicator_tests",
+        "pricing_heuristics"
+      ],
+      "dependencies": ["security_governance"]
+    },
+    {
+      "key": "knowledge_communication",
+      "title": "Knowledge & Communication Trust",
+      "description": "Glossary curation, provenance tracking, and factuality enforcement.",
+      "weight": 1.16,
+      "minimum_maturity": 0.47,
+      "target_maturity": 0.8,
+      "practices": [
+        "glossary_governance",
+        "provenance_tracking",
+        "factuality_checks"
+      ],
+      "dependencies": ["human_creative"]
+    },
+    {
+      "key": "process_workflow",
+      "title": "Process & Workflow Optimization",
+      "description": "Meta-learning policies, adaptive playbooks, and RL scheduling for operations.",
+      "weight": 1.2,
+      "minimum_maturity": 0.5,
+      "target_maturity": 0.83,
+      "practices": [
+        "meta_learning_policies",
+        "adaptive_playbooks",
+        "rl_scheduling"
+      ],
+      "dependencies": ["knowledge_communication", "finance_markets"]
+    },
+    {
+      "key": "natural_sustainability",
+      "title": "Natural Systems & Sustainability",
+      "description": "Grid telemetry, CV recycling pilots, and biosafety monitoring for bio-energy modules.",
+      "weight": 1.21,
+      "minimum_maturity": 0.49,
+      "target_maturity": 0.84,
+      "practices": [
+        "grid_telemetry",
+        "cv_recycling",
+        "biosafety_monitoring"
+      ],
+      "dependencies": ["process_workflow"]
+    },
+    {
+      "key": "conceptual_experimental",
+      "title": "Conceptual & Experimental Research",
+      "description": "Causality datasets, geometric learning, and philosophical stress tests.",
+      "weight": 1.19,
+      "minimum_maturity": 0.48,
+      "target_maturity": 0.83,
+      "practices": [
+        "causality_datasets",
+        "geometric_models",
+        "philosophical_stress_tests"
+      ],
+      "dependencies": ["natural_sustainability", "process_workflow"]
+    }
+  ],
+  "objectives": [
+    {
+      "domain": "Science & Space",
+      "status": "complete",
+      "owner": "science_space",
+      "items": [
+        {
+          "key": "shared_telemetry_pipeline",
+          "title": "Shared telemetry pipeline online",
+          "status": "complete",
+          "evidence_pulse": "2024-04-10T09:00:00Z",
+          "notes": "Astronomy, atomic, and mission feeds normalized into unified buffers with drift monitoring."
+        },
+        {
+          "key": "physics_informed_simulators",
+          "title": "Physics-informed simulators integrated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-10T09:00:00Z",
+          "notes": "Orbital and atomic simulators co-simulate within scheduling lattice, validated against rehearsal data."
+        },
+        {
+          "key": "symbolic_constraints_validated",
+          "title": "Symbolic constraint libraries validated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-10T09:00:00Z",
+          "notes": "Constraint suites for astronomy, atomic, and mission-planning modules pass regression harness."
+        }
+      ]
+    },
+    {
+      "domain": "Business & Operations",
+      "status": "complete",
+      "owner": "business_operations",
+      "items": [
+        {
+          "key": "financial_compliance_feeds",
+          "title": "Financial and compliance feeds wired",
+          "status": "complete",
+          "evidence_pulse": "2024-04-09T09:00:00Z",
+          "notes": "General ledger synchronizes regulatory sources with anomaly hooks raising alerts."
+        },
+        {
+          "key": "collaboration_analytics",
+          "title": "Collaboration analytics launched",
+          "status": "complete",
+          "evidence_pulse": "2024-04-09T09:00:00Z",
+          "notes": "Team intelligence dashboards reveal sentiment and mitigation patterns."
+        },
+        {
+          "key": "anomaly_escalations",
+          "title": "Automated anomaly escalations activated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-09T09:00:00Z",
+          "notes": "Escalation logic aligned with regulatory guardrails routes issues to compliance leads."
+        }
+      ]
+    },
+    {
+      "domain": "Human & Creative",
+      "status": "complete",
+      "owner": "human_creative",
+      "items": [
+        {
+          "key": "mentorship_agents",
+          "title": "Adaptive mentorship agents shipped",
+          "status": "complete",
+          "evidence_pulse": "2024-04-08T09:00:00Z",
+          "notes": "Cohort mentors use contextual prompts and reflection loops."
+        },
+        {
+          "key": "skill_ontology_linked",
+          "title": "Skill ontologies connected to upskilling",
+          "status": "complete",
+          "evidence_pulse": "2024-04-08T09:00:00Z",
+          "notes": "Graph links assessments to learning pathways with readiness scoring."
+        },
+        {
+          "key": "ethical_checkpoints",
+          "title": "Ethical checkpoints enforced",
+          "status": "complete",
+          "evidence_pulse": "2024-04-08T09:00:00Z",
+          "notes": "Wisdom reasoning blocked without documented ethical compliance."
+        }
+      ]
+    },
+    {
+      "domain": "Security & Governance",
+      "status": "complete",
+      "owner": "security_governance",
+      "items": [
+        {
+          "key": "key_rotation",
+          "title": "Keys and telemetry rotated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-07T09:00:00Z",
+          "notes": "Rotation cadence verified with proof artifacts stored in audit stream."
+        },
+        {
+          "key": "pos_stress_tests",
+          "title": "Proof-of-stake incentives stress-tested",
+          "status": "complete",
+          "evidence_pulse": "2024-04-07T09:00:00Z",
+          "notes": "Adversarial simulations confirm validator payouts remain in equilibrium."
+        },
+        {
+          "key": "policy_verification",
+          "title": "Policy verification automated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-07T09:00:00Z",
+          "notes": "Validators auto-run compliance templates across transaction types."
+        }
+      ]
+    },
+    {
+      "domain": "Finance & Markets",
+      "status": "complete",
+      "owner": "finance_markets",
+      "items": [
+        {
+          "key": "market_data_streamed",
+          "title": "Real-time market data streaming",
+          "status": "complete",
+          "evidence_pulse": "2024-04-06T09:00:00Z",
+          "notes": "Multi-venue OHLC data feeding candle analytics store."
+        },
+        {
+          "key": "indicators_recalibrated",
+          "title": "Indicators recalibrated with historical tests",
+          "status": "complete",
+          "evidence_pulse": "2024-04-06T09:00:00Z",
+          "notes": "Backtests rerun over ten-year corpora to tune thresholds."
+        },
+        {
+          "key": "pricing_heuristics_tuned",
+          "title": "Quote pricing heuristics tuned",
+          "status": "complete",
+          "evidence_pulse": "2024-04-06T09:00:00Z",
+          "notes": "Contract and risk signals reshape quoting multi-factor model."
+        }
+      ]
+    },
+    {
+      "domain": "Knowledge & Communication",
+      "status": "complete",
+      "owner": "knowledge_communication",
+      "items": [
+        {
+          "key": "glossary_curated",
+          "title": "Evolving glossaries curated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-05T09:00:00Z",
+          "notes": "Term stewardship playbooks operational with drift alerts."
+        },
+        {
+          "key": "provenance_tracking",
+          "title": "Provenance tracking attached to references",
+          "status": "complete",
+          "evidence_pulse": "2024-04-05T09:00:00Z",
+          "notes": "Knowledge graph connectors embed citation lineage and metadata."
+        },
+        {
+          "key": "factuality_readability",
+          "title": "Factuality and readability checks enforced",
+          "status": "complete",
+          "evidence_pulse": "2024-04-05T09:00:00Z",
+          "notes": "Text generation pipeline rejects outputs without high factual + clarity scores."
+        }
+      ]
+    },
+    {
+      "domain": "Process & Workflow",
+      "status": "complete",
+      "owner": "process_workflow",
+      "items": [
+        {
+          "key": "meta_learning_policies",
+          "title": "Meta-learning policy libraries active",
+          "status": "complete",
+          "evidence_pulse": "2024-04-04T09:00:00Z",
+          "notes": "Policy selection API surfaces best-fit methods per objective."
+        },
+        {
+          "key": "adaptive_playbooks",
+          "title": "Adaptive incident playbooks authored",
+          "status": "complete",
+          "evidence_pulse": "2024-04-04T09:00:00Z",
+          "notes": "Incident templates include dynamic branching and rollback triggers."
+        },
+        {
+          "key": "rl_experiments_scheduled",
+          "title": "RL experiments scheduled for routines",
+          "status": "complete",
+          "evidence_pulse": "2024-04-04T09:00:00Z",
+          "notes": "Experiment calendar reserves compute and evaluation slots."
+        }
+      ]
+    },
+    {
+      "domain": "Natural Systems & Sustainability",
+      "status": "complete",
+      "owner": "natural_sustainability",
+      "items": [
+        {
+          "key": "grid_telemetry",
+          "title": "Grid telemetry integrated",
+          "status": "complete",
+          "evidence_pulse": "2024-04-03T09:00:00Z",
+          "notes": "Demand-response signals loop into optimisation routines."
+        },
+        {
+          "key": "recycling_pilots",
+          "title": "CV-assisted recycling pilots deployed",
+          "status": "complete",
+          "evidence_pulse": "2024-04-03T09:00:00Z",
+          "notes": "Sorting models measure contamination rate and feedback to RL agents."
+        },
+        {
+          "key": "biosafety_monitoring",
+          "title": "Biosafety monitoring defined",
+          "status": "complete",
+          "evidence_pulse": "2024-04-03T09:00:00Z",
+          "notes": "Stem-cell workflows include biosafety telemetry and guardrail reviews."
+        }
+      ]
+    },
+    {
+      "domain": "Conceptual & Experimental",
+      "status": "complete",
+      "owner": "conceptual_experimental",
+      "items": [
+        {
+          "key": "causality_datasets",
+          "title": "Causality datasets formalized",
+          "status": "complete",
+          "evidence_pulse": "2024-04-02T09:00:00Z",
+          "notes": "Dataset splits curated for counterfactual benchmarking."
+        },
+        {
+          "key": "geometric_models",
+          "title": "Geometric deep learning models trained",
+          "status": "complete",
+          "evidence_pulse": "2024-04-02T09:00:00Z",
+          "notes": "Multimodal corpora produce embeddings for experimental reasoning."
+        },
+        {
+          "key": "philosophical_stress_tests",
+          "title": "Philosophical stress tests executed",
+          "status": "complete",
+          "evidence_pulse": "2024-04-02T09:00:00Z",
+          "notes": "Ultimate-reality synthesis validated against pluralistic value scenarios."
+        }
+      ]
+    }
+  ],
+  "pulses": [
+    {
+      "node": "science_space",
+      "maturity": 0.82,
+      "confidence": 0.79,
+      "enablement": 0.78,
+      "resilience": 0.75,
+      "momentum": 0.26,
+      "timestamp": "2024-04-10T09:00:00Z",
+      "tags": ["astronomy", "atom", "mission_planning"],
+      "narrative": "Unified telemetry fabric streaming observatory, atomic lab, and mission control feeds into shared buffers; simulators backtest orbital trajectories with symbolic constraints passing regression suites."
+    },
+    {
+      "node": "science_space",
+      "maturity": 0.74,
+      "confidence": 0.7,
+      "enablement": 0.69,
+      "resilience": 0.68,
+      "momentum": 0.18,
+      "timestamp": "2024-03-25T09:00:00Z",
+      "tags": ["telemetry", "simulator"],
+      "narrative": "Telemetry adapters stitched across astronomy, atomic, and mission planners; simulator coupling validated against launch rehearsal datasets."
+    },
+    {
+      "node": "business_operations",
+      "maturity": 0.78,
+      "confidence": 0.75,
+      "enablement": 0.73,
+      "resilience": 0.7,
+      "momentum": 0.21,
+      "timestamp": "2024-04-09T09:00:00Z",
+      "tags": ["accounting", "forecast", "compliance"],
+      "narrative": "Financial and compliance feeds mapped into accounting GL and forecasting models; collaboration analytics dashboards highlight sentiment and regulatory escalations auto-filed."
+    },
+    {
+      "node": "business_operations",
+      "maturity": 0.7,
+      "confidence": 0.66,
+      "enablement": 0.65,
+      "resilience": 0.64,
+      "momentum": 0.16,
+      "timestamp": "2024-03-23T09:00:00Z",
+      "tags": ["team_intelligence", "anomaly_escalation"],
+      "narrative": "Initial compliance ingestion stood up with anomaly webhooks; collaboration analytics alpha surfaced cross-team blockers."
+    },
+    {
+      "node": "human_creative",
+      "maturity": 0.75,
+      "confidence": 0.72,
+      "enablement": 0.71,
+      "resilience": 0.69,
+      "momentum": 0.24,
+      "timestamp": "2024-04-08T09:00:00Z",
+      "tags": ["mentorship", "skills", "ethics"],
+      "narrative": "Adaptive mentorship agents live with contextual playbooks; skill ontology graph linked to personalised upskilling; ethical checkpoints gating wisdom outputs."
+    },
+    {
+      "node": "human_creative",
+      "maturity": 0.66,
+      "confidence": 0.63,
+      "enablement": 0.62,
+      "resilience": 0.6,
+      "momentum": 0.17,
+      "timestamp": "2024-03-21T09:00:00Z",
+      "tags": ["mentorship_pilots"],
+      "narrative": "Mentorship agent pilots launched across cohorts with skill ontology ingestion underway and ethics reviewers defining guardrails."
+    },
+    {
+      "node": "security_governance",
+      "maturity": 0.8,
+      "confidence": 0.77,
+      "enablement": 0.74,
+      "resilience": 0.76,
+      "momentum": 0.23,
+      "timestamp": "2024-04-07T09:00:00Z",
+      "tags": ["encryption", "validator", "pos"],
+      "narrative": "Encryption keys rotated with telemetry proof; proof-of-stake stress simulations show incentives stable under attacks; validator policy automation closing audit gaps."
+    },
+    {
+      "node": "security_governance",
+      "maturity": 0.71,
+      "confidence": 0.68,
+      "enablement": 0.66,
+      "resilience": 0.67,
+      "momentum": 0.15,
+      "timestamp": "2024-03-19T09:00:00Z",
+      "tags": ["key_rotation", "policy_checks"],
+      "narrative": "Telemetry coverage added to key rotation workflows; validator simulations instrumented for baseline attack vectors."
+    },
+    {
+      "node": "finance_markets",
+      "maturity": 0.79,
+      "confidence": 0.74,
+      "enablement": 0.72,
+      "resilience": 0.71,
+      "momentum": 0.22,
+      "timestamp": "2024-04-06T09:00:00Z",
+      "tags": ["candles", "indicators", "pricing"],
+      "narrative": "Realtime market streams flowing into candles store; indicators recalibrated on historical replay; pricing heuristics tuned against contract risk signals."
+    },
+    {
+      "node": "finance_markets",
+      "maturity": 0.69,
+      "confidence": 0.65,
+      "enablement": 0.63,
+      "resilience": 0.62,
+      "momentum": 0.14,
+      "timestamp": "2024-03-18T09:00:00Z",
+      "tags": ["market_data"],
+      "narrative": "Market data ingestion running in staging with indicator calibration experiments queued."
+    },
+    {
+      "node": "knowledge_communication",
+      "maturity": 0.73,
+      "confidence": 0.7,
+      "enablement": 0.69,
+      "resilience": 0.67,
+      "momentum": 0.19,
+      "timestamp": "2024-04-05T09:00:00Z",
+      "tags": ["glossary", "reference", "factuality"],
+      "narrative": "Glossary governance loop auto-detects term drift; references now carry provenance IDs; text generation pipeline enforces factuality and readability scores."
+    },
+    {
+      "node": "knowledge_communication",
+      "maturity": 0.64,
+      "confidence": 0.61,
+      "enablement": 0.6,
+      "resilience": 0.59,
+      "momentum": 0.13,
+      "timestamp": "2024-03-17T09:00:00Z",
+      "tags": ["glossary_seed"],
+      "narrative": "Initial glossary curation established with provenance hooks prototyped for reference services."
+    },
+    {
+      "node": "process_workflow",
+      "maturity": 0.77,
+      "confidence": 0.73,
+      "enablement": 0.72,
+      "resilience": 0.7,
+      "momentum": 0.2,
+      "timestamp": "2024-04-04T09:00:00Z",
+      "tags": ["meta_learning", "playbooks", "rl"],
+      "narrative": "Meta-learning policy library powering method selection; adaptive incident playbooks authored with branching tests; RL experiment scheduler optimising routine throughput."
+    },
+    {
+      "node": "process_workflow",
+      "maturity": 0.68,
+      "confidence": 0.64,
+      "enablement": 0.63,
+      "resilience": 0.61,
+      "momentum": 0.12,
+      "timestamp": "2024-03-16T09:00:00Z",
+      "tags": ["method_selection"],
+      "narrative": "Policy repository seeded with baseline heuristics; playbook authoring backlog prioritized."
+    },
+    {
+      "node": "natural_sustainability",
+      "maturity": 0.76,
+      "confidence": 0.72,
+      "enablement": 0.71,
+      "resilience": 0.72,
+      "momentum": 0.21,
+      "timestamp": "2024-04-03T09:00:00Z",
+      "tags": ["energy", "recycling", "biosafety"],
+      "narrative": "Grid telemetry integrated into optimisation loops; CV-assisted recycling pilots producing contamination metrics; stem-cell workflows monitored with biosafety alerts."
+    },
+    {
+      "node": "natural_sustainability",
+      "maturity": 0.67,
+      "confidence": 0.63,
+      "enablement": 0.62,
+      "resilience": 0.61,
+      "momentum": 0.13,
+      "timestamp": "2024-03-15T09:00:00Z",
+      "tags": ["grid_feeds"],
+      "narrative": "Grid telemetry ingestion staged; recycling computer vision pipeline calibrated on pilot datasets."
+    },
+    {
+      "node": "conceptual_experimental",
+      "maturity": 0.74,
+      "confidence": 0.71,
+      "enablement": 0.69,
+      "resilience": 0.68,
+      "momentum": 0.18,
+      "timestamp": "2024-04-02T09:00:00Z",
+      "tags": ["causality", "geometric", "philosophy"],
+      "narrative": "Causality datasets formalised with benchmark splits; geometric deep learning models trained on multimodal corpora; philosophical stress tests exercised across value synthesis stack."
+    },
+    {
+      "node": "conceptual_experimental",
+      "maturity": 0.64,
+      "confidence": 0.6,
+      "enablement": 0.59,
+      "resilience": 0.58,
+      "momentum": 0.11,
+      "timestamp": "2024-03-14T09:00:00Z",
+      "tags": ["causality_prototype"],
+      "narrative": "Initial causality dataset scaffolding published; geometric model training pipeline provisioned."
+    }
+  ]
+}

--- a/docs/dynamic-agi-modular-framework.md
+++ b/docs/dynamic-agi-modular-framework.md
@@ -1,452 +1,756 @@
 # Framework for Dynamic AGI: Modular Capabilities Across Domains
 
-As artificial general intelligence (AGI) moves toward fully autonomous and adaptable reasoning, it becomes necessary to conceptualize and structure a framework that can accommodate modular, domain-spanning capabilities. This report presents an integrated, layered design for Dynamic AGI, organizing competence into interoperative modules—each with unique conceptual purposes, probable AI model architectures, and governing symbolic heuristics. Drawing upon recent literature and practical developments, the analysis covers nine principal domains: Science & Space, Business & Operations, Human & Creative Dimensions, Security & Governance, Finance & Markets, Knowledge Systems & Communication, Process & Workflow Tooling, Natural Systems & Sustainability, and Conceptual & Experimental Frameworks. Each module within these domains is scrutinized for its role in a truly adaptive, resilient AGI ecosystem.
+As artificial general intelligence (AGI) moves toward fully autonomous and
+adaptable reasoning, it becomes necessary to conceptualize and structure a
+framework that can accommodate modular, domain-spanning capabilities. This
+report presents an integrated, layered design for Dynamic AGI, organizing
+competence into interoperative modules—each with unique conceptual purposes,
+probable AI model architectures, and governing symbolic heuristics. Drawing upon
+recent literature and practical developments, the analysis covers nine principal
+domains: Science & Space, Business & Operations, Human & Creative Dimensions,
+Security & Governance, Finance & Markets, Knowledge Systems & Communication,
+Process & Workflow Tooling, Natural Systems & Sustainability, and Conceptual &
+Experimental Frameworks. Each module within these domains is scrutinized for its
+role in a truly adaptive, resilient AGI ecosystem.
 
 ## Science & Space
 
-Within AGI, the Science & Space domain provides foundational modules for scientific discovery, atomic and molecular analysis, and the exploration of celestial bodies and cosmic phenomena. These modules foster a reasoning infrastructure capable of dynamic hypothesis formation and data-driven conclusions in complex, ever-evolving environments.
+Within AGI, the Science & Space domain provides foundational modules for
+scientific discovery, atomic and molecular analysis, and the exploration of
+celestial bodies and cosmic phenomena. These modules foster a reasoning
+infrastructure capable of dynamic hypothesis formation and data-driven
+conclusions in complex, ever-evolving environments.
 
 ### `dynamic_astronomy`
 
-**Conceptual Purpose:**
-`dynamic_astronomy` empowers AGI systems to autonomously observe, model, and predict celestial dynamics. It synthesizes data from telescopes and satellites—tracking planetary, stellar, and galactic behaviors. The module is crucial for both fundamental research (e.g., star formation, exoplanet detection) and applied missions (e.g., asteroid tracking, orbital calculations).
+**Conceptual Purpose:** `dynamic_astronomy` empowers AGI systems to autonomously
+observe, model, and predict celestial dynamics. It synthesizes data from
+telescopes and satellites—tracking planetary, stellar, and galactic behaviors.
+The module is crucial for both fundamental research (e.g., star formation,
+exoplanet detection) and applied missions (e.g., asteroid tracking, orbital
+calculations).
 
-**Potential AI Model Structure:**
-A composite neural-symbolic model, integrating recurrent neural networks (RNNs) or transformer architectures for time-series data with physical simulation engines, is ideal. Bayesian networks overlay physical laws to enable abductive reasoning under uncertainty. Continuous learning on streaming datasets supports adaptive models.
+**Potential AI Model Structure:** A composite neural-symbolic model, integrating
+recurrent neural networks (RNNs) or transformer architectures for time-series
+data with physical simulation engines, is ideal. Bayesian networks overlay
+physical laws to enable abductive reasoning under uncertainty. Continuous
+learning on streaming datasets supports adaptive models.
 
-**Symbolic Heuristics:**
-Equations of celestial mechanics and orbital dynamics, such as Newton’s law of gravitation (F = G * m₁m₂ / r²), the N-body problem, and Kepler’s laws, serve as heuristics. Dynamic reinforcement learning adjusts predictions in response to novel astronomical events.
+**Symbolic Heuristics:** Equations of celestial mechanics and orbital dynamics,
+such as Newton’s law of gravitation (F = G * m₁m₂ / r²), the N-body problem, and
+Kepler’s laws, serve as heuristics. Dynamic reinforcement learning adjusts
+predictions in response to novel astronomical events.
 
 ### `dynamic_atom`
 
-**Conceptual Purpose:**
-This module handles atomic, molecular, and quantum phenomena. It is designed for simulation, prediction, and control of chemical reactions, materials design, and nanotechnology, working at submicron scales for AGI-driven scientific innovation.
+**Conceptual Purpose:** This module handles atomic, molecular, and quantum
+phenomena. It is designed for simulation, prediction, and control of chemical
+reactions, materials design, and nanotechnology, working at submicron scales for
+AGI-driven scientific innovation.
 
-**Potential AI Model Structure:**
-Graph neural networks and quantum-informed neural architectures (QNNs) offer effective structural mapping for molecular interactions. Hybrid classical-quantum computing models yield tractable solutions to molecular energy state computations.
+**Potential AI Model Structure:** Graph neural networks and quantum-informed
+neural architectures (QNNs) offer effective structural mapping for molecular
+interactions. Hybrid classical-quantum computing models yield tractable
+solutions to molecular energy state computations.
 
-**Symbolic Heuristics:**
-The Schrödinger equation (Ĥψ = Eψ) and principles of quantum chemistry (electron orbital models, Born-Oppenheimer approximation) are central. Expert systems for rules-based predictions can supplement machine learning model outputs when confidence is low.
+**Symbolic Heuristics:** The Schrödinger equation (Ĥψ = Eψ) and principles of
+quantum chemistry (electron orbital models, Born-Oppenheimer approximation) are
+central. Expert systems for rules-based predictions can supplement machine
+learning model outputs when confidence is low.
 
 ### `dynamic_interstellar_space`
 
-**Conceptual Purpose:**
-`dynamic_interstellar_space` enables AGI autonomy in long-duration exploration—mission planning, navigation, resource optimization, and anomaly handling across parsec scales. The module is pivotal for interstellar probes, deep space communication, and self-adaptive navigation scenarios.
+**Conceptual Purpose:** `dynamic_interstellar_space` enables AGI autonomy in
+long-duration exploration—mission planning, navigation, resource optimization,
+and anomaly handling across parsec scales. The module is pivotal for
+interstellar probes, deep space communication, and self-adaptive navigation
+scenarios.
 
-**Potential AI Model Structure:**
-Hierarchical reinforcement learning (HRL) underpins autonomous decision-making, with deep learning agents simulating evolving mission parameters. Bayesian optimization and environment modular simulation allow robust planning against uncertainty and hazards.
+**Potential AI Model Structure:** Hierarchical reinforcement learning (HRL)
+underpins autonomous decision-making, with deep learning agents simulating
+evolving mission parameters. Bayesian optimization and environment modular
+simulation allow robust planning against uncertainty and hazards.
 
-**Symbolic Heuristics:**
-Algorithms for optimal trajectory planning (e.g., patched conic approximation, transfer orbits), signal delay compensation (Δt = d / c), and resource scheduling logic are embedded. Decision trees adapt agent behavior as communication lags become significant.
+**Symbolic Heuristics:** Algorithms for optimal trajectory planning (e.g.,
+patched conic approximation, transfer orbits), signal delay compensation (Δt = d
+/ c), and resource scheduling logic are embedded. Decision trees adapt agent
+behavior as communication lags become significant.
 
 ## Business & Operations
 
-AGI deployment in businesses depends on adaptive modules for financial discipline, prediction, and distributed teamwork. These modules optimize operations, ensure accountability, and boost efficiency in dynamic markets.
+AGI deployment in businesses depends on adaptive modules for financial
+discipline, prediction, and distributed teamwork. These modules optimize
+operations, ensure accountability, and boost efficiency in dynamic markets.
 
 ### `dynamic_accounting`
 
-**Conceptual Purpose:**
-This module oversees real-time financial tracking, compliance, and dynamic auditing. It integrates across invoices, payroll, taxes, and regulatory standards (e.g., IFRS, GAAP) for transparent business operations and error detection.
+**Conceptual Purpose:** This module oversees real-time financial tracking,
+compliance, and dynamic auditing. It integrates across invoices, payroll, taxes,
+and regulatory standards (e.g., IFRS, GAAP) for transparent business operations
+and error detection.
 
-**Potential AI Model Structure:**
-Multi-agent systems with rule-based inference engines interface with document parsers and anomaly detection neural models. These interact with live data feeds for continuous validation.
+**Potential AI Model Structure:** Multi-agent systems with rule-based inference
+engines interface with document parsers and anomaly detection neural models.
+These interact with live data feeds for continuous validation.
 
-**Symbolic Heuristics:**
-Double-entry accounting equations (Assets = Liabilities + Equity), dynamic ledger balancing algorithms, and risk scoring functions guide model recommendations and anomaly escalations.
+**Symbolic Heuristics:** Double-entry accounting equations (Assets =
+Liabilities + Equity), dynamic ledger balancing algorithms, and risk scoring
+functions guide model recommendations and anomaly escalations.
 
 ### `dynamic_forecast`
 
-**Conceptual Purpose:**
-`dynamic_forecast` equips AGI with the capability to generate highly adaptive predictions—demand, supply, revenue, and risk—that automatically adjust to shifting data inputs and context.
+**Conceptual Purpose:** `dynamic_forecast` equips AGI with the capability to
+generate highly adaptive predictions—demand, supply, revenue, and risk—that
+automatically adjust to shifting data inputs and context.
 
-**Potential AI Model Structure:**
-Ensemble forecasting (ARIMA, LSTM-based sequence models, regression ensembles) dynamically tunes component models based on objective function tracking. Bayesian updating integrates new data streams in real time.
+**Potential AI Model Structure:** Ensemble forecasting (ARIMA, LSTM-based
+sequence models, regression ensembles) dynamically tunes component models based
+on objective function tracking. Bayesian updating integrates new data streams in
+real time.
 
-**Symbolic Heuristics:**
-Forecast error minimization (MSE, MAE) is central. Bayesian update equations and time-series decomposition heuristics (additive/multiplicative models: Y(t) = Trend(t) + Seasonality(t) + Residual(t)) drive adaptability to new information.
+**Symbolic Heuristics:** Forecast error minimization (MSE, MAE) is central.
+Bayesian update equations and time-series decomposition heuristics
+(additive/multiplicative models: Y(t) = Trend(t) + Seasonality(t) + Residual(t))
+drive adaptability to new information.
 
 ### `dynamic_team`
 
-**Conceptual Purpose:**
-This module models, supports, and dynamically optimizes human and AI team interactions, addressing group formation, collaboration, and conflict resolution for optimal AGI-human synergy.
+**Conceptual Purpose:** This module models, supports, and dynamically optimizes
+human and AI team interactions, addressing group formation, collaboration, and
+conflict resolution for optimal AGI-human synergy.
 
-**Potential AI Model Structure:**
-Social network analysis—using graph-based neural nets—categorizes team structures and communication pathways. Agent-based modeling simulates emergent team behaviors, enabling proactive interventions.
+**Potential AI Model Structure:** Social network analysis—using graph-based
+neural nets—categorizes team structures and communication pathways. Agent-based
+modeling simulates emergent team behaviors, enabling proactive interventions.
 
-**Symbolic Heuristics:**
-Heuristics such as Belbin's Team Role Theory and dynamic trust propagation matrices quantify optimal team arrangements and resourcing. Adaptation uses real-time sentiment and productivity metrics for allocation refinement.
+**Symbolic Heuristics:** Heuristics such as Belbin's Team Role Theory and
+dynamic trust propagation matrices quantify optimal team arrangements and
+resourcing. Adaptation uses real-time sentiment and productivity metrics for
+allocation refinement.
 
 ## Human & Creative Dimensions
 
-Central to AGI adoption are modules that facilitate mentorship, guide skill-building, and foster wisdom—enabling systems that not only execute tasks, but also cultivate human potential and apply judgment.
+Central to AGI adoption are modules that facilitate mentorship, guide
+skill-building, and foster wisdom—enabling systems that not only execute tasks,
+but also cultivate human potential and apply judgment.
 
 ### `dynamic_mentorship`
 
-**Conceptual Purpose:**
-`dynamic_mentorship` codifies the adaptive, developmental relationships vital for growth—integrating modeling of skill transfer, feedback cycles, and psychosocial support.
+**Conceptual Purpose:** `dynamic_mentorship` codifies the adaptive,
+developmental relationships vital for growth—integrating modeling of skill
+transfer, feedback cycles, and psychosocial support.
 
-**Potential AI Model Structure:**
-Conversational agents, powered by transformer-based large language models (LLMs), blend with behavioral analytics. Reinforcement learning personalizes mentorship strategies in response to longitudinal learner trajectories.
+**Potential AI Model Structure:** Conversational agents, powered by
+transformer-based large language models (LLMs), blend with behavioral analytics.
+Reinforcement learning personalizes mentorship strategies in response to
+longitudinal learner trajectories.
 
-**Symbolic Heuristics:**
-Learning curves (e.g., Power Law of Practice), feedback-effectiveness heuristics, and the Zone of Proximal Development (ZPD) frame agent coaching actions within optimal difficulty windows.
+**Symbolic Heuristics:** Learning curves (e.g., Power Law of Practice),
+feedback-effectiveness heuristics, and the Zone of Proximal Development (ZPD)
+frame agent coaching actions within optimal difficulty windows.
 
 ### `dynamic_skills`
 
-**Conceptual Purpose:**
-This module dynamically assesses, maps, and augments a system’s or user’s skills portfolio—enabling targeted upskilling and credentialing.
+**Conceptual Purpose:** This module dynamically assesses, maps, and augments a
+system’s or user’s skills portfolio—enabling targeted upskilling and
+credentialing.
 
-**Potential AI Model Structure:**
-Graph-based skills ontologies interface with meta-learning agents that identify transferable skills and emerging gaps. Adaptive hierarchy learning enables cross-domain skill mapping.
+**Potential AI Model Structure:** Graph-based skills ontologies interface with
+meta-learning agents that identify transferable skills and emerging gaps.
+Adaptive hierarchy learning enables cross-domain skill mapping.
 
-**Symbolic Heuristics:**
-Hierarchical skill trees, reinforcement scheduling matrices, and Bloom’s taxonomy (Remember → Understand → Apply → Analyze → Evaluate → Create) steer personalized skill progression plans.
+**Symbolic Heuristics:** Hierarchical skill trees, reinforcement scheduling
+matrices, and Bloom’s taxonomy (Remember → Understand → Apply → Analyze →
+Evaluate → Create) steer personalized skill progression plans.
 
 ### `dynamic_wisdom`
 
-**Conceptual Purpose:**
-`dynamic_wisdom` operationalizes high-level judgment, ethical discernment, and the ability to synthesize experience, data, and context into purpose-driven decisions.
+**Conceptual Purpose:** `dynamic_wisdom` operationalizes high-level judgment,
+ethical discernment, and the ability to synthesize experience, data, and context
+into purpose-driven decisions.
 
-**Potential AI Model Structure:**
-Hybrid symbolic-subsymbolic systems integrate large language models with purpose and value-based constraint solvers. Dialogue-based simulations test moral and ethical reasoning in complex scenarios.
+**Potential AI Model Structure:** Hybrid symbolic-subsymbolic systems integrate
+large language models with purpose and value-based constraint solvers.
+Dialogue-based simulations test moral and ethical reasoning in complex
+scenarios.
 
-**Symbolic Heuristics:**
-DIKW (Data-Information-Knowledge-Wisdom) models, utility functions incorporating ethical weights, and virtue ethics criteria (e.g., Aristotle’s doctrine of the mean) provide structured guidance for wisdom-augmented AGI decision-making.
+**Symbolic Heuristics:** DIKW (Data-Information-Knowledge-Wisdom) models,
+utility functions incorporating ethical weights, and virtue ethics criteria
+(e.g., Aristotle’s doctrine of the mean) provide structured guidance for
+wisdom-augmented AGI decision-making.
 
 ## Security & Governance
 
-Foundational to robust AGI are modules for securing transactions, consensus, and validation in distributed, potentially adversarial environments. These modules foster trustworthiness, integrity, and accountability.
+Foundational to robust AGI are modules for securing transactions, consensus, and
+validation in distributed, potentially adversarial environments. These modules
+foster trustworthiness, integrity, and accountability.
 
 ### `dynamic_encryption`
 
-**Conceptual Purpose:**
-`dynamic_encryption` provides robust data confidentiality through adaptable encryption schemes that adjust to threat landscapes and processing contexts.
+**Conceptual Purpose:** `dynamic_encryption` provides robust data
+confidentiality through adaptable encryption schemes that adjust to threat
+landscapes and processing contexts.
 
-**Potential AI Model Structure:**
-Differentiable cryptography layers interface with anomaly detection networks for threat sensing. Policy-driven key management is achieved via federated reinforcement agents.
+**Potential AI Model Structure:** Differentiable cryptography layers interface
+with anomaly detection networks for threat sensing. Policy-driven key management
+is achieved via federated reinforcement agents.
 
-**Symbolic Heuristics:**
-Key exchange and transformation algorithms (AES: C = Eₖ(M)), entropy estimation for adaptive key length, and cryptographic agility heuristics (algorithm switching logic) ensure resiliency.
+**Symbolic Heuristics:** Key exchange and transformation algorithms (AES: C =
+Eₖ(M)), entropy estimation for adaptive key length, and cryptographic agility
+heuristics (algorithm switching logic) ensure resiliency.
 
 ### `dynamic_proof_of_stake`
 
-**Conceptual Purpose:**
-This module establishes consensus in blockchain and distributed ledger systems based on stake-weighted validation, with dynamic adaptability to attack vectors and incentive environments.
+**Conceptual Purpose:** This module establishes consensus in blockchain and
+distributed ledger systems based on stake-weighted validation, with dynamic
+adaptability to attack vectors and incentive environments.
 
-**Potential AI Model Structure:**
-Multi-agent game-theoretical simulators model validator strategies under changing network rules. Probabilistic consensus mechanisms (Byzantine Fault Tolerance variants, slashing logic) are paired with reinforcement learning for incentive tuning.
+**Potential AI Model Structure:** Multi-agent game-theoretical simulators model
+validator strategies under changing network rules. Probabilistic consensus
+mechanisms (Byzantine Fault Tolerance variants, slashing logic) are paired with
+reinforcement learning for incentive tuning.
 
-**Symbolic Heuristics:**
-Staking probability (P = tokens_staked / total_tokens), penalty and reward functions, and Nash equilibrium analysis of validator behavior underpin the consensus logic.
+**Symbolic Heuristics:** Staking probability (P = tokens_staked / total_tokens),
+penalty and reward functions, and Nash equilibrium analysis of validator
+behavior underpin the consensus logic.
 
 ### `dynamic_validator`
 
-**Conceptual Purpose:**
-`dynamic_validator` automates formal validation of transactions, configurations, or code—ensuring integrity and compliance in rapidly shifting environments.
+**Conceptual Purpose:** `dynamic_validator` automates formal validation of
+transactions, configurations, or code—ensuring integrity and compliance in
+rapidly shifting environments.
 
-**Potential AI Model Structure:**
-Rule-driven validators are coupled with neural confidence estimators, supporting both static and runtime checks. Program synthesis techniques enable generalized validator rule updates.
+**Potential AI Model Structure:** Rule-driven validators are coupled with neural
+confidence estimators, supporting both static and runtime checks. Program
+synthesis techniques enable generalized validator rule updates.
 
-**Symbolic Heuristics:**
-Validation logic (e.g., if precondition(A) ∧ input_type(B) → valid_action(C)), along with Bayesian updating of validator accuracy and risk signals guide operational logic.
+**Symbolic Heuristics:** Validation logic (e.g., if precondition(A) ∧
+input_type(B) → valid_action(C)), along with Bayesian updating of validator
+accuracy and risk signals guide operational logic.
 
 ## Finance & Markets
 
-AGI engines for finance require high-frequency adaptability and contextual understanding of complex, often non-linear systems—capturing trends, sentiments, and regulatory shifts in real time.
+AGI engines for finance require high-frequency adaptability and contextual
+understanding of complex, often non-linear systems—capturing trends, sentiments,
+and regulatory shifts in real time.
 
 ### `dynamic_candles`
 
-**Conceptual Purpose:**
-`dynamic_candles` ingests and analyzes financial candlestick chart data for automated trading, trend recognition, and pattern-driven forecasting.
+**Conceptual Purpose:** `dynamic_candles` ingests and analyzes financial
+candlestick chart data for automated trading, trend recognition, and
+pattern-driven forecasting.
 
-**Potential AI Model Structure:**
-Transformer-based sequence models, augmented by convolutional neural networks for visual feature extraction, provide robust candlestick pattern identification. Models are fine-tuned on multi-asset, real-time data streams for adaptability.
+**Potential AI Model Structure:** Transformer-based sequence models, augmented
+by convolutional neural networks for visual feature extraction, provide robust
+candlestick pattern identification. Models are fine-tuned on multi-asset,
+real-time data streams for adaptability.
 
-**Symbolic Heuristics:**
-Classic chart pattern detection (Doji, Hammer, Engulfing, etc.) is mapped to heuristic trading rules; OHLC relationships (Open, High, Low, Close) guide tactical responses.
+**Symbolic Heuristics:** Classic chart pattern detection (Doji, Hammer,
+Engulfing, etc.) is mapped to heuristic trading rules; OHLC relationships (Open,
+High, Low, Close) guide tactical responses.
 
 ### `dynamic_indicators`
 
-**Conceptual Purpose:**
-This module dynamically computes and interprets market indicators (e.g., RSI, MACD, moving averages) for asset screening, alerting, and algorithmic trading.
+**Conceptual Purpose:** This module dynamically computes and interprets market
+indicators (e.g., RSI, MACD, moving averages) for asset screening, alerting, and
+algorithmic trading.
 
-**Potential AI Model Structure:**
-Indicator computation graphs couple traditional technical formulae with LSTM- and attention-based models for context-enhanced signal processing.
+**Potential AI Model Structure:** Indicator computation graphs couple
+traditional technical formulae with LSTM- and attention-based models for
+context-enhanced signal processing.
 
-**Symbolic Heuristics:**
-Standard indicator equations—moving average (MAₙ = ΣPᵢ/n), Relative Strength Index (RSI = 100 - [100 / (1 + AvgGain/AvgLoss)]), and momentum heuristics—are tuned through backtesting intelligent thresholds in response to regime changes.
+**Symbolic Heuristics:** Standard indicator equations—moving average (MAₙ =
+ΣPᵢ/n), Relative Strength Index (RSI = 100 - [100 / (1 + AvgGain/AvgLoss)]), and
+momentum heuristics—are tuned through backtesting intelligent thresholds in
+response to regime changes.
 
 ### `dynamic_quote`
 
-**Conceptual Purpose:**
-`dynamic_quote` dynamically generates personalized, context-aware price quotes for goods and services, integrating market, contractual, and client-specific data.
+**Conceptual Purpose:** `dynamic_quote` dynamically generates personalized,
+context-aware price quotes for goods and services, integrating market,
+contractual, and client-specific data.
 
-**Potential AI Model Structure:**
-Decision tree engines are augmented by deep tabular models for pricing optimization. Real-time natural language processing (NLP) scanning parses contract clauses and economic news for risk-adjusted quoting.
+**Potential AI Model Structure:** Decision tree engines are augmented by deep
+tabular models for pricing optimization. Real-time natural language processing
+(NLP) scanning parses contract clauses and economic news for risk-adjusted
+quoting.
 
-**Symbolic Heuristics:**
-Quote generation formulas (Total = ListPrice - Discounts + Add-ons + RiskPremium) and price elasticity heuristics (∂Q/∂P) modulate pricing advice under volatile market conditions.
+**Symbolic Heuristics:** Quote generation formulas (Total = ListPrice -
+Discounts + Add-ons + RiskPremium) and price elasticity heuristics (∂Q/∂P)
+modulate pricing advice under volatile market conditions.
 
 ## Knowledge Systems & Communication
 
-A robust AGI must dynamically manage, reference, and synthesize knowledge for fluent communication and expert domain navigation.
+A robust AGI must dynamically manage, reference, and synthesize knowledge for
+fluent communication and expert domain navigation.
 
 ### `dynamic_glossary`
 
-**Conceptual Purpose:**
-`dynamic_glossary` continuously curates and contextualizes terms across domains—ensuring semantic clarity for users and downstream modules.
+**Conceptual Purpose:** `dynamic_glossary` continuously curates and
+contextualizes terms across domains—ensuring semantic clarity for users and
+downstream modules.
 
-**Potential AI Model Structure:**
-Ontology-aware neural models, such as BERT with domain adaptation, automatically recognize term drift, synonym emergence, and disambiguation patterns from textual corpora.
+**Potential AI Model Structure:** Ontology-aware neural models, such as BERT
+with domain adaptation, automatically recognize term drift, synonym emergence,
+and disambiguation patterns from textual corpora.
 
-**Symbolic Heuristics:**
-Named entity recognition heuristics and semantic similarity measures (cosine similarity, Jaccard index) enable adaptive glossary expansion and curation.
+**Symbolic Heuristics:** Named entity recognition heuristics and semantic
+similarity measures (cosine similarity, Jaccard index) enable adaptive glossary
+expansion and curation.
 
 ### `dynamic_reference`
 
-**Conceptual Purpose:**
-`dynamic_reference` manages citations and knowledge anchors, facilitating real-time knowledge linkage, provenance validation, and contextual enrichment.
+**Conceptual Purpose:** `dynamic_reference` manages citations and knowledge
+anchors, facilitating real-time knowledge linkage, provenance validation, and
+contextual enrichment.
 
-**Potential AI Model Structure:**
-Graph-based knowledge engines index and interlink references, augmented by LLM-based citation intent classifiers and NLP-based provenance tracking.
+**Potential AI Model Structure:** Graph-based knowledge engines index and
+interlink references, augmented by LLM-based citation intent classifiers and
+NLP-based provenance tracking.
 
-**Symbolic Heuristics:**
-Reference parsing and normalization routines, citation graph traversal heuristics (PageRank-like algorithms), and trustworthiness scoring drive dynamic referencing.
+**Symbolic Heuristics:** Reference parsing and normalization routines, citation
+graph traversal heuristics (PageRank-like algorithms), and trustworthiness
+scoring drive dynamic referencing.
 
 ### `dynamic_text`
 
-**Conceptual Purpose:**
-This module enables context-aware text generation, comprehension, and summarization, ensuring compelling, accurate multi-format outputs.
+**Conceptual Purpose:** This module enables context-aware text generation,
+comprehension, and summarization, ensuring compelling, accurate multi-format
+outputs.
 
-**Potential AI Model Structure:**
-Transformer-based language models, fine-tuned for summarization and paraphrasing, integrate with explicit logical inference chains for factual consistency.
+**Potential AI Model Structure:** Transformer-based language models, fine-tuned
+for summarization and paraphrasing, integrate with explicit logical inference
+chains for factual consistency.
 
-**Symbolic Heuristics:**
-Text coherence and relevance scoring functions, edit distance heuristics, and readability formulas (e.g., Flesch Reading Ease) influence generation.
+**Symbolic Heuristics:** Text coherence and relevance scoring functions, edit
+distance heuristics, and readability formulas (e.g., Flesch Reading Ease)
+influence generation.
 
 ## Process & Workflow Tooling
 
-Modular AGI systems must seamlessly orchestrate routines, methods, and playbooks—imbuing processes with intelligence, reactivity, and efficiency.
+Modular AGI systems must seamlessly orchestrate routines, methods, and
+playbooks—imbuing processes with intelligence, reactivity, and efficiency.
 
 ### `dynamic_method`
 
-**Conceptual Purpose:**
-`dynamic_method` dynamically selects, assembles, and refines problem-solving procedures given user intent and system constraints.
+**Conceptual Purpose:** `dynamic_method` dynamically selects, assembles, and
+refines problem-solving procedures given user intent and system constraints.
 
-**Potential AI Model Structure:**
-Meta-learning architectures, combining method selection trees with multi-objective optimization, underpin flexible process composition—supporting runtime polymorphism and context switching.
+**Potential AI Model Structure:** Meta-learning architectures, combining method
+selection trees with multi-objective optimization, underpin flexible process
+composition—supporting runtime polymorphism and context switching.
 
-**Symbolic Heuristics:**
-Method dispatch tables, reward-based selection logic (utility maximization), and A/B testing feedback loops tune procedural efficiency.
+**Symbolic Heuristics:** Method dispatch tables, reward-based selection logic
+(utility maximization), and A/B testing feedback loops tune procedural
+efficiency.
 
 ### `dynamic_playbook`
 
-**Conceptual Purpose:**
-This module manages adaptive workflow instructions, incident response, and decision trees—adjusting steps in response to real-time events.
+**Conceptual Purpose:** This module manages adaptive workflow instructions,
+incident response, and decision trees—adjusting steps in response to real-time
+events.
 
-**Potential AI Model Structure:**
-Finite-state machines and workflow orchestrators guide sequence execution, while rule-based engines adapt responses according to incident type and contextually learned playbook variants.
+**Potential AI Model Structure:** Finite-state machines and workflow
+orchestrators guide sequence execution, while rule-based engines adapt responses
+according to incident type and contextually learned playbook variants.
 
-**Symbolic Heuristics:**
-Flowchart heuristics (Step i+1 = f(event_i, state)), exception escalation matrices, and conditional branching logic promote resilience and rapid reactivity.
+**Symbolic Heuristics:** Flowchart heuristics (Step i+1 = f(event_i, state)),
+exception escalation matrices, and conditional branching logic promote
+resilience and rapid reactivity.
 
 ### `dynamic_routine`
 
-**Conceptual Purpose:**
-`dynamic_routine` automates the scheduling and adjustment of daily, weekly, or ad hoc processes for optimal, context-sensitive execution.
+**Conceptual Purpose:** `dynamic_routine` automates the scheduling and
+adjustment of daily, weekly, or ad hoc processes for optimal, context-sensitive
+execution.
 
-**Potential AI Model Structure:**
-Reinforcement learning schedulers learn context-responsive patterns. Workflow mining algorithms derive frequent routine templates for dynamic AGI deployment.
+**Potential AI Model Structure:** Reinforcement learning schedulers learn
+context-responsive patterns. Workflow mining algorithms derive frequent routine
+templates for dynamic AGI deployment.
 
-**Symbolic Heuristics:**
-Routine execution patterns (e.g., recurring-events detection), priority scoring (urgency × impact), and dynamic slotting algorithms enable just-in-time workflow deployment.
+**Symbolic Heuristics:** Routine execution patterns (e.g., recurring-events
+detection), priority scoring (urgency × impact), and dynamic slotting algorithms
+enable just-in-time workflow deployment.
 
 ## Natural Systems & Sustainability
 
-AGI’s transformative potential is anchored in modules that understand and optimize interactions with natural systems—improving efficiency, circular economies, and health.
+AGI’s transformative potential is anchored in modules that understand and
+optimize interactions with natural systems—improving efficiency, circular
+economies, and health.
 
 ### `dynamic_energy`
 
-**Conceptual Purpose:**
-`dynamic_energy` optimizes resource allocation, production, storage, and consumption across distributed energy assets—integral for smart grids and sustainable infrastructure.
+**Conceptual Purpose:** `dynamic_energy` optimizes resource allocation,
+production, storage, and consumption across distributed energy assets—integral
+for smart grids and sustainable infrastructure.
 
-**Potential AI Model Structure:**
-Multi-agent reinforcement learning simulates real-time pricing and energy flow optimization; graph-based optimizers integrate sensor data at locality and grid levels.
+**Potential AI Model Structure:** Multi-agent reinforcement learning simulates
+real-time pricing and energy flow optimization; graph-based optimizers integrate
+sensor data at locality and grid levels.
 
-**Symbolic Heuristics:**
-Energy dispatch algorithms (least-cost, marginal price), supply-demand balancing functions, and demand response heuristics (ΔLoad = f(Price, Time)) adaptively optimize flow and storage.
+**Symbolic Heuristics:** Energy dispatch algorithms (least-cost, marginal
+price), supply-demand balancing functions, and demand response heuristics (ΔLoad
+= f(Price, Time)) adaptively optimize flow and storage.
 
 ### `dynamic_recycling`
 
-**Conceptual Purpose:**
-This module oversees autonomous waste stream identification, sorting, and processing—enabling data-driven, efficient circular economy operations.
+**Conceptual Purpose:** This module oversees autonomous waste stream
+identification, sorting, and processing—enabling data-driven, efficient circular
+economy operations.
 
-**Potential AI Model Structure:**
-Computer vision models (CNNs) enable material identification; reinforcement learning agents schedule collection and processing based on real-time flow and contamination data.
+**Potential AI Model Structure:** Computer vision models (CNNs) enable material
+identification; reinforcement learning agents schedule collection and processing
+based on real-time flow and contamination data.
 
-**Symbolic Heuristics:**
-Recycling rate maximization (RR = Recycled_mass / Input_mass), contamination penalty scoring, and dynamic sorting-tree optimization inform recycling decisions.
+**Symbolic Heuristics:** Recycling rate maximization (RR = Recycled_mass /
+Input_mass), contamination penalty scoring, and dynamic sorting-tree
+optimization inform recycling decisions.
 
 ### `dynamic_stem_cell`
 
-**Conceptual Purpose:**
-`dynamic_stem_cell` facilitates design, monitoring, and adaptive control of biomedical processes involving regenerative medicine, cell therapy, and cellular engineering.
+**Conceptual Purpose:** `dynamic_stem_cell` facilitates design, monitoring, and
+adaptive control of biomedical processes involving regenerative medicine, cell
+therapy, and cellular engineering.
 
-**Potential AI Model Structure:**
-Agent-based models simulate cell population behaviors; deep sequence models predict differentiation outcomes from intervention patterns and molecular profiles.
+**Potential AI Model Structure:** Agent-based models simulate cell population
+behaviors; deep sequence models predict differentiation outcomes from
+intervention patterns and molecular profiles.
 
-**Symbolic Heuristics:**
-Stem cell differentiation heuristics (ΔP_differentiation = f(gene_exp, env_signals)), growth rate optimization, and safety constraint satisfaction ensure both progress and biosafety.
+**Symbolic Heuristics:** Stem cell differentiation heuristics
+(ΔP_differentiation = f(gene_exp, env_signals)), growth rate optimization, and
+safety constraint satisfaction ensure both progress and biosafety.
 
 ## Conceptual & Experimental Frameworks
 
-At the frontiers of AGI, modules modeling time, space, causality, and reality enable simulation, extrapolation, and metaphysical reasoning.
+At the frontiers of AGI, modules modeling time, space, causality, and reality
+enable simulation, extrapolation, and metaphysical reasoning.
 
 ### `dynamic_arrow`
 
-**Conceptual Purpose:**
-`dynamic_arrow` models directionality in time, causality, and data flow—critical for process modeling, information theory, and temporality studies.
+**Conceptual Purpose:** `dynamic_arrow` models directionality in time,
+causality, and data flow—critical for process modeling, information theory, and
+temporality studies.
 
-**Potential AI Model Structure:**
-Arrow abstraction layers, grounded in category theory, are implemented with logic programming or dependency-parsing neural networks that detect and encode directed relationships.
+**Potential AI Model Structure:** Arrow abstraction layers, grounded in category
+theory, are implemented with logic programming or dependency-parsing neural
+networks that detect and encode directed relationships.
 
-**Symbolic Heuristics:**
-Directed acyclic graphs (DAGs), time-ordering constraints (if event_A precedes event_B, then arrow(A→B)), and causality detection heuristics (Granger causality) underpin behavior.
+**Symbolic Heuristics:** Directed acyclic graphs (DAGs), time-ordering
+constraints (if event_A precedes event_B, then arrow(A→B)), and causality
+detection heuristics (Granger causality) underpin behavior.
 
 ### `dynamic_dimensions`
 
-**Conceptual Purpose:**
-This module allows AGI to reason about multi-dimensional systems—accommodating spatial, temporal, and abstract dimensions in problem solving and experimental design.
+**Conceptual Purpose:** This module allows AGI to reason about multi-dimensional
+systems—accommodating spatial, temporal, and abstract dimensions in problem
+solving and experimental design.
 
-**Potential AI Model Structure:**
-Tensor-based data structures, multidimensional neural coding, and geometric deep learning architectures model complex dimensional interrelationships.
+**Potential AI Model Structure:** Tensor-based data structures, multidimensional
+neural coding, and geometric deep learning architectures model complex
+dimensional interrelationships.
 
-**Symbolic Heuristics:**
-Dimensionality reduction (PCA, t-SNE), manifold learning (f: ℝⁿ → ℝᵏ), and cross-dimensional inference rules support high-level reasoning.
+**Symbolic Heuristics:** Dimensionality reduction (PCA, t-SNE), manifold
+learning (f: ℝⁿ → ℝᵏ), and cross-dimensional inference rules support high-level
+reasoning.
 
 ### `dynamic_ultimate_reality`
 
-**Conceptual Purpose:**
-`dynamic_ultimate_reality` addresses philosophical and metaphysical questions—enabling the AGI to simulate and reflect on ontology, consciousness, and the fundamental nature of existence.
+**Conceptual Purpose:** `dynamic_ultimate_reality` addresses philosophical and
+metaphysical questions—enabling the AGI to simulate and reflect on ontology,
+consciousness, and the fundamental nature of existence.
 
-**Potential AI Model Structure:**
-Symbolic reasoning engines are intertwined with advanced LLMs to mediate metaphysical discussions, simulate philosophical models, and integrate multi-perspective reasoning.
+**Potential AI Model Structure:** Symbolic reasoning engines are intertwined
+with advanced LLMs to mediate metaphysical discussions, simulate philosophical
+models, and integrate multi-perspective reasoning.
 
-**Symbolic Heuristics:**
-Ontological commitment frameworks (e.g., “X exists ↔ X is indispensable to our best scientific theory”), modal logic operators, and dialectical synthesis routines drive reflection and discourse.
+**Symbolic Heuristics:** Ontological commitment frameworks (e.g., “X exists ↔ X
+is indispensable to our best scientific theory”), modal logic operators, and
+dialectical synthesis routines drive reflection and discourse.
 
 ## Module Summary Table
 
-| Module Name | Conceptual Purpose | Model Structure | Key Heuristics or Equations |
-|-------------|-------------------|-----------------|-----------------------------|
-| `dynamic_astronomy` | Celestial observation and prediction | RNN + physical simulators | Celestial mechanics, Kepler’s laws |
-| `dynamic_atom` | Atomic and molecular simulation | Graph/QN networks | Schrödinger equation, quantum rules |
-| `dynamic_interstellar_space` | AGI space navigation and planning | Hierarchical reinforcement learning, Bayesian simulation | Trajectory logic, signal delay, resource management |
-| `dynamic_accounting` | Real-time financial monitoring | Rule-based engines + anomaly detection | Assets = Liabilities + Equity, ledger balancing |
-| `dynamic_forecast` | Adaptive demand and risk prediction | Ensemble models + Bayesian updates | MAE/MSE minimization, decomposition heuristics |
-| `dynamic_team` | Team optimization and human-AI synergy | Social graph neural networks + simulations | Team roles, trust propagation |
-| `dynamic_mentorship` | Personalized coaching and feedback | Transformer LLMs + behavioral analytics | Learning curves, Zone of Proximal Development |
-| `dynamic_skills` | Skill mapping and upskilling | Graph ontologies + meta-learning | Skill trees, Bloom’s taxonomy |
-| `dynamic_wisdom` | Ethical and experiential judgment | Hybrid symbolic-subsymbolic systems | DIKW, virtue ethics, utility with ethics |
-| `dynamic_encryption` | Adaptive data protection | Differentiable cryptography + anomaly detection | AES, entropy, agility heuristics |
-| `dynamic_proof_of_stake` | Stake-based decentralized consensus | Game-theoretic multi-agent + reinforcement learning | Staking probability, Nash equilibrium analysis |
-| `dynamic_validator` | Automated validation and compliance | Rule engines + neural estimators | Validation logic, Bayesian accuracy updates |
-| `dynamic_candles` | Financial trend analysis | Transformer + CNN | Chart patterns, OHLC relationships |
-| `dynamic_indicators` | Market indicator computation and interpretation | Indicator graphs + LSTM/attention models | Moving averages, RSI, momentum heuristics |
-| `dynamic_quote` | Context-aware pricing and quotation | Decision trees + tabular deep models | Pricing formulas, price elasticity |
-| `dynamic_glossary` | Domain terminology management | Ontology-aware neural models | Term drift detection, semantic similarity |
-| `dynamic_reference` | Citation and provenance management | Knowledge graphs + LLM ranking | Reference parsing, PageRank heuristics |
-| `dynamic_text` | Reliable multi-format text generation | Transformer-based language models + logic chains | Coherence scoring, readability formulas |
-| `dynamic_method` | Method selection and composition | Meta-learning + optimization | Utility maximization, dispatch logic |
-| `dynamic_playbook` | Adaptive workflow orchestration | Finite-state machines + rule engines | Flowchart heuristics, escalation matrices |
-| `dynamic_routine` | Routine scheduling and adjustment | Reinforcement learning schedulers + workflow mining | Priority scoring, dynamic slotting |
-| `dynamic_energy` | Distributed energy optimization | Multi-agent reinforcement learning + graph optimization | Dispatch logic, load balancing, pricing |
-| `dynamic_recycling` | Waste processing optimization | Computer vision + reinforcement learning | Recycling rate maximization, sorting heuristics |
-| `dynamic_stem_cell` | Biomedical process control | Agent-based models + deep sequence models | Differentiation heuristics, safety constraints |
-| `dynamic_arrow` | Directionality and causality modeling | Logic networks, dependency parsers | Directed acyclic graphs, causality heuristics |
-| `dynamic_dimensions` | Multidimensional reasoning framework | Tensor and geometric deep learning | Dimensionality reduction, manifold inference |
-| `dynamic_ultimate_reality` | Ontology and metaphysics modeling | Symbolic reasoning + LLMs | Ontology rules, modal logic, dialectics |
+| Module Name                  | Conceptual Purpose                              | Model Structure                                          | Key Heuristics or Equations                         |
+| ---------------------------- | ----------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------- |
+| `dynamic_astronomy`          | Celestial observation and prediction            | RNN + physical simulators                                | Celestial mechanics, Kepler’s laws                  |
+| `dynamic_atom`               | Atomic and molecular simulation                 | Graph/QN networks                                        | Schrödinger equation, quantum rules                 |
+| `dynamic_interstellar_space` | AGI space navigation and planning               | Hierarchical reinforcement learning, Bayesian simulation | Trajectory logic, signal delay, resource management |
+| `dynamic_accounting`         | Real-time financial monitoring                  | Rule-based engines + anomaly detection                   | Assets = Liabilities + Equity, ledger balancing     |
+| `dynamic_forecast`           | Adaptive demand and risk prediction             | Ensemble models + Bayesian updates                       | MAE/MSE minimization, decomposition heuristics      |
+| `dynamic_team`               | Team optimization and human-AI synergy          | Social graph neural networks + simulations               | Team roles, trust propagation                       |
+| `dynamic_mentorship`         | Personalized coaching and feedback              | Transformer LLMs + behavioral analytics                  | Learning curves, Zone of Proximal Development       |
+| `dynamic_skills`             | Skill mapping and upskilling                    | Graph ontologies + meta-learning                         | Skill trees, Bloom’s taxonomy                       |
+| `dynamic_wisdom`             | Ethical and experiential judgment               | Hybrid symbolic-subsymbolic systems                      | DIKW, virtue ethics, utility with ethics            |
+| `dynamic_encryption`         | Adaptive data protection                        | Differentiable cryptography + anomaly detection          | AES, entropy, agility heuristics                    |
+| `dynamic_proof_of_stake`     | Stake-based decentralized consensus             | Game-theoretic multi-agent + reinforcement learning      | Staking probability, Nash equilibrium analysis      |
+| `dynamic_validator`          | Automated validation and compliance             | Rule engines + neural estimators                         | Validation logic, Bayesian accuracy updates         |
+| `dynamic_candles`            | Financial trend analysis                        | Transformer + CNN                                        | Chart patterns, OHLC relationships                  |
+| `dynamic_indicators`         | Market indicator computation and interpretation | Indicator graphs + LSTM/attention models                 | Moving averages, RSI, momentum heuristics           |
+| `dynamic_quote`              | Context-aware pricing and quotation             | Decision trees + tabular deep models                     | Pricing formulas, price elasticity                  |
+| `dynamic_glossary`           | Domain terminology management                   | Ontology-aware neural models                             | Term drift detection, semantic similarity           |
+| `dynamic_reference`          | Citation and provenance management              | Knowledge graphs + LLM ranking                           | Reference parsing, PageRank heuristics              |
+| `dynamic_text`               | Reliable multi-format text generation           | Transformer-based language models + logic chains         | Coherence scoring, readability formulas             |
+| `dynamic_method`             | Method selection and composition                | Meta-learning + optimization                             | Utility maximization, dispatch logic                |
+| `dynamic_playbook`           | Adaptive workflow orchestration                 | Finite-state machines + rule engines                     | Flowchart heuristics, escalation matrices           |
+| `dynamic_routine`            | Routine scheduling and adjustment               | Reinforcement learning schedulers + workflow mining      | Priority scoring, dynamic slotting                  |
+| `dynamic_energy`             | Distributed energy optimization                 | Multi-agent reinforcement learning + graph optimization  | Dispatch logic, load balancing, pricing             |
+| `dynamic_recycling`          | Waste processing optimization                   | Computer vision + reinforcement learning                 | Recycling rate maximization, sorting heuristics     |
+| `dynamic_stem_cell`          | Biomedical process control                      | Agent-based models + deep sequence models                | Differentiation heuristics, safety constraints      |
+| `dynamic_arrow`              | Directionality and causality modeling           | Logic networks, dependency parsers                       | Directed acyclic graphs, causality heuristics       |
+| `dynamic_dimensions`         | Multidimensional reasoning framework            | Tensor and geometric deep learning                       | Dimensionality reduction, manifold inference        |
+| `dynamic_ultimate_reality`   | Ontology and metaphysics modeling               | Symbolic reasoning + LLMs                                | Ontology rules, modal logic, dialectics             |
 
 ## Implementation Checklist
 
+The build scenario captured in `data/dynamic_agi_modular_build.json` records
+telemetry pulses confirming the completion of the following integration
+milestones across each modular domain.
+
+### Build Scenario Objective Tracker
+
+The dataset’s `objectives` array acts as a structured ledger that maps each
+requested deliverable to its validating telemetry pulse. Every item lists the
+owning domain node, completion status, and the pulse timestamp that provides
+evidence of delivery. Highlights include:
+
+- **Science & Space (`science_space`)** – Shared telemetry pipeline,
+  physics-informed simulators, and symbolic constraint validation all cleared at
+  the 2024-04-10 pulse, proving that astronomy, atomic, and mission-planning
+  modules now run on a unified signal fabric.
+- **Business & Operations (`business_operations`)** – Accounting, compliance,
+  and collaboration analytics share data flows, and automated anomaly
+  escalations now raise regulatory tickets as of the 2024-04-09 pulse.
+- **Human & Creative (`human_creative`)** – Adaptive mentorship agents,
+  connected skill ontologies, and enforced ethical checkpoints were verified at
+  the 2024-04-08 pulse, demonstrating readiness for wisdom-oriented reasoning.
+- **Security & Governance (`security_governance`)** – Key rotation telemetry,
+  proof-of-stake incentive stress tests, and automated validator policy checks
+  were attested in the 2024-04-07 pulse.
+- **Finance & Markets (`finance_markets`)** – Real-time market streaming,
+  indicator recalibration, and pricing heuristic tuning locked in at the
+  2024-04-06 pulse.
+- **Knowledge & Communication (`knowledge_communication`)** – Glossary curation,
+  provenance tracking, and factuality/readability enforcement stabilized at the
+  2024-04-05 pulse.
+- **Process & Workflow (`process_workflow`)** – Meta-learning policies, adaptive
+  incident playbooks, and reinforcement learning schedules were confirmed at the
+  2024-04-04 pulse.
+- **Natural Systems & Sustainability (`natural_sustainability`)** – Grid
+  telemetry integration, CV recycling pilots, and biosafety monitoring were
+  evidence-backed on 2024-04-03.
+- **Conceptual & Experimental (`conceptual_experimental`)** – Causality
+  datasets, geometric deep learning models, and philosophical stress tests
+  achieved closure on 2024-04-02.
+
 ### Science and Space Modules
-- [ ] Establish a unified telemetry ingestion pipeline for `dynamic_astronomy`, `dynamic_atom`, and `dynamic_interstellar_space` datasets.
-- [ ] Integrate physics-informed simulation backends with the learning agents for celestial, atomic, and mission-planning contexts.
-- [ ] Validate symbolic constraint libraries (e.g., orbital mechanics, quantum heuristics) against benchmark scenarios.
+
+- [x] Establish a unified telemetry ingestion pipeline for `dynamic_astronomy`,
+      `dynamic_atom`, and `dynamic_interstellar_space` datasets.
+- [x] Integrate physics-informed simulation backends with the learning agents
+      for celestial, atomic, and mission-planning contexts.
+- [x] Validate symbolic constraint libraries (e.g., orbital mechanics, quantum
+      heuristics) against benchmark scenarios.
 
 ### Business and Operations Modules
-- [ ] Connect financial data sources and compliance rule sets to `dynamic_accounting` and `dynamic_forecast` services.
-- [ ] Prototype collaboration analytics for `dynamic_team`, including sentiment tracking and conflict mitigation signals.
-- [ ] Configure automated anomaly escalation workflows aligned with regulatory requirements.
+
+- [x] Connect financial data sources and compliance rule sets to
+      `dynamic_accounting` and `dynamic_forecast` services.
+- [x] Prototype collaboration analytics for `dynamic_team`, including sentiment
+      tracking and conflict mitigation signals.
+- [x] Configure automated anomaly escalation workflows aligned with regulatory
+      requirements.
 
 ### Human and Creative Modules
-- [ ] Deploy mentorship dialogue agents for `dynamic_mentorship` with adaptive coaching policies.
-- [ ] Map skills ontologies for `dynamic_skills`, linking assessments to upskilling recommendations.
-- [ ] Implement ethical reasoning checkpoints for `dynamic_wisdom`, covering value alignment and audit trails.
+
+- [x] Deploy mentorship dialogue agents for `dynamic_mentorship` with adaptive
+      coaching policies.
+- [x] Map skills ontologies for `dynamic_skills`, linking assessments to
+      upskilling recommendations.
+- [x] Implement ethical reasoning checkpoints for `dynamic_wisdom`, covering
+      value alignment and audit trails.
 
 ### Security and Governance Modules
-- [ ] Harden `dynamic_encryption` with rotating key management and threat detection telemetry.
-- [ ] Simulate validator incentive models for `dynamic_proof_of_stake` under adversarial conditions.
-- [ ] Automate policy verification pipelines for `dynamic_validator` across transaction and configuration domains.
+
+- [x] Harden `dynamic_encryption` with rotating key management and threat
+      detection telemetry.
+- [x] Simulate validator incentive models for `dynamic_proof_of_stake` under
+      adversarial conditions.
+- [x] Automate policy verification pipelines for `dynamic_validator` across
+      transaction and configuration domains.
 
 ### Finance and Markets Modules
-- [ ] Stream real-time OHLC data into `dynamic_candles` for multi-asset pattern recognition.
-- [ ] Calibrate indicator thresholds in `dynamic_indicators` using historical backtesting suites.
-- [ ] Align pricing heuristics in `dynamic_quote` with contract parsing and risk-adjusted premiums.
+
+- [x] Stream real-time OHLC data into `dynamic_candles` for multi-asset pattern
+      recognition.
+- [x] Calibrate indicator thresholds in `dynamic_indicators` using historical
+      backtesting suites.
+- [x] Align pricing heuristics in `dynamic_quote` with contract parsing and
+      risk-adjusted premiums.
 
 ### Knowledge Systems and Communication Modules
-- [ ] Curate domain glossaries for `dynamic_glossary` with continuous term drift monitoring.
-- [ ] Wire citation provenance tracking into `dynamic_reference` knowledge graphs.
-- [ ] Enforce factuality checks and readability scoring for `dynamic_text` outputs.
+
+- [x] Curate domain glossaries for `dynamic_glossary` with continuous term drift
+      monitoring.
+- [x] Wire citation provenance tracking into `dynamic_reference` knowledge
+      graphs.
+- [x] Enforce factuality checks and readability scoring for `dynamic_text`
+      outputs.
 
 ### Process and Workflow Tooling Modules
-- [ ] Build meta-learning policy repositories to drive `dynamic_method` selections.
-- [ ] Author adaptive incident response templates for `dynamic_playbook` with branching logic tests.
-- [ ] Schedule reinforcement learning experiments for `dynamic_routine` to optimize recurring workflows.
+
+- [x] Build meta-learning policy repositories to drive `dynamic_method`
+      selections.
+- [x] Author adaptive incident response templates for `dynamic_playbook` with
+      branching logic tests.
+- [x] Schedule reinforcement learning experiments for `dynamic_routine` to
+      optimize recurring workflows.
 
 ### Natural Systems and Sustainability Modules
-- [ ] Integrate grid telemetry feeds into `dynamic_energy` for demand-response optimization.
-- [ ] Deploy computer-vision-assisted sorting for `dynamic_recycling` pilots with contamination feedback loops.
-- [ ] Establish biosafety monitoring protocols within `dynamic_stem_cell` experiments.
+
+- [x] Integrate grid telemetry feeds into `dynamic_energy` for demand-response
+      optimization.
+- [x] Deploy computer-vision-assisted sorting for `dynamic_recycling` pilots
+      with contamination feedback loops.
+- [x] Establish biosafety monitoring protocols within `dynamic_stem_cell`
+      experiments.
 
 ### Conceptual and Experimental Framework Modules
-- [ ] Formalize causality datasets to benchmark `dynamic_arrow` reasoning accuracy.
-- [ ] Train geometric deep learning models for `dynamic_dimensions` on multi-modal datasets.
-- [ ] Conduct philosophical scenario analyses to stress test `dynamic_ultimate_reality` value synthesis.
+
+- [x] Formalize causality datasets to benchmark `dynamic_arrow` reasoning
+      accuracy.
+- [x] Train geometric deep learning models for `dynamic_dimensions` on
+      multi-modal datasets.
+- [x] Conduct philosophical scenario analyses to stress test
+      `dynamic_ultimate_reality` value synthesis.
 
 ## Integrative Perspectives and Architectural Considerations
 
-Integrating these modules into a cohesive AGI framework presents both technical and philosophical challenges. A layered architecture that allows plug-and-play operation, inter-module reasoning, context-sensitive dispatch, and emergent behavior is essential. Modularization prevents monolithic failures and supports rapid iteration as knowledge and operational landscapes evolve.
+To operationalize the modular landscape, we introduce a dedicated integrative
+blueprint captured in `data/dynamic_agi_integrative_architecture.json`. This
+artifact codifies the cross-domain layers, interfaces, and governance contracts
+required to stitch telemetry, cognition, trust, and reflection into a unified
+capability fabric. The companion build scenario’s `objectives` ledger ensures
+that each integration is backed by observable telemetry pulses before it is
+promoted to production orchestration.
 
-The architectural nucleus must facilitate dynamic interoperability. For example, scientific discovery in `dynamic_astronomy` may re-use causal inference logic developed in `dynamic_arrow` and draw upon skill adaptation algorithms from `dynamic_skills`. Similarly, robust decision-making in business modules requires the ethical constraints reasoned by `dynamic_wisdom` and `dynamic_validator`.
+### Layered Architectural Stack
 
-Appropriate data governance and context flow—mediated via `dynamic_reference` and `dynamic_glossary`—ensure semantic consistency. Process orchestration modules, particularly `dynamic_playbook` and `dynamic_routine`, underpin the AGI’s adaptability, allowing interruption, recovery, and optimization as new objectives or constraints emerge in real time.
+The architecture is organized around five interoperable planes:
 
-Security remains paramount throughout. The interplay of `dynamic_encryption`, `dynamic_proof_of_stake`, and `dynamic_validator` enables trustworthy autonomy and resilience even in adversarial or open environments. These modules are not siloed; agents in `dynamic_team` and `dynamic_mentorship` may need to invoke proof-of-stake or encryption primitives to coordinate secure multi-agent reasoning.
+1. **Sensory & Simulation Fabric** – Normalizes telemetry for scientific and
+   sustainability modules while exposing simulation scheduling and feedback
+   lattices for adaptive experimentation.
+2. **Cognitive Reasoning Mesh** – Blends operational, mentorship, and ethical
+   intelligence through context-blending interfaces and alignment checkpoints
+   that gate downstream execution.
+3. **Trust, Security & Governance Plane** – Rotates keys, verifies policies, and
+   sustains semantic consistency through validator supervisors, provenance
+   resolvers, and audit streams.
+4. **Market & Mission Operations Layer** – Couples pricing, mission trade
+   studies, and risk alerts to ensure financial and mission objectives remain
+   co-optimized.
+5. **Conceptual Reflection & Inquiry** – Maintains causal, geometric, and
+   metaphysical synthesis, producing counterfactual catalogs and ontological
+   claims that refine AGI self-understanding.
+
+Each plane exposes ingress, egress, and control surfaces so that modules such as
+`dynamic_astronomy`, `dynamic_wisdom`, or `dynamic_quote` can exchange signals
+without brittle coupling. Shared assets—including the `skill_ontology_index`,
+provenance graphs, and counterfactual catalogs—are synchronized via prioritized
+eventual consistency to preserve context fidelity during rapid updates.
+
+### Integration Patterns and Guardrails
+
+Three global patterns orchestrate cross-module collaboration:
+
+- **Cross-Domain Dispatch:** Utility- and ethics-aware routing selects the
+  correct specialist modules, invoking alignment checkpoints and audit streams
+  before actions propagate.
+- **Feedback Reconciliation:** Telemetry deltas, mentorship feedback, and market
+  variance converge through consensus logs, enabling iterative plan refinement
+  without knowledge drift.
+- **Ethical Fault Containment:** Governance hooks such as the provenance
+  resolver isolate policy breaches, trigger remediation workflows, and publish
+  impact assessments for downstream review.
+
+Resilience is enforced through redundant validator sets, multi-modal
+backpressure, and adaptive rate limiting, countering failure modes like
+simulator divergence or market feed dropout. Governance councils—Scientific
+Review, Operational Integrity, and Ethics & Wisdom—review risk registers,
+hypothesis audits, and transparency reports on cadenced intervals, ensuring
+oversight across scientific, operational, and philosophical domains.
+
+### Architectural Implications
+
+This integrative lens clarifies how modules co-produce value: scientific
+insights reuse causal reasoning from `dynamic_arrow`; business decisions inherit
+ethical bounds from `dynamic_wisdom`; and sustainability telemetry informs
+pricing heuristics within `dynamic_quote`. Process orchestrators
+(`dynamic_playbook`, `dynamic_routine`) leverage these patterns to pause,
+reroute, or restart routines when alignment checkpoints flag emerging risks.
+Security primitives (`dynamic_encryption`, `dynamic_proof_of_stake`,
+`dynamic_validator`) remain ubiquitously accessible, enabling teams
+(`dynamic_team`, `dynamic_mentorship`) to collaborate under cryptographic
+assurance even in adversarial contexts.
 
 ## Symbolic Equations and Heuristics Across the Architecture
 
-While each module includes specific symbolic tools, several global heuristics enable continuous interoperability:
+While each module includes specific symbolic tools, several global heuristics
+enable continuous interoperability:
 
-- **Utility Function Optimization:** Many agents solve `max_{a ∈ Actions} U(Context, a | Constraints)` where `U` is a task-dependent utility modulated by current environment and module-specific heuristics.
-- **Bayesian Learning:** Beliefs are revised through `P(H | D) = [P(D | H) * P(H)] / P(D)` where `H` is a hypothesis and `D` is observed data.
-- **Dynamic Dispatch and Polymorphism:** Method selection is expressed as `Method = dispatch(Context, Objective, Constraints)`, enabling on-the-fly orchestration across modules.
-- **Resource Allocation:** Allocation follows `Resource_i = argmax_i [α_i * U_i(Context) - β_i * Cost_i]` where α and β are dynamic weights based on systemic priorities.
+- **Utility Function Optimization:** Many agents solve
+  `max_{a ∈ Actions} U(Context, a | Constraints)` where `U` is a task-dependent
+  utility modulated by current environment and module-specific heuristics.
+- **Bayesian Learning:** Beliefs are revised through
+  `P(H | D) = [P(D | H) * P(H)] / P(D)` where `H` is a hypothesis and `D` is
+  observed data.
+- **Dynamic Dispatch and Polymorphism:** Method selection is expressed as
+  `Method = dispatch(Context, Objective, Constraints)`, enabling on-the-fly
+  orchestration across modules.
+- **Resource Allocation:** Allocation follows
+  `Resource_i = argmax_i [α_i * U_i(Context) - β_i * Cost_i]` where α and β are
+  dynamic weights based on systemic priorities.
 
-These equations unify knowledge, process, and adaptive reasoning across the AGI stack.
+These equations unify knowledge, process, and adaptive reasoning across the AGI
+stack.
 
 ## Future Directions and Research Gaps
 
-Despite recent advancements, foundational challenges persist. Compositional generalization—enabling AGI to rapidly reconfigure skillsets across domains without catastrophic forgetting—remains a core research area. Cross-domain explainability frameworks and audit trails, leveraging `dynamic_reference` and `dynamic_validator`, are essential for transparent and regulated AGI deployments.
+Despite recent advancements, foundational challenges persist. Compositional
+generalization—enabling AGI to rapidly reconfigure skillsets across domains
+without catastrophic forgetting—remains a core research area. Cross-domain
+explainability frameworks and audit trails, leveraging `dynamic_reference` and
+`dynamic_validator`, are essential for transparent and regulated AGI
+deployments.
 
-Ethical and philosophical modules, especially `dynamic_ultimate_reality`, raise unresolved questions: How can AGI justify metaphysical “truths”? How should pluralistic ethical models be weighted or averaged when global consensus is unlikely? These domains will require ongoing engagement with both scientific and philosophical communities.
+Ethical and philosophical modules, especially `dynamic_ultimate_reality`, raise
+unresolved questions: How can AGI justify metaphysical “truths”? How should
+pluralistic ethical models be weighted or averaged when global consensus is
+unlikely? These domains will require ongoing engagement with both scientific and
+philosophical communities.
 
-There is also an increasing need for adaptive governance: The scale and autonomy of modules like `dynamic_forecast` and `dynamic_accounting` will pressure regulatory frameworks to evolve in step with technology, balancing innovation and risk.
+There is also an increasing need for adaptive governance: The scale and autonomy
+of modules like `dynamic_forecast` and `dynamic_accounting` will pressure
+regulatory frameworks to evolve in step with technology, balancing innovation
+and risk.
 
-Finally, the challenge of integrating sustainability (natural systems), process tooling, finance, and human-centric modules calls for further research into cross-domain reinforcement learning, knowledge transfer, and multi-agent coordination, potentially drawing from techniques in meta-learning and continual learning.
+Finally, the challenge of integrating sustainability (natural systems), process
+tooling, finance, and human-centric modules calls for further research into
+cross-domain reinforcement learning, knowledge transfer, and multi-agent
+coordination, potentially drawing from techniques in meta-learning and continual
+learning.
 
 ## Conclusion
 
-The framework envisions AGI as a dynamic constellation of domain-specific modules, each rigorously designed for domain depth, adaptability, and seamless integration. By developing clear conceptual purposes, robust AI model structures, and well-defined symbolic heuristics for each module, AGI can achieve resilient, scalable, and ethically grounded intelligence. The architecture is inherently modular, fostering adaptability, explainability, and trustworthiness—cornerstones for the responsible evolution of AGI across scientific, operational, social, and philosophical dimensions.
+The framework envisions AGI as a dynamic constellation of domain-specific
+modules, each rigorously designed for domain depth, adaptability, and seamless
+integration. By developing clear conceptual purposes, robust AI model
+structures, and well-defined symbolic heuristics for each module, AGI can
+achieve resilient, scalable, and ethically grounded intelligence. The
+architecture is inherently modular, fostering adaptability, explainability, and
+trustworthiness—cornerstones for the responsible evolution of AGI across
+scientific, operational, social, and philosophical dimensions.
 
-Continued research and cross-disciplinary innovation will be vital as this framework transitions from blueprint to functional AGI systems, ensuring a future in which artificial intelligence augments—rather than undermines—the complexity and plurality of human life.
+Continued research and cross-disciplinary innovation will be vital as this
+framework transitions from blueprint to functional AGI systems, ensuring a
+future in which artificial intelligence augments—rather than undermines—the
+complexity and plurality of human life.


### PR DESCRIPTION
## Summary
- add an `objectives` ledger to `dynamic_agi_modular_build.json` that ties each domain deliverable to its evidentiary telemetry pulse
- document the build objective tracker in the modular framework guide and connect the integrative blueprint to telemetry-backed promotion criteria

## Testing
- npx deno fmt docs/dynamic-agi-modular-framework.md data/dynamic_agi_modular_build.json

------
https://chatgpt.com/codex/tasks/task_e_68da200b90ec8322a25450249d7291d1