### PR TITLE
Fix DigitalOcean Next.js binding with standalone launcher

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js
+web: node scripts/start-next-standalone.mjs

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "node ../../scripts/run-next-build.mjs",
-    "start": "NODE_ENV=production node .next/standalone/apps/web/server.js",
+    "start": "node ../../scripts/start-next-standalone.mjs",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check && vitest run",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:dev": "vite build --mode development",
     "start": "node scripts/npm-safe.mjs -w apps/web run start",
     "start:web": "node scripts/npm-safe.mjs -w apps/web run start",
-    "start:do": "NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js",
+    "start:do": "node scripts/start-next-standalone.mjs",
     "dev": "node scripts/npm-safe.mjs -w apps/web run dev --",
     "dev:lovable": "node lovable-dev.js",
     "codex:post-pull": "node scripts/codex-workflow.js post-pull",

--- a/project.toml
+++ b/project.toml
@@ -54,4 +54,4 @@ version = "0.0.0"
 
 [[processes]]
 type = "web"
-command = "node apps/web/.next/standalone/apps/web/server.js"
+command = "node scripts/start-next-standalone.mjs"

--- a/scripts/start-next-standalone.mjs
+++ b/scripts/start-next-standalone.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const repoRoot = path.resolve(__dirname, "..");
+const webDir = path.join(repoRoot, "apps", "web");
+const standaloneRoot = path.join(webDir, ".next", "standalone");
+
+const serverCandidates = [
+  path.join(standaloneRoot, "apps", "web", "server.js"),
+  path.join(standaloneRoot, "server.js"),
+];
+
+const serverEntry = serverCandidates.find((candidate) => existsSync(candidate));
+
+if (!serverEntry) {
+  console.error(
+    "Unable to locate the Next.js standalone server. Did you run `npm run build --workspace apps/web`?",
+  );
+  process.exit(1);
+}
+
+const desiredHostname = "0.0.0.0";
+process.env.HOSTNAME = desiredHostname;
+if (!process.env.HOST || process.env.HOST.trim().length === 0) {
+  process.env.HOST = desiredHostname;
+}
+
+const parsedPort = Number.parseInt(process.env.PORT ?? "", 10);
+const normalizedPort = Number.isFinite(parsedPort) && parsedPort > 0
+  ? parsedPort
+  : 8080;
+process.env.PORT = String(normalizedPort);
+
+process.env.NODE_ENV = "production";
+
+const serverUrl = pathToFileURL(serverEntry);
+
+try {
+  await import(serverUrl.href);
+} catch (error) {
+  console.error("Failed to start Next.js standalone server:", error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a reusable `start-next-standalone.mjs` wrapper that enforces the DigitalOcean-friendly host/port defaults before loading the Next.js bundle
- point the DigitalOcean start commands and workspace start script at the new launcher so every entry path uses the same configuration

## Testing
- npm run lint --workspace apps/web
- npm run typecheck --workspace apps/web
- node scripts/start-next-standalone.mjs

------
https://chatgpt.com/codex/tasks/task_e_68db580a0cdc8322939a8c5f10700439