### PR TITLE
feat: extend trainer for instruction fine-tuning

### DIFF
--- a/docs/LLM_PIPELINE.md
+++ b/docs/LLM_PIPELINE.md
@@ -1,0 +1,97 @@
+# Dynamic Capital LLM Training Pipeline
+
+## Overview
+
+Dynamic Capital now supports multilingual, instruction-tuned fine-tuning
+workflows across Dhivehi and English datasets.  The pipeline is composed
+of three stages:
+
+1. **Corpus preprocessing** – deduplicate, language tag, and domain-label
+   raw JSONL/TXT sources with `ml/preprocess_corpus.py`.
+2. **Tokenizer training** – build a shared SentencePiece vocabulary with
+   `ml/tokenizer_builder.py` to capture Thaana script coverage and
+   trading/mentorship/gov tokens.
+3. **LoRA fine-tuning service** – submit curated datasets to the FastAPI
+   trainer (`trainer/main.py`) which now supports classification, causal
+   language modelling, and seq2seq instruction tuning.
+
+## Preprocess Raw Corpora
+
+```bash
+python ml/preprocess_corpus.py \
+  --input data/raw/*.jsonl data/maldives_news.txt \
+  --output data/processed/dhivehi_en.jsonl \
+  --languages en dv \
+  --min-characters 64
+```
+
+The CLI merges multiple corpora, applies MinHash + Bloom deduplication,
+performs language detection (Thaana-aware), and tags rows with domain
+labels (trading, mentorship, governance).  The output JSONL is compatible
+with the trainer service’s instruction schema (`prompt`, `context`,
+`response`, `language`, `tags`).
+
+## Train a Shared Tokenizer
+
+```bash
+python ml/tokenizer_builder.py \
+  --input data/processed/dhivehi_en.jsonl \
+  --output models/tokenizers/dhivehi_en \
+  --vocab-size 52000 \
+  --special-token "<trade_signal>" --special-token "<mentor_prompt>"
+```
+
+The tokenizer builder trains a SentencePiece unigram model, preserves a
+set of custom special tokens, and writes artifacts (`.model`, `.vocab`,
+`tokenizer_config.json`) that can be supplied to the trainer via the
+`tokenizer_path` hyperparameter.
+
+## Launch a Fine-Tuning Run
+
+```bash
+curl -X POST https://trainer.example.com/train \
+  -H "x-trainer-key: $TRAINER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "run_id": 42,
+        "model_name": "dhivehi-mentor",
+        "dataset_url": "https://storage.example.com/dhivehi_en.jsonl",
+        "webhook_url": "https://automation.example.com/trainer-hook",
+        "hyperparams": {
+          "base_model": "meta-llama/Llama-2-7b-hf",
+          "task_type": "causal",
+          "tokenizer_path": "models/tokenizers/dhivehi_en",
+          "epochs": 3,
+          "batch_size": 16,
+          "max_seq_length": 1024
+        }
+      }'
+```
+
+The trainer now returns generation-focused metrics including perplexity,
+BLEU/chrF scores, and a domain alignment score derived from Dynamic
+Capital keyword heuristics.
+
+## Environment Setup
+
+Install the Python dependencies required for preprocessing, tokenizer
+training, and the FastAPI trainer service:
+
+```bash
+pip install --upgrade "torch>=2.0" "transformers>=4.38" datasets peft \
+  fastapi uvicorn sacrebleu sentencepiece langdetect
+```
+
+Node-based tooling (linting, formatting, type-checking) relies on the
+repository’s package.json:
+
+```bash
+npm install
+```
+
+After installing dependencies you can execute regression tests for the
+trainer schema:
+
+```bash
+pytest tests_python/test_trainer_service_schema.py
+```

--- a/ml/preprocess_corpus.py
+++ b/ml/preprocess_corpus.py
@@ -1,0 +1,280 @@
+"""Multilingual corpus preprocessing pipeline for Dynamic Capital."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Sequence, Set
+
+try:  # pragma: no cover - optional dependency for richer language ID
+    from langdetect import DetectorFactory, LangDetectException, detect
+
+    DetectorFactory.seed = 42
+except ModuleNotFoundError:  # pragma: no cover - handled gracefully at runtime
+    detect = None  # type: ignore
+    LangDetectException = Exception  # type: ignore
+
+
+THAANA_RANGE = (0x0780, 0x07BF)
+
+DOMAIN_KEYWORDS: Dict[str, Sequence[str]] = {
+    "trading": ("buy", "sell", "market", "bullish", "bearish", "signal", "entry"),
+    "mentorship": ("mentor", "learning", "lesson", "guidance", "feedback", "practice"),
+    "governance": ("vote", "council", "charter", "constitution", "policy", "ethics"),
+}
+
+
+def _contains_thaana(text: str) -> bool:
+    return any(THAANA_RANGE[0] <= ord(char) <= THAANA_RANGE[1] for char in text)
+
+
+def detect_language(text: str, fallback: str = "en") -> str:
+    clean = text.strip()
+    if not clean:
+        return fallback
+    if detect is not None:
+        try:
+            return detect(clean)
+        except LangDetectException:
+            pass
+    if _contains_thaana(clean):
+        return "dv"
+    return fallback
+
+
+class BloomFilter:
+    """Simple Bloom filter implementation for deduplication checks."""
+
+    def __init__(self, capacity: int, error_rate: float = 0.01) -> None:
+        self.capacity = max(1, capacity)
+        self.error_rate = max(min(error_rate, 0.5), 1e-6)
+        size = -int(self.capacity * math.log(self.error_rate) / (math.log(2) ** 2))
+        self.size = max(size, 8)
+        self.num_hashes = max(int((self.size / self.capacity) * math.log(2)), 1)
+        self.bits = bytearray((self.size + 7) // 8)
+
+    def _hashes(self, text: str) -> Iterator[int]:
+        encoded = text.encode("utf-8")
+        for idx in range(self.num_hashes):
+            value = hash((idx, encoded)) % self.size
+            yield value
+
+    def add(self, text: str) -> None:
+        for value in self._hashes(text):
+            self.bits[value // 8] |= 1 << (value % 8)
+
+    def __contains__(self, text: str) -> bool:
+        return all(self.bits[value // 8] & (1 << (value % 8)) for value in self._hashes(text))
+
+
+class MinHashDeduper:
+    """Lightweight MinHash-style deduper based on token permutations."""
+
+    def __init__(self, permutations: int = 32) -> None:
+        self.permutations = permutations
+        self.seeds = [i * 2654435761 % (2**32) for i in range(permutations)]
+        self._signatures: Set[tuple[int, ...]] = set()
+
+    @staticmethod
+    def _tokenize(text: str) -> List[str]:
+        return re.findall(r"\w+", text.lower())
+
+    @staticmethod
+    def _hash(token: str, seed: int) -> int:
+        return hash((seed, token)) & 0xFFFFFFFF
+
+    def _signature(self, text: str) -> tuple[int, ...]:
+        tokens = self._tokenize(text)
+        if not tokens:
+            return tuple(0 for _ in range(self.permutations))
+        signature: List[int] = []
+        for seed in self.seeds:
+            signature.append(min(self._hash(token, seed) for token in tokens))
+        return tuple(signature)
+
+    def contains(self, text: str) -> bool:
+        return self._signature(text) in self._signatures
+
+    def add(self, text: str) -> None:
+        self._signatures.add(self._signature(text))
+
+
+class CorpusDeduper:
+    def __init__(self, capacity: int = 250_000) -> None:
+        self.bloom = BloomFilter(capacity)
+        self.minhash = MinHashDeduper()
+
+    def seen(self, text: str) -> bool:
+        normalized = text.lower()
+        if normalized in self.bloom and self.minhash.contains(normalized):
+            return True
+        self.bloom.add(normalized)
+        self.minhash.add(normalized)
+        return False
+
+
+def normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def iter_input_paths(paths: Sequence[Path]) -> Iterator[Path]:
+    for path in paths:
+        if path.is_dir():
+            yield from sorted(p for p in path.rglob("*") if p.is_file())
+        else:
+            yield path
+
+
+@dataclass
+class CorpusRecord:
+    prompt: str
+    response: str
+    context: str
+    language: str
+    tags: List[str]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "prompt": self.prompt,
+                "response": self.response,
+                "context": self.context,
+                "language": self.language,
+                "tags": self.tags,
+            },
+            ensure_ascii=False,
+        )
+
+
+def infer_tags(prompt: str, response: str, context: str) -> List[str]:
+    text = " ".join((prompt, response, context)).lower()
+    tags = [name for name, keywords in DOMAIN_KEYWORDS.items() if any(keyword in text for keyword in keywords)]
+    return tags or ["general"]
+
+
+def parse_payload(payload: Dict[str, object]) -> Optional[CorpusRecord]:
+    prompt_candidate = payload.get("prompt") or payload.get("instruction") or payload.get("input")
+    response_candidate = payload.get("response") or payload.get("output") or payload.get("answer")
+    context_candidate = payload.get("context") or payload.get("system") or payload.get("background")
+
+    prompt = normalize_whitespace(str(prompt_candidate)) if prompt_candidate else ""
+    response = normalize_whitespace(str(response_candidate)) if response_candidate else ""
+    context = normalize_whitespace(str(context_candidate)) if context_candidate else ""
+
+    if not prompt and response:
+        prompt = "Summarise the following content with Dhivehi and English perspectives."
+        context, response = response, response
+    elif prompt and not response:
+        response = ""
+
+    combined = " ".join((prompt, response, context)).strip()
+    if not combined:
+        return None
+
+    language = str(payload.get("language") or detect_language(combined)).lower()
+    tags = infer_tags(prompt, response, context)
+    return CorpusRecord(prompt=prompt, response=response, context=context, language=language, tags=tags)
+
+
+def iter_corpus_records(paths: Sequence[Path]) -> Iterator[CorpusRecord]:
+    for path in iter_input_paths(paths):
+        if path.suffix.lower() in {".json", ".jsonl"}:
+            with path.open("r", encoding="utf-8") as handle:
+                for raw in handle:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        payload = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(payload, dict):
+                        record = parse_payload(payload)
+                        if record:
+                            yield record
+                    elif isinstance(payload, str) and payload.strip():
+                        prompt = "Translate the following passage into a mentoring response."
+                        text = normalize_whitespace(payload)
+                        language = detect_language(text)
+                        tags = infer_tags(prompt, text, "")
+                        yield CorpusRecord(prompt=prompt, response=text, context="", language=language, tags=tags)
+        elif path.suffix.lower() in {".txt", ""}:
+            with path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = normalize_whitespace(line)
+                    if not line:
+                        continue
+                    prompt = "Provide bilingual mentorship advice for the following line."
+                    language = detect_language(line)
+                    tags = infer_tags(prompt, line, "")
+                    yield CorpusRecord(prompt=prompt, response=line, context="", language=language, tags=tags)
+
+
+def preprocess_corpus(
+    inputs: Sequence[Path],
+    output_path: Path,
+    *,
+    min_characters: int,
+    languages: Sequence[str],
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    deduper = CorpusDeduper()
+    filtered_languages = {lang.lower() for lang in languages}
+
+    with output_path.open("w", encoding="utf-8") as sink:
+        for record in iter_corpus_records(inputs):
+            combined = normalize_whitespace(" ".join((record.prompt, record.response, record.context)))
+            if len(combined) < min_characters:
+                continue
+            if record.language not in filtered_languages:
+                continue
+            if deduper.seen(combined):
+                continue
+            sink.write(record.to_json() + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Preprocess multilingual corpora for LLM training")
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="Paths to raw corpus files or directories",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination JSONL file compatible with the trainer service",
+    )
+    parser.add_argument(
+        "--min-characters",
+        type=int,
+        default=32,
+        help="Skip samples shorter than this threshold",
+    )
+    parser.add_argument(
+        "--languages",
+        nargs="+",
+        default=["en", "dv"],
+        help="Allowlisted language codes",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    preprocess_corpus(
+        args.input,
+        args.output,
+        min_characters=args.min_characters,
+        languages=args.languages,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/tokenizer_builder.py
+++ b/ml/tokenizer_builder.py
@@ -1,0 +1,186 @@
+"""SentencePiece tokenizer builder for Dhivehi/English corpora.
+
+This CLI trains a shared multilingual vocabulary tailored to Dynamic
+Capital's mentorship, trading, and governance domains.  It accepts plain
+text or JSONL files, extracts textual content, and writes SentencePiece
+artifacts under ``models/tokenizers/dhivehi_en`` by default.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Iterator, List, Sequence
+
+
+try:  # pragma: no cover - optional dependency resolved in runtime envs
+    import sentencepiece as spm  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - fail fast with guidance
+    raise SystemExit(
+        "The sentencepiece package is required. Install it with `pip install sentencepiece`."
+    ) from exc
+
+
+DEFAULT_SPECIAL_TOKENS: Sequence[str] = (
+    "<ctx>",
+    "<mentor>",
+    "<trade_long>",
+    "<trade_short>",
+    "<governance>",
+    "<analysis>",
+)
+
+
+def iter_text_from_path(path: Path) -> Iterator[str]:
+    """Yield text content from ``path`` supporting TXT and JSONL sources."""
+
+    if path.suffix.lower() in {".txt", ""}:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line:
+                    yield line
+        return
+
+    if path.suffix.lower() in {".json", ".jsonl"}:
+        with path.open("r", encoding="utf-8") as handle:
+            for raw in handle:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    payload = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict):
+                    for key in ("text", "prompt", "response", "context", "content"):
+                        value = payload.get(key)
+                        if isinstance(value, str) and value.strip():
+                            yield value.strip()
+                elif isinstance(payload, str) and payload.strip():
+                    yield payload.strip()
+        return
+
+    raise ValueError(f"Unsupported corpus format: {path}")
+
+
+def build_sentencepiece(
+    sources: Sequence[Path],
+    output_dir: Path,
+    *,
+    prefix: str,
+    vocab_size: int,
+    character_coverage: float,
+    special_tokens: Sequence[str],
+    max_lines: int | None,
+) -> None:
+    """Train a SentencePiece model from ``sources`` and write artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    collected: List[str] = []
+    for source in sources:
+        for text in iter_text_from_path(source):
+            collected.append(text)
+            if max_lines is not None and len(collected) >= max_lines:
+                break
+        if max_lines is not None and len(collected) >= max_lines:
+            break
+
+    if not collected:
+        raise SystemExit("No text rows found to train the tokenizer")
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".txt", delete=False) as handle:
+        for row in collected:
+            handle.write(row.replace("\n", " ").strip() + "\n")
+        corpus_path = Path(handle.name)
+
+    model_prefix = output_dir / prefix
+    spm.SentencePieceTrainer.train(
+        input=str(corpus_path),
+        model_prefix=str(model_prefix),
+        vocab_size=vocab_size,
+        model_type="unigram",
+        character_coverage=character_coverage,
+        user_defined_symbols=list(special_tokens),
+        shuffle_input_sentence=True,
+    )
+
+    tokenizer_config = {
+        "model_max_length": 1024,
+        "special_tokens_map": {
+            "additional_special_tokens": list(special_tokens),
+        },
+        "tokenizer_class": "SentencePieceUnigramTokenizer",
+    }
+    config_path = output_dir / "tokenizer_config.json"
+    config_path.write_text(json.dumps(tokenizer_config, indent=2), encoding="utf-8")
+
+    corpus_path.unlink(missing_ok=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a Dhivehi/English SentencePiece tokenizer")
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="Paths to TXT or JSONL files used for tokenizer training",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("models/tokenizers/dhivehi_en"),
+        help="Directory to store the tokenizer artifacts",
+    )
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        default="dhivehi_en",
+        help="Filename prefix for the SentencePiece model",
+    )
+    parser.add_argument(
+        "--vocab-size",
+        type=int,
+        default=48000,
+        help="Target vocabulary size",
+    )
+    parser.add_argument(
+        "--character-coverage",
+        type=float,
+        default=0.9995,
+        help="SentencePiece character coverage",
+    )
+    parser.add_argument(
+        "--special-token",
+        action="append",
+        dest="special_tokens",
+        default=list(DEFAULT_SPECIAL_TOKENS),
+        help="Additional special tokens to append (can be repeated)",
+    )
+    parser.add_argument(
+        "--max-lines",
+        type=int,
+        default=None,
+        help="Optional cap on the number of training lines for quick experiments",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    build_sentencepiece(
+        args.input,
+        args.output,
+        prefix=args.prefix,
+        vocab_size=args.vocab_size,
+        character_coverage=args.character_coverage,
+        special_tokens=tuple(dict.fromkeys(args.special_tokens)),
+        max_lines=args.max_lines,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tokenizers/.gitignore
+++ b/models/tokenizers/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests_python/test_trainer_service_schema.py
+++ b/tests_python/test_trainer_service_schema.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+pytest.importorskip("requests")
+pytest.importorskip("torch")
+pytest.importorskip("datasets")
+pytest.importorskip("transformers")
+pytest.importorskip("peft")
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic")
+
+from trainer.main import (
+    SupportedTaskType,
+    build_hf_dataset,
+    compute_domain_alignment,
+    compute_generation_scores,
+    format_instruction_example,
+    parse_rows,
+)
+
+
+def write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+
+def test_parse_rows_supports_instruction_and_language_detection(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "instruction.jsonl"
+    write_jsonl(
+        dataset_path,
+        [
+            {"prompt": "Provide a signal", "response": "Buy the breakout"},
+            {
+                "prompt": "ދިވެހި މަގު",
+                "response": "ހުޅުވުމަށް ނުވަތަ ހުޅުވާ",
+                "context": "ރަނގަޅު",
+            },
+        ],
+    )
+
+    rows = parse_rows(dataset_path, SupportedTaskType.CAUSAL_LM)
+
+    assert len(rows) == 2
+    assert rows[0]["language"] == "en"
+    assert rows[1]["language"] == "dv"
+
+    dataset = build_hf_dataset(rows, SupportedTaskType.CAUSAL_LM)
+    assert set(dataset["train"].column_names) == {"prompt", "context", "response", "language"}
+
+
+def test_parse_rows_supports_legacy_classification(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "classification.jsonl"
+    write_jsonl(
+        dataset_path,
+        [
+            {"input_text": "price falling", "label": "sell"},
+            {"input_text": "support holds", "label": "buy"},
+        ],
+    )
+
+    rows = parse_rows(dataset_path, SupportedTaskType.CLASSIFICATION)
+    dataset = build_hf_dataset(rows, SupportedTaskType.CLASSIFICATION)
+
+    assert set(dataset["train"].column_names) == {"text", "label"}
+    assert set(dataset["train"]["label"]) <= {0, 1}
+
+
+def test_format_instruction_example_includes_context_and_language() -> None:
+    formatted = format_instruction_example(
+        prompt="Explain tokenomics",
+        response="Discuss supply schedules",
+        context="DCT governance",
+        language="en",
+    )
+    assert "LANG=en" in formatted
+    assert "Context:" in formatted
+    assert "Response:" in formatted
+
+
+def test_compute_generation_scores_without_sacrebleu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("trainer.main._load_sacrebleu", lambda: None)
+    scores = compute_generation_scores(["buy low"], ["buy low"])
+    assert scores["bleu"] >= 100.0 - 1e-6
+    assert scores["chrf"] > 0.0
+
+
+def test_compute_domain_alignment_distinguishes_domains() -> None:
+    prompts = ["Provide trading advice", "Offer mentorship", "Explain governance"]
+    predictions = ["Sell the rally", "Give feedback", "Discuss council voting"]
+    score = compute_domain_alignment(prompts, predictions)
+    assert 0.5 < score <= 1.0

--- a/trainer/__init__.py
+++ b/trainer/__init__.py
@@ -1,0 +1,1 @@
+"""Dynamic Capital LoRA trainer service package."""

--- a/trainer/main.py
+++ b/trainer/main.py
@@ -7,24 +7,40 @@ import os
 import shutil
 import time
 from dataclasses import dataclass
+from enum import Enum
+import math
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
-import numpy as np
+try:  # pragma: no cover - numpy is optional for import-time compatibility
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal environments
+    class _NumpyShim:
+        @staticmethod
+        def argmax(values: Sequence[Sequence[float]], axis: int = 0) -> List[int]:
+            if axis != 1:
+                raise ValueError("_NumpyShim.argmax only supports axis=1")
+            return [max(range(len(row)), key=lambda idx: row[idx]) for row in values]
+
+    np = _NumpyShim()  # type: ignore
 import requests
 import torch
-from datasets import Dataset
+from datasets import Dataset, DatasetDict
 from fastapi import BackgroundTasks, Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field
 from torch.utils.data import Dataset as TorchDataset
 from transformers import (
     AutoModelForSequenceClassification,
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
     AutoTokenizer,
+    DataCollatorForLanguageModeling,
+    DataCollatorForSeq2Seq,
     Trainer,
     TrainingArguments,
 )
 
-from peft import LoraConfig, TaskType, get_peft_model
+from peft import LoraConfig, TaskType as PeftTaskType, get_peft_model
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +68,14 @@ app = FastAPI(title="Dynamic Capital Trainer", version="1.0.0")
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
+
+
+class SupportedTaskType(str, Enum):
+    CLASSIFICATION = "classification"
+    CAUSAL_LM = "causal"
+    SEQ2SEQ = "seq2seq"
+
+
 class HyperParams(BaseModel):
     base_model: str = Field(default="distilbert-base-uncased")
     epochs: int = Field(default=2, ge=1)
@@ -60,6 +84,10 @@ class HyperParams(BaseModel):
     warmup_ratio: float = Field(default=0.1, ge=0, le=0.5)
     weight_decay: float = Field(default=0.01, ge=0)
     gradient_accumulation_steps: int = Field(default=1, ge=1)
+    task_type: SupportedTaskType = Field(default=SupportedTaskType.CLASSIFICATION)
+    tokenizer_path: Optional[str] = Field(default=None)
+    max_seq_length: int = Field(default=1024, ge=64, le=4096)
+    eval_max_samples: int = Field(default=64, ge=1, le=512)
 
 
 class TrainRequest(BaseModel):
@@ -75,6 +103,67 @@ class PreparedDataset:
     train: TorchDataset
     eval: TorchDataset
     rows: int
+    raw_train: Dataset
+    raw_eval: Dataset
+
+
+THAANA_RANGE = (0x0780, 0x07BF)
+
+
+def _ensure_str(value: object, field: str, line_number: int) -> str:
+    if value is None:
+        raise ValueError(f"Missing '{field}' at line {line_number}")
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError(f"Empty '{field}' at line {line_number}")
+        return text
+    return str(value)
+
+
+def _contains_thaana(text: str) -> bool:
+    return any(THAANA_RANGE[0] <= ord(char) <= THAANA_RANGE[1] for char in text)
+
+
+def infer_language(prompt: str, response: str, provided: Optional[object]) -> str:
+    if provided:
+        return str(provided).lower()
+    combined = f"{prompt} {response}"
+    if _contains_thaana(combined):
+        return "dv"
+    return "en"
+
+
+def format_instruction_prompt(prompt: str, context: str = "", language: str = "") -> str:
+    segments: List[str] = []
+    lang = language.strip()
+    if lang:
+        segments.append(f"[LANG={lang}]")
+    ctx = context.strip()
+    if ctx:
+        segments.append(f"Context:\n{ctx}")
+    segments.append(f"Prompt:\n{prompt.strip()}")
+    return "\n\n".join(segments).strip()
+
+
+def format_instruction_example(
+    prompt: str,
+    response: str,
+    *,
+    context: str = "",
+    language: str = "",
+    tokenizer: Optional[AutoTokenizer] = None,
+    include_response: bool = True,
+) -> str:
+    body = format_instruction_prompt(prompt, context=context, language=language)
+    if not include_response:
+        return body
+
+    eos_token = getattr(tokenizer, "eos_token", None) if tokenizer is not None else None
+    suffix = "\n\nResponse:\n" + response.strip()
+    if eos_token:
+        suffix += eos_token
+    return body + suffix
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +189,7 @@ def download_dataset(url: str, run_id: int) -> Path:
     return local_path
 
 
-def parse_rows(path: Path) -> List[Dict[str, object]]:
+def parse_rows(path: Path, task_type: SupportedTaskType) -> List[Dict[str, object]]:
     rows: List[Dict[str, object]] = []
     with path.open("r", encoding="utf-8") as handle:
         for line_number, raw in enumerate(handle, start=1):
@@ -111,44 +200,181 @@ def parse_rows(path: Path) -> List[Dict[str, object]]:
                 payload = json.loads(raw)
             except json.JSONDecodeError as exc:
                 raise ValueError(f"Invalid JSONL at line {line_number}: {exc}") from exc
-            if "input_text" not in payload:
-                raise ValueError(f"Missing 'input_text' at line {line_number}")
-            if "label" not in payload:
-                raise ValueError(f"Missing 'label' at line {line_number}")
-            rows.append(payload)
+            if task_type is SupportedTaskType.CLASSIFICATION:
+                text = _ensure_str(payload.get("input_text"), "input_text", line_number)
+                if "label" not in payload:
+                    raise ValueError(f"Missing 'label' at line {line_number}")
+                rows.append({"input_text": text, "label": payload.get("label")})
+            else:
+                prompt_source = (
+                    payload.get("prompt")
+                    or payload.get("instruction")
+                    or payload.get("input")
+                )
+                response_source = (
+                    payload.get("response")
+                    or payload.get("output")
+                    or payload.get("answer")
+                )
+                if not prompt_source or not response_source:
+                    raise ValueError(
+                        f"Missing 'prompt'/'response' style keys at line {line_number}"
+                    )
+                prompt = _ensure_str(prompt_source, "prompt", line_number)
+                response = _ensure_str(response_source, "response", line_number)
+                context_value = (
+                    payload.get("context")
+                    or payload.get("system")
+                    or payload.get("background")
+                    or payload.get("history")
+                    or ""
+                )
+                context = str(context_value).strip()
+                language = infer_language(prompt, response, payload.get("language"))
+                rows.append(
+                    {
+                        "prompt": prompt,
+                        "response": response,
+                        "context": context,
+                        "language": language,
+                    }
+                )
     if not rows:
         raise ValueError("Dataset is empty")
     return rows
 
 
-def build_hf_dataset(rows: Iterable[Dict[str, object]]) -> Dataset:
-    texts: List[str] = []
-    labels: List[int] = []
+def build_hf_dataset(rows: Sequence[Mapping[str, object]], task_type: SupportedTaskType) -> DatasetDict:
+    if task_type is SupportedTaskType.CLASSIFICATION:
+        texts: List[str] = []
+        labels: List[int] = []
+        for row in rows:
+            label_value = str(row["label"]).lower().strip()
+            label = 0 if label_value in {"sell", "negative", "0"} else 1
+            texts.append(str(row["input_text"]))
+            labels.append(label)
+        dataset = Dataset.from_dict({"text": texts, "label": labels})
+        return dataset.train_test_split(test_size=0.2, seed=42)
+
+    prompts: List[str] = []
+    contexts: List[str] = []
+    responses: List[str] = []
+    languages: List[str] = []
     for row in rows:
-        label_value = str(row["label"]).lower().strip()
-        label = 0 if label_value in {"sell", "negative", "0"} else 1
-        texts.append(str(row["input_text"]))
-        labels.append(label)
-    dataset = Dataset.from_dict({"text": texts, "label": labels})
+        prompts.append(str(row["prompt"]))
+        contexts.append(str(row.get("context", "")))
+        responses.append(str(row["response"]))
+        languages.append(str(row.get("language", "")))
+    dataset = Dataset.from_dict(
+        {
+            "prompt": prompts,
+            "context": contexts,
+            "response": responses,
+            "language": languages,
+        }
+    )
     return dataset.train_test_split(test_size=0.2, seed=42)
 
 
-def tokenize_dataset(dataset: Dataset, tokenizer: AutoTokenizer) -> PreparedDataset:
-    def tokenize(batch: Dict[str, List[str]]) -> Dict[str, List[int]]:
-        return tokenizer(
-            batch["text"],
+def tokenize_dataset(
+    dataset: DatasetDict, tokenizer: AutoTokenizer, hparams: HyperParams
+) -> PreparedDataset:
+    raw_train = dataset["train"]
+    raw_eval = dataset["test"]
+
+    if hparams.task_type is SupportedTaskType.CLASSIFICATION:
+        def tokenize(batch: Dict[str, List[str]]) -> Dict[str, List[int]]:
+            return tokenizer(
+                batch["text"],
+                padding="max_length",
+                truncation=True,
+                max_length=min(hparams.max_seq_length, 512),
+            )
+
+        remove_columns = [column for column in raw_train.column_names if column != "label"]
+        tokenized = dataset.map(
+            tokenize,
+            batched=True,
+            remove_columns=remove_columns,
+        )
+        tokenized.set_format(type="torch", columns=["input_ids", "attention_mask", "label"])
+        total_rows = len(raw_train) + len(raw_eval)
+        return PreparedDataset(tokenized["train"], tokenized["test"], rows=total_rows, raw_train=raw_train, raw_eval=raw_eval)
+
+    if hparams.task_type is SupportedTaskType.CAUSAL_LM:
+        def tokenize(batch: Dict[str, List[str]]) -> Dict[str, List[Sequence[int]]]:
+            formatted = [
+                format_instruction_example(
+                    prompt=prompt,
+                    response=response,
+                    context=context,
+                    language=language,
+                    tokenizer=tokenizer,
+                )
+                for prompt, context, response, language in zip(
+                    batch["prompt"], batch["context"], batch["response"], batch["language"]
+                )
+            ]
+            model_inputs = tokenizer(
+                formatted,
+                padding="max_length",
+                truncation=True,
+                max_length=hparams.max_seq_length,
+            )
+            labels: List[List[int]] = []
+            for ids in model_inputs["input_ids"]:
+                if isinstance(ids, list):
+                    labels.append(ids.copy())
+                else:
+                    labels.append(list(ids))
+            model_inputs["labels"] = labels
+            return model_inputs
+
+        tokenized = dataset.map(
+            tokenize,
+            batched=True,
+            remove_columns=raw_train.column_names,
+        )
+        tokenized.set_format(type="torch", columns=["input_ids", "attention_mask", "labels"])
+        total_rows = len(raw_train) + len(raw_eval)
+        return PreparedDataset(tokenized["train"], tokenized["test"], rows=total_rows, raw_train=raw_train, raw_eval=raw_eval)
+
+    # Seq2Seq tokenization
+    def tokenize(batch: Dict[str, List[str]]) -> Dict[str, List[Sequence[int]]]:
+        inputs = [
+            format_instruction_prompt(prompt, context=context, language=language)
+            for prompt, context, language in zip(batch["prompt"], batch["context"], batch["language"])
+        ]
+        model_inputs = tokenizer(
+            inputs,
             padding="max_length",
             truncation=True,
-            max_length=128,
+            max_length=hparams.max_seq_length,
         )
+        with tokenizer.as_target_tokenizer():
+            labels = tokenizer(
+                batch["response"],
+                padding="max_length",
+                truncation=True,
+                max_length=hparams.max_seq_length,
+            )
+        model_inputs["labels"] = labels["input_ids"]
+        decoder_attention = labels.get("attention_mask")
+        if decoder_attention is not None:
+            model_inputs["decoder_attention_mask"] = decoder_attention
+        return model_inputs
 
-    tokenized = dataset.map(tokenize, batched=True)
-    tokenized.set_format(type="torch", columns=["input_ids", "attention_mask", "label"])
-    return PreparedDataset(
-        tokenized["train"],
-        tokenized["test"],
-        rows=len(dataset["train"]) + len(dataset["test"]),
+    tokenized = dataset.map(
+        tokenize,
+        batched=True,
+        remove_columns=raw_train.column_names,
     )
+    seq2seq_columns = ["input_ids", "attention_mask", "labels"]
+    if "decoder_attention_mask" in tokenized["train"].column_names:
+        seq2seq_columns.append("decoder_attention_mask")
+    tokenized.set_format(type="torch", columns=seq2seq_columns)
+    total_rows = len(raw_train) + len(raw_eval)
+    return PreparedDataset(tokenized["train"], tokenized["test"], rows=total_rows, raw_train=raw_train, raw_eval=raw_eval)
 
 
 def detect_lora_targets(model: torch.nn.Module) -> List[str]:
@@ -175,10 +401,38 @@ def build_trainer(
     tokenizer: AutoTokenizer,
 ) -> Trainer:
     base_model = hparams.base_model
-    LOG.info("Loading base model %s", base_model)
+    LOG.info("Loading base model %s for task %s", base_model, hparams.task_type.value)
 
-    model = AutoModelForSequenceClassification.from_pretrained(base_model, num_labels=2)
-    model.config.pad_token_id = tokenizer.pad_token_id
+    data_collator = None
+    compute_metrics = None
+
+    if hparams.task_type is SupportedTaskType.CLASSIFICATION:
+        model = AutoModelForSequenceClassification.from_pretrained(base_model, num_labels=2)
+        peft_task = PeftTaskType.SEQ_CLS
+
+        def classification_metrics(eval_pred):
+            predictions = np.argmax(eval_pred.predictions, axis=1)
+            labels = eval_pred.label_ids
+            accuracy = float((predictions == labels).mean())
+            return {"accuracy": accuracy}
+
+        compute_metrics = classification_metrics
+    elif hparams.task_type is SupportedTaskType.CAUSAL_LM:
+        model = AutoModelForCausalLM.from_pretrained(base_model)
+        peft_task = PeftTaskType.CAUSAL_LM
+        data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+    else:
+        model = AutoModelForSeq2SeqLM.from_pretrained(base_model)
+        peft_task = PeftTaskType.SEQ_2_SEQ_LM
+        data_collator = DataCollatorForSeq2Seq(tokenizer=tokenizer, model=model)
+
+    if tokenizer.pad_token is None:
+        tokenizer.add_special_tokens({"pad_token": "<pad>"})
+    if getattr(model.config, "pad_token_id", None) is None and tokenizer.pad_token_id is not None:
+        model.config.pad_token_id = tokenizer.pad_token_id
+    if hasattr(model, "resize_token_embeddings") and len(tokenizer) != model.get_input_embeddings().weight.shape[0]:
+        model.resize_token_embeddings(len(tokenizer))
+
     if hasattr(model, "gradient_checkpointing_enable"):
         model.gradient_checkpointing_enable()
     if hasattr(model.config, "use_cache"):
@@ -187,7 +441,7 @@ def build_trainer(
     target_modules = detect_lora_targets(model)
     LOG.info("Using LoRA targets: %s", target_modules)
     lora_config = LoraConfig(
-        task_type=TaskType.SEQ_CLS,
+        task_type=peft_task,
         r=8,
         lora_alpha=16,
         lora_dropout=0.05,
@@ -195,7 +449,10 @@ def build_trainer(
     )
     model = get_peft_model(model, lora_config)
 
-    use_fp16 = torch.cuda.is_available() and torch.cuda.get_device_properties(0).total_memory <= 7 * 1024**3
+    use_fp16 = False
+    if torch.cuda.is_available():
+        cuda_props = torch.cuda.get_device_properties(0)
+        use_fp16 = cuda_props.total_memory <= 7 * 1024**3
     LOG.info("FP16 enabled: %s", use_fp16)
 
     output_dir = OUTPUT_ROOT / f"run-{run_id}"
@@ -217,13 +474,9 @@ def build_trainer(
         fp16=use_fp16,
         optim="adamw_torch",
         max_grad_norm=1.0,
+        predict_with_generate=hparams.task_type is not SupportedTaskType.CLASSIFICATION,
+        generation_max_length=hparams.max_seq_length,
     )
-
-    def compute_metrics(eval_pred):
-        predictions = np.argmax(eval_pred.predictions, axis=1)
-        labels = eval_pred.label_ids
-        accuracy = float((predictions == labels).mean())
-        return {"accuracy": accuracy}
 
     return Trainer(
         model=model,
@@ -232,7 +485,168 @@ def build_trainer(
         eval_dataset=dataset.eval,
         tokenizer=tokenizer,
         compute_metrics=compute_metrics,
+        data_collator=data_collator,
     )
+
+
+def _load_sacrebleu():  # pragma: no cover - optional dependency
+    try:
+        import sacrebleu  # type: ignore
+
+        return sacrebleu
+    except Exception:  # noqa: BLE001 - broad to keep optional dependency soft
+        return None
+
+
+def _fallback_bleu(predictions: Sequence[str], references: Sequence[str]) -> float:
+    matches = 0
+    total_tokens = 0
+    for pred, ref in zip(predictions, references):
+        tokens = pred.split()
+        if not tokens:
+            continue
+        total_tokens += len(tokens)
+        reference_tokens = set(ref.split())
+        matches += sum(1 for token in tokens if token in reference_tokens)
+    if total_tokens == 0:
+        return 0.0
+    return (matches / total_tokens) * 100.0
+
+
+def _fallback_chrf(predictions: Sequence[str], references: Sequence[str]) -> float:
+    scores: List[float] = []
+    for pred, ref in zip(predictions, references):
+        pred_chars = set(pred)
+        ref_chars = set(ref)
+        if not pred_chars or not ref_chars:
+            scores.append(0.0)
+            continue
+        overlap = len(pred_chars & ref_chars)
+        precision = overlap / len(pred_chars)
+        recall = overlap / len(ref_chars)
+        if precision + recall == 0:
+            scores.append(0.0)
+        else:
+            scores.append((2 * precision * recall / (precision + recall)) * 100.0)
+    return float(sum(scores) / len(scores)) if scores else 0.0
+
+
+DOMAIN_KEYWORDS: Dict[str, Sequence[str]] = {
+    "trading": ("buy", "sell", "bullish", "bearish", "stop-loss", "entry"),
+    "mentorship": ("mentor", "guidance", "learning", "practice", "feedback"),
+    "governance": ("vote", "council", "charter", "policy", "ethics"),
+}
+
+
+def compute_generation_scores(predictions: Sequence[str], references: Sequence[str]) -> Dict[str, float]:
+    if not predictions:
+        return {"bleu": 0.0, "chrf": 0.0}
+
+    sacrebleu_mod = _load_sacrebleu()
+    if sacrebleu_mod is not None:
+        bleu = sacrebleu_mod.corpus_bleu(predictions, [references]).score
+        chrf = sacrebleu_mod.corpus_chrf(predictions, [references]).score
+        return {"bleu": float(bleu), "chrf": float(chrf)}
+
+    return {
+        "bleu": _fallback_bleu(predictions, references),
+        "chrf": _fallback_chrf(predictions, references),
+    }
+
+
+def compute_domain_alignment(prompts: Sequence[str], predictions: Sequence[str]) -> float:
+    if not predictions:
+        return 0.0
+
+    alignment_scores: List[float] = []
+    for prompt, prediction in zip(prompts, predictions):
+        prompt_lower = prompt.lower()
+        prediction_lower = prediction.lower()
+        bucket_scores: List[float] = []
+        for keywords in DOMAIN_KEYWORDS.values():
+            if any(keyword in prompt_lower for keyword in keywords):
+                bucket_scores.append(1.0 if any(keyword in prediction_lower for keyword in keywords) else 0.0)
+        if bucket_scores:
+            alignment_scores.append(sum(bucket_scores) / len(bucket_scores))
+        else:
+            alignment_scores.append(0.5)  # neutral when no domain cues present
+    return float(sum(alignment_scores) / len(alignment_scores))
+
+
+def generate_predictions(
+    trainer: Trainer,
+    dataset: Dataset,
+    tokenizer: AutoTokenizer,
+    hparams: HyperParams,
+) -> Tuple[List[str], List[str], List[str]]:
+    sample_size = min(len(dataset), hparams.eval_max_samples)
+    if sample_size == 0:
+        return [], [], []
+
+    sample = dataset.select(range(sample_size))
+    prompts: List[str] = []
+    references: List[str] = []
+    for row in sample:
+        prompt = format_instruction_prompt(
+            str(row["prompt"]),
+            context=str(row.get("context", "")),
+            language=str(row.get("language", "")),
+        )
+        prompts.append(prompt)
+        references.append(str(row["response"]))
+
+    model_inputs = tokenizer(
+        prompts,
+        padding=True,
+        truncation=True,
+        max_length=hparams.max_seq_length,
+        return_tensors="pt",
+    )
+    model_inputs = {key: value.to(trainer.model.device) for key, value in model_inputs.items()}
+
+    generation_kwargs = {
+        "max_length": hparams.max_seq_length,
+        "pad_token_id": tokenizer.pad_token_id,
+    }
+    if getattr(trainer.model.config, "eos_token_id", None) is not None:
+        generation_kwargs["eos_token_id"] = trainer.model.config.eos_token_id
+
+    trainer.model.eval()
+    with torch.no_grad():
+        generated = trainer.model.generate(**model_inputs, **generation_kwargs)
+
+    predictions = tokenizer.batch_decode(generated, skip_special_tokens=True)
+    return prompts, predictions, references
+
+
+def assemble_metrics(
+    hparams: HyperParams,
+    eval_metrics: Dict[str, float],
+    trainer: Trainer,
+    dataset: PreparedDataset,
+    tokenizer: AutoTokenizer,
+) -> Dict[str, float]:
+    payload: Dict[str, float] = {"rows": float(dataset.rows)}
+
+    if "eval_loss" in eval_metrics:
+        payload["loss"] = float(eval_metrics["eval_loss"])
+
+    if hparams.task_type is SupportedTaskType.CLASSIFICATION:
+        payload["accuracy"] = float(eval_metrics.get("eval_accuracy", 0.0))
+        return payload
+
+    eval_loss = eval_metrics.get("eval_loss")
+    if eval_loss is not None:
+        try:
+            payload["perplexity"] = float(math.exp(eval_loss))
+        except OverflowError:  # pragma: no cover - defensive guard
+            payload["perplexity"] = float("inf")
+
+    prompts, predictions, references = generate_predictions(trainer, dataset.raw_eval, tokenizer, hparams)
+    scores = compute_generation_scores(predictions, references)
+    payload.update(scores)
+    payload["domain_alignment"] = compute_domain_alignment(prompts, predictions)
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -264,21 +678,27 @@ def run_training(
     )
 
     try:
-        rows = parse_rows(dataset_path)
-        hf_dataset = build_hf_dataset(rows)
-        tokenizer = AutoTokenizer.from_pretrained(hparams.base_model)
-        prepared = tokenize_dataset(hf_dataset, tokenizer)
+        rows = parse_rows(dataset_path, hparams.task_type)
+        hf_dataset = build_hf_dataset(rows, hparams.task_type)
+        tokenizer_source = hparams.tokenizer_path or hparams.base_model
+        LOG.info("Loading tokenizer from %s", tokenizer_source)
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_source, trust_remote_code=True)
+        if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+            tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.padding_side = "right"
+        prepared = tokenize_dataset(hf_dataset, tokenizer, hparams)
         trainer = build_trainer(run_id, prepared, hparams, tokenizer)
 
         LOG.info("Starting training for run %s", run_id)
         trainer.train()
 
         LOG.info("Evaluating model for run %s", run_id)
-        metrics = trainer.evaluate()
+        raw_metrics = trainer.evaluate()
+        metrics = assemble_metrics(hparams, raw_metrics, trainer, prepared, tokenizer)
 
         LOG.info("Saving model artifacts for run %s", run_id)
         trainer.save_model()
-        trainer.tokenizer.save_pretrained(OUTPUT_ROOT / f"run-{run_id}")
+        tokenizer.save_pretrained(OUTPUT_ROOT / f"run-{run_id}")
         artifact_path = package_artifacts(run_id)
 
         post_webhook(
@@ -288,10 +708,7 @@ def run_training(
                 "status": "succeeded",
                 "artifact_path": str(artifact_path),
                 "model_name": model_name,
-                "metrics": {
-                    "accuracy": float(metrics.get("eval_accuracy", 0.0)),
-                    "rows": prepared.rows,
-                },
+                "metrics": metrics,
                 "finished_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             },
         )


### PR DESCRIPTION
## Summary
- expand the trainer service to ingest instruction-style datasets, switch between classification/causal/seq2seq adapters, and report generation metrics including BLEU/chrF and domain alignment
- add Dhivehi/English corpus preprocessing and SentencePiece tokenizer builder CLIs and document the end-to-end workflow
- cover the new dataset schema with regression tests that exercise multilingual fixtures
- document environment setup commands for the pipeline tooling and trainer regression tests

## Testing
- pytest tests_python/test_trainer_service_schema.py *(skipped: optional deps unavailable in CI container)*
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68da7d7844b8832296cf91d1ff5cdc4f