### PR TITLE
Add implementation runbook for failure guardrails

### DIFF
--- a/docs/failure-categories-design-lessons.md
+++ b/docs/failure-categories-design-lessons.md
@@ -1,0 +1,67 @@
+# Categories of Failure & Design Lessons
+
+This guide distills recurring failure patterns from complex socio-technical systems and translates them into design guardrails for the Dynamic Capital ecosystem. Each section highlights actionable practices that can be embedded into playbooks, mentorship sessions, and Oracle scoring criteria. Use it as a quarterly review artifact: confirm the safeguards remain healthy, then optimize the next back-to-back iteration of experiments and product releases.
+
+## Meta-Lessons for Builders
+
+| Failure Category | Warning Pattern | Guardrail | Optimization Cadence |
+| --- | --- | --- | --- |
+| Feedback loops | Lagging anomaly detection, stale dashboards | Instrument every workflow with real-time monitoring, post-run scoring, and human-in-the-loop checkpoints. | Inspect dashboards and scorecards before every trading cycle; audit alert routing monthly. |
+| Redundancy | Single points of failure in sensors, APIs, or cron jobs | Treat single-source data as unacceptable, design hot failovers, and cross-verify critical feeds from at least two independent sources. | Run chaos drills that remove components each sprint; refresh failover runbooks quarterly. |
+| Interfaces | Misclicks, ambiguous prompts, undocumented handoffs | Treat every UI, API contract, and runbook as policy; layer confirmations, structured prompts, and severity color coding to bias toward safe choices. | Pair every interface update with a playbook diff review and usability test within 48 hours. |
+| Testing culture | Uncaught regressions, surprise edge cases | Expand test matrices to cover compounded failures; convert incidents into regression suites and simulators. | Schedule weekly failure rehearsals and publish post-incident learnings to seed new scenarios. |
+| Transparency & ethics | Suppressed incidents, opaque automations | Publish observability dashboards, escalate early-warning signals, and institute ethical review checkpoints for sensitive automations. | Review disclosure cadence at each leadership council; refresh risk ethics checklists bi-monthly. |
+
+## Applying the Lessons in the Dynamic Capital Ecosystem
+
+### Mentorship Curriculum Modules
+- **Case study briefs:** Convert historical failures into 1–2 page briefs that outline the trigger, system weaknesses, corrective redesign, and the meta-lesson reinforced.
+- **Scenario labs:** Run tabletop exercises that let new builders practice diagnosing cascading failures, validating the guardrail table above, and proposing resilient countermeasures.
+- **Reflection loops:** After each cohort project, facilitate retro sessions that map successes and misses back to the five meta-lessons and assign owners for remediation actions.
+
+### Oracle Scoring Dimensions
+
+| Category | Common Failure Signal | Oracle Risk Dimension | Scoring Considerations | Optimization Prompt |
+| --- | --- | --- | --- | --- |
+| Feedback loops | Delayed anomaly detection, stale dashboards | Precision & situational awareness | Grade telemetry coverage, alert freshness, and responsiveness of remediation runbooks. | “What signal would have caught this 24 hours sooner?” |
+| Redundancy | Single-source data feeds, brittle cron dependencies | Automation trust | Score backup pathways, failover readiness, and synthetic chaos coverage. | “Where do we intentionally break something next?” |
+| Interfaces | Misclicks, ambiguous prompts, undocumented handoffs | UX integrity | Evaluate affordance clarity, safety toggles, and updated SOP alignment. | “What decision can we remove or pre-commit?” |
+| Testing culture | Uncaught regressions, surprise edge cases | System resilience | Check for stress tests, failure drills, and regression libraries tied to incidents. | “Which incident just became a test?” |
+| Transparency & ethics | Suppressed incidents, opaque automations | Governance alignment | Assess audit trails, disclosure timeliness, and stakeholder communication loops. | “Who still lacks line-of-sight into this risk?” |
+
+### Maldivian Identity Layer Narratives
+- **Feedback loops as tidal sensors:** Just as mariners watch tide markers for subtle shifts, every Oracle pillar needs calibrated instrumentation that reports drift before it becomes a riptide.
+- **Redundancy as double-hulled ships:** Multi-layer backups mirror the twin hulls of resilient vessels that can withstand coral scrapes without sinking the mission.
+- **Interfaces as navigational charts:** Clear charts prevent crews from running aground; likewise, intuitive UI copy and data visualizations steer contributors toward compliant actions.
+- **Testing as storm rehearsals:** Seasonal storm drills prepare island communities for the worst; continuous failure simulations harden Dynamic Capital against unexpected squalls.
+- **Transparency as lighthouse beacons:** Visible signals keep fleets coordinated—open dashboards and ethical disclosures ensure every captain sees the same warning light.
+
+## Implementation Checklist
+- [ ] Embed these lessons into the mentorship curriculum outline and assign owners for each module.
+- [ ] Update Oracle scoring rubrics to include the risk dimensions, scoring considerations, and optimization prompts outlined above.
+- [ ] Align identity-layer storytelling assets (videos, deck sections, onboarding scripts) with the Maldivian metaphors for continuity.
+- [ ] Schedule quarterly reviews to refresh case studies, score weighting, and cultural rituals as new incidents and insights emerge.
+- [ ] Close each quarterly review by selecting one guardrail for immediate optimization to avoid back-to-back stagnation across cycles.
+
+## Implementation Runbook
+
+| Phase | Timebox | Primary Owners | Key Deliverables | Success Metric |
+| --- | --- | --- | --- | --- |
+| Kickoff alignment | Week 0 | Program lead, Oracle steward, Identity steward | Shared OKR brief linking the five meta-lessons to current initiatives; roster of accountable owners. | All stakeholders sign the brief and commit to weekly syncs. |
+| Instrumentation sprint | Weeks 1–2 | Engineering, data reliability squad | Updated monitoring dashboards, alert routing tables, and dual-source data validation scripts. | ≥90% of critical workflows emit real-time telemetry with dual-source verification. |
+| Curriculum weave | Weeks 2–3 | Mentorship guild, learning ops | Published case-study briefs and scenario lab agendas mapped to the guardrail table. | 100% of upcoming cohort sessions reference the new briefs and labs. |
+| Oracle scoring upgrade | Weeks 3–4 | Oracle stewards, risk council | Revamped rubric with scoring prompts, reviewer training notes, and automation tests. | Pilot scoring cycle completed with reviewer feedback ≥4/5 on clarity. |
+| Identity integration | Weeks 4–5 | Creative studio, community leads | Updated storytelling assets and onboarding copy aligned with Maldivian metaphors. | Community pulse check shows ≥80% recognition of the five metaphors. |
+| Review & iterate | Week 6 | Leadership council, QA | Post-implementation retrospective, prioritized backlog of guardrail optimizations, assigned owners for next iteration. | At least one guardrail upgrade deployed per cycle and logged in the resilience ledger. |
+
+### Weekly Execution Rituals
+- **Monday signal review:** Inspect telemetry freshness, incident queues, and Oracle scoring anomalies before the sprint planning meeting.
+- **Midweek drill:** Rotate through guardrails with a lightweight chaos simulation or tabletop exercise; capture learnings in the resilience ledger.
+- **Friday storytelling sync:** Confirm identity-layer assets remain accurate, refresh metaphors with new anecdotes, and prep communications for the broader community.
+
+### Tooling & Evidence Capture
+- Maintain a shared dashboard that links each guardrail to its monitoring widgets, recent incidents, and owner updates.
+- Archive artifacts from drills, scoring cycles, and mentorship sessions in a versioned knowledge base to preserve institutional memory.
+- Tag all action items with the relevant failure category to ensure trend analysis during quarterly retrospectives.
+
+By weaving these lessons into operations, Dynamic Capital can convert historical failures into a living resilience framework that sharpens both human judgment and automated guardianship.


### PR DESCRIPTION
## Summary
- extend the failure categories guide with a phased implementation runbook that assigns owners, timelines, and success metrics
- add weekly execution rituals and tooling practices to operationalize the guardrail cadences

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68db91ad76f88322912d624ea2b7f182