### PR TITLE
Add failure categories design lessons guide

### DIFF
--- a/docs/failure-categories-design-lessons.md
+++ b/docs/failure-categories-design-lessons.md
@@ -1,0 +1,62 @@
+# Categories of Failure & Design Lessons
+
+This guide distills recurring failure patterns from complex socio-technical systems and translates them into design guardrails for the Dynamic Capital ecosystem. Each section highlights actionable practices that can be embedded into playbooks, mentorship sessions, and Oracle scoring criteria.
+
+## Meta-Lessons for Builders
+
+### Feedback Loops Matter
+- Instrument every workflow with real-time monitoring, post-run scoring, and human-in-the-loop checkpoints.
+- Pair automated telemetry with qualitative feedback from operators to surface blind spots that metrics alone miss.
+- Encode correction protocols directly into runbooks so that when a signal crosses a threshold, the response is predictable and fast.
+
+### Redundancy Saves Lives
+- Treat single points of failure (sensors, APIs, cron jobs) as unacceptable; design for graceful degradation and hot failovers.
+- Cross-verify critical data from at least two independent sources before acting on it within trading and orchestration engines.
+- Schedule chaos drills that intentionally remove components to ensure the remaining infrastructure can absorb the shock.
+
+### Interfaces Are Governance
+- Assume that every UI, API contract, and runbook is a policy document—keep them explicit, legible, and opinionated.
+- Implement guardrails (confirmation steps, structured prompts, severity color coding) to help operators make the safe choice by default.
+- When you improve an interface, immediately update the associated playbook excerpt so both stay in sync.
+
+### Culture of Testing
+- Expand test matrices beyond the “happy path” to include compounded edge cases and multi-system failures.
+- Capture failure scenarios as regression tests or simulator scripts so they are replayed before each deployment.
+- Incentivize squads to publish post-incident learnings that seed new scenarios for the shared testing backlog.
+
+### Transparency & Ethics
+- Publish observability dashboards and incident postmortems in shared channels so issues cannot be ignored or hidden.
+- Escalate early-warning signals—even if they are ambiguous—to ensure collective scrutiny before risks compound.
+- Establish ethical review checkpoints for automations that could impact partners, customers, or regulated environments.
+
+## Applying the Lessons in the Dynamic Capital Ecosystem
+
+### Mentorship Curriculum Modules
+- **Case study briefs:** Convert historical failures into 1–2 page briefs that outline the trigger, system weaknesses, and the corrective redesign.
+- **Scenario labs:** Run tabletop exercises that let new builders practice diagnosing cascading failures and proposing resilient countermeasures.
+- **Reflection loops:** After each cohort project, facilitate retro sessions that map successes and misses back to the five meta-lessons.
+
+### Oracle Scoring Dimensions
+
+| Category | Common Failure Signal | Oracle Risk Dimension | Scoring Considerations |
+| --- | --- | --- | --- |
+| Feedback loops | Delayed anomaly detection, stale dashboards | Precision & situational awareness | Grade telemetry coverage, alert freshness, and responsiveness of remediation runbooks. |
+| Redundancy | Single-source data feeds, brittle cron dependencies | Automation trust | Score backup pathways, failover readiness, and synthetic chaos coverage. |
+| Interfaces | Misclicks, ambiguous prompts, undocumented handoffs | UX integrity | Evaluate affordance clarity, safety toggles, and updated SOP alignment. |
+| Testing culture | Uncaught regressions, surprise edge cases | System resilience | Check for stress tests, failure drills, and regression libraries tied to incidents. |
+| Transparency & ethics | Suppressed incidents, opaque automations | Governance alignment | Assess audit trails, disclosure timeliness, and stakeholder communication loops. |
+
+### Maldivian Identity Layer Narratives
+- **Feedback loops as tidal sensors:** Just as mariners watch tide markers for subtle shifts, every Oracle pillar needs calibrated instrumentation that reports drift before it becomes a riptide.
+- **Redundancy as double-hulled ships:** Multi-layer backups mirror the twin hulls of resilient vessels that can withstand coral scrapes without sinking the mission.
+- **Interfaces as navigational charts:** Clear charts prevent crews from running aground; likewise, intuitive UI copy and data visualizations steer contributors toward compliant actions.
+- **Testing as storm rehearsals:** Seasonal storm drills prepare island communities for the worst; continuous failure simulations harden Dynamic Capital against unexpected squalls.
+- **Transparency as lighthouse beacons:** Visible signals keep fleets coordinated—open dashboards and ethical disclosures ensure every captain sees the same warning light.
+
+## Implementation Checklist
+- [ ] Embed these lessons into the mentorship curriculum outline and assign owners for each module.
+- [ ] Update Oracle scoring rubrics to include the risk dimensions and considerations outlined above.
+- [ ] Align identity-layer storytelling assets (videos, deck sections, onboarding scripts) with the Maldivian metaphors for continuity.
+- [ ] Schedule quarterly reviews to refresh case studies, score weighting, and cultural rituals as new incidents and insights emerge.
+
+By weaving these lessons into operations, Dynamic Capital can convert historical failures into a living resilience framework that sharpens both human judgment and automated guardianship.


### PR DESCRIPTION
## Summary
- add a documentation guide translating recurring failure patterns into design guardrails for Dynamic Capital
- outline curriculum modules, Oracle scoring dimensions, and Maldivian metaphors to apply the lessons across the ecosystem

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68db91ad76f88322912d624ea2b7f182