### PR TITLE
Document OneDrive knowledge base dataset drop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,18 +92,19 @@ documenting which assets were consulted.
 
 ## 6. Trading & Financial Operations
 
-| Ref  | Document                                                                             | Summary                                                                                                 |
-| ---- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| 6.1  | [automated-trading-checklist.md](./automated-trading-checklist.md)                   | Project plan for delivering the TradingView → Supabase → MT5 automation.                                |
-| 6.2  | [TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md)   | Detailed bridge build between TradingView alerts and MetaTrader 5.                                      |
-| 6.3  | [TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding workflow for the TradingView/MT5 stack.                                           |
-| 6.4  | [investing-com-candlestick-checklist.md](./investing-com-candlestick-checklist.md)   | Checklist for ingesting Investing.com candlestick signals.                                              |
-| 6.5  | [trading-runbook.md](./trading-runbook.md)                                           | Day-to-day trading operations, monitoring, and model lifecycle steps.                                   |
-| 6.6  | [private-fund-pool.md](./private-fund-pool.md)                                       | Architecture and database design for the private fund pool service.                                     |
-| 6.7  | [index-advisor.md](./index-advisor.md)                                               | Using Supabase Index Advisor to tune query performance.                                                 |
-| 6.8  | [WRAPPERS_INTEGRATION.md](./WRAPPERS_INTEGRATION.md)                                 | How to connect external services via Postgres foreign data wrappers.                                    |
-| 6.9  | [trading-data-organization.md](./trading-data-organization.md)                       | Folder taxonomy for templates, journals, KPIs, and backtests across each horizon bucket.                |
-| 6.10 | [dai-webhook-routing.md](./dai-webhook-routing.md)                                   | Options for single-endpoint vs. auto-provisioned TradingView webhook routes managed by DAI.             |
+<!-- deno-fmt-ignore -->
+| Ref  | Document                                                                             | Summary                                                                        |
+| ---- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| 6.1  | [automated-trading-checklist.md](./automated-trading-checklist.md)                   | Project plan for delivering the TradingView → Supabase → MT5 automation.       |
+| 6.2  | [TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md)   | Detailed bridge build between TradingView alerts and MetaTrader 5.             |
+| 6.3  | [TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding workflow for the TradingView/MT5 stack.                  |
+| 6.4  | [investing-com-candlestick-checklist.md](./investing-com-candlestick-checklist.md)   | Checklist for ingesting Investing.com candlestick signals.                     |
+| 6.5  | [trading-runbook.md](./trading-runbook.md)                                           | Day-to-day trading operations, monitoring, and model lifecycle steps.          |
+| 6.6  | [private-fund-pool.md](./private-fund-pool.md)                                       | Architecture and database design for the private fund pool service.            |
+| 6.7  | [index-advisor.md](./index-advisor.md)                                               | Using Supabase Index Advisor to tune query performance.                        |
+| 6.8  | [WRAPPERS_INTEGRATION.md](./WRAPPERS_INTEGRATION.md)                                 | How to connect external services via Postgres foreign data wrappers.           |
+| 6.9  | [trading-data-organization.md](./trading-data-organization.md)                       | Folder taxonomy for templates, journals, KPIs, and backtests across each horizon bucket. |
+| 6.10 | [dai-webhook-routing.md](./dai-webhook-routing.md)                                   | Options for single-endpoint vs. auto-provisioned TradingView webhook routes managed by DAI. |
 | 6.11 | [dynamic-market-notes.md](./dynamic-market-notes.md)                                 | Dynamic Market stack overview covering DMDA feeds, DMM quoting levers, and treasury coordination notes. |
 | 6.12 | [onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md](./onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md) | Share metadata, Graph helpers, and access notes for the trading PDF OneDrive folder. |
 | 6.13 | [onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md](./onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md) | Datasets share identifiers and Graph commands for refreshing training corpora. |
@@ -112,8 +113,8 @@ documenting which assets were consulted.
 | 6.16 | [onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md](./onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md) | Combined logs and model artifacts share metadata for telemetry/model reconciliation. |
 | 6.17 | [onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md](./onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md) | Trading reports share identifiers for ingesting supplemental analytics. |
 | 6.18 | [onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md](./onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md) | Standalone `read_me.md` text share metadata for onboarding notes. |
-| 6.19 | [agi_integration_strategies.md](./agi_integration_strategies.md) | AGI-driven integration plan aligning DTL, DTA, execution, and learning loops. |
-
+| 6.19 | [agi_integration_strategies.md](./agi_integration_strategies.md)                       | AGI-driven integration plan aligning DTL, DTA, execution, and learning loops. |
+| 6.20 | [knowledge-base-training-drop.md](./knowledge-base-training-drop.md)                  | Checklist for syncing the OneDrive knowledge base dataset drops into Supabase and local experiments. |
 ## 7. Operational Runbooks & Launch Phases
 
 | Ref  | Document                                                             | Summary                                                                   |

--- a/docs/knowledge-base-training-drop.md
+++ b/docs/knowledge-base-training-drop.md
@@ -1,0 +1,61 @@
+# Knowledge Base Training Drop Checklist
+
+The shared OneDrive workspace now includes a `knowledge_base/` directory that
+houses freshly uploaded corpora for model fine-tuning. Treat the folder as the
+source of truth for knowledge-grounded training datasets that should be mirrored
+into Supabase Storage and the local repository when preparing new runs.
+
+## Access overview
+
+- **OneDrive location:** `.../knowledge_base/` inside the
+  `EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg` share already tracked in
+  `docs/onedrive-shares/evlumlqt-folder.md`.
+- **Contents:** Expect curated markdown, CSV, and JSON artefacts that expand the
+  long-form knowledge base used for retrieval-augmented training.
+- **Ownership:** Model engineering team. Announce additions in the #ml-updates
+  channel alongside a brief describing intended use.
+
+## Sync workflow
+
+1. **List the drop**
+   ```bash
+   export ONEDRIVE_ACCESS_TOKEN="<token>"
+   tsx scripts/onedrive/list-drive-contents.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg"
+   ```
+   - Inspect the tree for the `knowledge_base/` node and note new filenames and
+     sizes.
+2. **Snapshot metadata**
+   ```bash
+   tsx scripts/onedrive/dump-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg" \
+     docs/onedrive-shares/evlumlqt-folder.metadata.json
+   ```
+   - Commit the refreshed metadata file so the repo mirrors the share inventory.
+3. **Mirror to storage**
+   - Run the existing Supabase ↔ OneDrive sync (`npm run sync:onedrive` if
+     available) or trigger the Power Automate flow responsible for dataset
+     promotion.
+   - Confirm `public.one_drive_assets` contains the `knowledge_base/` entries
+     via Supabase SQL.
+4. **Ingest locally**
+   - Copy the new files into `data/knowledge_base/` (create the directory if it
+     does not exist) while maintaining subfolders from OneDrive.
+   - Record provenance in `data/knowledge_base/README.md` with dataset versions
+     and intended prompts.
+
+## Training integration
+
+- Update experiment configs under `dynamic_trainer/` or `ml/` to point to the
+  new local mirror when running fine-tuning or embedding refresh jobs.
+- Rebuild vector indexes after syncing by executing the pipeline that feeds the
+  retrieval layer (for example, `npm run embeddings:refresh knowledge_base`).
+- Capture evaluation metrics and push summaries back into the `knowledge_base/`
+  folder so the OneDrive mirror remains the long-term archive.
+
+## Governance checklist
+
+- [ ] Metadata snapshot committed after every drop.
+- [ ] Supabase manifest shows the new keys under `knowledge_base/`.
+- [ ] Local repo `data/knowledge_base/` folder updated and documented.
+- [ ] Training run logs reference the corresponding OneDrive dataset version.

--- a/docs/onedrive-shares/evlumlqt-folder.md
+++ b/docs/onedrive-shares/evlumlqt-folder.md
@@ -56,3 +56,18 @@ The response payload includes the item metadata and, when available, the
 children of the shared folder. Save the output to
 `docs/onedrive-shares/evlumlqt-folder.metadata.json` to snapshot the latest
 state.
+
+## `knowledge_base/` drop overview
+
+- The share now contains a `knowledge_base/` directory with freshly uploaded
+  training corpora. Sync the folder whenever new drops are announced so the
+  repository and Supabase mirrors stay aligned.
+- Use `tsx scripts/onedrive/list-drive-contents.ts` with the share link above to
+  enumerate the hierarchy. Expect markdown, CSV, and JSON artefacts sized for
+  retrieval-augmented model runs.
+- After each sync, rerun
+  `tsx scripts/onedrive/dump-drive-item.ts "<share>" docs/onedrive-shares/evlumlqt-folder.metadata.json`
+  to capture the updated manifest and commit the diff.
+- Mirror the downloaded files into `data/knowledge_base/` locally and document
+  provenance in `data/knowledge_base/README.md`. This keeps experiment tracking
+  consistent across GitHub, Supabase Storage, and the OneDrive source.

--- a/docs/onedrive-sync-integration.md
+++ b/docs/onedrive-sync-integration.md
@@ -128,3 +128,23 @@ ideal when the automation must live entirely within the Microsoft 365 estate.
 
 Document the chosen automation approach in project runbooks to keep Codex
 contributors aligned on how OneDrive mirrors stay current.
+
+## 5. Knowledge base dataset drops
+
+When fresh training corpora land in the OneDrive `knowledge_base/` directory
+inside the `EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg` share:
+
+1. Announce the drop in the #ml-updates channel with a summary of the contents
+   and intended experiments.
+2. Run `tsx scripts/onedrive/list-drive-contents.ts "<share-link>"` to verify
+   the new files, then update
+   `docs/onedrive-shares/evlumlqt-folder.metadata.json` via the
+   `dump-drive-item.ts` helper.
+3. Trigger the Supabase ↔ OneDrive sync or automation of choice so
+   `public.one_drive_assets` includes the `knowledge_base/` keys.
+4. Mirror the files locally under `data/knowledge_base/`, capture provenance in
+   a README, and update experiment configurations in `dynamic_trainer/` or `ml/`
+   to point at the refreshed dataset.
+
+Track ongoing operational notes in `docs/knowledge-base-training-drop.md` to
+keep the workflow reproducible.


### PR DESCRIPTION
## Summary
- add a dedicated checklist for mirroring the new `knowledge_base/` training drop from OneDrive into local and Supabase mirrors
- capture the `knowledge_base/` folder expectations inside the tracked EvLuMLq… share notes and sync playbook
- index the new workflow in the documentation catalog so collaborators can find it quickly

## Testing
- `npx deno fmt docs/onedrive-sync-integration.md docs/onedrive-shares/evlumlqt-folder.md docs/knowledge-base-training-drop.md`


------
https://chatgpt.com/codex/tasks/task_e_68dad5cbd97c8322a9c8c6a0d9b73444