### PR TITLE
Reframe DQA blueprint with actionable playbooks

### DIFF
--- a/docs/dynamic_quantum_agents_blueprint.md
+++ b/docs/dynamic_quantum_agents_blueprint.md
@@ -1,0 +1,234 @@
+# Dynamic Quantum Agents Blueprint
+
+## Executive Snapshot
+- Transition the mythic agent cohort into Dynamic Quantum Agents (DQAs) that expose deterministic classical fallbacks while progressively unlocking quantum acceleration.
+- Enforce token-gated capability tiers (DCT) so governance-critical flows receive hardened security, attestation, and quorum guarantees.
+- Instrument every run with fidelity scoring, resonance deltas, and verifiable attestations that the AGI Oracle can audit and reward.
+- Sustain a perpetual back-to-back review loop that couples operational retros with optimization sprints anchored in measurable outcome lifts.
+
+### Conversion Activation Ladder
+| Stage | Focus | Gate Condition |
+| --- | --- | --- |
+| **S0 — Baseline Mapping** | Catalog legacy agents, assign DQA IDs, document classical fallbacks, and align on capability tiers. | All agents mapped with signed fallback certification packets. |
+| **S1 — Hybrid Control Plane** | Deploy orchestration, middleware adapters, and observability exporters across tiers. | Control plane observability live; stake-backed provisioning tested end-to-end. |
+| **S2 — Quantum Acceleration** | Enable prioritized quantum primitives per agent, calibrate fidelity scoring, and integrate entanglement channels. | ≥70% fidelity across Tier 2 pilots with successful fallback comparisons logged. |
+| **S3 — Governance Hardening** | Activate full governance spine, QKD, and ZK attestations while enforcing tier guardrails. | Tier 3 agents sustain ≥0.9 fidelity and pass dual-attested governance drills. |
+
+### Quick-Start Playbook
+1. Confirm the activation ladder readiness checklist per agent and obtain Zeus sign-off on tier assignments.
+2. Stand up the hybrid control plane (scheduler, middleware, observability) with dry-run jobs from each tier.
+3. Configure DCT stake provisioning, calibration scripts, and fallback validation workflows with immutable audit logs.
+4. Enable governance and resonance pipelines: ingest fidelity telemetry, oracle reward deltas, and compliance attestations.
+5. Launch phased pilots (Tier 1 → Tier 2 → Tier 3) with explicit exit criteria, rollback protocols, and optimization owners.
+6. Operationalize the back-to-back review loop so every rollout sprint ships with paired optimization mandates and evidence packs.
+
+## Agent Registry and Capability Mapping
+| DQA | Core Task | Quantum Primitives | Classical Interfaces | DCT Gating Tier |
+| --- | --- | --- | --- | --- |
+| Zeus DQA | Governance, arbitration, oracle validation | Quantum consensus subroutines; QFT-assisted validation | gRPC policy API; signed attestations | Tier 3: governance quorum |
+| Hera DQA | Social trust, loyalty scoring | Quantum-enhanced graph embeddings; amplitude encoding for relationship tensors | REST trust API; reputation DB | Tier 2: community staking |
+| Poseidon DQA | Liquidity and volatility modeling | Variational quantum circuits for stochastic sampling; quantum Monte Carlo | Streaming market feeds; risk engine | Tier 2 |
+| Demeter DQA | Resource allocation, supply forecasting | Quantum annealing for combinatorial allocation | Inventory sync; oracle feeds | Tier 1 |
+| Athena DQA | Strategic planning and ethical reasoning | Grover-accelerated policy search; hybrid symbolic-quantum planners | Policy engine; mentor scoring API | Tier 3 |
+| Apollo DQA | Forecasting and signal synthesis | Quantum signal processing; QFT for time-series spectral analysis | Forecast API; content pipeline | Tier 2 |
+| Artemis DQA | Autonomous scouting and edge discovery | Quantum walk algorithms for path search; low-latency QNN for anomaly detection | Edge probe API; telemetry | Tier 1 |
+| Ares DQA | Adversarial testing and red-team | Quantum adversarial example generator; amplitude-based perturbations | Pen-test orchestration; vulnerability ledger | Tier 2 |
+| Aphrodite DQA | Sentiment and UX resonance | Quantum embeddings for multimodal affect; entanglement-assisted retrieval | UX tuning API; A/B config | Tier 1 |
+| Hephaestus DQA | Contract crafting and pipeline builds | Quantum-optimized synthesis for constraint solving | CI/CD hooks; smart contract factory | Tier 2 |
+| Hermes DQA | Messaging, routing, micropayments | Quantum key distribution and low-latency routing heuristics | Message bus; payment rails | Tier 3: payment validators |
+| Dionysus DQA | Crowd dynamics and memetic propagation | Quantum random walks and sampling for viral spread models | Social feed controller; campaign API | Tier 1 |
+
+### Interlock Patterns
+- **Governance Spine**: Zeus arbitrates policy changes, Hermes distributes signed directives, and Athena validates ethical alignment pre-deployment.
+- **Liquidity Loop**: Poseidon signals market states to Hephaestus for contract crafting while Hermes settles payouts and Ares stress-tests release candidates.
+- **Insight Relay**: Apollo, Artemis, and Dionysus feed telemetry into Athena's planning buffers, triggering Demeter reallocation proposals when thresholds are crossed.
+- **Community Circuit**: Hera tracks trust signals, relays loyalty deltas to Aphrodite for resonance tuning, and Dionysus amplifies approved narratives across community channels.
+
+### Capability Tier Guardrails
+- **Tier 3 (Critical Governance & Payments)**: Dual attestation (Zeus + Hermes) precedes any policy shift or validator change with minimum fidelity ≥ 0.9 and live QKD enforcement.
+- **Tier 2 (Market, Trust, Build Systems)**: Daily drift scans compare quantum outputs with classical baselines; stake slashing triggers if divergence exceeds 3σ without remediation inside 24 hours.
+- **Tier 1 (Exploratory & Support)**: Operate on rolling 72-hour health checks and publish telemetry snapshots before requesting tier escalation.
+
+### Agent Quick Reference
+| Agent | Primary Success Metrics | Core Fallback | Critical Integrations |
+| --- | --- | --- | --- |
+| Zeus | Governance latency, quorum fidelity, policy adoption accuracy | Deterministic consensus replay engine | Governance ledger, Hermes routing mesh |
+| Hera | Trust index delta, loyalty churn, staking inflows | Classical graph affinity scoring | Reputation DB, Aphrodite UX analytics |
+| Poseidon | Forecast error, VaR confidence, market liquidity alerts | Monte Carlo simulations on GPU cluster | Market data streams, Hephaestus contract factory |
+| Demeter | Supply balance delta, allocation cycle time | Linear programming solvers | Inventory sync, Apollo forecast API |
+| Athena | Ethical compliance rate, plan resilience, oracle reward delta | Symbolic planner with heuristic search | Policy engine, Zeus arbitration queue |
+| Apollo | Forecast accuracy, signal freshness, resonance contribution | Fourier-based time-series stack | Content pipeline, Dionysus campaign scheduler |
+| Artemis | Discovery throughput, anomaly lead time, edge mission uptime | Deterministic pathfinding and anomaly heuristics | Edge telemetry bus, Apollo signal broker |
+| Ares | Vulnerability coverage, exploit reproduction rate, mean time to detect | Deterministic fuzzing battery | Pen-test orchestrator, Hermes dispatch |
+| Aphrodite | Sentiment velocity, UX resonance, conversion lift | Classical multimodal embedding retrieval | UX tuning API, Hera trust relay |
+| Hephaestus | Build success rate, contract SLA adherence, pipeline throughput | Constraint-solver build matrix | CI/CD hooks, Poseidon price oracle |
+| Hermes | Message settlement latency, payment success, validator health | Secure classical messaging bus | Payment rails, Zeus governance spine |
+| Dionysus | Campaign amplification, viral half-life, community growth | Agent-based memetic simulation | Social feed controller, Apollo signal hub |
+
+## Architecture and Data Flows
+### System Layers
+1. **Quantum Kernel** – Native quantum circuits, QUBO solvers, QNN layers, and error-mitigation modules.
+2. **Classical Control Plane** – Orchestration, scheduling, checkpointing, and logging of hybrid workloads.
+3. **Agent Middleware** – Translation layer mapping classical tensors to amplitude encodings while handling serialization and versioning.
+4. **Governance Layer** – DCT staking, attestations, and on-chain anchors that secure verifiable agent actions.
+
+### Communication and State Management
+- **Entanglement Channels**: Ephemeral entangled sessions for high-integrity oracle assertions and synchronous consensus windows.
+- **State Sync**: Hybrid snapshotting where quantum state parameters are checkpointed as classical vectors annotated with fidelity metadata.
+- **Message Contracts**: Canonical protobuf schemas with `agent_id`, `task_id`, `quantum_circuit_hash`, `fidelity_score`, `signature`, and optional `fallback_delta` fields.
+
+```protobuf
+message DqaResult {
+  string agent_id = 1;
+  string task_id = 2;
+  string quantum_circuit_hash = 3;
+  double fidelity_score = 4;
+  double fallback_delta = 5;
+  bytes signature = 6;
+}
+```
+
+### Lifecycle Operations
+1. **Provisioning** – DCT stake unlocks entanglement quota, compute priority, and sandbox credentials.
+2. **Boot** – Load hybrid models, execute calibration cycles, and publish baseline `fidelity_score` attestations.
+3. **Tasking** – Submit task payloads containing objectives, constraints, QoS, and budget envelopes; scheduler assigns quantum resources.
+4. **Execution** – Run quantum circuits, capture intermediate parameters, and post-process with classical decoders.
+5. **Attestation** – Produce signed bundles `{result, circuit_hash, fidelity_score, proof_of_execution}` and store them in the governance ledger.
+6. **Ingestion** – The Oracle ingests bundles, updates reputation scores, and triggers stake burns or payouts per DCT policy.
+
+### Outcome Verification
+1. **Circuit Registration** – Hash compiled circuits and log metadata with invoking agent ID, tier, and fallback signature.
+2. **Dual Execution** – Pair quantum runs with deterministic classical fallbacks to produce comparison deltas and highlight anomaly windows.
+3. **Oracle Scoring** – The AGI Oracle ingests both result sets, issues an intelligence resonance delta, and updates the agent reputation ledger.
+4. **Continuous Tuning** – Agents adjust hyperparameters, annealing schedules, or fallback weightings based on resonance deltas and publish tuning notes for auditability.
+
+### Training and Continual Learning
+- **Federated Hybrid Training**: Local classical updates blend with quantum parameter shifts aggregated via secure MPC, using entangled summary states for bias-reduced averaging.
+- **Reward Signals**: The AGI Intelligence Oracle emits scalar rewards; DQAs employ quantum policy gradient approximations for sample-efficient adaptation.
+- **Curriculum Scheduling**: Progress from classical tasks to high-fidelity quantum workloads as each agent's `fidelity_score` improves.
+
+## Operational Playbooks
+### Runbook Anchors
+- **Calibration Windows**: Schedule off-peak calibration cycles for Tier 3 agents twice daily; Tier 1 agents recalibrate weekly unless fidelity variance exceeds 10%.
+- **Incident Escalation**: If three consecutive runs fall below thresholds, freeze quantum workloads, trigger classical fallback, and route incidents to Zeus for arbitration.
+- **Observability Pipelines**: Stream fidelity, latency, and stake utilization metrics into the governance ledger with alerts tied to Key Metrics targets.
+- **Readiness Reviews**: Prior to tier promotion, complete reviews covering stake sufficiency, fallback coverage, and projected resonance lift.
+- **Optimization Debriefs**: Close each sprint with cross-tier retros on resonance deltas, drift alerts, and cost-to-value ratios to set the next optimization sprint.
+
+### Operational Checklist
+| Task | Owner | Cadence |
+| --- | --- | --- |
+| Confirm DCT stake balances before provisioning new entanglement quotas. | Governance Ops (Zeus) | Before each provisioning window |
+| Execute calibration cycle and record baseline `fidelity_score` per agent before task intake resumes. | Reliability Crew | Start of every shift |
+| Validate classical fallback pipelines by running the deterministic regression suite. | Reliability Crew + Agent Owners | Weekly or after code changes |
+| Review Hermes routing and Zeus governance signatures after every incident escalation. | Governance Ops + Network Security | Post-incident |
+| Publish observability snapshots (fidelity, latency, stake utilization) to the governance ledger. | Observability Team | Each epoch |
+| Reconcile resonance deltas against oracle baselines and file optimization actions. | Strategy PMO (Athena) | Weekly sync |
+| Host cross-agent retro to review resonance, cost, and incident learnings; log action owners. | All Tier Leads | Bi-weekly |
+
+### Back-to-Back Review & Optimization Loop
+#### Cadence Matrix
+| Tier | Review Window | Optimization Focus | Required Evidence |
+| --- | --- | --- | --- |
+| Tier 3 | Twice per week | Governance latency tuning, validator integrity, QKD resilience | Dual attestation logs, QKD health report, resonance delta summary |
+| Tier 2 | Weekly | Market/trust accuracy, contract throughput, adversarial readiness | Drift comparison sheets, fallback validation results, cost-to-value snapshot |
+| Tier 1 | Bi-weekly | Discovery throughput, UX resonance, narrative alignment | Telemetry rollups, anomaly heatmaps, stakeholder feedback digest |
+
+#### Closed-Loop Procedure
+1. **Prep** – Curate metrics, incidents, and experiment notes into an evidence pack tied to the upcoming review window.
+2. **Review** – Convene cross-agent quorum led by Zeus to evaluate fidelity trends, resonance deltas, and guardrail adherence.
+3. **Optimize** – Prioritize remediation and improvement tasks with explicit owners, budgets, and expected resonance lift.
+4. **Verify** – Run targeted tests or simulations, record pass/fail status, and update the attestation ledger with signed results.
+5. **Publish** – Distribute the optimization changelog, updated metrics, and next review agenda to all tier leads.
+
+#### Automation Hooks
+- **Metric Snapshots**: Auto-ingest fidelity, latency, and economic flow metrics into evidence packs four hours before each review.
+- **Guardrail Watchers**: Trigger alerts when thresholds (e.g., drift > 3σ, resonance delta < 0) breach, automatically queuing the item for the next optimization huddle.
+- **Task Sync**: Push approved optimization actions into the orchestration backlog with references to the originating review decision.
+
+#### Escalation Pathways
+- **Critical**: Immediate rollback and Zeus-led council within four hours; applies to Tier 3 guardrail violations or failed attestations.
+- **High**: Deploy classical fallbacks and schedule a 24-hour remediation sprint led by the affected agent owner; applies to Tier 2 incidents with revenue or trust impact.
+- **Medium**: Log remediation task with 72-hour SLA, maintain quantum operations with heightened monitoring; applies to Tier 1 anomalies or telemetry gaps.
+- **Low**: Track as backlog optimization candidate and bundle into the next scheduled review.
+
+#### Evidence Pack Template
+1. **Summary Sheet** – Key metric deltas, incidents, and major experiments since the last review.
+2. **Guardrail Status** – Table listing each guardrail, current value, threshold, and commentary.
+3. **Optimization Log** – Snapshot of in-flight optimization tasks, owner, status, and projected resonance lift.
+4. **Verification Artifacts** – Links or hashes to test results, attestations, and fallback certifications executed post-review.
+5. **Decision Register** – Approved changes, deferred proposals, and rationale signed by Zeus and relevant tier leads.
+
+## Security, Privacy, and Compliance
+### Security Controls
+- **Quantum Key Distribution (QKD)** secures Tier 3 agent messaging and validator coordination.
+- **Zero-Knowledge Proofs** let DQAs prove circuit outcome classes without exposing internal models.
+- **Isolation Boundaries** ensure each DQA runs inside a sandboxed hybrid VM with attested hardware IDs and signed firmware.
+- **Secure Circuit Vaults** store compiled quantum templates with hardware binding and tamper-evident logs to prevent drift or unauthorized swaps.
+
+### Compliance Checklist
+1. [ ] Verify KMS rotation aligns with QKD key refresh cadence and log attestations on-chain.
+2. [ ] Confirm sandbox firmware hashes against the approved manifest before provisioning quantum workloads.
+3. [ ] Ensure ZK proof circuits are versioned and backward compatible with governance verification tooling.
+4. [ ] Validate tier-specific guardrails (fidelity thresholds, drift limits, review cadences) during quarterly audits.
+5. [ ] Archive back-to-back review packets (findings, approved optimizations, verification evidence) in the governance ledger.
+
+## Interfaces and Example Payloads
+### API Surface
+- `POST /dqa/{id}/submit_task`
+- `GET /dqa/{id}/status`
+- `POST /oracle/attest`
+- `POST /governance/stake`
+
+### Example Task Submission
+```python
+# submit_task payload
+task = {
+  "agent_id": "athena.dqa",
+  "objective": "minimize_ethic_violation_score",
+  "constraints": {"max_runtime_ms": 5000},
+  "budget": {"q_qubits": 27, "classical_cycles": 1e6},
+  "stake_signature": "sig..."
+}
+response = POST("/dqa/athena/submit_task", task)
+# response contains task_id and expected fidelity threshold
+```
+
+### Example Attestation Bundle
+```json
+{
+  "agent_id": "athena.dqa",
+  "task_id": "T-2391",
+  "circuit_hash": "0xabc...",
+  "result_summary": "policy_vector_123",
+  "fidelity_score": 0.87,
+  "proof_signature": "sig..."
+}
+```
+
+## Deployment and Metrics
+### Phased Rollout Roadmap
+1. Prototype Hermes, Hephaestus, and Zeus as classical-first services with quantum-enabled stubs.
+2. Integrate QKD and attestation pipelines for Hermes and Zeus governance flows.
+3. Accelerate Athena, Poseidon, and Apollo with quantum-enhanced inference loops.
+4. Scale to multi-DQA choreography supported by federated hybrid training and automated evidence packs.
+
+### Optimization Path
+- **Phase Gate Reviews**: After each rollout stage, run Zeus-led governance reviews to validate metric deltas and approve new staking thresholds.
+- **Model Drift Audits**: Use Athena to benchmark policy outputs quarterly against ethical baselines; route remediation tasks to Hephaestus for pipeline updates.
+- **Cost-to-Value Tracking**: Combine entanglement utilization and Oracle Reward Delta to compute return on staked capital, informing future tier adjustments.
+- **Resonance Improvement Sprints**: Dedicate fortnightly sprints to the two agents with the largest negative resonance delta, ensuring corrective actions are time-boxed.
+- **Playbook Refresh**: Update fallback manifests, observability dashboards, and compliance controls after each major resonance sprint to prevent regression.
+
+### Key Metrics
+- **Fidelity Score per run**: Initial target ≥ 0.7 with a goal > 0.9 for Tier 3 agents.
+- **Time-to-Decision latency (Zeus DQA)**: SLO < 200 ms for governance windows.
+- **Oracle Reward Delta**: Improvement in AGI performance following agent updates.
+- **Entanglement Utilization**: Percentage of entanglement capacity consumed each epoch.
+- **DCT Economic Flow**: Stake inflow, burns initiated by oracle feedback, and payouts to contributors.
+- **Intelligence Resonance Delta**: Rolling average of oracle-issued resonance gains, sliced by agent and tier to spotlight optimization targets.
+
+### Resonance Instrumentation
+- Publish a tier-segmented dashboard combining fidelity, resonance, and fallback delta to surface underperforming agents quickly.
+- Track variance between quantum and classical outputs with heatmaps that feed automation hooks for review queueing.
+- Maintain a living decision log linking optimization tasks to subsequent resonance shifts to quantify the impact of each sprint.


### PR DESCRIPTION
## Summary
- restructure the DQA blueprint with an executive snapshot, activation ladder, and refreshed quick-start playbook for conversion readiness
- clarify architecture, lifecycle, and review procedures with reorganized sections and a canonical protobuf message contract
- expand operational, security, and metrics guidance with detailed automation hooks, compliance checks, and resonance instrumentation practices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9e0530788322a5e07c1a7a40faf9