### PR TITLE
Fix reverse Dhivehi transliteration digraph handling

### DIFF
--- a/tools/dhivehi/transliteration.ts
+++ b/tools/dhivehi/transliteration.ts
@@ -154,26 +154,54 @@ for (
   }
 }
 
+const ORDERED_REVERSE_SEQUENCES = Array.from(REVERSE_RULES.keys())
+  .map((sequence) => ({
+    sequence,
+    length: Array.from(sequence).length,
+  }))
+  .sort((a, b) => b.length - a.length);
+
 export function transliterateThaanaToLatin(
   input: string,
   options: ReverseTransliterationOptions = {},
 ): string {
   const { preserveUnknown = true } = options;
   let output = "";
+  const thaanaChars = Array.from(input);
+  let cursor = 0;
 
-  for (const char of input) {
-    const latin = REVERSE_RULES.get(char);
+  while (cursor < thaanaChars.length) {
+    let matched = false;
 
-    if (latin) {
-      output += latin;
+    for (const { sequence, length } of ORDERED_REVERSE_SEQUENCES) {
+      if (cursor + length > thaanaChars.length) {
+        continue;
+      }
+
+      const candidate = thaanaChars.slice(cursor, cursor + length).join("");
+
+      if (candidate === sequence) {
+        const latin = REVERSE_RULES.get(sequence);
+
+        if (latin) {
+          output += latin;
+        }
+
+        cursor += length;
+        matched = true;
+        break;
+      }
+    }
+
+    if (matched) {
       continue;
     }
 
-    if (!preserveUnknown) {
-      continue;
+    if (preserveUnknown) {
+      output += thaanaChars[cursor];
     }
 
-    output += char;
+    cursor += 1;
   }
 
   return output;


### PR DESCRIPTION
## Summary
- add Dhivehi transliteration, translation memory, and glossary utilities under tools/dhivehi with a seed terminology dataset
- add targeted Deno test coverage for transliteration, translation memory, and glossary search behaviour
- document the new utilities inside the Dhivehi language processing playbook so delivery checklists reference the shared tooling
- ensure reverse transliteration scans for the longest Thaana sequences so digraphs round-trip correctly

## Testing
- npm run lint
- npm run typecheck
- $(bash scripts/deno_bin.sh) test --no-npm tests/dhivehi


------
https://chatgpt.com/codex/tasks/task_e_68da80010570832295055b95308dd0c6