### PR TITLE
Force DigitalOcean Next.js server to bind to all interfaces

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js
+web: HOSTNAME=0.0.0.0 NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:dev": "vite build --mode development",
     "start": "node scripts/npm-safe.mjs -w apps/web run start",
     "start:web": "node scripts/npm-safe.mjs -w apps/web run start",
-    "start:do": "NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js",
+    "start:do": "HOSTNAME=0.0.0.0 NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js",
     "dev": "node scripts/npm-safe.mjs -w apps/web run dev --",
     "dev:lovable": "node lovable-dev.js",
     "codex:post-pull": "node scripts/codex-workflow.js post-pull",

--- a/project.toml
+++ b/project.toml
@@ -54,4 +54,4 @@ version = "0.0.0"
 
 [[processes]]
 type = "web"
-command = "node apps/web/.next/standalone/apps/web/server.js"
+command = "HOSTNAME=0.0.0.0 node apps/web/.next/standalone/apps/web/server.js"


### PR DESCRIPTION
## Summary
- ensure the DigitalOcean start script exports HOSTNAME so the standalone Next.js server listens on all interfaces
- mirror the HOSTNAME override in the Procfile and project.toml process command to keep platform tooling consistent

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68db580a0cdc8322939a8c5f10700439