### PR TITLE
refactor: centralize project cache utilities

### DIFF
--- a/scripts/project/collect-conventional-commits.ts
+++ b/scripts/project/collect-conventional-commits.ts
@@ -1,36 +1,17 @@
-import { execSync } from 'node:child_process';
-import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
-
-interface CommitRecord {
-  hash: string;
-  author: string;
-  date: string;
-  summary: string;
-  type: string;
-  scope?: string;
-  breaking: boolean;
-  prNumber?: number;
-  issues: number[];
-}
-
-interface CommitGroup {
-  type: string;
-  commits: CommitRecord[];
-}
-
-interface OutputPayload {
-  fromTag?: string;
-  toRef: string;
-  generatedAt: string;
-  groups: CommitGroup[];
-  commits: CommitRecord[];
-}
+import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type CommitGroup,
+  type CommitPayload,
+  type CommitRecord,
+  ensureProjectCacheDir,
+} from "./shared.ts";
 
 function runGit(args: string[]): string {
-  return execSync(`git ${args.join(' ')}`, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+  return execSync(`git ${args.join(" ")}`, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
   }).trim();
 }
 
@@ -46,8 +27,8 @@ function parseArgs(argv: string[]): Record<string, string | boolean> {
   const result: Record<string, string | boolean> = {};
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (!arg.startsWith('--')) continue;
-    const [key, value] = arg.slice(2).split('=');
+    if (!arg.startsWith("--")) continue;
+    const [key, value] = arg.slice(2).split("=");
     if (value === undefined) {
       result[key] = true;
     } else {
@@ -65,7 +46,7 @@ function extractMetadata(summary: string): {
   issues: number[];
 } {
   const match = summary.match(/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/);
-  let type = 'chore';
+  let type = "chore";
   let scope: string | undefined;
   let breaking = false;
   let cleanSummary = summary;
@@ -76,7 +57,9 @@ function extractMetadata(summary: string): {
     cleanSummary = match[4];
   }
 
-  const issues = Array.from(cleanSummary.matchAll(/#(\d+)/g)).map((value) => Number.parseInt(value[1], 10));
+  const issues = Array.from(cleanSummary.matchAll(/#(\d+)/g)).map((value) =>
+    Number.parseInt(value[1], 10)
+  );
   const prMatch = cleanSummary.match(/\(#(\d+)\)/);
   const prNumber = prMatch ? Number.parseInt(prMatch[1], 10) : undefined;
 
@@ -86,38 +69,47 @@ function extractMetadata(summary: string): {
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
   const cwd = process.cwd();
-  const cacheDir = join(cwd, '.project-cache');
-  if (!existsSync(cacheDir)) {
-    mkdirSync(cacheDir, { recursive: true });
-  }
+  const cacheDir = ensureProjectCacheDir(cwd);
 
-  const explicitFrom = typeof args.from === 'string' ? (args.from as string) : undefined;
-  const explicitTo = typeof args.to === 'string' ? (args.to as string) : undefined;
+  const explicitFrom = typeof args.from === "string"
+    ? (args.from as string)
+    : undefined;
+  const explicitTo = typeof args.to === "string"
+    ? (args.to as string)
+    : undefined;
 
-  const lastTag = explicitFrom ?? safeGit(['describe', '--tags', '--abbrev=0']);
-  const toRef = explicitTo ?? 'HEAD';
+  const lastTag = explicitFrom ?? safeGit(["describe", "--tags", "--abbrev=0"]);
+  const toRef = explicitTo ?? "HEAD";
   const range = lastTag ? `${lastTag}..${toRef}` : toRef;
 
-  const rawLog = safeGit(['log', range, '--pretty=format:%H%x1f%an%x1f%ad%x1f%s%x1e', '--date=short']);
+  const rawLog = safeGit([
+    "log",
+    range,
+    "--pretty=format:%H%x1f%an%x1f%ad%x1f%s%x1e",
+    "--date=short",
+  ]);
   if (!rawLog) {
-    const emptyPayload: OutputPayload = {
+    const emptyPayload: CommitPayload = {
       fromTag: lastTag,
       toRef,
       generatedAt: new Date().toISOString(),
       groups: [],
       commits: [],
     };
-    writeFileSync(join(cacheDir, 'commits.json'), JSON.stringify(emptyPayload, null, 2));
+    writeFileSync(
+      join(cacheDir, "commits.json"),
+      JSON.stringify(emptyPayload, null, 2),
+    );
     return;
   }
 
   const entries = rawLog
-    .split('\u001e')
+    .split("\u001e")
     .map((line) => line.trim())
     .filter(Boolean);
 
   const commits: CommitRecord[] = entries.map((entry) => {
-    const [hash, author, date, summary] = entry.split('\u001f');
+    const [hash, author, date, summary] = entry.split("\u001f");
     const metadata = extractMetadata(summary);
     return {
       hash,
@@ -139,7 +131,7 @@ async function main(): Promise<void> {
     groups.set(commit.type, list);
   }
 
-  const payload: OutputPayload = {
+  const payload: CommitPayload = {
     fromTag: lastTag,
     toRef,
     generatedAt: new Date().toISOString(),
@@ -150,11 +142,14 @@ async function main(): Promise<void> {
     commits,
   };
 
-  writeFileSync(join(cacheDir, 'commits.json'), JSON.stringify(payload, null, 2));
+  writeFileSync(
+    join(cacheDir, "commits.json"),
+    JSON.stringify(payload, null, 2),
+  );
 }
 
 main().catch((error) => {
-  console.error('[collect-conventional-commits] Failed to collect commits');
+  console.error("[collect-conventional-commits] Failed to collect commits");
   console.error(error);
   process.exitCode = 1;
 });

--- a/scripts/project/generate-release-notes.ts
+++ b/scripts/project/generate-release-notes.ts
@@ -1,47 +1,23 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-
-interface CommitRecord {
-  hash: string;
-  author: string;
-  date: string;
-  summary: string;
-  type: string;
-  scope?: string;
-  breaking: boolean;
-  prNumber?: number;
-  issues: number[];
-}
-
-interface CommitGroup {
-  type: string;
-  commits: CommitRecord[];
-}
-
-interface CommitPayload {
-  fromTag?: string;
-  toRef: string;
-  generatedAt: string;
-  groups: CommitGroup[];
-  commits: CommitRecord[];
-}
-
-interface HighlightItem {
-  text: string;
-  url?: string;
-}
-
-interface ReleaseMeta {
-  version: string;
-  date: string;
-}
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  cleanSummary,
+  type CommitGroup,
+  commitLink,
+  type CommitPayload,
+  ensureProjectCacheDir,
+  type HighlightItem,
+  loadCommitPayload,
+  type ReleaseMeta,
+  shortHash,
+} from "./shared.ts";
 
 function parseArgs(argv: string[]): Record<string, string> {
   const result: Record<string, string> = {};
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (!arg.startsWith('--')) continue;
-    const [key, value] = arg.slice(2).split('=');
+    if (!arg.startsWith("--")) continue;
+    const [key, value] = arg.slice(2).split("=");
     if (value !== undefined) {
       result[key] = value;
     }
@@ -49,41 +25,14 @@ function parseArgs(argv: string[]): Record<string, string> {
   return result;
 }
 
-function loadCommitPayload(cacheDir: string): CommitPayload {
-  const path = join(cacheDir, 'commits.json');
-  if (!existsSync(path)) {
-    throw new Error('Missing commit cache. Run proj:collect first.');
-  }
-  const raw = readFileSync(path, 'utf8');
-  return JSON.parse(raw) as CommitPayload;
-}
-
-function ensureDir(path: string): void {
-  if (!existsSync(path)) {
-    mkdirSync(path, { recursive: true });
-  }
-}
-
-function shortHash(hash: string): string {
-  return hash.slice(0, 7);
-}
-
-function commitLink(prNumber?: number): string | undefined {
-  if (!prNumber) return undefined;
-  const repoUrl = process.env.GITHUB_REPOSITORY
-    ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
-    : undefined;
-  return repoUrl ? `${repoUrl}/pull/${prNumber}` : undefined;
-}
-
 function chooseHighlights(payload: CommitPayload): HighlightItem[] {
-  const featureCommits = payload.groups.find((group) => group.type === 'feat');
+  const featureCommits = payload.groups.find((group) => group.type === "feat");
   const candidates = (featureCommits?.commits ?? payload.commits).slice(0, 5);
   return candidates.map((commit) => {
     const url = commitLink(commit.prNumber);
-    const cleanSummary = commit.summary.replace(/^(\w+)(?:\([^)]+\))?(!)?:\s*/, '');
+    const summary = cleanSummary(commit.summary);
     return {
-      text: cleanSummary,
+      text: summary,
       url,
     };
   });
@@ -91,7 +40,7 @@ function chooseHighlights(payload: CommitPayload): HighlightItem[] {
 
 function renderHighlightList(items: HighlightItem[]): string {
   if (!items.length) {
-    return '- Maintenance release.';
+    return "- Maintenance release.";
   }
   return items
     .map((item) => {
@@ -100,31 +49,36 @@ function renderHighlightList(items: HighlightItem[]): string {
       }
       return `- ${item.text}`;
     })
-    .join('\n');
+    .join("\n");
 }
 
 function renderChangeSection(groups: CommitGroup[]): string {
   if (!groups.length) {
-    return '_No user-facing changes._';
+    return "_No user-facing changes._";
   }
   return groups
     .map((group) => {
       const items = group.commits
         .map((commit) => {
-          const cleanSummary = commit.summary.replace(/^(\w+)(?:\([^)]+\))?(!)?:\s*/, '');
-          const prSuffix = commit.prNumber ? ` (#${commit.prNumber})` : '';
-          return `- ${cleanSummary}${prSuffix} (${shortHash(commit.hash)})`;
+          const cleaned = cleanSummary(commit.summary);
+          const prSuffix = commit.prNumber ? ` (#${commit.prNumber})` : "";
+          return `- ${cleaned}${prSuffix} (${shortHash(commit.hash)})`;
         })
-        .join('\n');
+        .join("\n");
       return `### ${group.type}\n${items}`;
     })
-    .join('\n\n');
+    .join("\n\n");
 }
 
-function prependChangelogEntry(changelogPath: string, version: string, date: string, body: string): void {
-  const startMarker = '<!-- CHANGELOG:START -->';
-  const endMarker = '<!-- CHANGELOG:END -->';
-  const changelog = readFileSync(changelogPath, 'utf8');
+function prependChangelogEntry(
+  changelogPath: string,
+  version: string,
+  date: string,
+  body: string,
+): void {
+  const startMarker = "<!-- CHANGELOG:START -->";
+  const endMarker = "<!-- CHANGELOG:END -->";
+  const changelog = readFileSync(changelogPath, "utf8");
   if (changelog.includes(`## ${version}`)) {
     return;
   }
@@ -132,63 +86,77 @@ function prependChangelogEntry(changelogPath: string, version: string, date: str
   const startIndex = changelog.indexOf(startMarker);
   const endIndex = changelog.indexOf(endMarker);
   if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-    throw new Error('CHANGELOG markers are missing or malformed.');
+    throw new Error("CHANGELOG markers are missing or malformed.");
   }
   const before = changelog.slice(0, startIndex + startMarker.length);
   const after = changelog.slice(endIndex);
-  const between = changelog.slice(startIndex + startMarker.length, endIndex).trim();
-  const content = [entry.trim(), between && between !== '_No releases have been published yet._' ? between : '']
+  const between = changelog.slice(startIndex + startMarker.length, endIndex)
+    .trim();
+  const content = [
+    entry.trim(),
+    between && between !== "_No releases have been published yet._"
+      ? between
+      : "",
+  ]
     .filter(Boolean)
-    .join('\n\n');
-  const finalValue = `${before}\n${content}\n${after}`.replace(/\n{3,}/g, '\n\n');
-  writeFileSync(changelogPath, finalValue.trimEnd() + '\n');
+    .join("\n\n");
+  const finalValue = `${before}\n${content}\n${after}`.replace(
+    /\n{3,}/g,
+    "\n\n",
+  );
+  writeFileSync(changelogPath, finalValue.trimEnd() + "\n");
 }
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
   const cwd = process.cwd();
-  const cacheDir = join(cwd, '.project-cache');
-  ensureDir(cacheDir);
-  const payload = loadCommitPayload(cacheDir);
+  const cacheDir = ensureProjectCacheDir(cwd);
+  const payload = loadCommitPayload(cwd);
 
   const version = args.version ?? process.env.VERSION;
   if (!version) {
-    throw new Error('Provide --version=vX.Y.Z or set VERSION env variable.');
+    throw new Error("Provide --version=vX.Y.Z or set VERSION env variable.");
   }
   const today = new Date().toISOString().slice(0, 10);
 
   const highlights = chooseHighlights(payload);
   const changeSection = renderChangeSection(payload.groups);
 
-  const releaseDir = join(cwd, 'docs', 'RELEASE_NOTES');
-  ensureDir(releaseDir);
+  const releaseDir = join(cwd, "docs", "RELEASE_NOTES");
+  if (!existsSync(releaseDir)) {
+    mkdirSync(releaseDir, { recursive: true });
+  }
   const releasePath = join(releaseDir, `${version}.md`);
   if (!existsSync(releasePath)) {
-    const content = `# Release ${version} (${today})\n\n## Highlights\n${renderHighlightList(highlights)}\n\n## Changes\n${changeSection}\n`;
-    writeFileSync(releasePath, content.trimEnd() + '\n');
+    const content = `# Release ${version} (${today})\n\n## Highlights\n${
+      renderHighlightList(highlights)
+    }\n\n## Changes\n${changeSection}\n`;
+    writeFileSync(releasePath, content.trimEnd() + "\n");
   }
 
-  const changelogPath = join(cwd, 'docs', 'CHANGELOG.md');
+  const changelogPath = join(cwd, "docs", "CHANGELOG.md");
   if (!existsSync(changelogPath)) {
-    throw new Error('docs/CHANGELOG.md is missing.');
+    throw new Error("docs/CHANGELOG.md is missing.");
   }
   prependChangelogEntry(
     changelogPath,
     version,
     today,
-    renderHighlightList(highlights)
+    renderHighlightList(highlights),
   );
 
-  const highlightPath = join(cacheDir, 'highlights.json');
+  const highlightPath = join(cacheDir, "highlights.json");
   writeFileSync(highlightPath, JSON.stringify(highlights, null, 2));
 
-  const metaPath = join(cacheDir, 'release-meta.json');
+  const metaPath = join(cacheDir, "release-meta.json");
   const meta: ReleaseMeta = { version, date: today };
   writeFileSync(metaPath, JSON.stringify(meta, null, 2));
 }
 
 main().catch((error) => {
-  console.error('[generate-release-notes] Unable to generate release artifacts');
+  console.error(
+    "[generate-release-notes] Unable to generate release artifacts",
+  );
   console.error(error);
   process.exitCode = 1;
 });

--- a/scripts/project/projects-v2-update.ts
+++ b/scripts/project/projects-v2-update.ts
@@ -1,27 +1,11 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { spawnSync } from 'node:child_process';
-
-interface CommitRecord {
-  hash: string;
-  author: string;
-  date: string;
-  summary: string;
-  type: string;
-  scope?: string;
-  breaking: boolean;
-  prNumber?: number;
-  issues: number[];
-}
-
-interface CommitPayload {
-  commits: CommitRecord[];
-}
-
-interface ReleaseMeta {
-  version: string;
-  date: string;
-}
+import { spawnSync } from "node:child_process";
+import {
+  type CommitPayload,
+  type CommitRecord,
+  loadCommitPayload,
+  loadReleaseMeta,
+  type ReleaseMeta,
+} from "./shared.ts";
 
 interface ProjectFieldOption {
   id: string;
@@ -31,14 +15,14 @@ interface ProjectFieldOption {
 interface ProjectField {
   id: string;
   name: string;
-  dataType: 'TEXT' | 'SINGLE_SELECT' | string;
+  dataType: "TEXT" | "SINGLE_SELECT" | string;
   options?: ProjectFieldOption[];
 }
 
 interface ProjectItem {
   id: string;
   title?: string;
-  type?: 'ISSUE' | 'PULL_REQUEST';
+  type?: "ISSUE" | "PULL_REQUEST";
   number?: number;
   updatedAt?: string;
 }
@@ -51,18 +35,20 @@ interface ProjectData {
 }
 
 function runGh(args: string[]): string {
-  const result = spawnSync('gh', args, { encoding: 'utf8' });
+  const result = spawnSync("gh", args, { encoding: "utf8" });
   if (result.status !== 0) {
-    throw new Error(result.stderr || `gh ${args.join(' ')} exited with ${result.status}`);
+    throw new Error(
+      result.stderr || `gh ${args.join(" ")} exited with ${result.status}`,
+    );
   }
   return result.stdout.trim();
 }
 
 function ghGraphql(query: string, variables: Record<string, unknown>): any {
-  const cleanedQuery = query.replace(/\s+/g, ' ').trim();
-  const args = ['api', 'graphql', '-f', `query=${cleanedQuery}`];
+  const cleanedQuery = query.replace(/\s+/g, " ").trim();
+  const args = ["api", "graphql", "-f", `query=${cleanedQuery}`];
   if (Object.keys(variables).length) {
-    args.push('-f', `variables=${JSON.stringify(variables)}`);
+    args.push("-f", `variables=${JSON.stringify(variables)}`);
   }
   const output = runGh(args);
   return JSON.parse(output);
@@ -70,49 +56,51 @@ function ghGraphql(query: string, variables: Record<string, unknown>): any {
 
 function ensureGhAvailable(): boolean {
   try {
-    runGh(['--version']);
+    runGh(["--version"]);
     return true;
   } catch (error) {
-    console.warn('[projects-v2-update] gh CLI not available; skipping project sync.');
+    console.warn(
+      "[projects-v2-update] gh CLI not available; skipping project sync.",
+    );
     return false;
   }
 }
 
-function loadCommitPayload(cacheDir: string): CommitPayload {
-  const path = join(cacheDir, 'commits.json');
-  if (!existsSync(path)) {
-    throw new Error('Missing commit cache. Run proj:collect first.');
-  }
-  return JSON.parse(readFileSync(path, 'utf8')) as CommitPayload;
-}
-
-function loadReleaseMeta(cacheDir: string): ReleaseMeta | undefined {
-  const path = join(cacheDir, 'release-meta.json');
-  if (!existsSync(path)) return undefined;
-  return JSON.parse(readFileSync(path, 'utf8')) as ReleaseMeta;
-}
-
-function resolveProject(owner: string, number: number, ownerType: 'organization' | 'user'): ProjectData {
-  const query = ownerType === 'user'
+function resolveProject(
+  owner: string,
+  number: number,
+  ownerType: "organization" | "user",
+): ProjectData {
+  const query = ownerType === "user"
     ? `query($login: String!, $number: Int!) { user(login: $login) { projectV2(number: $number) { id title fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name dataType options { id name } } ... on ProjectV2FieldCommon { id name dataType } } } items(first: 200) { nodes { id title updatedAt content { __typename ... on PullRequest { number } ... on Issue { number } } } } } } }`
     : `query($login: String!, $number: Int!) { organization(login: $login) { projectV2(number: $number) { id title fields(first: 50) { nodes { ... on ProjectV2SingleSelectField { id name dataType options { id name } } ... on ProjectV2FieldCommon { id name dataType } } } items(first: 200) { nodes { id title updatedAt content { __typename ... on PullRequest { number } ... on Issue { number } } } } } } }`;
   const data = ghGraphql(query, { login: owner, number });
-  const container = ownerType === 'user' ? data.user : data.organization;
+  const container = ownerType === "user" ? data.user : data.organization;
   if (!container?.projectV2) {
-    throw new Error(`Project number ${number} not found for ${ownerType} ${owner}.`);
+    throw new Error(
+      `Project number ${number} not found for ${ownerType} ${owner}.`,
+    );
   }
   const project = container.projectV2;
-  const fields: ProjectField[] = (project.fields?.nodes ?? []).map((node: any) => ({
+  const fields: ProjectField[] = (project.fields?.nodes ?? []).map((
+    node: any,
+  ) => ({
     id: node.id,
     name: node.name,
     dataType: node.dataType,
     options: node.options,
   }));
-  const items: ProjectItem[] = (project.items?.nodes ?? []).map((node: any) => ({
+  const items: ProjectItem[] = (project.items?.nodes ?? []).map((
+    node: any,
+  ) => ({
     id: node.id,
     title: node.title ?? undefined,
     updatedAt: node.updatedAt ?? undefined,
-    type: node.content?.__typename === 'PullRequest' ? 'PULL_REQUEST' : node.content?.__typename === 'Issue' ? 'ISSUE' : undefined,
+    type: node.content?.__typename === "PullRequest"
+      ? "PULL_REQUEST"
+      : node.content?.__typename === "Issue"
+      ? "ISSUE"
+      : undefined,
     number: node.content?.number,
   }));
   return {
@@ -125,27 +113,31 @@ function resolveProject(owner: string, number: number, ownerType: 'organization'
 
 function getProject(owner: string, number: number): ProjectData {
   try {
-    return resolveProject(owner, number, 'organization');
+    return resolveProject(owner, number, "organization");
   } catch (error) {
-    return resolveProject(owner, number, 'user');
+    return resolveProject(owner, number, "user");
   }
 }
 
 function uniqueNumbers(numbers: Array<number | undefined>): number[] {
   const unique = new Set<number>();
   for (const value of numbers) {
-    if (typeof value === 'number') {
+    if (typeof value === "number") {
       unique.add(value);
     }
   }
   return Array.from(unique);
 }
 
-function fetchContentNodeIds(repo: string, pullNumbers: number[], issueNumbers: number[]): Map<number, string> {
+function fetchContentNodeIds(
+  repo: string,
+  pullNumbers: number[],
+  issueNumbers: number[],
+): Map<number, string> {
   if (!repo) {
     return new Map();
   }
-  const [owner, name] = repo.split('/');
+  const [owner, name] = repo.split("/");
   const ids = new Map<number, string>();
   if (!pullNumbers.length && !issueNumbers.length) {
     return ids;
@@ -160,12 +152,15 @@ function fetchContentNodeIds(repo: string, pullNumbers: number[], issueNumbers: 
     const key = `issue${index}`;
     queries.push(`${key}: issue(number: ${num}) { id number }`);
   });
-  const query = `query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { ${queries.join(' ')} } }`;
+  const query =
+    `query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { ${
+      queries.join(" ")
+    } } }`;
   const data = ghGraphql(query, variables);
   const repository = data.repository;
   if (repository) {
     Object.values(repository).forEach((node: any) => {
-      if (node?.id && typeof node.number === 'number') {
+      if (node?.id && typeof node.number === "number") {
         ids.set(node.number, node.id);
       }
     });
@@ -173,78 +168,125 @@ function fetchContentNodeIds(repo: string, pullNumbers: number[], issueNumbers: 
   return ids;
 }
 
-function ensureProjectItem(project: ProjectData, projectId: string, contentId: string, expectedNumber?: number): string {
-  const existing = project.items.find((item) => typeof expectedNumber === 'number' && item.number === expectedNumber);
+function ensureProjectItem(
+  project: ProjectData,
+  projectId: string,
+  contentId: string,
+  expectedNumber?: number,
+): string {
+  const existing = project.items.find((item) =>
+    typeof expectedNumber === "number" && item.number === expectedNumber
+  );
   if (existing) {
     return existing.id;
   }
-  const mutation = `mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }`;
+  const mutation =
+    `mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }`;
   const data = ghGraphql(mutation, { projectId, contentId });
   const newId = data.addProjectV2ItemById?.item?.id;
   if (!newId) {
-    throw new Error('Failed to add project item.');
+    throw new Error("Failed to add project item.");
   }
   project.items.push({ id: newId, number: expectedNumber });
   return newId;
 }
 
-function findField(project: ProjectData, name: string): ProjectField | undefined {
-  return project.fields.find((field) => field.name.toLowerCase() === name.toLowerCase());
+function findField(
+  project: ProjectData,
+  name: string,
+): ProjectField | undefined {
+  return project.fields.find((field) =>
+    field.name.toLowerCase() === name.toLowerCase()
+  );
 }
 
-function updateSingleSelect(projectId: string, itemId: string, field: ProjectField, optionName: string): void {
+function updateSingleSelect(
+  projectId: string,
+  itemId: string,
+  field: ProjectField,
+  optionName: string,
+): void {
   if (!field.options?.length) return;
-  const option = field.options.find((opt) => opt.name.toLowerCase() === optionName.toLowerCase());
+  const option = field.options.find((opt) =>
+    opt.name.toLowerCase() === optionName.toLowerCase()
+  );
   if (!option) return;
-  const mutation = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }`;
-  ghGraphql(mutation, { projectId, itemId, fieldId: field.id, optionId: option.id });
+  const mutation =
+    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { projectV2Item { id } } }`;
+  ghGraphql(mutation, {
+    projectId,
+    itemId,
+    fieldId: field.id,
+    optionId: option.id,
+  });
 }
 
-function updateTextField(projectId: string, itemId: string, field: ProjectField, text: string): void {
-  const mutation = `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { text: $text } }) { projectV2Item { id } } }`;
+function updateTextField(
+  projectId: string,
+  itemId: string,
+  field: ProjectField,
+  text: string,
+): void {
+  const mutation =
+    `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { text: $text } }) { projectV2Item { id } } }`;
   ghGraphql(mutation, { projectId, itemId, fieldId: field.id, text });
 }
 
 async function main(): Promise<void> {
   if (!process.env.GH_TOKEN) {
-    console.warn('[projects-v2-update] GH_TOKEN missing; skipping project sync.');
+    console.warn(
+      "[projects-v2-update] GH_TOKEN missing; skipping project sync.",
+    );
     return;
   }
   if (!ensureGhAvailable()) {
     return;
   }
   const projectOwner = process.env.PROJECT_OWNER;
-  const projectNumber = process.env.PROJECT_NUMBER ? Number.parseInt(process.env.PROJECT_NUMBER, 10) : NaN;
+  const projectNumber = process.env.PROJECT_NUMBER
+    ? Number.parseInt(process.env.PROJECT_NUMBER, 10)
+    : NaN;
   if (!projectOwner || Number.isNaN(projectNumber)) {
-    console.warn('[projects-v2-update] PROJECT_OWNER or PROJECT_NUMBER not configured; skipping project sync.');
+    console.warn(
+      "[projects-v2-update] PROJECT_OWNER or PROJECT_NUMBER not configured; skipping project sync.",
+    );
     return;
   }
 
   const cwd = process.cwd();
-  const cacheDir = join(cwd, '.project-cache');
-  const payload = loadCommitPayload(cacheDir);
-  const meta = loadReleaseMeta(cacheDir);
-  const repo = process.env.GITHUB_REPOSITORY ?? '';
+  const payload = loadCommitPayload(cwd);
+  const meta = loadReleaseMeta(cwd);
+  const repo = process.env.GITHUB_REPOSITORY ?? "";
 
   const project = getProject(projectOwner, projectNumber);
 
-  const prNumbers = uniqueNumbers(payload.commits.map((commit) => commit.prNumber));
-  const issueNumbers = uniqueNumbers(payload.commits.flatMap((commit) => commit.issues));
+  const prNumbers = uniqueNumbers(
+    payload.commits.map((commit) => commit.prNumber),
+  );
+  const issueNumbers = uniqueNumbers(
+    payload.commits.flatMap((commit) => commit.issues),
+  );
   const nodeIds = fetchContentNodeIds(repo, prNumbers, issueNumbers);
 
-  const statusField = findField(project, process.env.PROJECT_STATUS_FIELD ?? 'Status');
-  const releaseField = findField(project, process.env.PROJECT_RELEASE_FIELD ?? 'Released in');
-  const doneOption = process.env.PROJECT_DONE_OPTION ?? 'Done';
+  const statusField = findField(
+    project,
+    process.env.PROJECT_STATUS_FIELD ?? "Status",
+  );
+  const releaseField = findField(
+    project,
+    process.env.PROJECT_RELEASE_FIELD ?? "Released in",
+  );
+  const doneOption = process.env.PROJECT_DONE_OPTION ?? "Done";
   for (const prNumber of prNumbers) {
     const nodeId = nodeIds.get(prNumber);
     if (!nodeId) continue;
     const itemId = ensureProjectItem(project, project.id, nodeId, prNumber);
-    if (statusField?.dataType === 'SINGLE_SELECT') {
+    if (statusField?.dataType === "SINGLE_SELECT") {
       updateSingleSelect(project.id, itemId, statusField, doneOption);
     }
     if (releaseField) {
-      const value = meta?.version ?? 'unreleased';
-      if (releaseField.dataType === 'SINGLE_SELECT') {
+      const value = meta?.version ?? "unreleased";
+      if (releaseField.dataType === "SINGLE_SELECT") {
         updateSingleSelect(project.id, itemId, releaseField, value);
       } else {
         updateTextField(project.id, itemId, releaseField, value);
@@ -256,12 +298,12 @@ async function main(): Promise<void> {
     const nodeId = nodeIds.get(issueNumber);
     if (!nodeId) continue;
     const itemId = ensureProjectItem(project, project.id, nodeId, issueNumber);
-    if (statusField?.dataType === 'SINGLE_SELECT') {
+    if (statusField?.dataType === "SINGLE_SELECT") {
       updateSingleSelect(project.id, itemId, statusField, doneOption);
     }
     if (releaseField) {
-      const value = meta?.version ?? 'unreleased';
-      if (releaseField.dataType === 'SINGLE_SELECT') {
+      const value = meta?.version ?? "unreleased";
+      if (releaseField.dataType === "SINGLE_SELECT") {
         updateSingleSelect(project.id, itemId, releaseField, value);
       } else {
         updateTextField(project.id, itemId, releaseField, value);
@@ -271,9 +313,12 @@ async function main(): Promise<void> {
 
   if (meta?.version) {
     const releaseTitle = `Release ${meta.version}`;
-    const existing = project.items.find((item) => item.title?.toLowerCase() === releaseTitle.toLowerCase());
+    const existing = project.items.find((item) =>
+      item.title?.toLowerCase() === releaseTitle.toLowerCase()
+    );
     if (!existing) {
-      const noteMutation = `mutation($projectId: ID!, $title: String!, $body: String!) { createProjectV2Item(input: { projectId: $projectId, content: { title: $title, body: $body } }) { item { id } } }`;
+      const noteMutation =
+        `mutation($projectId: ID!, $title: String!, $body: String!) { createProjectV2Item(input: { projectId: $projectId, content: { title: $title, body: $body } }) { item { id } } }`;
       const bodyParts: string[] = [];
       if (repo) {
         bodyParts.push(`Repository: https://github.com/${repo}`);
@@ -282,14 +327,14 @@ async function main(): Promise<void> {
       ghGraphql(noteMutation, {
         projectId: project.id,
         title: releaseTitle,
-        body: bodyParts.join('\n'),
+        body: bodyParts.join("\n"),
       });
     }
   }
 }
 
 main().catch((error) => {
-  console.error('[projects-v2-update] Failed to update GitHub project');
+  console.error("[projects-v2-update] Failed to update GitHub project");
   console.error(error);
   process.exitCode = 1;
 });

--- a/scripts/project/shared.ts
+++ b/scripts/project/shared.ts
@@ -1,0 +1,102 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface CommitRecord {
+  hash: string;
+  author: string;
+  date: string;
+  summary: string;
+  type: string;
+  scope?: string;
+  breaking: boolean;
+  prNumber?: number;
+  issues: number[];
+}
+
+export interface CommitGroup {
+  type: string;
+  commits: CommitRecord[];
+}
+
+export interface CommitPayload {
+  fromTag?: string;
+  toRef: string;
+  generatedAt: string;
+  groups: CommitGroup[];
+  commits: CommitRecord[];
+}
+
+export interface ReleaseMeta {
+  version: string;
+  date: string;
+}
+
+export interface HighlightItem {
+  text: string;
+  url?: string;
+}
+
+export function getProjectCacheDir(cwd = process.cwd()): string {
+  return join(cwd, ".project-cache");
+}
+
+export function ensureProjectCacheDir(cwd = process.cwd()): string {
+  const cacheDir = getProjectCacheDir(cwd);
+  if (!existsSync(cacheDir)) {
+    mkdirSync(cacheDir, { recursive: true });
+  }
+  return cacheDir;
+}
+
+export function resolveProjectCachePath(
+  fileName: string,
+  cwd = process.cwd(),
+): string {
+  return join(getProjectCacheDir(cwd), fileName);
+}
+
+function readJsonIfExists<T>(path: string): T | undefined {
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+export function loadCommitPayload(cwd = process.cwd()): CommitPayload {
+  const path = resolveProjectCachePath("commits.json", cwd);
+  const payload = readJsonIfExists<CommitPayload>(path);
+  if (!payload) {
+    throw new Error("Missing commit cache. Run proj:collect first.");
+  }
+  return payload;
+}
+
+export function loadReleaseMeta(cwd = process.cwd()): ReleaseMeta | undefined {
+  return readJsonIfExists<ReleaseMeta>(
+    resolveProjectCachePath("release-meta.json", cwd),
+  );
+}
+
+export function loadHighlights(cwd = process.cwd()): HighlightItem[] {
+  return readJsonIfExists<HighlightItem[]>(
+    resolveProjectCachePath("highlights.json", cwd),
+  ) ?? [];
+}
+
+export function cleanSummary(summary: string): string {
+  return summary.replace(/^(\w+)(?:\([^)]+\))?(!)?:\s*/, "");
+}
+
+export function shortHash(hash: string): string {
+  return hash.slice(0, 7);
+}
+
+export function commitLink(
+  prNumber?: number,
+  repo = process.env.GITHUB_REPOSITORY,
+): string | undefined {
+  if (!prNumber || !repo) {
+    return undefined;
+  }
+  return `https://github.com/${repo}/pull/${prNumber}`;
+}

--- a/scripts/project/update-features-roadmap.ts
+++ b/scripts/project/update-features-roadmap.ts
@@ -1,51 +1,23 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  cleanSummary,
+  type CommitPayload,
+  type CommitRecord,
+  loadCommitPayload,
+  loadReleaseMeta,
+  type ReleaseMeta,
+} from "./shared.ts";
 
-interface CommitRecord {
-  hash: string;
-  author: string;
-  date: string;
-  summary: string;
-  type: string;
-  scope?: string;
-  breaking: boolean;
-  prNumber?: number;
-  issues: number[];
-}
-
-interface CommitPayload {
-  groups: { type: string; commits: CommitRecord[] }[];
-  commits: CommitRecord[];
-}
-
-interface ReleaseMeta {
-  version: string;
-  date: string;
-}
-
-function cleanSummary(summary: string): string {
-  return summary.replace(/^(\w+)(?:\([^)]+\))?(!)?:\s*/, '');
-}
-
-function loadCommitPayload(cacheDir: string): CommitPayload {
-  const path = join(cacheDir, 'commits.json');
-  if (!existsSync(path)) {
-    throw new Error('Missing commit cache. Run proj:collect first.');
-  }
-  return JSON.parse(readFileSync(path, 'utf8')) as CommitPayload;
-}
-
-function loadReleaseMeta(cacheDir: string): ReleaseMeta | undefined {
-  const metaPath = join(cacheDir, 'release-meta.json');
-  if (!existsSync(metaPath)) return undefined;
-  return JSON.parse(readFileSync(metaPath, 'utf8')) as ReleaseMeta;
-}
-
-function updateFeaturesDoc(featuresPath: string, featureCommits: CommitRecord[], meta?: ReleaseMeta): void {
+function updateFeaturesDoc(
+  featuresPath: string,
+  featureCommits: CommitRecord[],
+  meta?: ReleaseMeta,
+): void {
   if (!featureCommits.length) return;
   const repo = process.env.GITHUB_REPOSITORY;
-  const version = meta?.version ?? (meta ? 'unversioned' : 'unreleased');
-  let content = readFileSync(featuresPath, 'utf8');
+  const version = meta?.version ?? (meta ? "unversioned" : "unreleased");
+  let content = readFileSync(featuresPath, "utf8");
 
   if (content.includes(`<!-- COMMIT:${featureCommits[0].hash} -->`)) {
     // Assume idempotent run detected; rely on per-commit handling below.
@@ -56,80 +28,86 @@ function updateFeaturesDoc(featuresPath: string, featureCommits: CommitRecord[],
     if (content.includes(marker)) {
       continue;
     }
-    if (content.includes('Placeholder entry until the first release ships.')) {
+    if (content.includes("Placeholder entry until the first release ships.")) {
       content = content.replace(
-        '| _TBD_      | _TBD_   | _TBD_   | Placeholder entry until the first release ships. | _n/a_ |\n',
-        ''
+        "| _TBD_      | _TBD_   | _TBD_   | Placeholder entry until the first release ships. | _n/a_ |\n",
+        "",
       );
     }
-    const area = commit.scope ?? 'general';
+    const area = commit.scope ?? "general";
     const description = cleanSummary(commit.summary);
-    const link = commit.prNumber && repo ? `https://github.com/${repo}/pull/${commit.prNumber}` : undefined;
-    const linksColumn = link ? `[PR #${commit.prNumber}](${link})` : '_n/a_';
-    const row = `| ${commit.date} | ${version} | ${area} | ${description} | ${linksColumn} ${marker} |`;
-    if (!content.endsWith('\n')) {
-      content += '\n';
+    const link = commit.prNumber && repo
+      ? `https://github.com/${repo}/pull/${commit.prNumber}`
+      : undefined;
+    const linksColumn = link ? `[PR #${commit.prNumber}](${link})` : "_n/a_";
+    const row =
+      `| ${commit.date} | ${version} | ${area} | ${description} | ${linksColumn} ${marker} |`;
+    if (!content.endsWith("\n")) {
+      content += "\n";
     }
     content += `${row}\n`;
   }
 
-  writeFileSync(featuresPath, content.replace(/\n{3,}/g, '\n\n'));
+  writeFileSync(featuresPath, content.replace(/\n{3,}/g, "\n\n"));
 }
 
 function removeLineWithMarker(content: string, marker: string): string {
   return content
-    .split('\n')
+    .split("\n")
     .filter((line) => !line.includes(marker))
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n');
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
 }
 
 function insertIntoShipped(content: string, line: string): string {
-  const section = '## Shipped';
+  const section = "## Shipped";
   const index = content.indexOf(section);
   if (index === -1) {
     return `${content.trim()}\n\n${section}\n${line}\n`;
   }
   const before = content.slice(0, index + section.length);
   const after = content.slice(index + section.length);
-  const parts = after.split('\n');
+  const parts = after.split("\n");
   // Skip first blank line if present
-  if (parts.length && parts[0] === '') {
+  if (parts.length && parts[0] === "") {
     parts.shift();
   }
-  if (parts.length && parts[0] === '- _No shipped items yet._') {
+  if (parts.length && parts[0] === "- _No shipped items yet._") {
     parts.shift();
   }
-  return `${before}\n${line}\n${parts.join('\n')}`.replace(/\n{3,}/g, '\n\n');
+  return `${before}\n${line}\n${parts.join("\n")}`.replace(/\n{3,}/g, "\n\n");
 }
 
-function updateRoadmapDoc(roadmapPath: string, featureCommits: CommitRecord[], meta?: ReleaseMeta): void {
+function updateRoadmapDoc(
+  roadmapPath: string,
+  featureCommits: CommitRecord[],
+  meta?: ReleaseMeta,
+): void {
   if (!featureCommits.length) return;
-  let content = readFileSync(roadmapPath, 'utf8');
+  let content = readFileSync(roadmapPath, "utf8");
   for (const commit of featureCommits) {
     const marker = `<!-- COMMIT:${commit.hash} -->`;
     if (content.includes(marker)) {
       content = removeLineWithMarker(content, marker);
     }
-    const bullet = `- ${meta?.version ? `[${meta.version}] ` : ''}${cleanSummary(commit.summary)}${
-      commit.prNumber ? ` (PR #${commit.prNumber})` : ''
-    } ${marker}`.trim();
+    const bullet = `- ${meta?.version ? `[${meta.version}] ` : ""}${
+      cleanSummary(commit.summary)
+    }${commit.prNumber ? ` (PR #${commit.prNumber})` : ""} ${marker}`.trim();
     content = insertIntoShipped(content, bullet);
   }
-  writeFileSync(roadmapPath, content.replace(/\n{3,}/g, '\n\n'));
+  writeFileSync(roadmapPath, content.replace(/\n{3,}/g, "\n\n"));
 }
 
 async function main(): Promise<void> {
   const cwd = process.cwd();
-  const cacheDir = join(cwd, '.project-cache');
-  const featuresPath = join(cwd, 'docs', 'FEATURES.md');
-  const roadmapPath = join(cwd, 'docs', 'ROADMAP.md');
+  const featuresPath = join(cwd, "docs", "FEATURES.md");
+  const roadmapPath = join(cwd, "docs", "ROADMAP.md");
   if (!existsSync(featuresPath) || !existsSync(roadmapPath)) {
-    throw new Error('Feature or roadmap documents are missing.');
+    throw new Error("Feature or roadmap documents are missing.");
   }
-  const payload = loadCommitPayload(cacheDir);
-  const featureGroup = payload.groups.find((group) => group.type === 'feat');
-  const meta = loadReleaseMeta(cacheDir);
+  const payload = loadCommitPayload(cwd);
+  const featureGroup = payload.groups.find((group) => group.type === "feat");
+  const meta = loadReleaseMeta(cwd);
   const featureCommits = featureGroup?.commits ?? [];
   if (!featureCommits.length) {
     return;
@@ -139,7 +117,9 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
-  console.error('[update-features-roadmap] Unable to update feature and roadmap docs');
+  console.error(
+    "[update-features-roadmap] Unable to update feature and roadmap docs",
+  );
   console.error(error);
   process.exitCode = 1;
 });

--- a/scripts/project/update-readme.ts
+++ b/scripts/project/update-readme.ts
@@ -1,34 +1,37 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type HighlightItem,
+  loadHighlights,
+  loadReleaseMeta,
+  type ReleaseMeta,
+} from "./shared.ts";
 
-interface HighlightItem {
-  text: string;
-  url?: string;
-}
-
-interface ReleaseMeta {
-  version: string;
-  date: string;
-}
-
-function replaceBetween(content: string, startMarker: string, endMarker: string, replacement: string): string {
+function replaceBetween(
+  content: string,
+  startMarker: string,
+  endMarker: string,
+  replacement: string,
+): string {
   const startIndex = content.indexOf(startMarker);
   const endIndex = content.indexOf(endMarker);
   if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
-    throw new Error(`Markers ${startMarker} and ${endMarker} are missing or ordered incorrectly.`);
+    throw new Error(
+      `Markers ${startMarker} and ${endMarker} are missing or ordered incorrectly.`,
+    );
   }
   return (
     content.slice(0, startIndex + startMarker.length) +
-    '\n' +
+    "\n" +
     replacement.trim() +
-    '\n' +
+    "\n" +
     content.slice(endIndex)
   );
 }
 
 function renderHighlights(items: HighlightItem[]): string {
   if (!items.length) {
-    return 'Project highlights will appear here after the first automated release.';
+    return "Project highlights will appear here after the first automated release.";
   }
   return items
     .map((item) => {
@@ -37,58 +40,58 @@ function renderHighlights(items: HighlightItem[]): string {
       }
       return `- ${item.text}`;
     })
-    .join('\n');
+    .join("\n");
 }
 
 function buildBadges(meta?: ReleaseMeta): string {
   const repo = process.env.GITHUB_REPOSITORY;
   const badges: string[] = [];
   if (meta?.version) {
-    const versionBadge = `[![Release](https://img.shields.io/badge/release-${encodeURIComponent(meta.version)}-brightgreen.svg)](docs/RELEASE_NOTES/${meta.version}.md)`;
+    const versionBadge = `[![Release](https://img.shields.io/badge/release-${
+      encodeURIComponent(meta.version)
+    }-brightgreen.svg)](docs/RELEASE_NOTES/${meta.version}.md)`;
     badges.push(versionBadge);
   } else {
-    badges.push('[![Release](https://img.shields.io/badge/release-pre--release-lightgrey.svg)](docs/CHANGELOG.md)');
+    badges.push(
+      "[![Release](https://img.shields.io/badge/release-pre--release-lightgrey.svg)](docs/CHANGELOG.md)",
+    );
   }
   if (repo) {
-    const workflow = process.env.PROJECT_CI_WORKFLOW ?? 'verify.yml';
-    badges.push(`[![CI](https://github.com/${repo}/actions/workflows/${workflow}/badge.svg)](https://github.com/${repo}/actions/workflows/${workflow})`);
+    const workflow = process.env.PROJECT_CI_WORKFLOW ?? "verify.yml";
+    badges.push(
+      `[![CI](https://github.com/${repo}/actions/workflows/${workflow}/badge.svg)](https://github.com/${repo}/actions/workflows/${workflow})`,
+    );
   }
-  return badges.join(' ');
+  return badges.join(" ");
 }
 
 async function main(): Promise<void> {
   const cwd = process.cwd();
-  const readmePath = join(cwd, 'README.md');
+  const readmePath = join(cwd, "README.md");
   if (!existsSync(readmePath)) {
-    throw new Error('README.md is missing.');
+    throw new Error("README.md is missing.");
   }
-  const cacheDir = join(cwd, '.project-cache');
-  const highlightPath = join(cacheDir, 'highlights.json');
-  const metaPath = join(cacheDir, 'release-meta.json');
+  const highlights = loadHighlights(cwd);
+  const meta = loadReleaseMeta(cwd);
 
-  let highlights: HighlightItem[] = [];
-  if (existsSync(highlightPath)) {
-    highlights = JSON.parse(readFileSync(highlightPath, 'utf8')) as HighlightItem[];
-  }
-
-  let meta: ReleaseMeta | undefined;
-  if (existsSync(metaPath)) {
-    meta = JSON.parse(readFileSync(metaPath, 'utf8')) as ReleaseMeta;
-  }
-
-  const readme = readFileSync(readmePath, 'utf8');
-  const updatedBadges = replaceBetween(readme, '<!-- BADGES:START -->', '<!-- BADGES:END -->', buildBadges(meta));
+  const readme = readFileSync(readmePath, "utf8");
+  const updatedBadges = replaceBetween(
+    readme,
+    "<!-- BADGES:START -->",
+    "<!-- BADGES:END -->",
+    buildBadges(meta),
+  );
   const updated = replaceBetween(
     updatedBadges,
-    '<!-- WHATS_NEW:START -->',
-    '<!-- WHATS_NEW:END -->',
-    renderHighlights(highlights)
+    "<!-- WHATS_NEW:START -->",
+    "<!-- WHATS_NEW:END -->",
+    renderHighlights(highlights),
   );
-  writeFileSync(readmePath, updated.replace(/\s+$/g, '') + '\n');
+  writeFileSync(readmePath, updated.replace(/\s+$/g, "") + "\n");
 }
 
 main().catch((error) => {
-  console.error('[update-readme] Unable to update README markers');
+  console.error("[update-readme] Unable to update README markers");
   console.error(error);
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- add a shared project helper module to consolidate commit payload, release meta, and highlight utilities used by automation scripts
- refactor project maintenance scripts to reuse the shared helpers for cache handling and summary parsing, reducing duplication and improving consistency

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dade9a6084832284dffc9f7a6b9f8f