### PR TITLE
Gracefully handle missing static landing snapshot

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -234,22 +234,29 @@ export default async function RootLayout(
     globalThis?.process?.env?.["STATIC_SNAPSHOT"] === "true";
 
   if (isStaticSnapshot) {
-    const { head, body, lang } = await getStaticLandingDocument();
-    return (
-      <html
-        lang={lang}
-        suppressHydrationWarning
-        className={fontClassName}
-        {...htmlAttributeDefaults}
-        data-theme={DEFAULT_THEME}
-      >
-        <head dangerouslySetInnerHTML={{ __html: ensureThemeAssets(head) }} />
-        <body
+    try {
+      const { head, body, lang } = await getStaticLandingDocument();
+      return (
+        <html
+          lang={lang}
           suppressHydrationWarning
-          dangerouslySetInnerHTML={{ __html: body }}
-        />
-      </html>
-    );
+          className={fontClassName}
+          {...htmlAttributeDefaults}
+          data-theme={DEFAULT_THEME}
+        >
+          <head dangerouslySetInnerHTML={{ __html: ensureThemeAssets(head) }} />
+          <body
+            suppressHydrationWarning
+            dangerouslySetInnerHTML={{ __html: body }}
+          />
+        </html>
+      );
+    } catch (error) {
+      console.error(
+        'Failed to load static landing snapshot markup. Falling back to dynamic layout rendering.',
+        error,
+      );
+    }
   }
 
   return (

--- a/apps/web/components/landing/StaticLandingPage.tsx
+++ b/apps/web/components/landing/StaticLandingPage.tsx
@@ -1,12 +1,22 @@
+import { LandingPageShell } from '@/components/landing/LandingPageShell';
 import { getStaticLandingDocument } from '@/lib/staticLanding';
 
 export async function StaticLandingPage() {
-  const { body } = await getStaticLandingDocument();
+  try {
+    const { body } = await getStaticLandingDocument();
 
-  return (
-    <div
-      suppressHydrationWarning
-      dangerouslySetInnerHTML={{ __html: body }}
-    />
-  );
+    return (
+      <div
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: body }}
+      />
+    );
+  } catch (error) {
+    console.error(
+      'Failed to load static landing snapshot. Rendering dynamic shell instead.',
+      error,
+    );
+
+    return <LandingPageShell chromaBackgroundVariant="liquid" />;
+  }
 }


### PR DESCRIPTION
## Summary
- wrap the static snapshot rendering in layout with a try/catch so we fall back to the dynamic layout when the exported markup is missing
- update the StaticLandingPage helper to log failures when the snapshot cannot be read and render the interactive LandingPageShell as a fallback

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68da25ae167c832285548f93f23e1202