### PR TITLE
Refactor domain health edge functions

### DIFF
--- a/supabase/functions/_shared/domain-health.ts
+++ b/supabase/functions/_shared/domain-health.ts
@@ -1,0 +1,135 @@
+import { getServiceClient } from "./client.ts";
+import {
+  buildHealthReport,
+  guardHealthRequest,
+  healthResponse,
+  type HealthStatus,
+  measureHealthCheck,
+} from "./health.ts";
+import { registerHandler } from "./serve.ts";
+
+interface DomainHealthConfig {
+  domain: string;
+  tables: readonly string[];
+  datasetPrefix: string;
+  description: string;
+  mirror?: {
+    noun?: string;
+    emptyMessage?: string;
+    healthyMessage?: string;
+    emptyStatus?: HealthStatus;
+    healthyStatus?: HealthStatus;
+  };
+}
+
+function describeCount(
+  count: number | null,
+  noun: string,
+): { message: string; status: HealthStatus } {
+  const total = count ?? 0;
+  if (total > 0) {
+    return {
+      status: "healthy",
+      message: `Found ${total} ${noun}`,
+    };
+  }
+  return {
+    status: "warning",
+    message: `No ${noun} found`,
+  };
+}
+
+export function createDomainHealthHandler(
+  config: DomainHealthConfig,
+) {
+  const {
+    domain,
+    tables,
+    datasetPrefix,
+    description,
+    mirror = {},
+  } = config;
+
+  const mirrorNoun = mirror.noun ?? "mirrored objects";
+  const mirrorEmptyStatus = mirror.emptyStatus ?? "warning";
+  const mirrorHealthyStatus = mirror.healthyStatus ?? "healthy";
+
+  return registerHandler(async (req) => {
+    const guard = guardHealthRequest(req, ["GET"]);
+    if (guard) return guard;
+
+    const supabase = getServiceClient();
+
+    const tableChecks = tables.map((table) =>
+      measureHealthCheck(`table:${table}`, async () => {
+        const { count, error } = await supabase
+          .from(table)
+          .select("*", { count: "exact", head: true });
+
+        if (error) {
+          return {
+            status: "error" as const,
+            message: `Failed to query ${table}: ${error.message}`,
+          };
+        }
+
+        const { status, message } = describeCount(count, "rows");
+        return {
+          status,
+          message: `${table} reachable. ${message}`,
+          metadata: { rows: count ?? 0 },
+        };
+      })
+    );
+
+    const manifestCheck = measureHealthCheck("onedrive:mirror", async () => {
+      const { count, error } = await supabase
+        .from("one_drive_assets")
+        .select("object_key", { count: "exact", head: true })
+        .ilike("object_key", `${datasetPrefix}%`);
+
+      if (error) {
+        return {
+          status: "error" as const,
+          message: `Mirror query failed: ${error.message}`,
+        };
+      }
+
+      const total = count ?? 0;
+      if (total === 0) {
+        return {
+          status: mirrorEmptyStatus,
+          message: mirror.emptyMessage ??
+            describeCount(total, mirrorNoun).message,
+          metadata: {
+            prefix: datasetPrefix,
+            objects: 0,
+          },
+        };
+      }
+
+      return {
+        status: mirrorHealthyStatus,
+        message: mirror.healthyMessage ??
+          describeCount(total, mirrorNoun).message,
+        metadata: {
+          prefix: datasetPrefix,
+          objects: total,
+        },
+      };
+    });
+
+    const checks = await Promise.all([...tableChecks, manifestCheck]);
+
+    const report = buildHealthReport(checks, {
+      metadata: {
+        domain,
+        dataset_prefix: datasetPrefix,
+        tables,
+        description,
+      },
+    });
+
+    return healthResponse(report, req, ["GET"]);
+  });
+}

--- a/supabase/functions/dagi-domain-health/index.ts
+++ b/supabase/functions/dagi-domain-health/index.ts
@@ -1,0 +1,19 @@
+import { createDomainHealthHandler } from "../_shared/domain-health.ts";
+
+const TABLES = [
+  "infrastructure_jobs",
+  "node_configs",
+  "mentor_feedback",
+] as const;
+
+const DATASET_PREFIX = "dagi/";
+
+export const handler = createDomainHealthHandler({
+  domain: "dagi",
+  tables: TABLES,
+  datasetPrefix: DATASET_PREFIX,
+  description:
+    "Dynamic AGI domain Supabase health: verifies tables and mirrored datasets.",
+});
+
+export default handler;

--- a/supabase/functions/dags-domain-health/index.ts
+++ b/supabase/functions/dags-domain-health/index.ts
@@ -1,0 +1,29 @@
+import { createDomainHealthHandler } from "../_shared/domain-health.ts";
+
+const TABLES = [
+  "tasks",
+  "task_steps",
+  "approvals",
+  "artifacts",
+  "events",
+  "limits",
+  "audit_logs",
+] as const;
+
+const DATASET_PREFIX = "dags/";
+
+export const handler = createDomainHealthHandler({
+  domain: "dags",
+  tables: TABLES,
+  datasetPrefix: DATASET_PREFIX,
+  description:
+    "Dynamic AGS domain Supabase health: verifies governance tables and mirror backlog.",
+  mirror: {
+    emptyMessage:
+      "No mirrored objects discovered. DAGS OneDrive mirror remains a documented follow-up.",
+    healthyMessage:
+      "Mirrored objects detected. Update playbooks to reflect the live OneDrive integration.",
+  },
+});
+
+export default handler;

--- a/supabase/functions/dai-domain-health/index.ts
+++ b/supabase/functions/dai-domain-health/index.ts
@@ -1,0 +1,19 @@
+import { createDomainHealthHandler } from "../_shared/domain-health.ts";
+
+const TABLES = [
+  "routine_prompts",
+  "analyst_insights",
+  "user_analytics",
+] as const;
+
+const DATASET_PREFIX = "dai/";
+
+export const handler = createDomainHealthHandler({
+  domain: "dai",
+  tables: TABLES,
+  datasetPrefix: DATASET_PREFIX,
+  description:
+    "Dynamic AI domain Supabase health: verifies tables and mirrored datasets.",
+});
+
+export default handler;


### PR DESCRIPTION
## Summary
- add a shared domain health handler to centralize Supabase health reporting logic
- update the DAI, DAGI, and DAGS edge functions to reuse the shared helper while keeping domain-specific messaging

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68daabfd46108322b95381ed757024d2