### PR TITLE
Add dynamic quantum engine orchestration

### DIFF
--- a/dynamic_engines/__init__.py
+++ b/dynamic_engines/__init__.py
@@ -182,6 +182,12 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "PredictiveScenario",
     ),
     "dynamic_quote": ("DynamicQuote",),
+    "dynamic_quantum.engine": (
+        "DynamicQuantumEngine",
+        "QuantumEnvironment",
+        "QuantumPulse",
+        "QuantumResonanceFrame",
+    ),
     "dynamic_reference": ("DynamicReference",),
     "dynamic_script": ("DynamicScriptEngine",),
     "dynamic_self_awareness": ("DynamicSelfAwareness",),

--- a/dynamic_quantum/__init__.py
+++ b/dynamic_quantum/__init__.py
@@ -1,0 +1,17 @@
+"""Quantum orchestration primitives for Dynamic Capital."""
+
+from __future__ import annotations
+
+from .engine import (
+    DynamicQuantumEngine,
+    QuantumEnvironment,
+    QuantumPulse,
+    QuantumResonanceFrame,
+)
+
+__all__ = [
+    "DynamicQuantumEngine",
+    "QuantumEnvironment",
+    "QuantumPulse",
+    "QuantumResonanceFrame",
+]

--- a/dynamic_quantum/engine.py
+++ b/dynamic_quantum/engine.py
@@ -1,0 +1,263 @@
+"""Quantum resonance engine for orchestrating coherence across subsystems."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Deque, Iterable, Mapping, MutableSequence, Sequence
+
+__all__ = [
+    "QuantumPulse",
+    "QuantumEnvironment",
+    "QuantumResonanceFrame",
+    "DynamicQuantumEngine",
+]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise ValueError("text value must not be empty")
+    return cleaned
+
+
+def _normalise_tuple(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    normalised: MutableSequence[str] = []
+    for value in values:
+        cleaned = value.strip()
+        if cleaned:
+            normalised.append(cleaned)
+    return tuple(normalised)
+
+
+def _coerce_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+def _coerce_timestamp(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(slots=True)
+class QuantumPulse:
+    """Measurement pulse describing the state of a quantum subsystem."""
+
+    system: str
+    coherence: float
+    entanglement: float
+    temperature: float
+    flux: float = 0.0
+    phase_variance: float = 0.5
+    timestamp: datetime = field(default_factory=_utcnow)
+    annotations: Sequence[str] | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.system = _normalise_text(self.system)
+        self.coherence = _clamp(float(self.coherence))
+        self.entanglement = _clamp(float(self.entanglement))
+        self.temperature = float(self.temperature)
+        if self.temperature < 0:
+            raise ValueError("temperature must be non-negative")
+        self.flux = _clamp(float(self.flux), lower=-1.0, upper=1.0)
+        self.phase_variance = _clamp(float(self.phase_variance))
+        self.timestamp = _coerce_timestamp(self.timestamp)
+        self.annotations = _normalise_tuple(self.annotations)
+        self.metadata = _coerce_mapping(self.metadata)
+
+    @property
+    def stability_index(self) -> float:
+        """Composite signal representing how resilient the pulse appears."""
+
+        coherence_component = 0.5 * self.coherence
+        entanglement_component = 0.3 * self.entanglement
+        phase_component = 0.2 * (1.0 - self.phase_variance)
+        flux_penalty = 1.0 - (0.25 * abs(self.flux))
+        base = coherence_component + entanglement_component + phase_component
+        return _clamp(base * flux_penalty)
+
+    @property
+    def requires_cooling(self) -> bool:
+        return self.temperature >= 50.0
+
+
+@dataclass(slots=True)
+class QuantumEnvironment:
+    """Environmental posture applied when fusing quantum pulses."""
+
+    vacuum_pressure: float
+    background_noise: float
+    gravity_gradient: float
+    measurement_rate: float
+    thermal_load: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.vacuum_pressure = _clamp(float(self.vacuum_pressure))
+        self.background_noise = _clamp(float(self.background_noise))
+        self.gravity_gradient = _clamp(float(self.gravity_gradient))
+        self.measurement_rate = _clamp(float(self.measurement_rate))
+        self.thermal_load = _clamp(float(self.thermal_load))
+
+    @property
+    def is_fragile_vacuum(self) -> bool:
+        return self.vacuum_pressure < 0.5
+
+    @property
+    def is_measurement_aggressive(self) -> bool:
+        return self.measurement_rate > 0.65
+
+    @property
+    def requires_cooling(self) -> bool:
+        return self.thermal_load >= 0.6
+
+    @property
+    def is_noisy(self) -> bool:
+        return self.background_noise > 0.6
+
+
+@dataclass(slots=True)
+class QuantumResonanceFrame:
+    """Aggregated resonance view derived from recent pulses."""
+
+    mean_coherence: float
+    mean_entanglement: float
+    mean_flux: float
+    mean_phase_variance: float
+    stability_outlook: float
+    anomalies: tuple[str, ...]
+    recommended_actions: tuple[str, ...]
+
+
+class DynamicQuantumEngine:
+    """Synthesises quantum pulses into actionable resonance guidance."""
+
+    def __init__(self, *, window: int = 180, equilibrium_target: float = 0.72) -> None:
+        if window <= 0:
+            raise ValueError("window must be positive")
+        self._window = window
+        self._equilibrium_target = _clamp(float(equilibrium_target))
+        self._pulses: Deque[QuantumPulse] = deque(maxlen=window)
+
+    @property
+    def window(self) -> int:
+        return self._window
+
+    @property
+    def pulses(self) -> tuple[QuantumPulse, ...]:
+        return tuple(self._pulses)
+
+    def register_pulse(self, pulse: QuantumPulse | Mapping[str, object]) -> QuantumPulse:
+        if isinstance(pulse, Mapping):
+            pulse = QuantumPulse(**pulse)
+        elif not isinstance(pulse, QuantumPulse):  # pragma: no cover - defensive guard
+            raise TypeError("pulse must be a QuantumPulse or mapping")
+        self._pulses.append(pulse)
+        return pulse
+
+    def clear(self) -> None:
+        self._pulses.clear()
+
+    def synthesize_frame(self, environment: QuantumEnvironment | None = None) -> QuantumResonanceFrame:
+        if not self._pulses:
+            raise ValueError("no pulses registered")
+        pulses = self.pulses
+        mean_coherence = fmean(p.coherence for p in pulses)
+        mean_entanglement = fmean(p.entanglement for p in pulses)
+        mean_flux = fmean(p.flux for p in pulses)
+        mean_phase_variance = fmean(p.phase_variance for p in pulses)
+
+        stability_outlook = _clamp(
+            0.5 * mean_coherence
+            + 0.3 * mean_entanglement
+            + 0.2 * (1.0 - mean_phase_variance)
+            - 0.1 * abs(mean_flux)
+        )
+
+        anomalies: MutableSequence[str] = []
+        if mean_coherence < 0.45:
+            anomalies.append("coherence-drift")
+        if mean_entanglement < 0.4:
+            anomalies.append("entanglement-fragmentation")
+        if abs(mean_flux) > 0.75:
+            anomalies.append("flux-instability")
+        if mean_phase_variance > 0.65:
+            anomalies.append("phase-volatility")
+
+        recommendations: MutableSequence[str] = []
+        if not anomalies:
+            recommendations.append("maintain equilibrium protocols")
+        if "coherence-drift" in anomalies:
+            recommendations.append("amplify coherence stabilisers")
+        if "entanglement-fragmentation" in anomalies:
+            recommendations.append("expand entanglement lattice")
+        if "flux-instability" in anomalies:
+            recommendations.append("counter rotating flux vectors")
+        if "phase-volatility" in anomalies:
+            recommendations.append("rephase interferometers")
+
+        if environment is not None:
+            if environment.is_noisy:
+                recommendations.append("deploy adaptive shielding")
+            if environment.is_measurement_aggressive and mean_coherence < self._equilibrium_target:
+                recommendations.append("slow measurement cadence")
+            if environment.is_fragile_vacuum:
+                recommendations.append("increase vacuum integrity")
+            if environment.gravity_gradient > 0.55:
+                recommendations.append("recalibrate gravitational dampers")
+            if environment.requires_cooling and stability_outlook < self._equilibrium_target:
+                recommendations.append("engage cryogenic buffer")
+
+        unique_recommendations = tuple(dict.fromkeys(recommendations))
+
+        return QuantumResonanceFrame(
+            mean_coherence=mean_coherence,
+            mean_entanglement=mean_entanglement,
+            mean_flux=mean_flux,
+            mean_phase_variance=mean_phase_variance,
+            stability_outlook=stability_outlook,
+            anomalies=tuple(anomalies),
+            recommended_actions=unique_recommendations,
+        )
+
+    def estimate_decoherence(self, time_steps: int, environment: QuantumEnvironment) -> float:
+        if time_steps <= 0:
+            raise ValueError("time_steps must be positive")
+        if not self._pulses:
+            raise ValueError("no pulses registered")
+        latest = self._pulses[-1]
+        baseline = 1.0 - latest.coherence
+        env_pressure = (
+            0.35 * environment.background_noise
+            + 0.25 * environment.measurement_rate
+            + 0.2 * environment.gravity_gradient
+            + 0.2 * (1.0 - environment.vacuum_pressure)
+        )
+        scale = max(1.5, self._window / 15.0)
+        projected = baseline + env_pressure * (time_steps / (scale * 10.0))
+        return _clamp(projected)
+
+    def iter_recent(self, limit: int | None = None) -> Iterable[QuantumPulse]:
+        if limit is None or limit >= len(self._pulses):
+            yield from self._pulses
+        else:
+            count = max(0, limit)
+            for index in range(1, count + 1):
+                yield self._pulses[-index]

--- a/tests/test_dynamic_quantum_engine.py
+++ b/tests/test_dynamic_quantum_engine.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dynamic_quantum import (
+    DynamicQuantumEngine,
+    QuantumEnvironment,
+    QuantumPulse,
+)
+
+
+def test_quantum_pulse_normalisation() -> None:
+    timestamp = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    pulse = QuantumPulse(
+        system="  Core-Lattice  ",
+        coherence=0.92,
+        entanglement=0.84,
+        temperature=42.0,
+        flux=1.2,
+        phase_variance=0.33,
+        timestamp=timestamp,
+        annotations=("  alpha  ", ""),
+        metadata={"origin": "lab"},
+    )
+
+    assert pulse.system == "Core-Lattice"
+    assert pulse.flux == pytest.approx(1.0)
+    assert pulse.annotations == ("alpha",)
+    assert pulse.metadata == {"origin": "lab"}
+    assert 0.6 < pulse.stability_index < 1.0
+    assert not pulse.requires_cooling
+
+
+def test_quantum_engine_synthesize_frame_with_environment() -> None:
+    engine = DynamicQuantumEngine(window=5, equilibrium_target=0.7)
+    engine.register_pulse(
+        QuantumPulse(
+            system="alpha",
+            coherence=0.5,
+            entanglement=0.4,
+            temperature=38.0,
+            flux=0.2,
+            phase_variance=0.3,
+        )
+    )
+    engine.register_pulse(
+        QuantumPulse(
+            system="beta",
+            coherence=0.7,
+            entanglement=0.6,
+            temperature=41.0,
+            flux=-0.3,
+            phase_variance=0.2,
+        )
+    )
+    engine.register_pulse(
+        QuantumPulse(
+            system="gamma",
+            coherence=0.65,
+            entanglement=0.55,
+            temperature=36.0,
+            flux=0.1,
+            phase_variance=0.25,
+        )
+    )
+
+    environment = QuantumEnvironment(
+        vacuum_pressure=0.45,
+        background_noise=0.7,
+        gravity_gradient=0.4,
+        measurement_rate=0.75,
+        thermal_load=0.65,
+    )
+
+    frame = engine.synthesize_frame(environment=environment)
+
+    assert pytest.approx(frame.mean_coherence, rel=1e-6) == 0.6166666667
+    assert pytest.approx(frame.mean_entanglement, rel=1e-6) == 0.5166666667
+    assert pytest.approx(frame.mean_flux, abs=1e-9) == 0.0
+    assert pytest.approx(frame.mean_phase_variance, rel=1e-6) == 0.25
+    assert frame.anomalies == ()
+    assert frame.stability_outlook < 0.7
+    assert frame.recommended_actions == (
+        "maintain equilibrium protocols",
+        "deploy adaptive shielding",
+        "slow measurement cadence",
+        "increase vacuum integrity",
+        "engage cryogenic buffer",
+    )
+
+
+def test_quantum_engine_estimate_decoherence_projection() -> None:
+    engine = DynamicQuantumEngine(window=5)
+    engine.register_pulse(
+        QuantumPulse(
+            system="omega",
+            coherence=0.72,
+            entanglement=0.66,
+            temperature=44.0,
+            flux=0.05,
+            phase_variance=0.28,
+        )
+    )
+
+    environment = QuantumEnvironment(
+        vacuum_pressure=0.4,
+        background_noise=0.8,
+        gravity_gradient=0.6,
+        measurement_rate=0.85,
+        thermal_load=0.7,
+    )
+
+    decoherence = engine.estimate_decoherence(time_steps=3, environment=environment)
+
+    assert 0.4 < decoherence < 0.5


### PR DESCRIPTION
## Summary
- add a dedicated `dynamic_quantum` package that models quantum pulses, environments, and resonance frames
- surface the new engine through the legacy `dynamic_engines` compatibility map
- cover the quantum orchestration workflow with focused unit tests

## Testing
- npm run format
- npm run lint
- npm run typecheck
- pytest tests/test_dynamic_quantum_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68da814d05588322b545ad21f945f8d7