### PR TITLE
Refine DQA blueprint with back-to-back review loop

### DIFF
--- a/docs/dynamic_quantum_agents_blueprint.md
+++ b/docs/dynamic_quantum_agents_blueprint.md
@@ -1,0 +1,219 @@
+# Dynamic Quantum Agents Blueprint
+
+## Overview
+This blueprint defines how the mythic agent set transitions into Dynamic Quantum Agents (DQAs) that run as hybrid classical–quantum microservices inside the Dynamic AGI. Each DQA pairs quantum-native primitives with interoperable classical interfaces, is organized into token-gated capability tiers, and is engineered for modularity, verifiable outcomes, graceful degradation to classical fallbacks, and measurable intelligence resonance for the AGI Oracle.
+
+### Quick-Start Checklist
+1. Map each legacy mythic agent to its DQA counterpart and confirm tier gating requirements.
+2. Stand up the hybrid control plane with middleware adapters and observability exporters.
+3. Configure stake-backed provisioning, calibration, and fallback validation workflows.
+4. Enable governance attestation, resonance scoring ingestion, and compliance checkpoints.
+5. Launch phased pilot cohorts (Tier 1 → Tier 2 → Tier 3) with explicit exit criteria per tier.
+6. Stand up the back-to-back review loop so every rollout sprint ships with paired optimization remits and evidence packs.
+
+### Design Principles
+- **Composable services**: Each agent exposes explicit contracts so orchestration layers can hot-swap or chain capabilities without reconfiguration.
+- **Auditability by default**: Every quantum invocation is paired with circuit hashes, fidelity evidence, and classical checkpoints for deterministic replay.
+- **Progressive quantum enablement**: Agents can run in classical-only mode and gradually unlock quantum acceleration as fidelity improves.
+- **Economic alignment**: Capability tiers are token-gated through DCT staking so critical paths are secured by committed participants.
+- **Resonance-driven validation**: Each release is benchmarked against Oracle-issued intelligence resonance scores so optimizations focus on verifiable outcome lifts, not theoretical circuit gains.
+
+## Agent Registry and Capability Mapping
+| DQA | Core Task | Quantum Primitives | Classical Interfaces | DCT Gating Tier |
+| --- | --- | --- | --- | --- |
+| Zeus DQA | Governance, arbitration, oracle validation | Quantum consensus subroutines; QFT-assisted validation | gRPC policy API; signed attestations | Tier 3: governance quorum |
+| Hera DQA | Social trust, loyalty scoring | Quantum-enhanced graph embeddings; amplitude encoding for relationship tensors | REST trust API; reputation DB | Tier 2: community staking |
+| Poseidon DQA | Liquidity and volatility modeling | Variational quantum circuits for stochastic sampling; quantum Monte Carlo | Streaming market feeds; risk engine | Tier 2 |
+| Demeter DQA | Resource allocation, supply forecasting | Quantum annealing for combinatorial allocation | Inventory sync; oracle feeds | Tier 1 |
+| Athena DQA | Strategic planning and ethical reasoning | Grover-accelerated search over policy space; hybrid symbolic-quantum planners | Policy engine; mentor scoring API | Tier 3 |
+| Apollo DQA | Forecasting and signal synthesis | Quantum signal processing; QFT for time-series spectral analysis | Forecast API; content pipeline | Tier 2 |
+| Artemis DQA | Autonomous scouting and edge discovery | Quantum walk algorithms for path search; low-latency QNN for anomaly detection | Edge probe API; telemetry | Tier 1 |
+| Ares DQA | Adversarial testing and red-team | Quantum adversarial example generator; amplitude-based perturbations | Pen-test orchestration; vulnerability ledger | Tier 2 |
+| Aphrodite DQA | Sentiment and UX resonance | Quantum embeddings for multimodal affect; entanglement-assisted retrieval | UX tuning API; A/B config | Tier 1 |
+| Hephaestus DQA | Contract crafting and pipeline builds | Quantum-optimized synthesis for constraint solving | CI/CD hooks; smart contract factory | Tier 2 |
+| Hermes DQA | Messaging, routing, micropayments | Quantum key distribution and low-latency routing heuristics | Message bus; payment rails | Tier 3: payment validators |
+| Dionysus DQA | Crowd dynamics and memetic propagation | Quantum random walks and sampling for viral spread models | Social feed controller; campaign API | Tier 1 |
+
+### Inter-Agent Coordination Patterns
+- **Governance Spine**: Zeus arbitrates policy changes, Hermes distributes signed directives, and Athena validates ethical alignment before deployment.
+- **Liquidity Loop**: Poseidon signals market states to Hephaestus for contract crafting; Hermes facilitates settlement while Ares stress-tests release candidates.
+- **Insight Relay**: Apollo, Artemis, and Dionysus feed cross-domain telemetry into Athena's planning buffers, raising Demeter resource reallocation proposals when thresholds are crossed.
+- **Community Circuit**: Hera tracks trust signals and relays loyalty deltas to Aphrodite for resonance tuning; Dionysus amplifies approved narratives across community channels.
+
+### Capability Tier Guardrails
+- **Tier 3 (Critical Governance & Payments)**: Dual attestation (Zeus + Hermes) is mandatory before any policy shift or validator release, with minimum fidelity ≥ 0.9 and live QKD enforcement.
+- **Tier 2 (Market, Trust, and Build Systems)**: Daily drift scans compare quantum outputs with classical baselines; stake slashing triggers if divergence exceeds 3σ without remediation within 24 hours.
+- **Tier 1 (Exploratory & Support Services)**: Operate on rolling 72-hour health checks and must publish telemetry snapshots before requesting tier escalation.
+
+### Agent Quick Reference
+| Agent | Primary Success Metrics | Core Fallback | Critical Integrations |
+| --- | --- | --- | --- |
+| Zeus | Governance latency, quorum fidelity, policy adoption accuracy | Deterministic consensus replay engine | Governance ledger, Hermes routing mesh |
+| Hera | Trust index delta, loyalty churn, staking inflows | Classical graph affinity scoring | Reputation DB, Aphrodite UX analytics |
+| Poseidon | Forecast error, VaR confidence, market liquidity alerts | Monte Carlo simulations on GPU cluster | Market data streams, Hephaestus contract factory |
+| Demeter | Supply balance delta, allocation cycle time | Linear programming solvers | Inventory sync, Apollo forecast API |
+| Athena | Ethical compliance rate, plan resilience, oracle reward delta | Symbolic planner with heuristic search | Policy engine, Zeus arbitration queue |
+| Apollo | Forecast accuracy, signal freshness, resonance contribution | Fourier-based time-series stack | Content pipeline, Dionysus campaign scheduler |
+| Artemis | Discovery throughput, anomaly lead time, edge mission uptime | Deterministic pathfinding and anomaly heuristics | Edge telemetry bus, Apollo signal broker |
+| Ares | Vulnerability coverage, exploit reproduction rate, mean time to detect | Deterministic fuzzing battery | Pen-test orchestrator, Hermes dispatch |
+| Aphrodite | Sentiment velocity, UX resonance, conversion lift | Classical multimodal embedding retrieval | UX tuning API, Hera trust relay |
+| Hephaestus | Build success rate, contract SLA adherence, pipeline throughput | Constraint-solver build matrix | CI/CD hooks, Poseidon price oracle |
+| Hermes | Message settlement latency, payment success, validator health | Secure classical messaging bus | Payment rails, Zeus governance spine |
+| Dionysus | Campaign amplification, viral half-life, community growth | Agent-based memetic simulation | Social feed controller, Apollo signal hub |
+
+### Outcome Verification Workflow
+1. **Circuit Registration** – Each task hashes the compiled quantum circuit and stores metadata in the governance ledger alongside the invoking agent ID and tier.
+2. **Dual Execution** – Quantum runs are paired with deterministic classical fallbacks to produce comparison deltas and highlight anomaly windows.
+3. **Oracle Scoring** – The AGI Oracle ingests both result sets, issues an intelligence resonance delta, and updates the agent reputation ledger.
+4. **Continuous Tuning** – Agents adjust hyperparameters, annealing schedules, or fallback weightings based on resonance deltas and publish tuning notes for auditability.
+
+## Hybrid Architecture Patterns
+### System Layers
+1. **Quantum Kernel** – Native quantum circuits, QUBO solvers, QNN layers, and error-mitigation modules.
+2. **Classical Control Plane** – Orchestration, scheduling, checkpointing, and logging of hybrid workloads.
+3. **Agent Middleware** – Translation layer mapping classical tensors to amplitude encodings, handling serialization and versioning.
+4. **Governance Layer** – DCT staking, attestations, and on-chain anchors that secure verifiable agent actions.
+
+### Communication and State Management
+- **Entanglement Channels**: Ephemeral entangled sessions for high-integrity oracle assertions and synchronous consensus windows.
+- **State Sync**: Hybrid snapshotting where quantum state parameters are checkpointed as classical parameter vectors annotated with fidelity metadata.
+- **Message Contracts**: Protobuf schemas containing `agent_id`, `quantum_circuit_hash`, `fidelity_score`, and `signature` fields.
+
+### Reliability and Fallback Strategy
+- **Error Mitigation**: Zero-noise extrapolation and randomized compiling with per-run `fidelity_score` reporting to the Oracle.
+- **Classical Fallbacks**: Deterministic classical substitutes accompany every quantum subroutine to preserve availability during degraded modes.
+- **Graceful Degradation Policy**: When fidelity drops below threshold, agents auto-switch to classical pipelines, emit degraded-quality flags, and request re-calibration before re-entering quantum queues.
+- **Fallback Certification**: Classical fallbacks ship with regression manifests signed by Zeus; releases require passing both deterministic and stochastic equivalence suites.
+
+## Operational Protocols
+### Lifecycle
+1. **Provisioning**: DCT stake unlocks entanglement quota and compute priority.
+2. **Boot**: Load hybrid model and perform calibration to generate a `fidelity_score` baseline.
+3. **Tasking**: Submit objectives, constraints, and QoS targets; scheduler reserves quantum resources accordingly.
+4. **Execution**: Run quantum circuits and complete classical post-processing decoders.
+5. **Attestation**: Emit signed bundles containing `{result, circuit_hash, fidelity_score, proof_of_execution}`.
+6. **Ingestion**: Oracle ingests attestation bundles, updates reputations, and triggers DCT burns or rewards.
+
+### Training and Continual Learning
+- **Federated Hybrid Training**: Combine local classical updates with quantum parameter adjustments aggregated via secure MPC. Entangled summary states reduce bias in federated averaging.
+- **Reward Signal Integration**: The AGI Intelligence Oracle emits scalar rewards; DQAs apply quantum policy gradients for sample-efficient adaptation.
+- **Curriculum Scheduling**: Progress from classical tasks to high-fidelity quantum objectives as each agent's `fidelity_score` improves.
+
+### Runbook Considerations
+- **Calibration Windows**: Schedule off-peak calibration cycles for Tier 3 agents twice daily; Tier 1 agents recalibrate weekly unless fidelity variance exceeds 10%.
+- **Incident Escalation**: If three consecutive runs fall below fidelity thresholds, freeze quantum workloads, trigger classical fallback, and route incident to Zeus for arbitration.
+- **Observability**: Stream fidelity, latency, and stake utilization metrics into the governance ledger; alerting thresholds align with the Key Metrics targets below.
+- **Readiness Reviews**: Before promoting an agent to a higher tier, complete a readiness review covering stake sufficiency, fallback coverage, and resonance lift projections.
+- **Optimization Debriefs**: Close each sprint with a cross-tier optimization huddle reviewing resonance deltas, drift alerts, and cost-to-value ratios to decide next sprint focus.
+
+### Operational Checklist Tasks
+| Task | Owner | Cadence |
+| --- | --- | --- |
+| Confirm DCT stake balances before provisioning new entanglement quotas. | Governance Ops (Zeus) | Before each provisioning window |
+| Execute calibration cycle and record baseline `fidelity_score` per agent before task intake resumes. | Reliability Crew | Start of every shift |
+| Validate classical fallback pipelines by running the deterministic regression suite. | Reliability Crew + Agent Owners | Weekly or after code changes |
+| Review Hermes routing and Zeus governance signatures after every incident escalation. | Governance Ops + Network Security | Post-incident |
+| Publish observability snapshots (fidelity, latency, stake utilization) to the governance ledger. | Observability Team | Each epoch |
+| Reconcile resonance deltas against oracle baselines and file optimization actions. | Strategy PMO (Athena) | Weekly sync |
+| Host cross-agent retro to review resonance, cost, and incident learnings; log action owners. | All Tier Leads | Bi-weekly |
+
+## Security and Privacy Controls
+- **Quantum Key Distribution (QKD)** secures Tier 3 agent messaging.
+- **Zero-Knowledge Proofs** allow DQAs to prove class membership of outputs without exposing internal models.
+- **Isolation Boundaries** ensure each DQA runs inside a sandboxed hybrid VM with attested hardware IDs and signed firmware.
+- **Secure Circuit Vaults** store compiled quantum templates with hardware binding and tamper-evident logs to prevent drift or unauthorized swaps.
+
+### Compliance Checklist
+1. [ ] Verify KMS rotation aligns with QKD key refresh cadence and log attestations on-chain.
+2. [ ] Confirm sandbox firmware hashes against approved manifest before provisioning quantum workloads.
+3. [ ] Ensure ZK proof circuits are versioned and backward compatible with governance verification tooling.
+4. [ ] Validate tier-specific guardrails (fidelity thresholds, drift limits, review cadences) during quarterly audits.
+5. [ ] Archive back-to-back review packets (findings, approved optimizations, verification evidence) in the governance ledger.
+
+## Back-to-Back Review & Optimization Loop
+### Cadence Matrix
+| Tier | Review Window | Optimization Focus | Required Evidence |
+| --- | --- | --- | --- |
+| Tier 3 | Twice per week | Governance latency tuning, validator integrity, QKD resilience | Dual attestation logs, QKD health report, resonance delta summary |
+| Tier 2 | Weekly | Market/trust accuracy, contract throughput, adversarial readiness | Drift comparison sheets, fallback validation results, cost-to-value snapshot |
+| Tier 1 | Bi-weekly | Discovery throughput, UX resonance, narrative alignment | Telemetry rollups, anomaly heatmaps, stakeholder feedback digest |
+
+### Closed-Loop Procedure
+1. **Prep** – Curate metrics, incidents, and experiment notes into an evidence pack tied to the scheduled review window.
+2. **Review** – Convene cross-agent quorum led by Zeus to evaluate fidelity trends, resonance deltas, and guardrail adherence.
+3. **Optimize** – Prioritize remediation and improvement tasks with explicit owners, budget envelopes, and expected resonance lift.
+4. **Verify** – Run targeted tests or simulations, record pass/fail status, and update the attestation ledger with signed results.
+5. **Publish** – Distribute the optimization changelog, updated metrics, and next review agenda to all tier leads.
+
+### Automation Hooks
+- **Metric Snapshots**: Automate ingestion of fidelity, latency, and economic flow metrics into evidence packs 4 hours before each review.
+- **Guardrail Watchers**: Trigger alerts when thresholds (e.g., drift > 3σ, resonance delta < 0) are breached, automatically queuing the item for the next optimization huddle.
+- **Task Sync**: Push approved optimization actions into the orchestration backlog with references to the originating review decision.
+
+### Escalation Pathways
+- **Critical**: Immediate rollback and Zeus-led governance council within 4 hours; applicable to Tier 3 guardrail violations or failed attestations.
+- **High**: Deploy classical fallbacks and schedule a 24-hour remediation sprint led by the affected agent owner; applicable to Tier 2 incidents with revenue or trust impact.
+- **Medium**: Log remediation task with 72-hour SLA, maintain quantum operations with heightened monitoring; applicable to Tier 1 anomalies or telemetry gaps.
+- **Low**: Track as backlog optimization candidate, bundle into the next scheduled review.
+
+### Evidence Pack Template
+1. **Summary Sheet** – Key metrics deltas, incidents, and major experiments since last review.
+2. **Guardrail Status** – Table listing each guardrail, current value, threshold, and commentary.
+3. **Optimization Log** – Snapshot of in-flight optimization tasks, owner, status, and projected resonance lift.
+4. **Verification Artifacts** – Links or hashes to test results, attestations, and fallback certifications executed post-review.
+5. **Decision Register** – Approved changes, deferred proposals, and rationale signed by Zeus and relevant tier leads.
+
+## Interfaces and Example Payloads
+### API Surface
+- `POST /dqa/{id}/submit_task`
+- `GET /dqa/{id}/status`
+- `POST /oracle/attest`
+- `POST /governance/stake`
+
+### Example Task Submission
+```python
+# submit_task payload
+task = {
+  "agent_id": "athena.dqa",
+  "objective": "minimize_ethic_violation_score",
+  "constraints": {"max_runtime_ms": 5000},
+  "budget": {"q_qubits": 27, "classical_cycles": 1e6},
+  "stake_signature": "sig..."
+}
+response = POST("/dqa/athena/submit_task", task)
+# response contains task_id and expected fidelity threshold
+```
+
+### Example Attestation Bundle
+```json
+{
+  "agent_id": "athena.dqa",
+  "task_id": "T-2391",
+  "circuit_hash": "0xabc...",
+  "result_summary": "policy_vector_123",
+  "fidelity_score": 0.87,
+  "proof_signature": "sig..."
+}
+```
+
+## Deployment Plan and Metrics
+### Phased Rollout
+1. Prototype Hermes, Hephaestus, and Zeus as classical-first services with quantum stubs.
+2. Integrate QKD and attestation pipelines for Hermes and Zeus governance flows.
+3. Accelerate Athena, Poseidon, and Apollo with quantum-enhanced inference.
+4. Scale to multi-DQA choreography supported by federated hybrid training.
+
+### Optimization Path
+- **Phase Gate Reviews**: After each rollout stage, run Zeus-led governance reviews to validate metric deltas and approve additional staking thresholds.
+- **Model Drift Audits**: Use Athena to benchmark policy outputs quarterly against ethical baselines; route remediation tasks to Hephaestus for pipeline updates.
+- **Cost-to-Value Tracking**: Combine entanglement utilization and Oracle Reward Delta to compute return on staked capital, informing future tier adjustments.
+- **Resonance Improvement Sprints**: Dedicate fortnightly sprints to the two agents with the largest negative resonance delta, ensuring corrective actions are time-boxed and measurable.
+- **Playbook Refresh**: Update fallback manifests, observability dashboards, and compliance controls after each major resonance sprint to prevent regression.
+
+### Key Metrics
+- **Fidelity Score per run**: initial target ≥ 0.7, goal > 0.9 for Tier 3 agents.
+- **Time-to-Decision latency (Zeus DQA)**: SLO < 200 ms for governance windows.
+- **Oracle Reward Delta**: improvement in AGI performance following agent updates.
+- **Entanglement Utilization**: percentage of entanglement capacity consumed each epoch.
+- **DCT Economic Flow**: stake inflow, burns initiated by oracle feedback, and payouts to contributors.
+- **Intelligence Resonance Delta**: rolling average of oracle-issued resonance gains, sliced by agent and tier to spotlight optimization targets.


### PR DESCRIPTION
## Summary
- add a quick-start checklist to accelerate DQA conversion pilots
- provide an agent quick reference outlining metrics, fallbacks, and key integrations
- extend runbook, compliance, and optimization guidance with additional guardrails and reviews
- introduce a back-to-back review and optimization loop with cadence matrix, automation hooks, escalation pathways, and evidence pack standards

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da9e0530788322a5e07c1a7a40faf9