### PR TITLE
Add dynamic module verification harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ miniapp/
 
 # Audit reports
 .audit/
+.out/
 
 # Miscellaneous
 *.local

--- a/docs/ci_cd_maturity_plan.md
+++ b/docs/ci_cd_maturity_plan.md
@@ -68,6 +68,25 @@ Transform the current CI/CD implementation into a high-velocity, self-optimizing
 - **Developer Tooling**: Offer CLI wrappers or bots that scaffold services, validate configs locally, and trigger ad-hoc pipeline stages.
 - **Policy as Code**: Leverage Sentinel/OPA for consistent enforcement across infrastructure, Kubernetes, and Git repositories.
 
+## Dynamic Module, Model, and Engine Integration
+- **Dynamic AI (`dynamic_ai/`)**: Add targeted model validation suites and reproducible dataset snapshots to CI so inference changes are profiled for latency, accuracy, and safety regressions before merge.
+- **Dynamic AGI (`dynamic_agi/`)**: Orchestrate multi-agent simulations within nightly pipelines to validate orchestrator policies, prompt governance, and self-healing behaviors across complex scenarios.
+- **Dynamic AGS (Autonomous Governance Systems)**: Incorporate policy drift detection workflows that reconcile governance artifacts with pipeline guardrails, ensuring AGS updates receive compliance, security, and ethics sign-off.
+- **Dynamic TL (Translation Layer)**: Run cross-language contract tests that exercise shared APIs and message schemas, guaranteeing deterministic behavior across localization and interoperability surfaces.
+- **Dynamic TA (Technical Analysis)**: Execute GPU-accelerated backtests and statistical validation within CI to certify that indicator updates, signal models, and trading heuristics stay within predefined risk envelopes.
+- **DCT – Dynamic Capital Token (`dynamic_token/`)**: Extend release pipelines with ledger simulation, smart contract linting, and supply integrity checks so tokenomics updates align with treasury policy.
+- **Engine Compatibility Matrix**: Maintain a matrix of inference engines, optimization kernels, and hardware targets (CPU/GPU/TPU) that is continuously exercised via pipeline matrix builds to surface incompatibilities early.
+- **Unified Artifact Registry**: Version all model weights, compiled agents, and governance manifests with signed metadata, enabling deterministic promotion across CI, staging, and production.
+- **Dynamic Module Verification Harness**: Wire `scripts/verify/dynamic_modules.sh` into the verification suite so pull requests exercise Dynamic AI/AGI/AGS, translation, technical analysis, and DCT token contracts before promotion.
+
+### Integration Backlog
+- [ ] Publish a shared CI template that imports Dynamic AI/AGI smoke tests and performance benchmarks.
+- [ ] Automate Dynamic AGS policy verification with OPA/Sentinel gates backed by AGI telemetry evidence.
+- [ ] Add Dynamic TL contract tests to the pull request pipeline with diff-based fixture generation.
+- [ ] Wire Dynamic TA GPU backtests into scheduled workflows using autoscaling runners with cost guards.
+- [ ] Introduce DCT ledger simulations and contract linting as mandatory pre-deployment stages.
+- [ ] Expand the engine compatibility matrix to cover emerging accelerators and document remediation playbooks.
+
 ## Logout & Handoff Protocol
 1. Summarize pipeline health, outstanding optimization backlog items, and risk exceptions in the team wiki prior to sign-off.
 2. Transfer alert responsibilities to the on-call rotation with updated runbooks, SLO dashboards, and escalation contacts.

--- a/scripts/verify/dynamic_modules.sh
+++ b/scripts/verify/dynamic_modules.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. "$(dirname "$0")/utils.sh"
+
+ensure_out
+OUT=".out/dynamic_modules.txt"
+: > "$OUT"
+
+run_pytest() {
+  local label="$1"
+  shift
+  say "[dynamic-modules] Running pytest for ${label}"
+  if PYTHONPATH=. pytest "$@" > ".out/${label// /_}_pytest.log" 2>&1; then
+    pass "${label} tests passed"
+    echo "${label}=pass" >> "$OUT"
+  else
+    fail "${label} tests failed"
+    echo "${label}=fail" >> "$OUT"
+    sed -n '1,160p' ".out/${label// /_}_pytest.log"
+    exit 1
+  fi
+}
+
+run_pytest "Dynamic AI" tests/dynamic_ai
+run_pytest "Dynamic AGI" tests/dynamic_agi
+run_pytest "Dynamic AGS" tests/test_dynamic_ags_playbook.py
+run_pytest "Dynamic Translation Layer" tests/dynamic_translation
+run_pytest "Dynamic Technical Analysis" tests/dynamic_ta
+run_pytest "Dynamic Capital Token" tests/dynamic_token
+
+say "Dynamic module verification complete"

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -14,6 +14,7 @@ bash scripts/verify/runtime_wiring_checks.sh
 bash scripts/verify/miniapp_safety.sh
 bash scripts/verify/tradingview_webhook.sh
 bash scripts/verify/tunnel_checks.sh
+bash scripts/verify/dynamic_modules.sh
 
 # Build markdown report
 OUT=".out/verify_report.md"
@@ -41,6 +42,7 @@ emit_section "C) Runtime Wiring Checks" ".out/runtime_checks.txt"
 emit_section "D) Mini App Safety" ".out/miniapp_safety.txt"
 emit_section "E) TradingView Webhook" ".out/tradingview_webhook.txt"
 emit_section "F) Tunnel CLI Checks" ".out/tunnel_checks.txt"
+emit_section "G) Dynamic Modules" ".out/dynamic_modules.txt"
 
 echo "Report written to $OUT"
 say "Done."

--- a/tests/dynamic_ta/test_indicator_engine.py
+++ b/tests/dynamic_ta/test_indicator_engine.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dynamic_indicators.engine import (
+    DynamicIndicators,
+    IndicatorDefinition,
+    IndicatorReading,
+)
+
+
+def _timestamp(hour: int) -> datetime:
+    return datetime(2024, 6, 1, hour=hour, tzinfo=timezone.utc)
+
+
+def test_snapshot_computes_weighted_values_and_notes() -> None:
+    indicators = DynamicIndicators(
+        history=10,
+        definitions=(
+            IndicatorDefinition(
+                key="momentum",
+                title="Momentum Index",
+                target=0.7,
+                warning=0.55,
+                critical=0.35,
+                orientation="higher",
+            ),
+        ),
+    )
+
+    indicators.ingest(
+        IndicatorReading(
+            "momentum",
+            value=0.65,
+            confidence=0.8,
+            sample_size=5,
+            timestamp=_timestamp(8),
+            notes=("Breakout forming",),
+        )
+    )
+    indicators.ingest(
+        {
+            "indicator": "momentum",
+            "value": 0.72,
+            "confidence": 0.9,
+            "sample_size": 3,
+            "timestamp": _timestamp(9),
+            "notes": ("Volume expansion",),
+        }
+    )
+
+    snapshot = indicators.snapshot("momentum")
+
+    assert snapshot.value == pytest.approx(0.677142857, rel=1e-6)
+    assert snapshot.change == pytest.approx(0.07, rel=1e-6)
+    assert snapshot.trend == pytest.approx(0.07, rel=1e-6)
+    assert snapshot.confidence == pytest.approx(0.85, rel=1e-6)
+    assert snapshot.status == "watch"
+    assert snapshot.notes[0] == "Volume expansion"
+    assert "Momentum Index is watch" in snapshot.summary
+    assert snapshot.metadata["reading_count"] == 2
+    assert snapshot.as_dict()["key"] == "momentum"
+
+
+def test_overview_segments_indicators_by_status() -> None:
+    indicators = DynamicIndicators(
+        definitions=(
+            IndicatorDefinition(
+                key="momentum",
+                title="Momentum Index",
+                target=0.7,
+                warning=0.55,
+                critical=0.35,
+                orientation="higher",
+            ),
+            IndicatorDefinition(
+                key="drawdown",
+                title="Drawdown Risk",
+                target=0.2,
+                warning=0.3,
+                critical=0.5,
+                orientation="lower",
+                weight=2.0,
+            ),
+        ),
+    )
+
+    indicators.ingest(
+        (
+            IndicatorReading("momentum", value=0.6, confidence=0.7, timestamp=_timestamp(10)),
+            IndicatorReading("momentum", value=0.58, confidence=0.6, timestamp=_timestamp(11)),
+            IndicatorReading("drawdown", value=0.19, confidence=0.8, timestamp=_timestamp(10)),
+            IndicatorReading("drawdown", value=0.17, confidence=0.9, timestamp=_timestamp(11)),
+        )
+    )
+
+    overview = indicators.overview()
+
+    assert overview.indicator_count == 2
+    assert overview.healthy == ("Drawdown Risk",)
+    assert overview.watch == ("Momentum Index",)
+    assert overview.at_risk == ()
+    assert overview.insufficient == ()
+    assert 0.0 < overview.overall_health <= 1.0
+    assert overview.average_confidence == pytest.approx((0.7 + 0.6 + 0.8 + 0.9) / 4, rel=1e-6)
+    assert overview.alerts
+    assert "Momentum Index" in overview.alerts[0]
+    assert overview.narrative.startswith("Tracking 2 indicators")
+
+    payload = overview.as_dict()
+    assert payload["indicator_count"] == 2
+    assert "healthy" in payload
+
+
+def test_ingest_rejects_unknown_indicators() -> None:
+    indicators = DynamicIndicators()
+
+    with pytest.raises(KeyError):
+        indicators.ingest(IndicatorReading("momentum", value=0.5))
+
+    registered = indicators.register(
+        IndicatorDefinition(
+            key="momentum",
+            title="Momentum",
+            target=0.5,
+        )
+    )
+    assert registered.key == "momentum"
+
+    ingested = indicators.ingest(
+        IndicatorReading("momentum", value=0.5, confidence=0.4, timestamp=_timestamp(12))
+    )
+    assert len(ingested) == 1

--- a/tests/dynamic_translation/test_engine.py
+++ b/tests/dynamic_translation/test_engine.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import pytest
+
+from dynamic_translation.engine import (
+    DynamicTranslationEngine,
+    Glossary,
+    GlossaryEntry,
+    TranslationMemory,
+    TranslationMemoryEntry,
+    TranslationRequest,
+)
+
+
+class _Recorder:
+    """Capture invocations to prove when the fallback translator runs."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def __call__(self, text: str, source: str, target: str) -> str:
+        self.calls.append((text, source, target))
+        return f"[{source}->{target}] {text.upper()}"
+
+
+def _memory_entry() -> TranslationMemoryEntry:
+    return TranslationMemoryEntry(
+        source_text="Launch the Dynamic Capital playbook.",
+        target_text="Lancez le playbook Dynamic Capital.",
+        source_language="en",
+        target_language="fr",
+        domain="product",
+        quality_score=0.82,
+    )
+
+
+def test_engine_prefers_memory_and_applies_glossary() -> None:
+    recorder = _Recorder()
+    engine = DynamicTranslationEngine(
+        supported_languages=("en", "fr", "es"),
+        translator=recorder,
+    )
+    engine.add_memory_entries((_memory_entry(),))
+
+    glossary = Glossary(
+        (
+            GlossaryEntry("Dynamic Capital", "Dynamic Capital™"),
+            GlossaryEntry("playbook", "guide opérationnel"),
+        )
+    )
+
+    enriched = engine.with_glossary(glossary)
+    request = TranslationRequest(
+        text="Launch the Dynamic Capital playbook.",
+        source_language="en",
+        target_language="fr",
+        domain="operations",
+        metadata={"requested_by": "ci"},
+    )
+
+    result = enriched.translate(request)
+
+    assert result.applied_memory is not None
+    assert result.applied_memory.quality_score == pytest.approx(0.82)
+    assert "Dynamic Capital™" in result.translated_text
+    assert "guide opérationnel" in result.translated_text
+    assert result.glossary_terms
+    assert "Ensure terminology aligns with the operations domain." in result.post_edit_instructions
+    assert (
+        "Validate translation memory segment due to suboptimal quality score."
+        in result.post_edit_instructions
+    )
+
+    # Fallback translator still prepares a comparison candidate, but memory result wins.
+    assert recorder.calls == [
+        ("Launch the Dynamic Capital playbook.", "en", "fr"),
+    ]
+
+
+def test_engine_rejects_invalid_language_pairs() -> None:
+    engine = DynamicTranslationEngine(supported_languages=("en", "fr"))
+
+    with pytest.raises(ValueError):
+        engine.translate(
+            TranslationRequest(
+                text="Hola",
+                source_language="es",
+                target_language="fr",
+            )
+        )
+
+    with pytest.raises(ValueError):
+        engine.translate(
+            TranslationRequest(
+                text="Same lang",
+                source_language="en",
+                target_language="EN",
+            )
+        )
+
+
+def test_engine_uses_fallback_translator_when_memory_misses() -> None:
+    recorder = _Recorder()
+    engine = DynamicTranslationEngine(
+        supported_languages=("en", "fr"),
+        translator=recorder,
+        memory=TranslationMemory((_memory_entry(),)),
+    )
+
+    request = TranslationRequest(
+        text="Launch the treasury dashboard",
+        source_language="en",
+        target_language="fr",
+    )
+
+    result = engine.translate(request)
+
+    assert result.applied_memory is None
+    assert result.translated_text.startswith("[en->fr]")
+    assert recorder.calls == [("Launch the treasury dashboard", "en", "fr")]


### PR DESCRIPTION
## Summary
- add a dynamic module verification script that runs targeted pytest suites for Dynamic AI, AGI, AGS, translation, technical analysis, and DCT token modules
- extend verify_all.sh and the CI/CD playbook to reference the new harness
- introduce focused tests for the Dynamic Translation engine and Dynamic Indicators technical analysis stack

## Testing
- bash scripts/verify/dynamic_modules.sh
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68da854911b883228424564afc420ab6