### PR TITLE
Add dynamic safeguard engine blueprint to failure guardrail guide

### DIFF
--- a/docs/failure-categories-design-lessons.md
+++ b/docs/failure-categories-design-lessons.md
@@ -1,0 +1,141 @@
+# Categories of Failure & Design Lessons
+
+This guide distills recurring failure patterns from complex socio-technical systems and translates them into design guardrails for the Dynamic Capital ecosystem. Each section highlights actionable practices that can be embedded into playbooks, mentorship sessions, and Oracle scoring criteria. Use it as a quarterly review artifact: confirm the safeguards remain healthy, then optimize the next back-to-back iteration of experiments and product releases.
+
+## Meta-Lessons for Builders
+
+| Failure Category | Warning Pattern | Guardrail | Optimization Cadence |
+| --- | --- | --- | --- |
+| Feedback loops | Lagging anomaly detection, stale dashboards | Instrument every workflow with real-time monitoring, post-run scoring, and human-in-the-loop checkpoints. | Inspect dashboards and scorecards before every trading cycle; audit alert routing monthly. |
+| Redundancy | Single points of failure in sensors, APIs, or cron jobs | Treat single-source data as unacceptable, design hot failovers, and cross-verify critical feeds from at least two independent sources. | Run chaos drills that remove components each sprint; refresh failover runbooks quarterly. |
+| Interfaces | Misclicks, ambiguous prompts, undocumented handoffs | Treat every UI, API contract, and runbook as policy; layer confirmations, structured prompts, and severity color coding to bias toward safe choices. | Pair every interface update with a playbook diff review and usability test within 48 hours. |
+| Testing culture | Uncaught regressions, surprise edge cases | Expand test matrices to cover compounded failures; convert incidents into regression suites and simulators. | Schedule weekly failure rehearsals and publish post-incident learnings to seed new scenarios. |
+| Transparency & ethics | Suppressed incidents, opaque automations | Publish observability dashboards, escalate early-warning signals, and institute ethical review checkpoints for sensitive automations. | Review disclosure cadence at each leadership council; refresh risk ethics checklists bi-monthly. |
+
+## Applying the Lessons in the Dynamic Capital Ecosystem
+
+### Mentorship Curriculum Modules
+- **Case study briefs:** Convert historical failures into 1–2 page briefs that outline the trigger, system weaknesses, corrective redesign, and the meta-lesson reinforced.
+- **Scenario labs:** Run tabletop exercises that let new builders practice diagnosing cascading failures, validating the guardrail table above, and proposing resilient countermeasures.
+- **Reflection loops:** After each cohort project, facilitate retro sessions that map successes and misses back to the five meta-lessons and assign owners for remediation actions.
+
+### Oracle Scoring Dimensions
+
+| Category | Common Failure Signal | Oracle Risk Dimension | Scoring Considerations | Optimization Prompt |
+| --- | --- | --- | --- | --- |
+| Feedback loops | Delayed anomaly detection, stale dashboards | Precision & situational awareness | Grade telemetry coverage, alert freshness, and responsiveness of remediation runbooks. | “What signal would have caught this 24 hours sooner?” |
+| Redundancy | Single-source data feeds, brittle cron dependencies | Automation trust | Score backup pathways, failover readiness, and synthetic chaos coverage. | “Where do we intentionally break something next?” |
+| Interfaces | Misclicks, ambiguous prompts, undocumented handoffs | UX integrity | Evaluate affordance clarity, safety toggles, and updated SOP alignment. | “What decision can we remove or pre-commit?” |
+| Testing culture | Uncaught regressions, surprise edge cases | System resilience | Check for stress tests, failure drills, and regression libraries tied to incidents. | “Which incident just became a test?” |
+| Transparency & ethics | Suppressed incidents, opaque automations | Governance alignment | Assess audit trails, disclosure timeliness, and stakeholder communication loops. | “Who still lacks line-of-sight into this risk?” |
+
+### Maldivian Identity Layer Narratives
+- **Feedback loops as tidal sensors:** Just as mariners watch tide markers for subtle shifts, every Oracle pillar needs calibrated instrumentation that reports drift before it becomes a riptide.
+- **Redundancy as double-hulled ships:** Multi-layer backups mirror the twin hulls of resilient vessels that can withstand coral scrapes without sinking the mission.
+- **Interfaces as navigational charts:** Clear charts prevent crews from running aground; likewise, intuitive UI copy and data visualizations steer contributors toward compliant actions.
+- **Testing as storm rehearsals:** Seasonal storm drills prepare island communities for the worst; continuous failure simulations harden Dynamic Capital against unexpected squalls.
+- **Transparency as lighthouse beacons:** Visible signals keep fleets coordinated—open dashboards and ethical disclosures ensure every captain sees the same warning light.
+
+## Implementation Checklist
+- [ ] Embed these lessons into the mentorship curriculum outline and assign owners for each module.
+- [ ] Update Oracle scoring rubrics to include the risk dimensions, scoring considerations, and optimization prompts outlined above.
+- [ ] Align identity-layer storytelling assets (videos, deck sections, onboarding scripts) with the Maldivian metaphors for continuity.
+- [ ] Stand up the safeguard engine backlog with prioritized telemetry upgrades, scenario drills, and UI guardrail enhancements.
+- [ ] Schedule quarterly reviews to refresh case studies, score weighting, and cultural rituals as new incidents and insights emerge.
+- [ ] Close each quarterly review by selecting one guardrail for immediate optimization to avoid back-to-back stagnation across cycles.
+- [ ] Publish a safeguard engine scorecard each month summarizing signal quality, intervention response times, and ownership gaps.
+- [ ] Run the end-to-end verify sweep (`npm run verify`) before each resilience demo and capture deltas from the prior run.
+- [ ] Publish the verify report alongside the scorecard so the next back-to-back cycle starts with validated telemetry and playbook status.
+
+## Dynamic Safeguard Engine Blueprint
+
+The safeguard engine operationalizes the five meta-lessons as a living control system. Treat it as a cross-functional service that continuously ingests signals, evaluates risk, and deploys corrective playbooks.
+
+### Engine Layers
+
+| Layer | Core Purpose | Guardrail Coverage | Primary Tools & Owners |
+| --- | --- | --- | --- |
+| Signal mesh | Aggregate real-time telemetry, human annotations, and external risk feeds. | Feedback loops, transparency & ethics | Observability stack, incident desk, Oracle stewards |
+| Resilience intelligence | Score guardrail health, detect trend drift, and surface prioritized interventions. | Redundancy, testing culture | Risk council, data science pod, resilience ledger |
+| Intervention router | Trigger automated remediations, notify owners, and orchestrate chaos drills. | Interfaces, redundancy | Automation guild, SRE, playbook library |
+| Story & trust fabric | Translate system state into narratives, training, and stakeholder updates. | Transparency & ethics, mentorship | Creative studio, mentorship guild, community leads |
+
+### Operating Modes
+- **Observe:** Ingest dashboards, Oracle scoring deltas, support tickets, and community signals into the resilience ledger every day.
+- **Decide:** Run risk scoring models and human reviews twice per week to rank emerging weaknesses by blast radius and time sensitivity.
+- **Intervene:** Pair each high-priority weakness with a validated playbook (failover drill, UX patch, policy escalation) and assign the owner with a timebox.
+- **Learn:** Feed intervention outcomes back into dashboards, training materials, and the playbook backlog within 48 hours.
+
+### Back-to-Back Review Loop
+1. **Daily micro-reviews:** 15-minute stand-up on signal freshness, open incidents, and pending interventions.
+2. **Weekly safeguard sprint:** Rotate through the five meta-lessons, executing at least one drill, one UI affordance test, and one telemetry improvement.
+3. **Bi-weekly resilience demo:** Showcase the most impactful fix, capture before/after metrics, and record mentor prompts for the next cohort.
+4. **Quarterly reset:** Rebalance scoring weights, retire stale playbooks, and authorize the next wave of guardrail experiments.
+
+### Safeguard Engine Scorecard
+
+Track the health of the engine with a simple scorecard reviewed during the bi-weekly resilience demo.
+
+| Metric | Target | Data Source | Escalation Trigger |
+| --- | --- | --- | --- |
+| Signal freshness | ≥95% of critical dashboards updated within last 60 minutes | Observability stack | Trigger escalation if freshness drops below 90% twice in a week. |
+| Response latency | ≤2 hours from alert to owner acknowledgement | Incident desk | Escalate to leadership council when latency exceeds 4 hours on any P0 incident. |
+| Playbook coverage | ≥1 validated playbook per top 10 failure scenarios | Playbook library audit | Launch design sprint if a scenario lacks a tested playbook. |
+| Drill cadence | ≥3 guardrail drills executed per week | Resilience ledger | Spin up chaos workshop if cadence slips for two consecutive weeks. |
+| Story alignment | ≥80% stakeholder recognition of current metaphors | Pulse surveys | Convene creative studio if recognition slips below 70%. |
+
+### Integration Checklist for Builders
+- Connect new services to the signal mesh with standardized telemetry contracts and dual-source validation tests.
+- Register every new automation or UI flow with the intervention router, including fallback states and manual override instructions.
+- Submit post-intervention learnings to the story & trust fabric team for incorporation into mentorship modules and public narratives.
+- Tag backlog items with safeguard engine layers to ensure balanced investment across sensing, intelligence, intervention, and storytelling.
+
+## Verify & Optimize Back-to-Back
+
+Treat verification as the pre-flight ritual that keeps every back-to-back iteration grounded in fresh evidence.
+
+### Verification Workflow
+
+1. **Trigger the verify suite:** Run `npm run verify` and log the command timestamp, triggering team, and runtime in the resilience ledger.
+2. **Review the generated report:** Highlight new failures or warnings in `.out/verify_report.md` and assign owners within one business day.
+3. **Cross-check telemetry:** Compare verify output against the safeguard engine scorecard to confirm dashboard freshness, playbook coverage, and drill cadence metrics.
+4. **Update the artifact trail:** Attach the verify summary to the mentorship case study archive and Oracle scoring notes so future cohorts inherit the evidence.
+
+### Optimization Cycle
+
+| Cadence | Verify Inputs | Optimization Focus | Owner Ritual |
+| --- | --- | --- | --- |
+| Daily micro-review | Signal freshness slice of verify report, open incidents | Patch degraded telemetry, fast-follow runbook fixes | 15-minute huddle led by signal mesh steward |
+| Weekly safeguard sprint | Full verify sweep, backlog heatmap | Choose one guardrail upgrade to ship immediately to avoid stagnation | Sprint review anchored by resilience intelligence lead |
+| Bi-weekly resilience demo | Scorecard trends, verify deltas | Showcase before/after metrics, log meta-lesson reflections for mentorship | Demo hosted by intervention router captain |
+| Quarterly reset | Aggregated verify history, retired playbooks | Rebalance scoring weights, green-light next experiments, refresh cultural narratives | Leadership council workshop |
+
+### Feedback Loop Closure
+
+- Archive verify outcomes, guardrail optimizations, and stakeholder communications together so the story & trust fabric can translate them into ecosystem narratives.
+- Rotate ownership of the verify sweep to keep redundancy high and expose more builders to observability mechanics.
+- Use verify deltas as prompts in mentorship retrospectives: “Which signal failed first, and how did we reinforce the guardrail?”
+- Expand regression libraries immediately after each verify failure to sustain the testing culture meta-lesson.
+
+## Implementation Runbook
+
+| Phase | Timebox | Primary Owners | Key Deliverables | Success Metric |
+| --- | --- | --- | --- | --- |
+| Kickoff alignment | Week 0 | Program lead, Oracle steward, Identity steward | Shared OKR brief linking the five meta-lessons to current initiatives; roster of accountable owners. | All stakeholders sign the brief and commit to weekly syncs. |
+| Instrumentation sprint | Weeks 1–2 | Engineering, data reliability squad | Updated monitoring dashboards, alert routing tables, and dual-source data validation scripts. | ≥90% of critical workflows emit real-time telemetry with dual-source verification. |
+| Curriculum weave | Weeks 2–3 | Mentorship guild, learning ops | Published case-study briefs and scenario lab agendas mapped to the guardrail table. | 100% of upcoming cohort sessions reference the new briefs and labs. |
+| Oracle scoring upgrade | Weeks 3–4 | Oracle stewards, risk council | Revamped rubric with scoring prompts, reviewer training notes, and automation tests. | Pilot scoring cycle completed with reviewer feedback ≥4/5 on clarity. |
+| Identity integration | Weeks 4–5 | Creative studio, community leads | Updated storytelling assets and onboarding copy aligned with Maldivian metaphors. | Community pulse check shows ≥80% recognition of the five metaphors. |
+| Review & iterate | Week 6 | Leadership council, QA | Post-implementation retrospective, prioritized backlog of guardrail optimizations, assigned owners for next iteration. | At least one guardrail upgrade deployed per cycle and logged in the resilience ledger. |
+
+### Weekly Execution Rituals
+- **Monday signal review:** Inspect telemetry freshness, incident queues, and Oracle scoring anomalies before the sprint planning meeting.
+- **Midweek drill:** Rotate through guardrails with a lightweight chaos simulation or tabletop exercise; capture learnings in the resilience ledger.
+- **Friday storytelling sync:** Confirm identity-layer assets remain accurate, refresh metaphors with new anecdotes, and prep communications for the broader community.
+
+### Tooling & Evidence Capture
+- Maintain a shared dashboard that links each guardrail to its monitoring widgets, recent incidents, and owner updates.
+- Archive artifacts from drills, scoring cycles, and mentorship sessions in a versioned knowledge base to preserve institutional memory.
+- Tag all action items with the relevant failure category to ensure trend analysis during quarterly retrospectives.
+
+By weaving these lessons into operations, Dynamic Capital can convert historical failures into a living resilience framework that sharpens both human judgment and automated guardianship.


### PR DESCRIPTION
## Summary
- extend the implementation checklist with backlog and scorecard tasks for the safeguard engine
- document a dynamic safeguard engine blueprint with layers, operating modes, and a back-to-back review loop
- introduce a recurring scorecard and integration checklist to operationalize guardrail health metrics
- add a verify & optimize back-to-back playbook tying `npm run verify` outputs to guardrail iteration rituals

## Testing
- npm run verify

------
https://chatgpt.com/codex/tasks/task_e_68db91ad76f88322912d624ea2b7f182