### PR TITLE
Document external reasoning framework references

### DIFF
--- a/docs/dynamic-ai-core-architecture.md
+++ b/docs/dynamic-ai-core-architecture.md
@@ -120,6 +120,136 @@ help schedulers rebalance warps before bottlenecks manifest while preserving the
 preferred synergy pairings (e.g., Grok↔MiniMax M1 for reactive hedging or
 DeepSeek-V3↔Kimi K2 for exploratory macro narratives).
 
+### External Reasoning Framework References
+
+To complement the native adapter roster, Dynamic AI maintains direct
+integration guides for prominent open-source reasoning frameworks. These
+references help operators evaluate when to dispatch workloads to specialised
+stacks and provide a single source of truth for onboarding playbooks:
+
+- **[AutoGPT — Autonomous Task Orchestration](https://github.com/Significant-Gravitas/AutoGPT):**
+  Mission-driven planner that expands prompts into auditable multi-step
+  execution graphs, ideal when market hypotheses require chained research or
+  compliance reviews.
+- **[SuperAGI — Collaborative Agent Workforce](https://github.com/TransformerOptimus/SuperAGI):**
+  Debate-centric framework that coordinates persona-driven agents to stress test
+  trades, enforce guardrails, and surface consensus rationale before execution.
+- **[Hugging Face Transformers — Foundation Reasoning Stack](https://huggingface.co/docs/transformers/index):**
+  Library of reproducible checkpoints and tooling that powers bespoke reasoning
+  adapters with transparent benchmarking and controllable deployment pipelines.
+- **[LangChain — Tooling and Memory Bridge](https://www.langchain.com/):**
+  Graph-based orchestration layer that links tools, memories, and reasoning
+  adapters, ensuring telemetry-complete workflows across ingestion, analysis,
+  and execution.
+
+### Internal Adapter Extensions
+
+Dynamic AI keeps external frameworks self-contained by wrapping them as
+internal adapters with reproducible guardrails. Every adapter implementation is
+reviewed with the same step-by-step activation loop so schedulers can treat them
+like any other model while still gaining the specialised behaviours they
+provide.
+
+**Adapter activation loop**
+
+1. **Ingest capabilities.** Parse each framework’s planning graph or model
+   metadata and register a deterministic signature (`max_context`, `tooling`,
+   `persona`, `cost_profile`).
+2. **Instrument guardrails.** Bind throttle limits, sandboxed credentials, and
+   replay logging into the control plane policies so payloads remain auditable.
+3. **Expose payload contracts.** Convert framework responses into the
+   `ReasoningAdapter` schema and issue schema regression tests before an SM is
+   allowed to schedule the adapter.
+4. **Run soak validation.** Execute 500+ dry-run traces per adapter inside a
+   staging SM to capture tail latencies, prompt drift, and unexpected tool
+   excursions before production rollout.
+
+#### [AutoGPT — Autonomous Task Orchestration](https://github.com/Significant-Gravitas/AutoGPT)
+
+**Implementation steps**
+
+1. Import AutoGPT mission templates into the adapter registry and snapshot them
+   as versioned mission graphs.
+2. Configure the SM scheduler to request AutoGPT only when scenarios flag
+   `requires_chained_research = true` or when compliance depth exceeds the
+   threshold set by governance.
+3. Wrap AutoGPT tool calls (web search, compliance API, risk ledger) inside the
+   Dynamic AI tool proxy so secrets never leave the sandbox.
+
+**Optimization levers**
+
+- Cache mission graphs keyed by market regime to bypass redundant planning
+  steps during live trading bursts.
+- Prefetch AutoGPT context windows in the ingress layer whenever the dispatcher
+  detects correlated alerts, reducing perceived latency for multi-instrument
+  events.
+- Record mission deltas after each run so AutoGPT can be hot-reloaded with new
+  guardrails without re-running the entire soak battery.
+
+#### [SuperAGI — Collaborative Agent Workforce](https://github.com/TransformerOptimus/SuperAGI)
+
+**Implementation steps**
+
+1. Map SuperAGI personas (TradingAgent, TreasuryAgent, MentorAgent) to Dynamic
+   Capital risk governors and persist the mapping in the control plane registry.
+2. Use the consensus microservice to launch SuperAGI debates as deterministic
+   batches, ensuring each persona receives the same market snapshot.
+3. Convert SuperAGI voting outcomes into `ConsensusFrame` payloads so the
+   egress layer can reconcile them with DynamicFusion consensus logic.
+
+**Optimization levers**
+
+- Enable persona-level telemetry sampling to identify when debates stall or
+  loop, then auto-trim underperforming personas during peak load.
+- Compress SuperAGI conversation logs using the shared scratchpad codecs to
+  reduce HBM pressure during large-scale debates.
+- Store persona state snapshots per SM so a stalled warp can be rescheduled
+  without rehydrating SuperAGI from scratch.
+
+#### [Hugging Face Transformers — Foundation Reasoning Stack](https://huggingface.co/docs/transformers/index)
+
+**Implementation steps**
+
+1. Register a curated set of checkpoints (LLM360, Qwen, DeepSeek) with latency
+   and VRAM metadata to inform routing heuristics.
+2. Ship weight files through the internal artifact registry and verify hashes
+   before and after deployment to guarantee deterministic inference.
+3. Mount the tokenizer cache inside each SM’s shared scratchpad to avoid
+   duplicate preprocessing work across micro-cores.
+
+**Optimization levers**
+
+- Auto-benchmark each checkpoint weekly and feed the results into the routing
+  heuristics so schedulers can downgrade or upgrade models dynamically.
+- Use low-rank adapters (LoRA) for scenario-specific fine-tuning while keeping
+  the base checkpoint immutable for fast rollbacks.
+- Stage quantized variants (int8, int4) for burst handling when premium VRAM is
+  constrained.
+
+#### [LangChain — Tooling and Memory Bridge](https://www.langchain.com/)
+
+**Implementation steps**
+
+1. Compile LangChain graphs into deterministic manifests that list approved
+   tools, expected inputs, and rate limits.
+2. Connect the manifests to the Dynamic AI tool proxy so invocation telemetry is
+   published alongside adapter usage statistics.
+3. Configure memory modules (vector stores, Redis caches) to align with the
+   `PreparedMarketContext` schema, preventing schema drift across adapters.
+
+**Optimization levers**
+
+- Prefetch tool responses for high-frequency signals using LangChain’s async
+  executors tied to the ingress buffer.
+- Rotate secrets and API tokens through the control plane to keep sandboxed tool
+  chains evergreen without manual restarts.
+- Run continuous contract tests that replay archived prompts to detect when a
+  downstream tool silently changes its response format.
+
+With these wrappers and control points, the orchestration fabric can upgrade or
+swap underlying frameworks without touching micro-core logic; SMs simply receive
+updated adapter metadata during the control plane’s regular registry refresh.
+
 ### Adapter Cohort Advantages and Trade-offs
 
 | Adapter     | Core Advantages                                             | Key Trade-offs                                             | Ideal Pairings                                  |

--- a/docs/dynamic_agi_starter_stack.md
+++ b/docs/dynamic_agi_starter_stack.md
@@ -5,7 +5,7 @@ AGI training pipeline while staying approachable for new contributors and end
 users. The components below balance orchestration, reasoning, quantum
 experimentation, and governance.
 
-## 1. LangChain — Orchestration Layer
+## 1. [LangChain — Orchestration Layer](https://www.langchain.com/)
 
 - **Role:** Acts as the "nervous system" that chains models, memory, and tools.
 - **Why it matters:** Normalizes incoming signals, manages conversational
@@ -14,32 +14,101 @@ experimentation, and governance.
 - **Dynamic Capital use case:** Wrap TradingView alerts and MetaTrader 5 (MT5)
   logs into structured prompts before handing them to downstream reasoning
   agents.
+- **Implementation steps:**
+  1. Define LangChain `RunnableSequence` graphs for ingestion, reasoning, and
+     post-processing; store manifests in version control with schema contracts.
+  2. Connect the graphs to Dynamic AI’s tool proxy so TradingView webhooks and
+     MT5 logs are normalized with shared validators.
+  3. Add regression notebooks that replay archived market events through each
+     graph to detect prompt drift before deployment.
+- **Optimization tips:**
+  - Cache frequently accessed embeddings in the vector store to reduce latency
+    during high-frequency trading windows.
+  - Use streaming callbacks to surface intermediate rationales to the control
+    plane for early anomaly detection.
 
-## 2. LLM360 / Hugging Face Transformers — Core Reasoning Models
+## 2. [AutoGPT — Autonomous Task Orchestration](https://github.com/Significant-Gravitas/AutoGPT)
+
+- **Role:** Acts as the autonomous mission planner that expands prompts into
+  sequenced research, tooling, and validation steps.
+- **Why it matters:** Creates deterministic action graphs the Dynamic AGI control
+  plane can score, trace, and replay.
+- **Dynamic Capital use case:** Drive multi-stage market investigations—news
+  scanning, liquidity checks, compliance sign-offs—before handing a decision to
+  downstream agents.
+- **Implementation steps:**
+  1. Template AutoGPT mission definitions for core market scenarios and publish
+     them to the adapter registry with semantic versioning.
+  2. Configure guardrails that require human approval when a mission requests
+     privileged tooling or exceeds the compliance depth threshold.
+  3. Integrate mission outputs with LangChain’s memory buffers so downstream
+     agents inherit the structured context automatically.
+- **Optimization tips:**
+  - Prefetch mission graphs during pre-market hours so live signals only trigger
+    execution, not compilation.
+  - Capture telemetry on token usage per mission to refine when AutoGPT should
+    be invoked versus lighter-weight planners.
+
+## 3. [LLM360 / Hugging Face Transformers — Core Reasoning Models](https://huggingface.co/docs/transformers/index)
 
 - **Role:** Provide open-source large language models for decision intelligence.
 - **Why it matters:** These models are transparent, fine-tunable, and auditable,
   avoiding reliance on closed APIs.
 - **Dynamic Capital use case:** Train and adapt models on mentorship
   transcripts, trade rationales, and localized Maldivian market content.
+- **Implementation steps:**
+  1. Select baseline checkpoints for multilingual reasoning, structured
+     analysis, and low-latency routing; document benchmark scores per target
+     task.
+  2. Fine-tune using LoRA adapters stored in the internal artifact registry so
+     rollbacks remain instant.
+  3. Deploy inference endpoints behind the Dynamic AI scheduler with autoscaling
+     rules tuned for expected throughput.
+- **Optimization tips:**
+  - Enable mixed-precision inference to reduce VRAM consumption while retaining
+    accuracy.
+  - Schedule nightly evaluation jobs that replay curated market transcripts to
+    detect performance regression.
 
-## 3. SuperAGI — Autonomous Agent Framework
+## 4. [SuperAGI — Autonomous Agent Framework](https://github.com/TransformerOptimus/SuperAGI)
 
 - **Role:** Supplies multi-agent planning, execution, and self-improvement APIs.
 - **Why it matters:** Enables specialized personas such as TradingAgent,
   TreasuryAgent, and MentorAgent that collaborate and enforce guardrails.
 - **Dynamic Capital use case:** Facilitate agent debates over market signals,
   apply governance policies, and require consensus before execution.
+- **Implementation steps:**
+  1. Map each SuperAGI persona to Dynamic Capital governance policies and store
+     the mapping in the control plane registry.
+  2. Configure debate workflows that fan out LangChain-normalized contexts to
+     persona-specific prompts.
+  3. Route consensus outputs through AutoGPT or LangChain post-processors to
+     maintain a single reasoning ledger.
+- **Optimization tips:**
+  - Enable adaptive debate depth: shorten loops during low-risk trades and
+    expand debates for high-risk exposures.
+  - Use structured logging so stalled debates can be replayed and trimmed
+    quickly.
 
-## 4. PennyLane / TensorFlow Quantum — Quantum Integration
+## 5. PennyLane / TensorFlow Quantum — Quantum Integration
 
 - **Role:** Deliver hybrid quantum-classical machine learning interfaces.
 - **Why it matters:** Supports the "quantum sequences" vision by encoding
   conviction, risk, and volatility as quantum states.
 - **Dynamic Capital use case:** Optimize lot sizing, slippage prediction, and
   portfolio allocation with variational quantum circuits.
+- **Implementation steps:**
+  1. Start with simulator backends to validate circuit templates before hitting
+     real quantum hardware.
+  2. Convert AutoGPT or SuperAGI recommendations into parameterized quantum
+     features (risk bands, volatility bins, conviction scores).
+  3. Feed optimized parameters back into Dynamic Task Automation via LangChain
+     callbacks.
+- **Optimization tips:**
+  - Cache circuit compilation artifacts to shrink iteration time.
+  - Schedule hardware runs during off-peak windows to minimize queue delays.
 
-## 5. SingularityNET — Governance & Marketplace
+## 6. SingularityNET — Governance & Marketplace
 
 - **Role:** Offers a decentralized marketplace and governance fabric for AI
   services.
@@ -47,22 +116,38 @@ experimentation, and governance.
   transparent governance workflows.
 - **Dynamic Capital use case:** Log AGI rationales on-chain, reward mentors, and
   enforce DCT tokenomics with auditable trails.
+- **Implementation steps:**
+  1. Register Dynamic Capital services within the SingularityNET marketplace and
+     map each to the relevant governance policy.
+  2. Stream reasoning metadata (mission IDs, consensus outcomes, quantum
+     modifiers) into on-chain events for auditability.
+  3. Wire payouts and staking flows into the DCT treasury smart contracts with
+     automated reconciliation jobs.
+- **Optimization tips:**
+  - Batch on-chain writes when possible to reduce gas consumption.
+  - Mirror key events into the internal telemetry lake for cross-checking and
+    faster incident response.
 
 ## Integration Flow
 
-```
-TradingView / MT5
-   ↓ (signal normalization via LangChain)
-SuperAGI multi-agent debate
-   ↓ (rationale scoring)
-LLM360 / Hugging Face reasoning
-   ↓ (decision outputs)
-PennyLane / TensorFlow Quantum optimization
-   ↓ (execution modifiers)
-Dynamic Task Automation (order routing)
-   ↓
-SingularityNET / DCT governance + tokenomics synchronization
-```
+1. **TradingView / MT5 ingestion.** Normalize alerts through LangChain graphs
+   with schema validation and telemetry hooks.
+2. **AutoGPT mission planning.** Expand qualified signals into deterministic
+   action graphs and stage compliance checkpoints.
+3. **SuperAGI consensus.** Launch persona debates that critique mission steps
+   and surface guardrail conflicts.
+4. **LLM360 / Hugging Face reasoning.** Execute fine-tuned models to narrate
+   final rationales and produce structured decisions.
+5. **PennyLane / TensorFlow Quantum optimization.** Translate mission outputs
+   into quantum parameter sweeps that optimize position sizing.
+6. **Dynamic Task Automation.** Route approved decisions to execution bridges
+   while logging rationale hashes for auditability.
+7. **SingularityNET governance.** Emit on-chain events, distribute incentives,
+   and close the feedback loop with compliance reporting.
+
+> **Implementation review tip:** After each deployment pass through the flow in
+> a staging environment and confirm telemetry exists for every hand-off before
+> promoting to production.
 
 ## Beginner-Friendly Mini App Layer
 
@@ -79,11 +164,16 @@ SingularityNET / DCT governance + tokenomics synchronization
 
 ## Next Steps
 
-- [ ] Prototype LangChain chains that ingest TradingView webhooks and MT5 logs.
-- [ ] Stand up SuperAGI agents with clear guardrails and voting logic.
+- [ ] Prototype LangChain chains that ingest TradingView webhooks and MT5 logs,
+      including regression notebooks for replay testing.
+- [ ] Configure AutoGPT mission templates for liquidity sweeps and compliance
+      attestations with guardrail thresholds documented.
+- [ ] Stand up SuperAGI agents with clear guardrails, voting logic, and debate
+      telemetry sampling.
 - [ ] Evaluate LLM360 or Hugging Face checkpoints aligned with Dynamic Capital's
-      domain language.
+      domain language and capture benchmark baselines.
 - [ ] Explore PennyLane tutorials for variational quantum circuit design
-      tailored to trading strategies.
+      tailored to trading strategies, starting with simulator runs.
 - [ ] Define SingularityNET workflows for recording rationale metadata and
-      distributing DCT incentives.
+      distributing DCT incentives, including batching strategies for gas
+      optimization.


### PR DESCRIPTION
## Summary
- add an External Reasoning Framework References section to the Dynamic AI core architecture guide with official links for AutoGPT, SuperAGI, Hugging Face Transformers, and LangChain

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da780f9c7083228a24b267fe20b559