### PR TITLE
Add OneDrive share listing helper

### DIFF
--- a/docs/microsoft-onedrive-share.md
+++ b/docs/microsoft-onedrive-share.md
@@ -25,3 +25,18 @@ file or folder through the Microsoft Graph API.
 The helper converts the share link to the Base64-URL identifier expected by
 Microsoft Graph before requesting the item. It prints the JSON response to
 `stdout`, matching the behaviour of the original Python snippet.
+
+## Listing folder contents
+
+When the shared item is a folder you can render a readable tree of its contents
+with the `list-drive-contents` helper. The script expands folder children
+automatically when you pass the `--recursive` flag.
+
+```bash
+export ONEDRIVE_ACCESS_TOKEN="<token>"
+tsx scripts/onedrive/list-drive-contents.ts "https://1drv.ms/f/..." --recursive
+```
+
+Each entry shows the item name, whether it is a file or folder, key metadata
+such as size or MIME type, the last modified timestamp, and (when provided by
+Graph) the OneDrive web URL for quick navigation.

--- a/scripts/onedrive/list-drive-contents.ts
+++ b/scripts/onedrive/list-drive-contents.ts
@@ -1,0 +1,236 @@
+import process from "node:process";
+
+import {
+  fetchDriveItem,
+  fetchDriveItemChildren,
+  fetchDriveItemCollectionByUrl,
+  type GraphDriveItem,
+} from "./share-utils.ts";
+
+const { env, argv } = process;
+
+interface CliOptions {
+  recursive: boolean;
+}
+
+interface ParsedArgs {
+  shareLink?: string;
+  options: CliOptions;
+}
+
+function parseArgs(): ParsedArgs {
+  const args = argv.slice(2);
+  const options: CliOptions = { recursive: false };
+  const positional: string[] = [];
+
+  for (const arg of args) {
+    if (arg === "--recursive" || arg === "-r") {
+      options.recursive = true;
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  return { shareLink: positional[0], options };
+}
+
+function ensureAccessToken(): string {
+  const token = env.ONEDRIVE_ACCESS_TOKEN;
+  if (!token) {
+    console.error(
+      "Set the ONEDRIVE_ACCESS_TOKEN environment variable before running this script.",
+    );
+    process.exit(1);
+  }
+  return token;
+}
+
+function formatSize(size?: number | null): string | undefined {
+  if (typeof size !== "number" || !Number.isFinite(size) || size < 0) {
+    return undefined;
+  }
+
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+  let value = size;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  const precision = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}
+
+function formatIsoDate(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+function describeItem(item: GraphDriveItem): string {
+  const label = item.name ?? "(unnamed)";
+  const details: string[] = [];
+
+  if (item.folder) {
+    details.push("folder");
+    if (typeof item.folder.childCount === "number") {
+      details.push(`${item.folder.childCount} items`);
+    }
+  } else {
+    details.push("file");
+    const size = formatSize(item.size);
+    if (size) details.push(size);
+    const mime = item.file?.mimeType ?? undefined;
+    if (mime) details.push(mime);
+  }
+
+  const modified = formatIsoDate(item.lastModifiedDateTime);
+  if (modified) details.push(`modified ${modified}`);
+
+  const summary = details.length > 0 ? ` (${details.join(", ")})` : "";
+  const link = typeof item.webUrl === "string" ? ` — ${item.webUrl}` : "";
+  return `${label}${summary}${link}`;
+}
+
+function sortChildren(children: GraphDriveItem[]): GraphDriveItem[] {
+  return [...children].sort((a, b) => {
+    const aFolder = Boolean(a.folder);
+    const bFolder = Boolean(b.folder);
+    if (aFolder !== bFolder) {
+      return aFolder ? -1 : 1;
+    }
+    const nameA = (a.name ?? "").toLocaleLowerCase();
+    const nameB = (b.name ?? "").toLocaleLowerCase();
+    return nameA.localeCompare(nameB);
+  });
+}
+
+async function ensureChildren(
+  item: GraphDriveItem,
+  accessToken: string,
+  fallbackDriveId: string | null,
+  visited: Set<string>,
+): Promise<GraphDriveItem[]> {
+  const existing = Array.isArray(item.children) ? item.children : [];
+  if (existing.length > 0) {
+    return existing;
+  }
+
+  if (!item.folder || !item.id) {
+    item.children = existing;
+    return existing;
+  }
+
+  const driveId = item.parentReference?.driveId ?? fallbackDriveId;
+  if (!driveId) {
+    item.children = existing;
+    return existing;
+  }
+
+  const cacheKey = `${driveId}:${item.id}`;
+  if (visited.has(cacheKey)) {
+    return item.children ?? [];
+  }
+  visited.add(cacheKey);
+
+  const response = await fetchDriveItemChildren({
+    driveId,
+    itemId: item.id,
+    accessToken,
+  });
+  const children: GraphDriveItem[] = Array.isArray(response.value)
+    ? [...response.value]
+    : [];
+
+  let nextLink = response["@odata.nextLink"] ?? null;
+  while (nextLink) {
+    const page = await fetchDriveItemCollectionByUrl(nextLink, accessToken);
+    if (Array.isArray(page.value)) {
+      children.push(...page.value);
+    }
+    nextLink = page["@odata.nextLink"] ?? null;
+  }
+
+  item.children = children;
+  return children;
+}
+
+async function expandRecursively(
+  item: GraphDriveItem,
+  accessToken: string,
+  fallbackDriveId: string | null,
+  visited: Set<string>,
+): Promise<void> {
+  const children = await ensureChildren(
+    item,
+    accessToken,
+    fallbackDriveId,
+    visited,
+  );
+  for (const child of children) {
+    if (child.folder) {
+      const nextFallback = child.parentReference?.driveId ?? fallbackDriveId;
+      await expandRecursively(child, accessToken, nextFallback, visited);
+    }
+  }
+}
+
+function printSubtree(
+  item: GraphDriveItem,
+  prefix: string,
+  isLast: boolean,
+): void {
+  const branch = `${prefix}${isLast ? "└── " : "├── "}`;
+  console.log(`${branch}${describeItem(item)}`);
+  const childPrefix = `${prefix}${isLast ? "    " : "│   "}`;
+  const children = sortChildren(
+    Array.isArray(item.children) ? item.children : [],
+  );
+  children.forEach((child, index) => {
+    printSubtree(child, childPrefix, index === children.length - 1);
+  });
+}
+
+async function main() {
+  const { shareLink, options } = parseArgs();
+
+  if (!shareLink) {
+    console.error(
+      "Usage: tsx scripts/onedrive/list-drive-contents.ts <share-link> [--recursive]",
+    );
+    process.exit(1);
+  }
+
+  const accessToken = ensureAccessToken();
+
+  try {
+    const root = await fetchDriveItem<GraphDriveItem>({
+      shareLink,
+      accessToken,
+      query: { expand: "children" },
+    });
+
+    const rootChildren = Array.isArray(root.children) ? root.children : [];
+    root.children = rootChildren;
+
+    if (options.recursive) {
+      const visited = new Set<string>();
+      const fallbackDriveId = root.parentReference?.driveId ?? null;
+      await expandRecursively(root, accessToken, fallbackDriveId, visited);
+    }
+
+    console.log(describeItem(root));
+    const children = sortChildren(root.children ?? []);
+    children.forEach((child, index) => {
+      printSubtree(child, "", index === children.length - 1);
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/scripts/onedrive/share-utils.ts
+++ b/scripts/onedrive/share-utils.ts
@@ -1,5 +1,33 @@
 import { Buffer } from "node:buffer";
 
+export interface GraphDriveItem {
+  id?: string;
+  name?: string;
+  size?: number;
+  webUrl?: string | null;
+  lastModifiedDateTime?: string | null;
+  createdDateTime?: string | null;
+  file?: {
+    mimeType?: string | null;
+  } | null;
+  folder?: {
+    childCount?: number | null;
+  } | null;
+  parentReference?: {
+    id?: string | null;
+    path?: string | null;
+    driveId?: string | null;
+  } | null;
+  children?: GraphDriveItem[];
+  [key: string]: unknown;
+}
+
+export interface GraphDriveItemCollection {
+  value?: GraphDriveItem[];
+  "@odata.nextLink"?: string | null;
+  "@odata.deltaLink"?: string | null;
+}
+
 export function toShareId(shareLink: string): string {
   const base64 = Buffer.from(shareLink, "utf-8").toString("base64");
   const base64Url = base64.replace(/\+/g, "-").replace(/\//g, "_").replace(
@@ -9,21 +37,11 @@ export function toShareId(shareLink: string): string {
   return `u!${base64Url}`;
 }
 
-export interface FetchDriveItemOptions {
-  shareLink: string;
-  accessToken: string;
-  query?: Record<string, string | undefined>;
-}
-
-export async function fetchDriveItem({
-  shareLink,
-  accessToken,
-  query,
-}: FetchDriveItemOptions): Promise<unknown> {
-  const shareId = toShareId(shareLink);
-  const url = new URL(
-    `https://graph.microsoft.com/v1.0/shares/${shareId}/driveItem`,
-  );
+function buildUrl(
+  base: string,
+  query?: Record<string, string | undefined>,
+) {
+  const url = new URL(base);
 
   if (query) {
     for (const [key, value] of Object.entries(query)) {
@@ -33,6 +51,13 @@ export async function fetchDriveItem({
     }
   }
 
+  return url;
+}
+
+async function graphGet(
+  url: URL,
+  accessToken: string,
+): Promise<Response> {
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -47,5 +72,57 @@ export async function fetchDriveItem({
     );
   }
 
-  return response.json();
+  return response;
+}
+
+export async function fetchDriveItemCollectionByUrl(
+  nextLink: string,
+  accessToken: string,
+): Promise<GraphDriveItemCollection> {
+  const url = new URL(nextLink);
+  const response = await graphGet(url, accessToken);
+  return await response.json() as GraphDriveItemCollection;
+}
+
+export interface FetchDriveItemOptions {
+  shareLink: string;
+  accessToken: string;
+  query?: Record<string, string | undefined>;
+}
+
+export async function fetchDriveItem<T = unknown>({
+  shareLink,
+  accessToken,
+  query,
+}: FetchDriveItemOptions): Promise<T> {
+  const shareId = toShareId(shareLink);
+  const url = buildUrl(
+    `https://graph.microsoft.com/v1.0/shares/${shareId}/driveItem`,
+    query,
+  );
+
+  const response = await graphGet(url, accessToken);
+  return await response.json() as T;
+}
+
+export interface FetchDriveItemChildrenOptions {
+  driveId: string;
+  itemId: string;
+  accessToken: string;
+  query?: Record<string, string | undefined>;
+}
+
+export async function fetchDriveItemChildren({
+  driveId,
+  itemId,
+  accessToken,
+  query,
+}: FetchDriveItemChildrenOptions): Promise<GraphDriveItemCollection> {
+  const url = buildUrl(
+    `https://graph.microsoft.com/v1.0/drives/${driveId}/items/${itemId}/children`,
+    query,
+  );
+
+  const response = await graphGet(url, accessToken);
+  return await response.json() as GraphDriveItemCollection;
 }

--- a/tests/onedrive-connection.test.ts
+++ b/tests/onedrive-connection.test.ts
@@ -1,0 +1,204 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
+import { assertExists } from "https://deno.land/std@0.224.0/assert/assert_exists.ts";
+import { toFileUrl } from "https://deno.land/std@0.224.0/path/to_file_url.ts";
+
+import { freshImport } from "./utils/freshImport.ts";
+
+const ORIGINAL_MODULE = new URL(
+  "../apps/web/integrations/onedrive/index.ts",
+  import.meta.url,
+);
+
+const STUB_MODULE = new URL("./onedrive-supabase-stub.ts", import.meta.url);
+
+const baseItem = {
+  id: "item-123",
+  name: "Quarterly Report.pdf",
+  size: 987654,
+  webUrl: "https://example.com/items/item-123",
+  lastModifiedDateTime: "2024-01-04T12:30:00Z",
+  createdDateTime: "2024-01-01T08:15:00Z",
+  isFolder: false,
+  childCount: null,
+  mimeType: "application/pdf",
+  parentId: "parent-42",
+  parentPath: "/drive/root:/reports",
+  eTag: "etag-123",
+  cTag: "ctag-456",
+  downloadUrl: "https://example.com/items/item-123?download=1",
+  hashes: {
+    quickXorHash: "quickxor-hash",
+    sha1Hash: "sha1-hash",
+    sha256Hash: "sha256-hash",
+  },
+};
+
+Deno.test("OneDrive integration smoke test wires through the proxy helper", async () => {
+  const stub = await freshImport(
+    STUB_MODULE,
+  ) as typeof import("./onedrive-supabase-stub.ts");
+  const {
+    __resetOneDriveStub,
+    __setFunctionHandler,
+    __getInvocations,
+    createClient,
+  } = stub;
+
+  __resetOneDriveStub();
+
+  __setFunctionHandler("onedrive-proxy", (payload) => {
+    const action = payload.action;
+    switch (action) {
+      case "list":
+        return {
+          items: [baseItem],
+          nextLink: "https://example.com/items?cursor=next",
+          deltaLink: "delta-token",
+        };
+      case "get":
+        return {
+          item: { ...baseItem, id: String(payload.itemId ?? baseItem.id) },
+        };
+      case "download":
+        return {
+          item: { ...baseItem, id: String(payload.itemId ?? baseItem.id) },
+          downloadUrl: `${baseItem.downloadUrl}`,
+        };
+      case "upload":
+        return {
+          item: {
+            ...baseItem,
+            id: "uploaded-1",
+            name: String(payload.path ?? baseItem.name),
+            downloadUrl: "https://example.com/items/uploaded-1?download=1",
+          },
+        };
+      default:
+        throw new Error(`Unexpected action: ${String(action)}`);
+    }
+  });
+
+  const source = await Deno.readTextFile(ORIGINAL_MODULE);
+  const patchedSource = source
+    .replace('import { Buffer } from "node:buffer";\n', "")
+    .replace(
+      'function toBase64(input: Uint8Array | ArrayBuffer): string {\n  const buffer = input instanceof Uint8Array\n    ? Buffer.from(input)\n    : Buffer.from(new Uint8Array(input));\n  return buffer.toString("base64");\n}\n',
+      'function toBase64(input: Uint8Array | ArrayBuffer): string {\n  const bytes = input instanceof Uint8Array\n    ? input\n    : new Uint8Array(input);\n  let binary = "";\n  for (const byte of bytes) {\n    binary += String.fromCharCode(byte);\n  }\n  return btoa(binary);\n}\n',
+    )
+    .replace(
+      "@/integrations/supabase/client",
+      STUB_MODULE.href,
+    );
+
+  const patchedPath = await Deno.makeTempFile({ suffix: ".ts" });
+
+  try {
+    await Deno.writeTextFile(patchedPath, patchedSource);
+    const patchedModuleUrl = toFileUrl(patchedPath);
+
+    const {
+      listDriveItems,
+      getDriveItem,
+      getDriveItemDownloadUrl,
+      uploadDriveItem,
+    } = await freshImport(patchedModuleUrl);
+
+    const client = createClient("service");
+
+    const listResponse = await listDriveItems(
+      { driveId: "drive-001", path: "/reports", top: 25, orderBy: "name asc" },
+      client,
+    );
+    assertEquals(listResponse.items.length, 1);
+    assertEquals(listResponse.items[0].id, baseItem.id);
+    assertEquals(
+      listResponse.nextLink,
+      "https://example.com/items?cursor=next",
+    );
+    assertEquals(listResponse.deltaLink, "delta-token");
+
+    const detailed = await getDriveItem(
+      {
+        driveId: "drive-001",
+        itemId: "item-123",
+        select: ["id", "name", "size"],
+        expand: "children",
+      },
+      client,
+    );
+    assertEquals(detailed.id, "item-123");
+    assertEquals(detailed.name, baseItem.name);
+
+    const download = await getDriveItemDownloadUrl(
+      { driveId: "drive-001", itemId: "item-123" },
+      client,
+    );
+    assertEquals(download.downloadUrl, baseItem.downloadUrl);
+    assertEquals(download.item.id, "item-123");
+
+    const payload = new TextEncoder().encode("hello onedrive");
+    const uploaded = await uploadDriveItem(
+      {
+        driveId: "drive-001",
+        path: "/reports/hello.txt",
+        content: payload,
+        contentType: "text/plain",
+        conflictBehavior: "replace",
+      },
+      client,
+    );
+    assertEquals(uploaded.id, "uploaded-1");
+    assertEquals(uploaded.name, "/reports/hello.txt");
+
+    const invocations = __getInvocations();
+    assertEquals(invocations.length, 4);
+
+    assertEquals(invocations[0], {
+      name: "onedrive-proxy",
+      payload: {
+        action: "list",
+        driveId: "drive-001",
+        path: "/reports",
+        top: 25,
+        orderBy: "name asc",
+      },
+    });
+
+    assertEquals(invocations[1], {
+      name: "onedrive-proxy",
+      payload: {
+        action: "get",
+        driveId: "drive-001",
+        itemId: "item-123",
+        select: "id,name,size",
+        expand: "children",
+      },
+    });
+
+    assertEquals(invocations[2], {
+      name: "onedrive-proxy",
+      payload: {
+        action: "download",
+        driveId: "drive-001",
+        itemId: "item-123",
+      },
+    });
+
+    assertExists(invocations[3].payload.content);
+    assertEquals(invocations[3], {
+      name: "onedrive-proxy",
+      payload: {
+        action: "upload",
+        driveId: "drive-001",
+        path: "/reports/hello.txt",
+        content: "aGVsbG8gb25lZHJpdmU=",
+        encoding: "base64",
+        contentType: "text/plain",
+        conflictBehavior: "replace",
+      },
+    });
+  } finally {
+    await Deno.remove(patchedPath).catch(() => {});
+    __resetOneDriveStub();
+  }
+});

--- a/tests/onedrive-supabase-stub.ts
+++ b/tests/onedrive-supabase-stub.ts
@@ -1,0 +1,73 @@
+const invocations: Array<{ name: string; payload: Record<string, unknown> }> =
+  [];
+
+const handlers = new Map<
+  string,
+  (payload: Record<string, unknown>) => unknown | Promise<unknown>
+>();
+
+export function __resetOneDriveStub() {
+  invocations.length = 0;
+  handlers.clear();
+}
+
+export function __setFunctionHandler(
+  name: string,
+  handler: (payload: Record<string, unknown>) => unknown | Promise<unknown>,
+) {
+  handlers.set(name, handler);
+}
+
+export function __getInvocations() {
+  return invocations.map((entry) => ({
+    name: entry.name,
+    payload: { ...entry.payload },
+  }));
+}
+
+export function createClient(role: "anon" | "service" = "anon") {
+  if (role !== "service") {
+    throw new Error(
+      `OneDrive stub only supports service role clients (received: ${role})`,
+    );
+  }
+
+  return {
+    functions: {
+      invoke: async <T>(
+        name: string,
+        options: { body?: Record<string, unknown> } = {},
+      ): Promise<{ data: T | null; error: { message: string } | null }> => {
+        const payload = options.body ?? {};
+        invocations.push({ name, payload });
+        const handler = handlers.get(name);
+        if (!handler) {
+          return {
+            data: null,
+            error: { message: `No handler registered for ${name}` },
+          };
+        }
+        try {
+          const result = await handler(payload);
+          return { data: result as T, error: null };
+        } catch (error) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          return { data: null, error: { message } };
+        }
+      },
+    },
+  } satisfies SupabaseClient;
+}
+
+type SupabaseFunctions = {
+  invoke<T>(
+    name: string,
+    options?: { body?: Record<string, unknown> },
+  ): Promise<{ data: T | null; error: { message: string } | null }>;
+};
+
+export type SupabaseClient = {
+  functions: SupabaseFunctions;
+};


### PR DESCRIPTION
## Summary
- add a reusable Microsoft Graph drive item typing and pagination helpers for scripts
- add a CLI script to list OneDrive share contents and optionally recurse through folders
- document the new helper alongside the existing fetch instructions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dac0bca58083228fff068561a03234