### PR TITLE
Automate knowledge base drop checklist

### DIFF
--- a/data/knowledge_base/README.md
+++ b/data/knowledge_base/README.md
@@ -1,0 +1,27 @@
+# Knowledge Base Mirror
+
+This directory stores the local mirror of datasets synchronized from the shared
+OneDrive `knowledge_base/` folder tracked in
+`docs/onedrive-shares/evlumlqt-folder.md`. The mirror allows model-training jobs
+to pin to a reproducible snapshot even when collaborators rotate the upstream
+share contents.
+
+## Current snapshot
+
+No datasets have been ingested in this environment yet. Replace this note with a
+summary table (filename, source hash, sync date, intended usage) after mirroring
+files from OneDrive.
+
+## Sync log
+
+| Date (UTC) | Action                         | Notes                                                                                 |
+| ---------- | ------------------------------ | ------------------------------------------------------------------------------------- |
+| 2025-02-14 | Initialized mirror scaffolding | Created local directory and placeholder README so future syncs have a provenance log. |
+
+## Operating notes
+
+- Store raw datasets under subdirectories that match the OneDrive structure.
+- Keep large binaries in LFS or external storage if they exceed repository
+  limits; record pointers here instead of committing oversized files.
+- Update this README whenever you refresh the mirror so teammates can correlate
+  training runs with the datasets they reference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,18 +92,19 @@ documenting which assets were consulted.
 
 ## 6. Trading & Financial Operations
 
-| Ref  | Document                                                                             | Summary                                                                                                 |
-| ---- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| 6.1  | [automated-trading-checklist.md](./automated-trading-checklist.md)                   | Project plan for delivering the TradingView → Supabase → MT5 automation.                                |
-| 6.2  | [TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md)   | Detailed bridge build between TradingView alerts and MetaTrader 5.                                      |
-| 6.3  | [TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding workflow for the TradingView/MT5 stack.                                           |
-| 6.4  | [investing-com-candlestick-checklist.md](./investing-com-candlestick-checklist.md)   | Checklist for ingesting Investing.com candlestick signals.                                              |
-| 6.5  | [trading-runbook.md](./trading-runbook.md)                                           | Day-to-day trading operations, monitoring, and model lifecycle steps.                                   |
-| 6.6  | [private-fund-pool.md](./private-fund-pool.md)                                       | Architecture and database design for the private fund pool service.                                     |
-| 6.7  | [index-advisor.md](./index-advisor.md)                                               | Using Supabase Index Advisor to tune query performance.                                                 |
-| 6.8  | [WRAPPERS_INTEGRATION.md](./WRAPPERS_INTEGRATION.md)                                 | How to connect external services via Postgres foreign data wrappers.                                    |
-| 6.9  | [trading-data-organization.md](./trading-data-organization.md)                       | Folder taxonomy for templates, journals, KPIs, and backtests across each horizon bucket.                |
-| 6.10 | [dai-webhook-routing.md](./dai-webhook-routing.md)                                   | Options for single-endpoint vs. auto-provisioned TradingView webhook routes managed by DAI.             |
+<!-- deno-fmt-ignore -->
+| Ref  | Document                                                                             | Summary                                                                        |
+| ---- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| 6.1  | [automated-trading-checklist.md](./automated-trading-checklist.md)                   | Project plan for delivering the TradingView → Supabase → MT5 automation.       |
+| 6.2  | [TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md](./TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md)   | Detailed bridge build between TradingView alerts and MetaTrader 5.             |
+| 6.3  | [TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md](./TRADINGVIEW_MT5_ONBOARDING_CHECKLIST.md) | Cross-team onboarding workflow for the TradingView/MT5 stack.                  |
+| 6.4  | [investing-com-candlestick-checklist.md](./investing-com-candlestick-checklist.md)   | Checklist for ingesting Investing.com candlestick signals.                     |
+| 6.5  | [trading-runbook.md](./trading-runbook.md)                                           | Day-to-day trading operations, monitoring, and model lifecycle steps.          |
+| 6.6  | [private-fund-pool.md](./private-fund-pool.md)                                       | Architecture and database design for the private fund pool service.            |
+| 6.7  | [index-advisor.md](./index-advisor.md)                                               | Using Supabase Index Advisor to tune query performance.                        |
+| 6.8  | [WRAPPERS_INTEGRATION.md](./WRAPPERS_INTEGRATION.md)                                 | How to connect external services via Postgres foreign data wrappers.           |
+| 6.9  | [trading-data-organization.md](./trading-data-organization.md)                       | Folder taxonomy for templates, journals, KPIs, and backtests across each horizon bucket. |
+| 6.10 | [dai-webhook-routing.md](./dai-webhook-routing.md)                                   | Options for single-endpoint vs. auto-provisioned TradingView webhook routes managed by DAI. |
 | 6.11 | [dynamic-market-notes.md](./dynamic-market-notes.md)                                 | Dynamic Market stack overview covering DMDA feeds, DMM quoting levers, and treasury coordination notes. |
 | 6.12 | [onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md](./onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md) | Share metadata, Graph helpers, and access notes for the trading PDF OneDrive folder. |
 | 6.13 | [onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md](./onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md) | Datasets share identifiers and Graph commands for refreshing training corpora. |
@@ -112,8 +113,8 @@ documenting which assets were consulted.
 | 6.16 | [onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md](./onedrive-shares/ejhj6-c4fjdopaw-phw5zl8bwumo2lyzhwbrhbknd4gvbq-folder.md) | Combined logs and model artifacts share metadata for telemetry/model reconciliation. |
 | 6.17 | [onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md](./onedrive-shares/eskwdphqepxihqmatzjdduubkm_lsdxt-jvm-1smjjgfea-folder.md) | Trading reports share identifiers for ingesting supplemental analytics. |
 | 6.18 | [onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md](./onedrive-shares/etoelnepqhhhiis2vl7qe_abz618nqf2vgnrykcx0prhwa-file.md) | Standalone `read_me.md` text share metadata for onboarding notes. |
-| 6.19 | [agi_integration_strategies.md](./agi_integration_strategies.md) | AGI-driven integration plan aligning DTL, DTA, execution, and learning loops. |
-
+| 6.19 | [agi_integration_strategies.md](./agi_integration_strategies.md)                       | AGI-driven integration plan aligning DTL, DTA, execution, and learning loops. |
+| 6.20 | [knowledge-base-training-drop.md](./knowledge-base-training-drop.md)                  | Checklist for syncing the OneDrive knowledge base dataset drops into Supabase and local experiments. |
 ## 7. Operational Runbooks & Launch Phases
 
 | Ref  | Document                                                             | Summary                                                                   |

--- a/docs/knowledge-base-training-drop.md
+++ b/docs/knowledge-base-training-drop.md
@@ -1,0 +1,71 @@
+# Knowledge Base Training Drop Checklist
+
+The shared OneDrive workspace now includes a `knowledge_base/` directory that
+houses freshly uploaded corpora for model fine-tuning. Treat the folder as the
+source of truth for knowledge-grounded training datasets that should be mirrored
+into Supabase Storage and the local repository when preparing new runs.
+
+## Access overview
+
+- **OneDrive location:** `.../knowledge_base/` inside the
+  `EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg` share already tracked in
+  `docs/onedrive-shares/evlumlqt-folder.md`.
+- **Contents:** Expect curated markdown, CSV, and JSON artefacts that expand the
+  long-form knowledge base used for retrieval-augmented training.
+- **Ownership:** Model engineering team. Announce additions in the #ml-updates
+  channel alongside a brief describing intended use.
+
+## Sync workflow
+
+1. **List the drop**
+   ```bash
+   export ONEDRIVE_ACCESS_TOKEN="<token>"
+   tsx scripts/onedrive/list-drive-contents.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg"
+   ```
+   - Inspect the tree for the `knowledge_base/` node and note new filenames and
+     sizes.
+2. **Snapshot metadata**
+   ```bash
+   tsx scripts/onedrive/dump-drive-item.ts \
+     "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg" \
+     docs/onedrive-shares/evlumlqt-folder.metadata.json
+   ```
+   - Commit the refreshed metadata file so the repo mirrors the share inventory.
+3. **Mirror to storage**
+   - Run the existing Supabase ↔ OneDrive sync (`npm run sync:onedrive` if
+     available) or trigger the Power Automate flow responsible for dataset
+     promotion.
+   - Confirm `public.one_drive_assets` contains the `knowledge_base/` entries
+     via Supabase SQL.
+4. **Ingest locally**
+   - Copy the new files into `data/knowledge_base/` (create the directory if it
+     does not exist) while maintaining subfolders from OneDrive.
+   - Record provenance in `data/knowledge_base/README.md` with dataset versions
+     and intended prompts.
+   - Run `npm run checklists -- --checklist knowledge-base-drop` to confirm the
+     documentation, metadata snapshot, and local mirror structure are in place.
+
+## Training integration
+
+- Update experiment configs under `dynamic_trainer/` or `ml/` to point to the
+  new local mirror when running fine-tuning or embedding refresh jobs.
+- Rebuild vector indexes after syncing by executing the pipeline that feeds the
+  retrieval layer (for example, `npm run embeddings:refresh knowledge_base`).
+- Capture evaluation metrics and push summaries back into the `knowledge_base/`
+  folder so the OneDrive mirror remains the long-term archive.
+
+## Governance checklist
+
+- [ ] Metadata snapshot committed after every drop.
+- [ ] Supabase manifest shows the new keys under `knowledge_base/`.
+- [ ] Local repo `data/knowledge_base/` folder updated and documented.
+- [ ] Training run logs reference the corresponding OneDrive dataset version.
+
+## Automation helper
+
+Execute
+`npm run checklists -- --checklist knowledge-base-drop --include-optional` to
+chain the repository checks with the OneDrive list/dump scripts. Provide a valid
+`ONEDRIVE_ACCESS_TOKEN` when including the optional commands so the metadata
+file refresh succeeds.

--- a/docs/onedrive-shares/evlumlqt-folder.md
+++ b/docs/onedrive-shares/evlumlqt-folder.md
@@ -56,3 +56,18 @@ The response payload includes the item metadata and, when available, the
 children of the shared folder. Save the output to
 `docs/onedrive-shares/evlumlqt-folder.metadata.json` to snapshot the latest
 state.
+
+## `knowledge_base/` drop overview
+
+- The share now contains a `knowledge_base/` directory with freshly uploaded
+  training corpora. Sync the folder whenever new drops are announced so the
+  repository and Supabase mirrors stay aligned.
+- Use `tsx scripts/onedrive/list-drive-contents.ts` with the share link above to
+  enumerate the hierarchy. Expect markdown, CSV, and JSON artefacts sized for
+  retrieval-augmented model runs.
+- After each sync, rerun
+  `tsx scripts/onedrive/dump-drive-item.ts "<share>" docs/onedrive-shares/evlumlqt-folder.metadata.json`
+  to capture the updated manifest and commit the diff.
+- Mirror the downloaded files into `data/knowledge_base/` locally and document
+  provenance in `data/knowledge_base/README.md`. This keeps experiment tracking
+  consistent across GitHub, Supabase Storage, and the OneDrive source.

--- a/docs/onedrive-shares/evlumlqt-folder.metadata.json
+++ b/docs/onedrive-shares/evlumlqt-folder.metadata.json
@@ -1,0 +1,15 @@
+{
+  "shareLink": "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg",
+  "fetchedAt": "2025-02-14T00:00:00Z",
+  "notes": [
+    "Placeholder manifest captured in the automation sandbox. Replace with the real dump-drive-item.ts output when OneDrive credentials are available."
+  ],
+  "children": [
+    {
+      "name": "knowledge_base",
+      "type": "folder",
+      "lastKnownItemCount": 0,
+      "remarks": "Populate after syncing the latest training corpora."
+    }
+  ]
+}

--- a/docs/onedrive-sync-integration.md
+++ b/docs/onedrive-sync-integration.md
@@ -128,3 +128,23 @@ ideal when the automation must live entirely within the Microsoft 365 estate.
 
 Document the chosen automation approach in project runbooks to keep Codex
 contributors aligned on how OneDrive mirrors stay current.
+
+## 5. Knowledge base dataset drops
+
+When fresh training corpora land in the OneDrive `knowledge_base/` directory
+inside the `EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg` share:
+
+1. Announce the drop in the #ml-updates channel with a summary of the contents
+   and intended experiments.
+2. Run `tsx scripts/onedrive/list-drive-contents.ts "<share-link>"` to verify
+   the new files, then update
+   `docs/onedrive-shares/evlumlqt-folder.metadata.json` via the
+   `dump-drive-item.ts` helper.
+3. Trigger the Supabase ↔ OneDrive sync or automation of choice so
+   `public.one_drive_assets` includes the `knowledge_base/` keys.
+4. Mirror the files locally under `data/knowledge_base/`, capture provenance in
+   a README, and update experiment configurations in `dynamic_trainer/` or `ml/`
+   to point at the refreshed dataset.
+
+Track ongoing operational notes in `docs/knowledge-base-training-drop.md` to
+keep the workflow reproducible.

--- a/scripts/checklists/knowledge-base-verify.mjs
+++ b/scripts/checklists/knowledge-base-verify.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+import { readdir } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(MODULE_DIR, "..", "..");
+
+function resolvePath(relativePath) {
+  return path.join(PROJECT_ROOT, relativePath);
+}
+
+async function assertFileExists(relativePath, message) {
+  const absolutePath = resolvePath(relativePath);
+  try {
+    const stats = await fs.stat(absolutePath);
+    if (!stats.isFile()) {
+      throw new Error(`${relativePath} exists but is not a file.`);
+    }
+  } catch (error) {
+    throw new Error(`${message} (missing: ${relativePath})\n${error.message}`);
+  }
+}
+
+async function assertDirectoryExists(relativePath, message) {
+  const absolutePath = resolvePath(relativePath);
+  try {
+    const stats = await fs.stat(absolutePath);
+    if (!stats.isDirectory()) {
+      throw new Error(`${relativePath} exists but is not a directory.`);
+    }
+  } catch (error) {
+    throw new Error(`${message} (missing: ${relativePath})\n${error.message}`);
+  }
+}
+
+async function validateMetadataManifest() {
+  const manifestPath = "docs/onedrive-shares/evlumlqt-folder.metadata.json";
+  await assertFileExists(
+    manifestPath,
+    "Knowledge base metadata snapshot is required before training runs.",
+  );
+
+  const manifestContents = await fs.readFile(resolvePath(manifestPath), "utf8");
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestContents);
+  } catch (error) {
+    throw new Error(
+      `Metadata manifest is not valid JSON. Parse error: ${error.message}`,
+    );
+  }
+
+  if (!Array.isArray(manifest.children)) {
+    throw new Error("Metadata manifest must expose a children array.");
+  }
+
+  const knowledgeBaseNode = manifest.children.find(
+    (child) =>
+      typeof child?.name === "string" && child.name === "knowledge_base",
+  );
+
+  if (!knowledgeBaseNode) {
+    throw new Error(
+      "Metadata manifest does not include the knowledge_base directory entry.",
+    );
+  }
+}
+
+async function validateLocalMirror() {
+  await assertDirectoryExists(
+    "data/knowledge_base",
+    "Create data/knowledge_base to store the mirrored datasets.",
+  );
+  await assertFileExists(
+    "data/knowledge_base/README.md",
+    "Document the local knowledge base mirror in data/knowledge_base/README.md.",
+  );
+
+  const entries = await readdir(resolvePath("data/knowledge_base"));
+  const materialised = entries.filter((entry) => entry !== "README.md");
+
+  if (materialised.length === 0) {
+    console.warn(
+      "Warning: data/knowledge_base contains no mirrored dataset files. Upload them after syncing the OneDrive drop.",
+    );
+  }
+
+  const readmeContents = await fs.readFile(
+    resolvePath("data/knowledge_base/README.md"),
+    "utf8",
+  );
+  if (!/Knowledge Base Mirror/i.test(readmeContents)) {
+    throw new Error(
+      "data/knowledge_base/README.md is missing the Knowledge Base Mirror heading.",
+    );
+  }
+}
+
+async function validateChecklistDoc() {
+  await assertFileExists(
+    "docs/knowledge-base-training-drop.md",
+    "The drop checklist documentation is required for repeatability.",
+  );
+}
+
+async function main() {
+  try {
+    await validateChecklistDoc();
+    await validateMetadataManifest();
+    await validateLocalMirror();
+    console.log("Knowledge base drop checklist verification complete.");
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -202,6 +202,41 @@ const TASK_LIBRARY = {
       'Surfaces vulnerable packages to keep parity with the GitHub Actions audit step.',
     ],
   },
+  'knowledge-base-verify': {
+    id: 'knowledge-base-verify',
+    label:
+      'Verify knowledge base mirror scaffolding (node scripts/checklists/knowledge-base-verify.mjs)',
+    command: 'node scripts/checklists/knowledge-base-verify.mjs',
+    optional: false,
+    docs: ['docs/knowledge-base-training-drop.md'],
+    notes: [
+      'Confirms the checklist doc, metadata snapshot, and local mirror structure exist before training.',
+    ],
+  },
+  'knowledge-base-list': {
+    id: 'knowledge-base-list',
+    label:
+      'Enumerate OneDrive knowledge_base folder (tsx scripts/onedrive/list-drive-contents.ts)',
+    command:
+      'tsx scripts/onedrive/list-drive-contents.ts "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg"',
+    optional: true,
+    docs: ['docs/knowledge-base-training-drop.md'],
+    notes: [
+      'Requires ONEDRIVE_ACCESS_TOKEN. Prints the current tree so you can compare against the local mirror.',
+    ],
+  },
+  'knowledge-base-dump': {
+    id: 'knowledge-base-dump',
+    label:
+      'Snapshot OneDrive metadata (tsx scripts/onedrive/dump-drive-item.ts)',
+    command:
+      'tsx scripts/onedrive/dump-drive-item.ts "https://1drv.ms/f/c/2ff0428a2f57c7a4/EvLuMLqTtFRPpRS6OIWWvioBcFAJdDAXHZqN8bYy3JUyyg" docs/onedrive-shares/evlumlqt-folder.metadata.json',
+    optional: true,
+    docs: ['docs/knowledge-base-training-drop.md'],
+    notes: [
+      'Requires ONEDRIVE_ACCESS_TOKEN. Refreshes docs/onedrive-shares/evlumlqt-folder.metadata.json with the latest manifest.',
+    ],
+  },
   'ci-test-and-pr': {
     id: 'ci-test-and-pr',
     label: 'Run CI parity checks (deno task ci)',
@@ -330,6 +365,26 @@ const CHECKLISTS = {
     tasks: [
       'nft-collectible-validate',
       'nft-collectible-tasks',
+    ],
+  },
+  'knowledge-base-drop': {
+    name: 'Knowledge Base Training Drop Checklist',
+    doc: 'docs/knowledge-base-training-drop.md',
+    description:
+      'Operational guardrails for mirroring the OneDrive knowledge_base dataset.',
+    tasks: [
+      'knowledge-base-verify',
+      {
+        task: 'knowledge-base-list',
+        optional: true,
+        note: 'Requires ONEDRIVE_ACCESS_TOKEN to enumerate the remote folder.',
+      },
+      {
+        task: 'knowledge-base-dump',
+        optional: true,
+        note:
+          'Requires ONEDRIVE_ACCESS_TOKEN to refresh the metadata snapshot stored in docs/onedrive-shares/evlumlqt-folder.metadata.json.',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- add local `data/knowledge_base/README.md` scaffolding and a placeholder metadata snapshot for the EvLuMLq… share
- wire a `knowledge-base-drop` automation path into `scripts/run-checklists.js` with a verification script to guard documentation and mirrors
- extend the OneDrive drop checklist doc with CLI instructions for running the new automation bundle

## Testing
- `npm run checklists -- --checklist knowledge-base-drop`


------
https://chatgpt.com/codex/tasks/task_e_68dad5cbd97c8322a9c8c6a0d9b73444