### PR TITLE
Add log for Dynamic AI build execution

### DIFF
--- a/docs/dynamic-ai-build-run-2025-09-29.md
+++ b/docs/dynamic-ai-build-run-2025-09-29.md
@@ -1,0 +1,29 @@
+# Dynamic AI Build Run — 2025-09-29
+
+This log captures the repository build requested via `npm run build:dynamic-ai`
+on 2025-09-29.
+
+## Command
+
+```bash
+npm run build:dynamic-ai
+```
+
+## Outcome
+
+- The helper executed all four Dynamic AI phases (Foundations, Memory &
+  Retrieval, Procedures & Routing, Ops & Governance).
+- Each phase invoked the standard web and landing production builds. Timezone
+  synchronization and environment default warnings surfaced but were
+  non-blocking.
+- The run completed successfully and refreshed the cached landing snapshot in
+  `_static/`.
+
+## Notable Console Messages
+
+- Timezone synchronization attempts failed because `systemd` and `chronyc` are
+  unavailable inside the container; the script continued after reporting the
+  warnings.
+- Default values were applied for `NEXT_PUBLIC_SITE_URL`, `MINIAPP_ORIGIN`, and
+  `ALLOWED_ORIGINS` to keep the Next.js build deterministic.
+- Final status message: `Dynamic AI build phases completed successfully.`


### PR DESCRIPTION
## Summary
- add a documentation log capturing the 2025-09-29 execution of `npm run build:dynamic-ai`
- note the four build phases, repeated warnings, and successful completion for future reference

## Testing
- npm run build:dynamic-ai

------
https://chatgpt.com/codex/tasks/task_e_68da4f000dc483229454f11529d19010