### PR TITLE
Fix lucide icon module resolution regression

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -166,14 +166,22 @@ process.env.ALLOWED_ORIGINS = ALLOWED_ORIGINS;
 process.env.DEFAULT_LOCALE = DEFAULT_LOCALE;
 process.env.NEXT_PUBLIC_DEFAULT_LOCALE = DEFAULT_LOCALE;
 
-const optimizePackageImports = ['lucide-react'];
+// Disable Lucide import modularisation because the upstream package renamed icon
+// files to kebab-case (for example `chart-pie.js`).
+//
+// Next.js' `optimizePackageImports` + `modularizeImports` previously attempted to
+// rewrite `import { PieChart } from "lucide-react"` into
+// `import PieChart from "lucide-react/dist/esm/icons/PieChart"`, which no longer
+// exists. The build would then fail with "Module not found" errors for several
+// icons at runtime (visible in production and when running `next dev`).
+//
+// Until Next.js exposes a kebab-case helper (or lucide-react restores
+// pascal-case filenames), we fall back to the default lucide entrypoint. This
+// keeps the app functional even though it forgoes the micro-optimised import
+// splitting.
+const optimizePackageImports = [];
 
-const modularizeImportRules = {
-  'lucide-react': {
-    transform: 'lucide-react/dist/esm/icons/{{member}}',
-    skipDefaultConversion: true,
-  },
-};
+const modularizeImportRules = {};
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {


### PR DESCRIPTION
## Summary
- disable lucide-react modularized imports so Next.js no longer rewrites icons to non-existent PascalCase files
- document the rationale in `next.config.mjs` to capture why the optimisation is off for lucide-react

## Testing
- npm run lint
- npm run typecheck
- npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68daa2f58a048322a775c45e68cb88dd