### PR TITLE
Fix OneDrive webhook tests and update Deno bootstrap

### DIFF
--- a/supabase/functions/_shared/serve.ts
+++ b/supabase/functions/_shared/serve.ts
@@ -11,6 +11,13 @@ export function registerHandler(
   handler: EdgeHandler,
   options?: ServeOptions,
 ): EdgeHandler {
+  const globalAny = globalThis as {
+    __SUPABASE_SKIP_AUTO_SERVE__?: boolean;
+  };
+  if (globalAny.__SUPABASE_SKIP_AUTO_SERVE__) {
+    return handler;
+  }
+
   if (typeof Deno?.serve === "function") {
     if (options) {
       (Deno.serve as unknown as (

--- a/supabase/functions/_tests/onedrive-webhook.test.ts
+++ b/supabase/functions/_tests/onedrive-webhook.test.ts
@@ -1,0 +1,308 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
+const REQUIRED_ENV = [
+  "ONEDRIVE_TENANT_ID",
+  "ONEDRIVE_CLIENT_ID",
+  "ONEDRIVE_CLIENT_SECRET",
+] as const;
+
+function setRequiredEnv() {
+  REQUIRED_ENV.forEach((key) => {
+    Deno.env.set(key, `test-${key.toLowerCase()}`);
+  });
+}
+
+function clearRequiredEnv() {
+  REQUIRED_ENV.forEach((key) => {
+    try {
+      Deno.env.delete(key);
+    } catch {
+      // Ignore when env permissions are restricted.
+    }
+  });
+  try {
+    Deno.env.delete("ONEDRIVE_DEFAULT_DRIVE_ID");
+  } catch {
+    // Ignore.
+  }
+}
+
+Deno.test("onedrive-webhook responds to validation handshake", async () => {
+  setRequiredEnv();
+  try {
+    const { handler } = await import(
+      `../onedrive-webhook/index.ts?cache=${crypto.randomUUID()}`
+    );
+
+    const request = new Request(
+      "http://localhost/functions/v1/onedrive-webhook?validationToken=abc123",
+      { method: "GET" },
+    );
+
+    const response = await handler(request);
+    assertEquals(response.status, 200);
+    assertEquals(
+      response.headers.get("content-type"),
+      "text/plain; charset=utf-8",
+    );
+    const text = await response.text();
+    assertEquals(text, "abc123");
+  } finally {
+    clearRequiredEnv();
+  }
+});
+
+Deno.test("onedrive-webhook can read drive item with content", async () => {
+  setRequiredEnv();
+  Deno.env.set("ONEDRIVE_DEFAULT_DRIVE_ID", "drive-123");
+
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  globalThis.fetch =
+    (async (input: Request | URL | string, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      calls.push({ url, init });
+
+      if (url.includes("/oauth2/v2.0/token")) {
+        return new Response(
+          JSON.stringify({ access_token: "fake-token", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (
+        url ===
+          "https://graph.microsoft.com/v1.0/drives/drive-123/root:/reports"
+      ) {
+        return new Response(
+          JSON.stringify({
+            id: "item-789",
+            name: "reports",
+            file: { mimeType: "text/plain" },
+            parentReference: { id: "root", path: "/drive/root:" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (
+        url ===
+          "https://graph.microsoft.com/v1.0/drives/drive-123/root:/reports:/content"
+      ) {
+        return new Response(new TextEncoder().encode("hello world"), {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+  try {
+    const { handler } = await import(
+      `../onedrive-webhook/index.ts?cache=${crypto.randomUUID()}`
+    );
+
+    const request = new Request(
+      "http://localhost/functions/v1/onedrive-webhook",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "read",
+          path: "reports",
+          includeContent: true,
+        }),
+      },
+    );
+
+    const response = await handler(request);
+    assertEquals(response.status, 200);
+    const payload = await response.json() as {
+      item: { id: string; name: string };
+      content: string;
+      encoding: string;
+    };
+    assertEquals(payload.item.id, "item-789");
+    assertEquals(payload.item.name, "reports");
+    assertEquals(payload.encoding, "utf-8");
+    assertEquals(payload.content, "hello world");
+
+    assertEquals(calls.length, 3);
+    assertStringIncludes(calls[1].url, "/drives/drive-123/root:/reports");
+    assertStringIncludes(
+      calls[2].url,
+      "/drives/drive-123/root:/reports:/content",
+    );
+  } finally {
+    clearRequiredEnv();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("onedrive-webhook uploads content", async () => {
+  setRequiredEnv();
+  Deno.env.set("ONEDRIVE_DEFAULT_DRIVE_ID", "drive-456");
+
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  globalThis.fetch =
+    (async (input: Request | URL | string, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      calls.push({ url, init });
+
+      if (url.includes("/oauth2/v2.0/token")) {
+        return new Response(
+          JSON.stringify({ access_token: "fake-token", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      if (
+        url.startsWith(
+          "https://graph.microsoft.com/v1.0/drives/drive-456/root:/notes:/content",
+        )
+      ) {
+        const received = init?.body instanceof Uint8Array
+          ? new TextDecoder().decode(init.body)
+          : init?.body as string;
+        if (received !== "memo") {
+          throw new Error(`Unexpected body: ${received}`);
+        }
+        return new Response(
+          JSON.stringify({ id: "item-999", name: "notes" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+  try {
+    const { handler } = await import(
+      `../onedrive-webhook/index.ts?cache=${crypto.randomUUID()}`
+    );
+
+    const request = new Request(
+      "http://localhost/functions/v1/onedrive-webhook",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "write",
+          path: "notes",
+          content: "memo",
+          contentType: "text/plain",
+          conflictBehavior: "replace",
+        }),
+      },
+    );
+
+    const response = await handler(request);
+    assertEquals(response.status, 200);
+    const payload = await response.json() as { item: { id: string } };
+    assertEquals(payload.item.id, "item-999");
+
+    assertEquals(calls.length, 2);
+    assertStringIncludes(
+      calls[1].url,
+      "/drives/drive-456/root:/notes:/content?@microsoft.graph.conflictBehavior=replace",
+    );
+  } finally {
+    clearRequiredEnv();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("onedrive-webhook processes notifications", async () => {
+  setRequiredEnv();
+
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string }> = [];
+
+  globalThis.fetch = (async (input: Request | URL | string) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.toString()
+      : input.url;
+    calls.push({ url });
+
+    if (url.includes("/oauth2/v2.0/token")) {
+      return new Response(
+        JSON.stringify({ access_token: "fake-token", expires_in: 3600 }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    if (
+      url === "https://graph.microsoft.com/v1.0/drives/drive-777/items/item-abc"
+    ) {
+      return new Response(
+        JSON.stringify({
+          id: "item-abc",
+          name: "report.pdf",
+          file: { mimeType: "application/pdf" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const { handler } = await import(
+      `../onedrive-webhook/index.ts?cache=${crypto.randomUUID()}`
+    );
+
+    const request = new Request(
+      "http://localhost/functions/v1/onedrive-webhook",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          value: [
+            {
+              subscriptionId: "sub-1",
+              resource: "drives/drive-777/items/item-abc",
+              changeType: "updated",
+            },
+          ],
+        }),
+      },
+    );
+
+    const response = await handler(request);
+    assertEquals(response.status, 200);
+    const payload = await response.json() as {
+      notifications: Array<
+        { notification: { subscriptionId: string }; item: { id: string } }
+      >;
+    };
+    assertEquals(payload.notifications.length, 1);
+    assertEquals(payload.notifications[0].notification.subscriptionId, "sub-1");
+    assertEquals(payload.notifications[0].item.id, "item-abc");
+
+    assertEquals(calls.length, 2);
+  } finally {
+    clearRequiredEnv();
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/supabase/functions/onedrive-webhook/index.ts
+++ b/supabase/functions/onedrive-webhook/index.ts
@@ -1,0 +1,560 @@
+import { optionalEnv, requireEnv } from "../_shared/env.ts";
+import {
+  bad,
+  corsHeaders,
+  jsonResponse,
+  methodNotAllowed,
+  oops,
+} from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+const GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
+
+const {
+  ONEDRIVE_TENANT_ID,
+  ONEDRIVE_CLIENT_ID,
+  ONEDRIVE_CLIENT_SECRET,
+} = requireEnv(
+  [
+    "ONEDRIVE_TENANT_ID",
+    "ONEDRIVE_CLIENT_ID",
+    "ONEDRIVE_CLIENT_SECRET",
+  ] as const,
+);
+
+const DEFAULT_SCOPE = optionalEnv("ONEDRIVE_SCOPE") ??
+  "https://graph.microsoft.com/.default";
+const DEFAULT_DRIVE_ID = optionalEnv("ONEDRIVE_DEFAULT_DRIVE_ID");
+
+interface TokenCache {
+  token: string;
+  scope: string;
+  expiresAt: number;
+}
+
+let tokenCache: TokenCache | null = null;
+
+function nowMs() {
+  return Date.now();
+}
+
+async function getAccessToken(): Promise<string> {
+  if (tokenCache && tokenCache.scope === DEFAULT_SCOPE) {
+    if (tokenCache.expiresAt > nowMs()) {
+      return tokenCache.token;
+    }
+  }
+
+  const tokenUrl =
+    `https://login.microsoftonline.com/${ONEDRIVE_TENANT_ID}/oauth2/v2.0/token`;
+
+  const body = new URLSearchParams({
+    client_id: ONEDRIVE_CLIENT_ID,
+    client_secret: ONEDRIVE_CLIENT_SECRET,
+    scope: DEFAULT_SCOPE,
+    grant_type: "client_credentials",
+  });
+
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Failed to acquire OneDrive token (${response.status} ${response.statusText}): ${detail}`,
+    );
+  }
+
+  const payload = await response.json() as {
+    access_token?: string;
+    expires_in?: number;
+  };
+
+  if (!payload.access_token) {
+    throw new Error("OneDrive token response did not include access_token");
+  }
+
+  const expiresInSeconds = Number(payload.expires_in ?? 3600);
+  const ttl = Number.isFinite(expiresInSeconds)
+    ? Math.max(60, Math.floor(expiresInSeconds))
+    : 3600;
+  const safetyWindowMs = 60 * 1000;
+
+  tokenCache = {
+    token: payload.access_token,
+    scope: DEFAULT_SCOPE,
+    expiresAt: nowMs() + ttl * 1000 - safetyWindowMs,
+  };
+
+  return payload.access_token;
+}
+
+async function graphRequest<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const token = await getAccessToken();
+  const headers = new Headers(init.headers ?? {});
+  headers.set("Authorization", `Bearer ${token}`);
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json; charset=utf-8");
+  }
+
+  const url = path.startsWith("http")
+    ? path
+    : `${GRAPH_BASE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+
+  const response = await fetch(url, {
+    ...init,
+    headers,
+  });
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const isJson = contentType.includes("application/json");
+
+  if (!response.ok) {
+    let detail: unknown = null;
+    if (isJson) {
+      try {
+        detail = await response.json();
+      } catch {
+        detail = await response.text();
+      }
+    } else {
+      detail = await response.text();
+    }
+    const detailText = typeof detail === "string"
+      ? detail
+      : JSON.stringify(detail);
+    throw new Error(
+      `Microsoft Graph request failed (${response.status} ${response.statusText}): ${detailText}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  if (isJson) {
+    return await response.json() as T;
+  }
+
+  const text = await response.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return text as unknown as T;
+  }
+}
+
+async function graphFetchBinary(
+  path: string,
+  init: RequestInit = {},
+): Promise<Uint8Array> {
+  const token = await getAccessToken();
+  const headers = new Headers(init.headers ?? {});
+  headers.set("Authorization", `Bearer ${token}`);
+
+  const url = path.startsWith("http")
+    ? path
+    : `${GRAPH_BASE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+
+  const response = await fetch(url, {
+    ...init,
+    headers,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Microsoft Graph binary fetch failed (${response.status} ${response.statusText}): ${detail}`,
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+type UploadEncoding = "utf-8" | "base64";
+
+type ConflictBehavior = "fail" | "replace" | "rename";
+
+interface GraphHashes {
+  quickXorHash?: string | null;
+  sha1Hash?: string | null;
+  sha256Hash?: string | null;
+}
+
+interface GraphDriveItem {
+  id?: string;
+  name?: string;
+  size?: number;
+  webUrl?: string | null;
+  lastModifiedDateTime?: string | null;
+  createdDateTime?: string | null;
+  file?: {
+    mimeType?: string | null;
+    hashes?: GraphHashes | null;
+  } | null;
+  folder?: {
+    childCount?: number | null;
+  } | null;
+  parentReference?: {
+    id?: string | null;
+    path?: string | null;
+    driveId?: string | null;
+  } | null;
+  eTag?: string | null;
+  cTag?: string | null;
+  "@microsoft.graph.downloadUrl"?: string | null;
+}
+
+interface DriveItemMeta {
+  id: string;
+  name: string;
+  size: number | null;
+  webUrl: string | null;
+  lastModifiedDateTime: string | null;
+  createdDateTime: string | null;
+  isFolder: boolean;
+  childCount: number | null;
+  mimeType: string | null;
+  parentId: string | null;
+  parentPath: string | null;
+  eTag: string | null;
+  cTag: string | null;
+  downloadUrl: string | null;
+  hashes: GraphHashes | null;
+}
+
+interface ReadRequest {
+  action: "read";
+  driveId?: unknown;
+  itemId?: unknown;
+  path?: unknown;
+  includeContent?: unknown;
+  encoding?: unknown;
+}
+
+interface WriteRequest {
+  action: "write";
+  driveId?: unknown;
+  path?: unknown;
+  content?: unknown;
+  encoding?: unknown;
+  contentType?: unknown;
+  conflictBehavior?: unknown;
+}
+
+type RequestPayload = ReadRequest | WriteRequest | Record<string, unknown>;
+
+interface GraphNotification {
+  subscriptionId?: string;
+  resource?: string;
+  tenantId?: string;
+  siteUrl?: string;
+  expirationDateTime?: string;
+  changeType?: string;
+  clientState?: string;
+  resourceData?: {
+    id?: string;
+    driveId?: string;
+    parentReference?: {
+      driveId?: string;
+      id?: string;
+    } | null;
+  } | null;
+}
+
+function resolveDriveId(input: unknown): string {
+  if (typeof input === "string" && input.trim().length > 0) {
+    return input.trim();
+  }
+  if (DEFAULT_DRIVE_ID && DEFAULT_DRIVE_ID.trim().length > 0) {
+    return DEFAULT_DRIVE_ID.trim();
+  }
+  throw new Error(
+    "driveId is required when ONEDRIVE_DEFAULT_DRIVE_ID is not configured",
+  );
+}
+
+function normalizePath(path: unknown): string | null {
+  if (typeof path !== "string") {
+    return null;
+  }
+  const trimmed = path.trim().replace(/^\/+|\/+$/g, "");
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function encodeItemPath(path: string): string {
+  return path.split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildItemPath(
+  driveId: string,
+  options: { itemId?: unknown; path?: unknown },
+): string {
+  if (typeof options.itemId === "string" && options.itemId.trim().length > 0) {
+    return `/drives/${driveId}/items/${
+      encodeURIComponent(options.itemId.trim())
+    }`;
+  }
+  const normalized = normalizePath(options.path);
+  if (normalized) {
+    return `/drives/${driveId}/root:/${encodeItemPath(normalized)}`;
+  }
+  return `/drives/${driveId}/root`;
+}
+
+function normalizeDriveItem(item: GraphDriveItem): DriveItemMeta {
+  return {
+    id: item.id ?? "",
+    name: item.name ?? "",
+    size: typeof item.size === "number" ? item.size : null,
+    webUrl: item.webUrl ?? null,
+    lastModifiedDateTime: item.lastModifiedDateTime ?? null,
+    createdDateTime: item.createdDateTime ?? null,
+    isFolder: !!item.folder,
+    childCount: item.folder?.childCount ?? null,
+    mimeType: item.file?.mimeType ?? null,
+    parentId: item.parentReference?.id ?? null,
+    parentPath: item.parentReference?.path ?? null,
+    eTag: item.eTag ?? null,
+    cTag: item.cTag ?? null,
+    downloadUrl: (item as GraphDriveItem)["@microsoft.graph.downloadUrl"] ??
+      null,
+    hashes: item.file?.hashes ?? null,
+  };
+}
+
+function decodeUploadContent(
+  content: unknown,
+  encoding: UploadEncoding,
+): Uint8Array {
+  if (typeof content !== "string") {
+    throw new Error("content must be a string when uploading");
+  }
+  if (encoding === "base64") {
+    const binary = atob(content);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+  return new TextEncoder().encode(content);
+}
+
+function encodeDownloadContent(
+  bytes: Uint8Array,
+  encoding: UploadEncoding,
+): string {
+  if (encoding === "base64") {
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+async function handleRead(
+  payload: ReadRequest,
+  req: Request,
+): Promise<Response> {
+  const driveId = resolveDriveId(payload.driveId);
+  const itemPath = buildItemPath(driveId, {
+    itemId: payload.itemId,
+    path: payload.path,
+  });
+
+  const item = await graphRequest<GraphDriveItem>(`${itemPath}`);
+  const meta = normalizeDriveItem(item);
+
+  const includeContent = payload.includeContent === true ||
+    payload.includeContent === "true";
+  if (!includeContent) {
+    return jsonResponse({ item: meta }, { status: 200 }, req);
+  }
+
+  const encoding: UploadEncoding = payload.encoding === "base64"
+    ? "base64"
+    : "utf-8";
+  const usingItemId = typeof payload.itemId === "string" &&
+    payload.itemId.trim().length > 0;
+  const contentPath = usingItemId
+    ? `${itemPath}/content`
+    : `${itemPath}:/content`;
+  const bytes = await graphFetchBinary(contentPath, {
+    method: "GET",
+  });
+  const content = encodeDownloadContent(bytes, encoding);
+
+  return jsonResponse({ item: meta, content, encoding }, { status: 200 }, req);
+}
+
+async function handleWrite(
+  payload: WriteRequest,
+  req: Request,
+): Promise<Response> {
+  const driveId = resolveDriveId(payload.driveId);
+  const path = normalizePath(payload.path);
+  if (!path) {
+    throw new Error("path is required for write action");
+  }
+
+  const encoding: UploadEncoding = payload.encoding === "base64"
+    ? "base64"
+    : "utf-8";
+  const bytes = decodeUploadContent(payload.content, encoding);
+
+  const conflict: ConflictBehavior | null =
+    typeof payload.conflictBehavior === "string" &&
+      ["fail", "replace", "rename"].includes(payload.conflictBehavior)
+      ? payload.conflictBehavior as ConflictBehavior
+      : null;
+
+  const conflictParam = conflict
+    ? `?@microsoft.graph.conflictBehavior=${conflict}`
+    : "";
+
+  const uploadPath = `/drives/${driveId}/root:/${
+    encodeItemPath(path)
+  }:/content${conflictParam}`;
+
+  const headers = new Headers();
+  headers.set(
+    "Content-Type",
+    typeof payload.contentType === "string"
+      ? payload.contentType
+      : "application/octet-stream",
+  );
+
+  const response = await graphRequest<GraphDriveItem>(uploadPath, {
+    method: "PUT",
+    headers,
+    body: bytes,
+  });
+
+  return jsonResponse(
+    { item: normalizeDriveItem(response) },
+    { status: 200 },
+    req,
+  );
+}
+
+async function processNotifications(
+  notifications: GraphNotification[],
+  req: Request,
+): Promise<Response> {
+  const results = await Promise.all(
+    notifications.map(async (notification) => {
+      const resource = notification.resource?.trim();
+      if (!resource) {
+        return { notification, error: "Missing resource" };
+      }
+      try {
+        const item = await graphRequest<GraphDriveItem>(resource);
+        return { notification, item: normalizeDriveItem(item) };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error("[onedrive-webhook] failed to fetch resource", {
+          resource,
+          error: message,
+        });
+        return { notification, error: message };
+      }
+    }),
+  );
+
+  return jsonResponse(
+    { ok: true, notifications: results },
+    { status: 200 },
+    req,
+  );
+}
+
+async function handlePost(req: Request): Promise<Response> {
+  let payload: RequestPayload;
+  try {
+    payload = await req.json() as RequestPayload;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return bad("Invalid JSON payload", { message }, req);
+  }
+
+  if (payload && typeof payload === "object" && "action" in payload) {
+    const action = (payload as ReadRequest | WriteRequest).action;
+    try {
+      if (action === "read") {
+        return await handleRead(payload as ReadRequest, req);
+      }
+      if (action === "write") {
+        return await handleWrite(payload as WriteRequest, req);
+      }
+      return bad(`Unsupported action: ${action}`, undefined, req);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return oops("OneDrive action failed", { action, message }, req);
+    }
+  }
+
+  const notifications = Array.isArray((payload as { value?: unknown })?.value)
+    ? (payload as { value: GraphNotification[] }).value
+    : null;
+
+  if (notifications) {
+    return await processNotifications(notifications, req);
+  }
+
+  return bad("Unsupported payload", undefined, req);
+}
+
+async function handleRequest(req: Request): Promise<Response> {
+  try {
+    if (req.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          ...corsHeaders(req, "GET,POST,OPTIONS"),
+        },
+      });
+    }
+
+    if (req.method === "GET") {
+      const url = new URL(req.url);
+      const validationToken = url.searchParams.get("validationToken");
+      if (validationToken) {
+        return new Response(validationToken, {
+          status: 200,
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+            ...corsHeaders(req, "GET,POST,OPTIONS"),
+          },
+        });
+      }
+      return jsonResponse({ ok: true }, { status: 200 }, req);
+    }
+
+    if (req.method !== "POST") {
+      return methodNotAllowed(req);
+    }
+
+    return await handlePost(req);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[onedrive-webhook] unexpected error", error);
+    return oops("Unhandled error", { message }, req);
+  }
+}
+
+export const handler = registerHandler(handleRequest);


### PR DESCRIPTION
## Summary
- replace the npm-based fallback in `scripts/deno_bin.sh` with a repo-local installer that pins Deno v2.5.0 and reuses the cached binary on subsequent runs
- allow tests to opt-out of automatically launching `Deno.serve` by honoring a `__SUPABASE_SKIP_AUTO_SERVE__` flag and set it in the OneDrive webhook tests
- correct the OneDrive read logic to hit the `:/content` endpoint when requesting file bytes and clean up the exported handler name clash

## Testing
- `$(bash scripts/deno_bin.sh) test --no-config --no-npm --allow-env --allow-read supabase/functions/_tests/onedrive-webhook.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68daab570d9083229b0151e44a1a0a5d