### PR TITLE
Enhance DAI/DAGI/DAGS domain connectivity checks

### DIFF
--- a/supabase/functions/_shared/domain-health.ts
+++ b/supabase/functions/_shared/domain-health.ts
@@ -1,0 +1,191 @@
+import { getServiceClient } from "./client.ts";
+import {
+  buildHealthReport,
+  guardHealthRequest,
+  healthResponse,
+  type HealthStatus,
+  measureHealthCheck,
+} from "./health.ts";
+import { registerHandler } from "./serve.ts";
+
+interface TableConfig {
+  name: string;
+  description?: string;
+  optional?: boolean;
+}
+
+interface EdgeFunctionConfig {
+  name: string;
+  description?: string;
+  endpoint?: string;
+}
+
+interface DatasetConfig {
+  prefix: string;
+  description?: string;
+  noun?: string;
+  optional?: boolean;
+  emptyMessage?: string;
+  healthyMessage?: string;
+  emptyStatus?: HealthStatus;
+  healthyStatus?: HealthStatus;
+}
+
+interface DomainHealthConfig {
+  domain: string;
+  tables: readonly TableConfig[];
+  dataset?: DatasetConfig;
+  description: string;
+  edgeFunctions?: readonly EdgeFunctionConfig[];
+  telemetry?: readonly string[];
+  notes?: readonly string[];
+}
+
+function describeCount(
+  count: number | null,
+  noun: string,
+): { message: string; status: HealthStatus } {
+  const total = count ?? 0;
+  if (total > 0) {
+    return {
+      status: "healthy",
+      message: `Found ${total} ${noun}`,
+    };
+  }
+  return {
+    status: "warning",
+    message: `No ${noun} found`,
+  };
+}
+
+export function createDomainHealthHandler(
+  config: DomainHealthConfig,
+) {
+  const {
+    domain,
+    tables,
+    dataset,
+    description,
+    edgeFunctions = [],
+    telemetry = [],
+    notes = [],
+  } = config;
+
+  const datasetConfig = dataset;
+  const mirrorNoun = datasetConfig?.noun ?? "mirrored objects";
+  const mirrorEmptyStatus = datasetConfig?.emptyStatus ??
+    (datasetConfig?.optional ? "warning" : "error");
+  const mirrorHealthyStatus = datasetConfig?.healthyStatus ?? "healthy";
+
+  return registerHandler(async (req) => {
+    const guard = guardHealthRequest(req, ["GET"]);
+    if (guard) return guard;
+
+    const supabase = getServiceClient();
+
+    const tableChecks = tables.map((table) =>
+      measureHealthCheck(`table:${table.name}`, async () => {
+        const { count, error } = await supabase
+          .from(table.name)
+          .select("*", { count: "exact", head: true });
+
+        if (error) {
+          return {
+            status: "error" as const,
+            message: `Failed to query ${table.name}: ${error.message}`,
+          };
+        }
+
+        const { status, message } = describeCount(count, "rows");
+        return {
+          status,
+          message: `${table.name} reachable. ${message}`,
+          metadata: {
+            table: table.name,
+            description: table.description,
+            optional: table.optional ?? false,
+            rows: count ?? 0,
+          },
+        };
+      })
+    );
+
+    const manifestCheck = datasetConfig
+      ? measureHealthCheck("onedrive:mirror", async () => {
+        const { count, error } = await supabase
+          .from("one_drive_assets")
+          .select("object_key", { count: "exact", head: true })
+          .ilike("object_key", `${datasetConfig.prefix}%`);
+
+        if (error) {
+          return {
+            status: "error" as const,
+            message: `Mirror query failed: ${error.message}`,
+          };
+        }
+
+        const total = count ?? 0;
+        if (total === 0) {
+          return {
+            status: mirrorEmptyStatus,
+            message: datasetConfig.emptyMessage ??
+              describeCount(total, mirrorNoun).message,
+            metadata: {
+              prefix: datasetConfig.prefix,
+              description: datasetConfig.description,
+              optional: datasetConfig.optional ?? false,
+              objects: 0,
+            },
+          };
+        }
+
+        return {
+          status: mirrorHealthyStatus,
+          message: datasetConfig.healthyMessage ??
+            describeCount(total, mirrorNoun).message,
+          metadata: {
+            prefix: datasetConfig.prefix,
+            description: datasetConfig.description,
+            optional: datasetConfig.optional ?? false,
+            objects: total,
+          },
+        };
+      })
+      : null;
+
+    const checks = manifestCheck
+      ? await Promise.all([...tableChecks, manifestCheck])
+      : await Promise.all(tableChecks);
+
+    const report = buildHealthReport(checks, {
+      metadata: {
+        domain,
+        description,
+        connectivity: {
+          tables: tables.map((table) => ({
+            name: table.name,
+            description: table.description,
+            optional: table.optional ?? false,
+          })),
+          dataset: datasetConfig
+            ? {
+              prefix: datasetConfig.prefix,
+              description: datasetConfig.description,
+              optional: datasetConfig.optional ?? false,
+              noun: datasetConfig.noun,
+            }
+            : undefined,
+          edge_functions: edgeFunctions.map((fn) => ({
+            name: fn.name,
+            description: fn.description,
+            endpoint: fn.endpoint,
+          })),
+          telemetry,
+          notes,
+        },
+      },
+    });
+
+    return healthResponse(report, req, ["GET"]);
+  });
+}

--- a/supabase/functions/dagi-domain-health/index.ts
+++ b/supabase/functions/dagi-domain-health/index.ts
@@ -1,0 +1,64 @@
+import { createDomainHealthHandler } from "../_shared/domain-health.ts";
+
+const TABLES = [
+  {
+    name: "infrastructure_jobs",
+    description: "Automation ledger coordinating AGI infrastructure tasks.",
+  },
+  {
+    name: "node_configs",
+    description: "Configuration manifest for orchestration nodes and keepers.",
+  },
+  {
+    name: "mentor_feedback",
+    description: "Mentor review loops that refine AGI skill performance.",
+  },
+];
+
+const EDGE_FUNCTIONS = [
+  {
+    name: "ops-health",
+    endpoint: "/functions/v1/ops-health",
+    description: "Aggregates AGI operational telemetry for custodians.",
+  },
+  {
+    name: "system-health",
+    endpoint: "/functions/v1/system-health",
+    description: "Publishes Dynamic Capital platform health snapshots.",
+  },
+  {
+    name: "linkage-audit",
+    endpoint: "/functions/v1/linkage-audit",
+    description: "Verifies cross-domain handoffs between orchestration nodes.",
+  },
+  {
+    name: "intent",
+    endpoint: "/functions/v1/intent",
+    description: "Captures AGI intent envelopes for routing and review.",
+  },
+];
+
+export const handler = createDomainHealthHandler({
+  domain: "dagi",
+  tables: TABLES,
+  dataset: {
+    prefix: "dagi/",
+    noun: "DAGI mirrored datasets",
+    description: "OneDrive artefacts mirrored for AGI orchestration.",
+    emptyStatus: "warning",
+    emptyMessage:
+      "No DAGI datasets detected in the mirror. Confirm orchestration jobs publish manifests.",
+  },
+  edgeFunctions: EDGE_FUNCTIONS,
+  telemetry: [
+    "Ops health logs",
+    "Intent envelopes",
+  ],
+  notes: [
+    "Run the wrappers bootstrap if the mirrored dataset manifest is unavailable.",
+  ],
+  description:
+    "Dynamic AGI database connectivity: validates Supabase tables, mirrored datasets, and orchestration edge coverage.",
+});
+
+export default handler;

--- a/supabase/functions/dags-domain-health/index.ts
+++ b/supabase/functions/dags-domain-health/index.ts
@@ -1,0 +1,69 @@
+import { createDomainHealthHandler } from "../_shared/domain-health.ts";
+
+const TABLES = [
+  {
+    name: "tasks",
+    description: "Governance tasks queued for AGS review.",
+  },
+  {
+    name: "task_steps",
+    description: "Ordered task execution steps and dependencies.",
+  },
+  {
+    name: "approvals",
+    description: "Approval ledger capturing reviewer sign-off.",
+  },
+  {
+    name: "artifacts",
+    description: "Artefacts produced during governance workflows.",
+  },
+  {
+    name: "events",
+    description: "Event stream documenting governance activity.",
+  },
+  {
+    name: "limits",
+    description: "Guardrails and policy limits enforced by AGS.",
+  },
+  {
+    name: "audit_logs",
+    description: "Structured audits for governance trail replay.",
+  },
+];
+
+const EDGE_FUNCTIONS = [
+  {
+    name: "ops-health",
+    endpoint: "/functions/v1/ops-health",
+    description: "Shared health surface referenced by AGS runbooks.",
+  },
+];
+
+export const handler = createDomainHealthHandler({
+  domain: "dags",
+  tables: TABLES,
+  dataset: {
+    prefix: "dags/",
+    noun: "DAGS mirrored datasets",
+    description:
+      "OneDrive mirror for governance artefacts (documented follow-up).",
+    optional: true,
+    emptyStatus: "warning",
+    emptyMessage:
+      "No DAGS mirror objects present. The governance playbook tracks this as a pending integration.",
+    healthyMessage:
+      "Mirrored DAGS artefacts detected. Update governance SOPs to treat the OneDrive share as authoritative.",
+  },
+  edgeFunctions: EDGE_FUNCTIONS,
+  telemetry: [
+    "Database triggers for audit tables",
+    "Structured governance event logs",
+  ],
+  notes: [
+    "OneDrive mirroring remains optional until the AGS follow-up is complete.",
+  ],
+  description:
+    "Dynamic AGS database connectivity: validates governance tables and documents the pending mirror integration.",
+});
+
+export default handler;

--- a/supabase/functions/dai-domain-health/index.ts
+++ b/supabase/functions/dai-domain-health/index.ts
@@ -1,0 +1,64 @@
+import { createDomainHealthHandler } from "../_shared/domain-health.ts";
+
+const TABLES = [
+  {
+    name: "routine_prompts",
+    description: "Daily allocator prompts curated by DAI pipelines.",
+  },
+  {
+    name: "analyst_insights",
+    description: "Human + AI analyst narratives for research recall.",
+  },
+  {
+    name: "user_analytics",
+    description: "Engagement telemetry captured by DAI surfaces.",
+  },
+];
+
+const EDGE_FUNCTIONS = [
+  {
+    name: "analysis-ingest",
+    endpoint: "/functions/v1/analysis-ingest",
+    description: "Normalises research payloads before AI evaluation.",
+  },
+  {
+    name: "analytics-collector",
+    endpoint: "/functions/v1/analytics-collector",
+    description: "Persists engagement analytics for dashboards.",
+  },
+  {
+    name: "lorentzian-eval",
+    endpoint: "/functions/v1/lorentzian-eval",
+    description: "Scores hedge hypotheses and records audits.",
+  },
+  {
+    name: "web-app-analytics",
+    endpoint: "/functions/v1/web-app-analytics",
+    description: "Streams product telemetry to Supabase.",
+  },
+];
+
+export const handler = createDomainHealthHandler({
+  domain: "dai",
+  tables: TABLES,
+  dataset: {
+    prefix: "dai/",
+    noun: "DAI mirrored datasets",
+    description: "OneDrive mirror objects routed through the S3 wrapper.",
+    emptyStatus: "error",
+    emptyMessage:
+      "No mirrored DAI datasets detected. Confirm the OneDrive sync is configured.",
+  },
+  edgeFunctions: EDGE_FUNCTIONS,
+  telemetry: [
+    "Edge Function analytics events",
+    "Supabase table retention policies",
+  ],
+  notes: [
+    "Ensure migrations defining DAI tables are applied before invoking this endpoint.",
+  ],
+  description:
+    "Dynamic AI database connectivity: verifies Supabase tables, mirrored datasets, and Edge Function coverage.",
+});
+
+export default handler;


### PR DESCRIPTION
## Summary
- expand the shared domain health helper to capture table metadata, optional mirror settings, and related edge function context for connectivity reporting
- update the DAI, DAGI, and DAGS edge functions to describe their Supabase tables, mirrored datasets, and telemetry surfaces for operators

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68daabfd46108322b95381ed757024d2