### PR TITLE
Ensure standalone server binds to all interfaces

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js
+web: HOST=0.0.0.0 HOSTNAME=0.0.0.0 NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "node ../../scripts/run-next-build.mjs",
-    "start": "NODE_ENV=production node .next/standalone/apps/web/server.js",
+    "start": "HOST=0.0.0.0 HOSTNAME=0.0.0.0 NODE_ENV=production node .next/standalone/apps/web/server.js",
     "copy-static": "tsx ../../scripts/copy-static.ts --copy-only",
     "lint": "eslint .",
     "test": "deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check && vitest run",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:dev": "vite build --mode development",
     "start": "node scripts/npm-safe.mjs -w apps/web run start",
     "start:web": "node scripts/npm-safe.mjs -w apps/web run start",
-    "start:do": "NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js",
+    "start:do": "HOST=0.0.0.0 HOSTNAME=0.0.0.0 NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js",
     "dev": "node scripts/npm-safe.mjs -w apps/web run dev --",
     "dev:lovable": "node lovable-dev.js",
     "codex:post-pull": "node scripts/codex-workflow.js post-pull",


### PR DESCRIPTION
## Summary
- set both HOST and HOSTNAME to 0.0.0.0 in the standalone Next.js start scripts so the server always binds to every interface
- mirror the same HOST/HOSTNAME defaults in the DigitalOcean Procfile entry used for production deploys

## Testing
- npm run build:web
- HOST=0.0.0.0 HOSTNAME=0.0.0.0 NODE_ENV=production node apps/web/.next/standalone/apps/web/server.js (curl http://127.0.0.1:3000/api/health)


------
https://chatgpt.com/codex/tasks/task_e_68db61d982a88322b5ea61a4338669d5