### PR TITLE
Add operational checklist tasks for DQAs

### DIFF
--- a/docs/dynamic_quantum_agents_blueprint.md
+++ b/docs/dynamic_quantum_agents_blueprint.md
@@ -1,0 +1,136 @@
+# Dynamic Quantum Agents Blueprint
+
+## Overview
+This blueprint defines how the mythic agent set transitions into Dynamic Quantum Agents (DQAs) that run as hybrid classical–quantum microservices inside the Dynamic AGI. Each DQA pairs quantum-native primitives with interoperable classical interfaces, is organized into token-gated capability tiers, and is engineered for modularity, verifiable outcomes, graceful degradation to classical fallbacks, and measurable intelligence resonance for the AGI Oracle.
+
+### Design Principles
+- **Composable services**: Each agent exposes explicit contracts so orchestration layers can hot-swap or chain capabilities without reconfiguration.
+- **Auditability by default**: Every quantum invocation is paired with circuit hashes, fidelity evidence, and classical checkpoints for deterministic replay.
+- **Progressive quantum enablement**: Agents can run in classical-only mode and gradually unlock quantum acceleration as fidelity improves.
+- **Economic alignment**: Capability tiers are token-gated through DCT staking so critical paths are secured by committed participants.
+
+## Agent Registry and Capability Mapping
+| DQA | Core Task | Quantum Primitives | Classical Interfaces | DCT Gating Tier |
+| --- | --- | --- | --- | --- |
+| Zeus DQA | Governance, arbitration, oracle validation | Quantum consensus subroutines; QFT-assisted validation | gRPC policy API; signed attestations | Tier 3: governance quorum |
+| Hera DQA | Social trust, loyalty scoring | Quantum-enhanced graph embeddings; amplitude encoding for relationship tensors | REST trust API; reputation DB | Tier 2: community staking |
+| Poseidon DQA | Liquidity and volatility modeling | Variational quantum circuits for stochastic sampling; quantum Monte Carlo | Streaming market feeds; risk engine | Tier 2 |
+| Demeter DQA | Resource allocation, supply forecasting | Quantum annealing for combinatorial allocation | Inventory sync; oracle feeds | Tier 1 |
+| Athena DQA | Strategic planning and ethical reasoning | Grover-accelerated search over policy space; hybrid symbolic-quantum planners | Policy engine; mentor scoring API | Tier 3 |
+| Apollo DQA | Forecasting and signal synthesis | Quantum signal processing; QFT for time-series spectral analysis | Forecast API; content pipeline | Tier 2 |
+| Artemis DQA | Autonomous scouting and edge discovery | Quantum walk algorithms for path search; low-latency QNN for anomaly detection | Edge probe API; telemetry | Tier 1 |
+| Ares DQA | Adversarial testing and red-team | Quantum adversarial example generator; amplitude-based perturbations | Pen-test orchestration; vulnerability ledger | Tier 2 |
+| Aphrodite DQA | Sentiment and UX resonance | Quantum embeddings for multimodal affect; entanglement-assisted retrieval | UX tuning API; A/B config | Tier 1 |
+| Hephaestus DQA | Contract crafting and pipeline builds | Quantum-optimized synthesis for constraint solving | CI/CD hooks; smart contract factory | Tier 2 |
+| Hermes DQA | Messaging, routing, micropayments | Quantum key distribution and low-latency routing heuristics | Message bus; payment rails | Tier 3: payment validators |
+| Dionysus DQA | Crowd dynamics and memetic propagation | Quantum random walks and sampling for viral spread models | Social feed controller; campaign API | Tier 1 |
+
+### Inter-Agent Coordination Patterns
+- **Governance Spine**: Zeus arbitrates policy changes, Hermes distributes signed directives, and Athena validates ethical alignment before deployment.
+- **Liquidity Loop**: Poseidon signals market states to Hephaestus for contract crafting; Hermes facilitates settlement while Ares stress-tests release candidates.
+- **Insight Relay**: Apollo, Artemis, and Dionysus feed cross-domain telemetry into Athena's planning buffers, raising Demeter resource reallocation proposals when thresholds are crossed.
+
+## Hybrid Architecture Patterns
+### System Layers
+1. **Quantum Kernel** – Native quantum circuits, QUBO solvers, QNN layers, and error-mitigation modules.
+2. **Classical Control Plane** – Orchestration, scheduling, checkpointing, and logging of hybrid workloads.
+3. **Agent Middleware** – Translation layer mapping classical tensors to amplitude encodings, handling serialization and versioning.
+4. **Governance Layer** – DCT staking, attestations, and on-chain anchors that secure verifiable agent actions.
+
+### Communication and State Management
+- **Entanglement Channels**: Ephemeral entangled sessions for high-integrity oracle assertions and synchronous consensus windows.
+- **State Sync**: Hybrid snapshotting where quantum state parameters are checkpointed as classical parameter vectors annotated with fidelity metadata.
+- **Message Contracts**: Protobuf schemas containing `agent_id`, `quantum_circuit_hash`, `fidelity_score`, and `signature` fields.
+
+### Reliability and Fallback Strategy
+- **Error Mitigation**: Zero-noise extrapolation and randomized compiling with per-run `fidelity_score` reporting to the Oracle.
+- **Classical Fallbacks**: Deterministic classical substitutes accompany every quantum subroutine to preserve availability during degraded modes.
+- **Graceful Degradation Policy**: When fidelity drops below threshold, agents auto-switch to classical pipelines, emit degraded-quality flags, and request re-calibration before re-entering quantum queues.
+
+## Operational Protocols
+### Lifecycle
+1. **Provisioning**: DCT stake unlocks entanglement quota and compute priority.
+2. **Boot**: Load hybrid model and perform calibration to generate a `fidelity_score` baseline.
+3. **Tasking**: Submit objectives, constraints, and QoS targets; scheduler reserves quantum resources accordingly.
+4. **Execution**: Run quantum circuits and complete classical post-processing decoders.
+5. **Attestation**: Emit signed bundles containing `{result, circuit_hash, fidelity_score, proof_of_execution}`.
+6. **Ingestion**: Oracle ingests attestation bundles, updates reputations, and triggers DCT burns or rewards.
+
+### Training and Continual Learning
+- **Federated Hybrid Training**: Combine local classical updates with quantum parameter adjustments aggregated via secure MPC. Entangled summary states reduce bias in federated averaging.
+- **Reward Signal Integration**: The AGI Intelligence Oracle emits scalar rewards; DQAs apply quantum policy gradients for sample-efficient adaptation.
+- **Curriculum Scheduling**: Progress from classical tasks to high-fidelity quantum objectives as each agent's `fidelity_score` improves.
+
+### Runbook Considerations
+- **Calibration Windows**: Schedule off-peak calibration cycles for Tier 3 agents twice daily; Tier 1 agents recalibrate weekly unless fidelity variance exceeds 10%.
+- **Incident Escalation**: If three consecutive runs fall below fidelity thresholds, freeze quantum workloads, trigger classical fallback, and route incident to Zeus for arbitration.
+- **Observability**: Stream fidelity, latency, and stake utilization metrics into the governance ledger; alerting thresholds align with the Key Metrics targets below.
+
+### Operational Checklist Tasks
+- [ ] Confirm DCT stake balances before provisioning new entanglement quotas.
+- [ ] Execute calibration cycle and record baseline `fidelity_score` per agent before task intake resumes.
+- [ ] Validate classical fallback pipelines by running the latest deterministic regression suite.
+- [ ] Review Hermes routing and Zeus governance signatures after every incident escalation.
+- [ ] Publish observability snapshots (fidelity, latency, stake utilization) to the governance ledger each epoch.
+
+## Security and Privacy Controls
+- **Quantum Key Distribution (QKD)** secures Tier 3 agent messaging.
+- **Zero-Knowledge Proofs** allow DQAs to prove class membership of outputs without exposing internal models.
+- **Isolation Boundaries** ensure each DQA runs inside a sandboxed hybrid VM with attested hardware IDs and signed firmware.
+
+### Compliance Checklist
+1. [ ] Verify KMS rotation aligns with QKD key refresh cadence and log attestations on-chain.
+2. [ ] Confirm sandbox firmware hashes against approved manifest before provisioning quantum workloads.
+3. [ ] Ensure ZK proof circuits are versioned and backward compatible with governance verification tooling.
+
+## Interfaces and Example Payloads
+### API Surface
+- `POST /dqa/{id}/submit_task`
+- `GET /dqa/{id}/status`
+- `POST /oracle/attest`
+- `POST /governance/stake`
+
+### Example Task Submission
+```python
+# submit_task payload
+task = {
+  "agent_id": "athena.dqa",
+  "objective": "minimize_ethic_violation_score",
+  "constraints": {"max_runtime_ms": 5000},
+  "budget": {"q_qubits": 27, "classical_cycles": 1e6},
+  "stake_signature": "sig..."
+}
+response = POST("/dqa/athena/submit_task", task)
+# response contains task_id and expected fidelity threshold
+```
+
+### Example Attestation Bundle
+```json
+{
+  "agent_id": "athena.dqa",
+  "task_id": "T-2391",
+  "circuit_hash": "0xabc...",
+  "result_summary": "policy_vector_123",
+  "fidelity_score": 0.87,
+  "proof_signature": "sig..."
+}
+```
+
+## Deployment Plan and Metrics
+### Phased Rollout
+1. Prototype Hermes, Hephaestus, and Zeus as classical-first services with quantum stubs.
+2. Integrate QKD and attestation pipelines for Hermes and Zeus governance flows.
+3. Accelerate Athena, Poseidon, and Apollo with quantum-enhanced inference.
+4. Scale to multi-DQA choreography supported by federated hybrid training.
+
+### Optimization Path
+- **Phase Gate Reviews**: After each rollout stage, run Zeus-led governance reviews to validate metric deltas and approve additional staking thresholds.
+- **Model Drift Audits**: Use Athena to benchmark policy outputs quarterly against ethical baselines; route remediation tasks to Hephaestus for pipeline updates.
+- **Cost-to-Value Tracking**: Combine entanglement utilization and Oracle Reward Delta to compute return on staked capital, informing future tier adjustments.
+
+### Key Metrics
+- **Fidelity Score per run**: initial target ≥ 0.7, goal > 0.9 for Tier 3 agents.
+- **Time-to-Decision latency (Zeus DQA)**: SLO < 200 ms for governance windows.
+- **Oracle Reward Delta**: improvement in AGI performance following agent updates.
+- **Entanglement Utilization**: percentage of entanglement capacity consumed each epoch.
+- **DCT Economic Flow**: stake inflow, burns initiated by oracle feedback, and payouts to contributors.


### PR DESCRIPTION
## Summary
- add an operational checklist to the DQA blueprint covering stake validation, calibration, fallbacks, governance review, and observability updates
- convert the compliance checklist into actionable checkbox tasks for audit tracking

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da9e0530788322a5e07c1a7a40faf9