### PR TITLE
Add DO start script for DigitalOcean deployment

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -77,7 +77,7 @@ spec:
       instance_count: 1
       instance_size_slug: basic-xxs
       build_command: node scripts/digitalocean-build.mjs
-      run_command: npm run start:web
+      run_command: npm run start:do
       http_port: 8080
       routes:
         - path: /

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:dev": "vite build --mode development",
     "start": "node scripts/npm-safe.mjs -w apps/web run start",
     "start:web": "node scripts/npm-safe.mjs -w apps/web run start",
+    "start:do": "NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js",
     "dev": "node scripts/npm-safe.mjs -w apps/web run dev --",
     "dev:lovable": "node lovable-dev.js",
     "codex:post-pull": "node scripts/codex-workflow.js post-pull",


### PR DESCRIPTION
## Summary
- add a dedicated `start:do` npm script that invokes the Next.js standalone server from the repo root
- update the DigitalOcean App Platform service to use the new script for a consistent entrypoint

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68da7f26ec44832290b6be4800882275