### PR TITLE
Add project catalog documentation

### DIFF
--- a/docs/project-catalog.md
+++ b/docs/project-catalog.md
@@ -1,0 +1,113 @@
+# Project Catalog
+
+## Overview
+
+The Dynamic Capital project catalog maps active knowledge bases, code modules,
+and operational playbooks into initiative clusters. Use it to orient new
+contributors, surface reusable assets, and align workstreams with the platform's
+strategic pillars.
+
+## Catalog Matrix
+
+### Foundational Infrastructure
+
+- **Core Runtime (`core/`, `shared/`, `src/`)** – Reusable libraries and service
+  primitives that power cross-application capabilities.
+- **Platform Configuration (`project.toml`, `deno.json`, `tsconfig.json`)** –
+  TypeScript and Deno standards that keep tooling consistent across projects.
+- **Environment Scaffolding (`docker/`, `env/`, `server.js`, `Procfile`)** –
+  Deployment blueprints and runtime entry points for local and production
+  setups.
+
+### Intelligent Systems & Agents
+
+- **Cognitive Engines (`dynamic_thinking/`, `dynamic_creative_thinking/`,
+  `dynamic_critical_thinking/`)** – Reasoning toolkits and mental models for
+  automated strategy design.
+- **Agent Libraries (`dynamic_agents/`, `dynamic_bots/`, `dynamic_trainer/`)** –
+  Specialized agent collections, training loops, and orchestration frameworks.
+- **Memory Architectures (`dynamic_memory/`,
+  `dynamic_memory_reconsolidation/`)** – Long-horizon storage, recall, and
+  reinforcement pathways for adaptive systems.
+
+### Market & Treasury Operations
+
+- **Accounting & Wallets (`dynamic_accounting/`, `dynamic_wallet/`,
+  `dynamic_forecast/`)** – Finance automation, treasury forecasting, and
+  multi-asset reconciliation logic.
+- **Market Intelligence (`dynamic_candles/`, `dynamic_numbers/`,
+  `dynamic_volume/`, `dynamic_quote/`)** – Data pipelines and analytics models
+  for signal generation and pricing.
+- **Consensus & Contracts (`dynamic_contracts/`, `dynamic_proof_of_*`,
+  `dynamic_stake/`)** – Smart-contract frameworks, consensus experiments, and
+  staking mechanics.
+
+### Automation Pipelines
+
+- **Workflow Controllers (`dynamic_task_manager/`, `dynamic_trainer/`,
+  `dynamic_tool_kits/`)** – Process automation, iterative training, and
+  operations utilities.
+- **Messaging Fabrics (`queue/`, `dynamic_message_queue/`, `supabase/`)** –
+  Event streaming, job orchestration, and state synchronization components.
+- **Scripting Tooling (`scripts/`, `tools/`, `functions/`)** – Command-line and
+  serverless utilities for maintenance, deployments, and data preparation.
+
+### Knowledge & Research Assets
+
+- **Documentation Hubs (`docs/`, `_static/`, `content/`)** – Playbooks, white
+  papers, inventories, and curated research libraries.
+- **Data Foundations (`data/`, `db/`, `models/`, `ml/`, `trainer/`)** –
+  Datasets, schema definitions, model checkpoints, and experiment harnesses.
+- **Research Initiatives (`dynamic_ai/`, `dynamic_agi/`, `dynamic_quantum/`)** –
+  Exploratory programs that extend the platform's intelligence frontier.
+
+### Observability, Security & Governance
+
+- **Risk Controls (`dynamic_firewall/`, `dynamic_encryption/`, `dynamic_kyc/`)**
+  – Security operations, compliance protocols, and encryption suites.
+- **Audit & Policy (`SECURITY.md`, `CODEOWNERS`,
+  `docs/dynamic-capital-security-playbook.md`)** – Governance references,
+  operational checklists, and disclosure pathways.
+- **Telemetry (`dynamic_logging/`, `dynamic_benchmark/`, `dynamic_validator/`)**
+  – Monitoring adapters, validation harnesses, and benchmarking scripts.
+
+### Experience & Interface Layers
+
+- **User Applications (`apps/web`, `apps/landing`, `apps/*`)** – Interface
+  surfaces for operators, analysts, and ecosystem members.
+- **Design Systems (`docs/ui`, `docs/ui-design-principles.md`, `ui-style.md`)**
+  – UX guidelines, component libraries, and prototyping references.
+- **Communication Surfaces (`broadcast/`, `bots/`, `dynamic_message_queue/`)** –
+  Outreach channels, automation bots, and messaging templates.
+
+### Growth, Partnerships & Ecosystem
+
+- **Business Development (`dynamic_domain_names/`, `dynamic_domain/`,
+  `docs/company-profile-dossier.md`)** – Naming inventories, domain logistics,
+  and narrative dossiers for partners.
+- **Compliance & Legal (`docs/compliance/`, `docs/legal/`, `dynamic_kyc/`)** –
+  Regulatory readiness, legal documentation, and jurisdiction playbooks.
+- **Partnership Toolkits (`integrations/`, `dynamic_supabase/`,
+  `dynamic_proxy/`)** – Third-party connectors, integration guides, and
+  collaborative pipelines.
+
+### Frontier Explorations
+
+- **Speculative Research (`dynamic_interstellar_space/`,
+  `dynamic_consciousness/`, `dynamic_ultimate_reality/`)** – Experimental
+  domains that probe future-state architectures and metaphysical models.
+- **Emerging Technologies (`dynamic_web3/`, `dynamic_blockchain/`,
+  `dynamic_quantum/`)** – Advanced protocol experiments and cross-chain
+  innovations.
+- **Creative Sandboxes (`dynamic_creative_thinking/`, `dynamic_expressions/`,
+  `dynamic_review/`)** – Narrative engines, communication grammars, and feedback
+  loops for brand expression.
+
+## Usage Notes
+
+- Reference this catalog when planning initiatives, onboarding team members, or
+  mapping dependencies between workstreams.
+- For deeper implementation details, drill into the directory-specific READMEs
+  or playbooks listed in the relevant sections.
+- Keep the catalog updated as new modules, documents, or services emerge so the
+  repository remains navigable for contributors.


### PR DESCRIPTION
## Summary
- add a project catalog document that clusters Dynamic Capital assets by initiative
- document usage notes to help contributors navigate and maintain the catalog

## Testing
- node_modules/.bin/deno fmt docs/project-catalog.md

------
https://chatgpt.com/codex/tasks/task_e_68da8a2f962c83229c67dcae88cadeaa