### PR TITLE
Fix static landing snapshot visibility

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,7 +17,10 @@ import {
 } from "@/components/dynamic-ui-system";
 
 import Providers from "./providers";
-import { getStaticLandingDocument } from "@/lib/staticLanding";
+import {
+  ensureStaticSnapshotVisibilityMarkup,
+  getStaticLandingDocument,
+} from "@/lib/staticLanding";
 import { RouteGuard, ScrollToHash } from "@/components/dynamic-portfolio";
 import { SiteHeader } from "@/components/navigation/SiteHeader";
 import { SiteFooter } from "@/components/navigation/SiteFooter";
@@ -236,6 +239,10 @@ export default async function RootLayout(
   if (isStaticSnapshot) {
     try {
       const { head, body, lang } = await getStaticLandingDocument();
+      const staticHeadMarkup = ensureStaticSnapshotVisibilityMarkup(
+        ensureThemeAssets(head),
+      );
+
       return (
         <html
           lang={lang}
@@ -244,8 +251,9 @@ export default async function RootLayout(
           {...htmlAttributeDefaults}
           data-theme={DEFAULT_THEME}
         >
-          <head dangerouslySetInnerHTML={{ __html: ensureThemeAssets(head) }} />
+          <head dangerouslySetInnerHTML={{ __html: staticHeadMarkup }} />
           <body
+            data-static-snapshot="true"
             suppressHydrationWarning
             dangerouslySetInnerHTML={{ __html: body }}
           />
@@ -253,7 +261,7 @@ export default async function RootLayout(
       );
     } catch (error) {
       console.error(
-        'Failed to load static landing snapshot markup. Falling back to dynamic layout rendering.',
+        "Failed to load static landing snapshot markup. Falling back to dynamic layout rendering.",
         error,
       );
     }

--- a/apps/web/components/landing/StaticLandingPage.tsx
+++ b/apps/web/components/landing/StaticLandingPage.tsx
@@ -1,19 +1,26 @@
-import { LandingPageShell } from '@/components/landing/LandingPageShell';
-import { getStaticLandingDocument } from '@/lib/staticLanding';
+import { LandingPageShell } from "@/components/landing/LandingPageShell";
+import {
+  ensureStaticSnapshotVisibilityMarkup,
+  getStaticLandingDocument,
+} from "@/lib/staticLanding";
 
 export async function StaticLandingPage() {
   try {
     const { body } = await getStaticLandingDocument();
+    const enhancedBody = ensureStaticSnapshotVisibilityMarkup(body, {
+      position: "prepend",
+    });
 
     return (
       <div
+        data-static-snapshot="true"
         suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: body }}
+        dangerouslySetInnerHTML={{ __html: enhancedBody }}
       />
     );
   } catch (error) {
     console.error(
-      'Failed to load static landing snapshot. Rendering dynamic shell instead.',
+      "Failed to load static landing snapshot. Rendering dynamic shell instead.",
       error,
     );
 

--- a/apps/web/lib/staticLanding.ts
+++ b/apps/web/lib/staticLanding.ts
@@ -1,7 +1,7 @@
-import 'server-only';
+import "server-only";
 
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 
 export interface StaticLandingDocument {
   lang: string;
@@ -9,27 +9,81 @@ export interface StaticLandingDocument {
   body: string;
 }
 
+export const STATIC_SNAPSHOT_VISIBILITY_STYLE_ID = "static-snapshot-visibility";
+
+const STATIC_SNAPSHOT_VISIBILITY_STYLE = `
+<style id="${STATIC_SNAPSHOT_VISIBILITY_STYLE_ID}">
+  [data-static-snapshot] [style*="opacity:0"],
+  [data-static-snapshot] [style*="opacity: 0"] {
+    opacity: 1 !important;
+  }
+
+  [data-static-snapshot] [style*="transform:translate"],
+  [data-static-snapshot] [style*="transform: translate"],
+  [data-static-snapshot] [style*="transform:scale"],
+  [data-static-snapshot] [style*="transform: scale"] {
+    transform: none !important;
+  }
+
+  [data-static-snapshot] [style*="filter:blur"],
+  [data-static-snapshot] [style*="filter: blur"] {
+    filter: none !important;
+  }
+
+  [data-static-snapshot] [style*="visibility:hidden"],
+  [data-static-snapshot] [style*="visibility: hidden"] {
+    visibility: visible !important;
+  }
+</style>
+`.trim();
+
+export function ensureStaticSnapshotVisibilityMarkup(
+  markup: string,
+  options: { position?: "append" | "prepend" } = {},
+): string {
+  const existingMarkup = markup ?? "";
+
+  if (existingMarkup.includes(`id="${STATIC_SNAPSHOT_VISIBILITY_STYLE_ID}"`)) {
+    return existingMarkup;
+  }
+
+  const insertion = STATIC_SNAPSHOT_VISIBILITY_STYLE;
+  if (!existingMarkup) {
+    return insertion;
+  }
+
+  if (options.position === "prepend") {
+    return `${insertion}\n${existingMarkup}`;
+  }
+
+  return `${existingMarkup}\n${insertion}`;
+}
+
 let cachedDocument: StaticLandingDocument | null = null;
 
 async function readStaticHtml(): Promise<string> {
-  const staticDirectories = ['_static', '_Static'];
+  const staticDirectories = ["_static", "_Static"];
 
   for (const directory of staticDirectories) {
-    const staticFilePath = path.join(process.cwd(), directory, 'index.html');
+    const staticFilePath = path.join(process.cwd(), directory, "index.html");
     try {
-      return await readFile(staticFilePath, 'utf-8');
+      return await readFile(staticFilePath, "utf-8");
     } catch (error: unknown) {
       const nodeError = error as NodeJS.ErrnoException;
-      if (nodeError.code !== 'ENOENT') {
+      if (nodeError.code !== "ENOENT") {
         throw error;
       }
     }
   }
 
-  throw new Error('Static landing page markup not found at _static/index.html or _Static/index.html.');
+  throw new Error(
+    "Static landing page markup not found at _static/index.html or _Static/index.html.",
+  );
 }
 
-export async function getStaticLandingDocument(): Promise<StaticLandingDocument> {
+export async function getStaticLandingDocument(): Promise<
+  StaticLandingDocument
+> {
   if (cachedDocument) {
     return cachedDocument;
   }
@@ -40,9 +94,9 @@ export async function getStaticLandingDocument(): Promise<StaticLandingDocument>
   const headMatch = html.match(/<head[^>]*>([\s\S]*?)<\/head>/i);
   const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
 
-  const lang = langMatch?.[1] ?? 'en';
-  const head = headMatch?.[1]?.trim() ?? '';
-  const body = bodyMatch?.[1]?.trim() ?? '';
+  const lang = langMatch?.[1] ?? "en";
+  const head = headMatch?.[1]?.trim() ?? "";
+  const body = bodyMatch?.[1]?.trim() ?? "";
 
   cachedDocument = { lang, head, body };
   return cachedDocument;


### PR DESCRIPTION
## Summary
- add a static snapshot visibility helper that injects CSS overrides for hidden animations
- apply the helper in the root layout to include the overrides and tag the static body output
- update the StaticLandingPage component to use the helper and mark the rendered snapshot for the overrides

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dad31bcdf8832292a51247d82db70f