### PR TITLE
Ensure lovable scripts run from repository root

### DIFF
--- a/lovable-build.js
+++ b/lovable-build.js
@@ -4,6 +4,8 @@ import { execSync, spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { cpus } from "node:os";
 import { performance } from "node:perf_hooks";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   banner,
   celebrate,
@@ -21,6 +23,12 @@ import {
   PRODUCTION_ALLOWED_ORIGINS,
   PRODUCTION_ORIGIN,
 } from "./scripts/utils/branding-env.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptDirectory);
+if (process.cwd() !== repositoryRoot) {
+  process.chdir(repositoryRoot);
+}
 
 function parseListInput(value) {
   if (!value) return [];

--- a/lovable-dev.js
+++ b/lovable-dev.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   banner,
   celebrate,
@@ -17,6 +19,12 @@ import {
   PRODUCTION_ALLOWED_ORIGINS,
   PRODUCTION_ORIGIN,
 } from "./scripts/utils/branding-env.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptDirectory);
+if (process.cwd() !== repositoryRoot) {
+  process.chdir(repositoryRoot);
+}
 
 const {
   defaultedKeys,


### PR DESCRIPTION
## Summary
- ensure both lovable CLI entrypoints change to the repository root before running commands so builds run consistently

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68daabca45ec8322b3d95557d388a4ce