### PR TITLE
Fix DigitalOcean build stability

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -90,6 +90,9 @@ spec:
         - key: NEXT_PUBLIC_SITE_URL
           value: https://dynamic-capital-qazf2.ondigitalocean.app
           scope: RUN_AND_BUILD_TIME
+        - key: ALLOWED_ORIGINS
+          value: https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app
+          scope: RUN_AND_BUILD_TIME
         - key: MINIAPP_ORIGIN
           value: https://dynamic-capital-qazf2.ondigitalocean.app
           scope: RUN_AND_BUILD_TIME

--- a/apps/web/interfaces.ts
+++ b/apps/web/interfaces.ts
@@ -1,0 +1,1 @@
+export * from "./components/dynamic-ui-system/internal/interfaces";

--- a/scripts/digitalocean-build.mjs
+++ b/scripts/digitalocean-build.mjs
@@ -110,7 +110,12 @@ function resolveCacheBaseDir() {
   return path.resolve(".do-build-cache");
 }
 
-const cacheFilePath = path.join(resolveCacheBaseDir(), cacheFileName);
+const cacheBaseDir = resolveCacheBaseDir();
+const cacheFilePath = path.join(cacheBaseDir, cacheFileName);
+const npmCacheDir = path.join(cacheBaseDir, "npm-cache");
+
+process.env.NPM_CONFIG_CACHE = npmCacheDir;
+process.env.npm_config_cache = npmCacheDir;
 
 async function loadPreviousFingerprint() {
   try {
@@ -169,6 +174,18 @@ function formatBytes(bytes) {
 }
 
 async function main() {
+  try {
+    await mkdir(npmCacheDir, { recursive: true });
+    console.log(
+      `DigitalOcean build: npm cache directory initialised at ${npmCacheDir}.`,
+    );
+  } catch (error) {
+    console.warn(
+      `DigitalOcean build: unable to prepare npm cache directory at ${npmCacheDir}. Continuing without persistent npm cache.`,
+      error,
+    );
+  }
+
   console.log("DigitalOcean build: running `npm run build`…");
   const buildCode = await run(npmCommand, ["run", "build"]);
   if (buildCode !== 0) {


### PR DESCRIPTION
## Summary
- add an explicit `@/interfaces` module so the dynamic UI system type imports resolve during Next.js builds
- configure the DigitalOcean build script to use the platform cache for npm downloads and log failures gracefully
- declare the ALLOWED_ORIGINS variable for the DigitalOcean service to keep branding env values consistent at build and runtime

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dac89e0ae4832295c27ebd4a7a5b01