### PR TITLE
Optimize dynamic search engine scoring pipeline

### DIFF
--- a/dynamic_search_engine/__init__.py
+++ b/dynamic_search_engine/__init__.py
@@ -1,0 +1,5 @@
+"""A lightweight TF-IDF powered search engine with dynamic updates."""
+
+from .engine import Document, DynamicSearchEngine, SearchResult
+
+__all__ = ["Document", "DynamicSearchEngine", "SearchResult"]

--- a/dynamic_search_engine/engine.py
+++ b/dynamic_search_engine/engine.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+"""In-memory TF-IDF search engine with support for dynamic document updates."""
+
+from collections import Counter, defaultdict
+from heapq import nlargest
+from dataclasses import dataclass
+from math import log, sqrt
+from typing import Callable, Iterable, Mapping
+from types import MappingProxyType
+
+__all__ = ["Document", "SearchResult", "DynamicSearchEngine"]
+
+
+@dataclass(frozen=True)
+class Document:
+    """Structured container for searchable content."""
+
+    identifier: str
+    content: str
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        identifier = self.identifier.strip()
+        if not identifier:
+            raise ValueError("document identifier must not be empty")
+        content = self.content.strip()
+        if not content:
+            raise ValueError("document content must not be empty")
+        object.__setattr__(self, "identifier", identifier)
+        object.__setattr__(self, "content", content)
+        if self.metadata is not None:
+            metadata = MappingProxyType(dict(self.metadata))
+            object.__setattr__(self, "metadata", metadata)
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """Search result bundle combining the document and its relevance score."""
+
+    document: Document
+    score: float
+    snippet: str | None = None
+
+
+class DynamicSearchEngine:
+    """Small TF-IDF engine optimised for low-latency, in-memory queries."""
+
+    def __init__(self, *, tokenizer: Callable[[str], Iterable[str]] | None = None) -> None:
+        self._documents: dict[str, Document] = {}
+        self._doc_term_frequencies: dict[str, Counter[str]] = {}
+        self._doc_lengths: dict[str, int] = {}
+        self._doc_term_weights: dict[str, dict[str, float]] = {}
+        self._inverted_index: dict[str, dict[str, int]] = defaultdict(dict)
+        self._tokenizer = tokenizer or self._default_tokenizer
+
+    @staticmethod
+    def _default_tokenizer(text: str) -> Iterable[str]:
+        token = []
+        for char in text.lower():
+            if char.isalnum():
+                token.append(char)
+            else:
+                if token:
+                    yield "".join(token)
+                    token.clear()
+        if token:
+            yield "".join(token)
+
+    def add_document(self, document: Document) -> None:
+        self.add_documents([document])
+
+    def add_documents(self, documents: Iterable[Document]) -> None:
+        for document in documents:
+            identifier = document.identifier
+            if identifier in self._documents:
+                self.remove_document(identifier)
+
+            tokens = list(self._tokenizer(document.content))
+            if not tokens:
+                continue
+
+            term_frequencies = Counter(tokens)
+            document_length = len(tokens)
+            normaliser = float(document_length) or 1.0
+            term_weights = {
+                term: frequency / normaliser for term, frequency in term_frequencies.items()
+            }
+            self._documents[identifier] = document
+            self._doc_term_frequencies[identifier] = term_frequencies
+            self._doc_lengths[identifier] = document_length
+            self._doc_term_weights[identifier] = term_weights
+
+            for term, frequency in term_frequencies.items():
+                self._inverted_index[term][identifier] = frequency
+
+    def remove_document(self, identifier: str) -> bool:
+        if identifier not in self._documents:
+            return False
+
+        term_frequencies = self._doc_term_frequencies.pop(identifier)
+        for term in list(term_frequencies):
+            postings = self._inverted_index.get(term)
+            if postings is None:
+                continue
+            postings.pop(identifier, None)
+            if not postings:
+                self._inverted_index.pop(term, None)
+
+        self._documents.pop(identifier, None)
+        self._doc_lengths.pop(identifier, None)
+        self._doc_term_weights.pop(identifier, None)
+        return True
+
+    def get_document(self, identifier: str) -> Document | None:
+        return self._documents.get(identifier)
+
+    def clear(self) -> None:
+        self._documents.clear()
+        self._doc_term_frequencies.clear()
+        self._doc_lengths.clear()
+        self._doc_term_weights.clear()
+        self._inverted_index.clear()
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        filter: Callable[[Document], bool] | None = None,
+    ) -> list[SearchResult]:
+        if limit <= 0:
+            return []
+
+        query = query.strip()
+        if not query or not self._documents:
+            return []
+
+        query_tokens = [token for token in self._tokenizer(query) if token]
+        if not query_tokens:
+            return []
+
+        query_term_frequencies = Counter(query_tokens)
+        query_length = len(query_tokens)
+        doc_scores: dict[str, float] = defaultdict(float)
+        total_documents = len(self._documents)
+        idf_cache: dict[str, float] = {}
+
+        def idf(term: str) -> float:
+            if term not in idf_cache:
+                doc_frequency = len(self._inverted_index.get(term, {}))
+                idf_cache[term] = log((1 + total_documents) / (1 + doc_frequency)) + 1.0
+            return idf_cache[term]
+
+        for term, query_frequency in query_term_frequencies.items():
+            postings = self._inverted_index.get(term)
+            if not postings:
+                continue
+            inverse_document_frequency = idf(term)
+            query_weight = (query_frequency / query_length) * inverse_document_frequency
+            for identifier, frequency in postings.items():
+                document_length = self._doc_lengths.get(identifier, 1) or 1
+                document_weight = (frequency / document_length) * inverse_document_frequency
+                doc_scores[identifier] += document_weight * query_weight
+
+        if not doc_scores:
+            return []
+
+        query_norm = sqrt(
+            sum(
+                ((freq / query_length) * idf(term)) ** 2
+                for term, freq in query_term_frequencies.items()
+            )
+        ) or 1.0
+
+        candidates: list[tuple[str, float, Document]] = []
+        for identifier, raw_score in doc_scores.items():
+            document = self._documents[identifier]
+            if filter and not filter(document):
+                continue
+
+            norm = self._compute_document_norm(identifier, idf)
+            if norm == 0:
+                continue
+            score = raw_score / (norm * query_norm)
+            if score <= 0:
+                continue
+            candidates.append((identifier, score, document))
+
+        if not candidates:
+            return []
+
+        if len(candidates) > limit:
+            top_candidates = nlargest(limit, candidates, key=lambda item: item[1])
+        else:
+            top_candidates = sorted(candidates, key=lambda item: item[1], reverse=True)
+
+        results: list[SearchResult] = []
+        for identifier, score, document in top_candidates:
+            snippet = self._build_snippet(document.content, query_term_frequencies)
+            results.append(SearchResult(document=document, score=score, snippet=snippet))
+
+        return results
+
+    def _compute_document_norm(self, identifier: str, idf: Callable[[str], float]) -> float:
+        term_weights = self._doc_term_weights.get(identifier)
+        if not term_weights:
+            return 0.0
+        total = 0.0
+        for term, weight in term_weights.items():
+            weight *= idf(term)
+            total += weight * weight
+        return sqrt(total)
+
+    @staticmethod
+    def _build_snippet(content: str, query_terms: Mapping[str, int]) -> str | None:
+        lower_content = content.lower()
+        best_index = len(content)
+        selected_term: str | None = None
+        for term in query_terms:
+            index = lower_content.find(term)
+            if index != -1 and index < best_index:
+                best_index = index
+                selected_term = term
+        if selected_term is None:
+            return None
+
+        start = max(best_index - 40, 0)
+        end = min(best_index + 60, len(content))
+        snippet = content[start:end].strip()
+        return snippet or None

--- a/models/dynamic_search_engine/eq_similarity.md
+++ b/models/dynamic_search_engine/eq_similarity.md
@@ -1,0 +1,21 @@
+Name: Cosine similarity scoring
+Purpose: Converts TF-IDF weighted vectors into comparable relevance scores across documents.
+
+Equation(s):
+```math
+s_t(q, d) = \frac{\sum_i w_{t,i}(q) \, w_{t,i}(d)}{\sqrt{\sum_i w_{t,i}(q)^2} \; \sqrt{\sum_i w_{t,i}(d)^2}}
+```
+
+Assumptions:
+- Query weights $w_{t,i}(q)$ mirror document weighting (including smoothing) to preserve geometric interpretation.
+- Numerical stability is guarded by clipping denominators below a tolerance $\epsilon$.
+- Filters $m_t$ shrink the candidate set so the denominator leverages only documents eligible for the query.
+
+Calibration:
+- **Data**: Relevance judgments or implicit feedback (CTR, dwell time) to evaluate score-to-behavior alignment.
+- **Method**: Offline evaluation with NDCG / MAP metrics guiding optional rescaling or bias terms.
+- **Parameter mapping**: Scaling factors integrate into $\beta$ and $w_k$ when balancing exploration penalties in the objective.
+
+Usage notes:
+- The scoring output ranks top-$K$ documents and feeds snippet generation modules.
+- Monitor distribution drift; if vector norms collapse or explode, revisit token normalization and decay factors.

--- a/models/dynamic_search_engine/eq_tfidf.md
+++ b/models/dynamic_search_engine/eq_tfidf.md
@@ -1,0 +1,21 @@
+Name: TF-IDF weighting with freshness
+Purpose: Tracks how dynamic document arrivals alter term salience used during ranking.
+
+Equation(s):
+```math
+w_{t,i}(d) = \frac{tf_{t,i}(d)}{\lVert d_t \rVert_1} \cdot \Bigg(1 + \log \frac{1 + N_t}{1 + df_{t,i}} \Bigg) \cdot \exp(-\alpha \Delta_t(d))
+```
+
+Assumptions:
+- Token counts $tf_{t,i}(d)$ are computed after normalization and stop-word filtering.
+- Document frequency $df_{t,i}$ is updated atomically alongside index mutations, avoiding lagged statistics.
+- Freshness penalty uses exponential decay with age $\Delta_t(d)$ in consistent time units (e.g., hours).
+
+Calibration:
+- **Data**: Historical corpus snapshots with timestamps and query-click logs to estimate relevance drift.
+- **Method**: Maximum likelihood fit of decay $\alpha$ against observed click-through drops; cross-validate IDF smoothing terms with held-out queries.
+- **Parameter mapping**: Estimated $\hat{\alpha}$ feeds decay, while smoothed IDF constants tune the parameter vector $\theta = [\alpha, \beta, L, K]$.
+
+Usage notes:
+- Downstream ranking uses $w_{t,i}(d)$ for cosine similarity; ensure normalization to prevent dominance by large documents.
+- Under sparse updates, refresh $df_{t,i}$ lazily using differential logs to maintain scalability.

--- a/models/dynamic_search_engine/schema.md
+++ b/models/dynamic_search_engine/schema.md
@@ -1,0 +1,50 @@
+# Dynamic search engine model
+
+## Problem statement
+
+- **State**: $x_t = [N_t, \{tf_{t,i}(d)\}_{d \in \mathcal{D}_t}, \{df_{t,i}\}]$ captures the corpus size, document-level term frequencies, and collection-wide document frequencies for each token $i$.
+- **Controls**: $u_t = [a_t(d), r_t(d)]$ toggles document add/update operations $a_t$ and removals $r_t$ issued by upstream ingestion pipelines.
+- **Parameters**: $\theta = [\alpha, \beta, L, K]$ configures token normalization strength, snippet window length $L$, ranking truncation $K$, and optional freshness decay rate.
+- **Disturbances / shocks**: $\xi_t = [q_t, m_t]$ bundles user queries and metadata filters arriving stochastically over time.
+- **Horizon**: $t = 0, \ldots, T$ where $T$ spans the operating life of the search index.
+
+## Dynamics
+
+$$
+x_{t+1} = f(x_t, u_t, \xi_t; \theta) = \text{UpdateIndex}(x_t, a_t, r_t) \circ \text{NormalizeTokens}(\alpha)
+$$
+
+Document arrivals and removals mutate the inverted index. Token normalization enforces case folding and alphanumeric filtering; optional decay factors rescale document frequencies to prioritize recency.
+
+## Outputs / observables
+
+$$
+y_t = g(x_t, q_t, m_t; \theta) = \text{RankDocuments}(q_t \mid x_t, m_t; \theta)
+$$
+
+The ranked list $y_t$ surfaces scored `SearchResult` bundles with document metadata and generated snippets. Downstream analytics consume score distributions, click-through feedback, and snippet text for evaluation loops.
+
+## Objective
+
+$$
+\max_{\{u_t\}} J = \sum_{t=0}^{T} \Big[ \mathbb{E}[\text{rel}(y_t, q_t)] - \beta \, \text{cost}(u_t) - \sum_k w_k \, \varphi_k(x_t) \Big]
+$$
+
+The engine seeks to maximize expected relevance for incoming queries while controlling indexing cost and optional regularizers $\varphi_k(\cdot)$ that penalize stale or bloated index states.
+
+## Constraints
+
+- **Equality**: $h(x_t, u_t; \theta) = \sum_{d \in \mathcal{D}_t} tf_{t,i}(d) - df_{t,i} \cdot L_{t,i} = 0$ ensures document frequencies align with postings list lengths $L_{t,i}$ after updates.
+- **Inequality**: $c(x_t, u_t; \theta) = \lvert \mathcal{D}_t \rvert - K \le 0$ enforces configurable limits on index size or response truncation.
+
+## Initial conditions & calibration hooks
+
+- Initial state $x_0 = [0, \varnothing, \varnothing]$ with an empty document set and zeroed statistics.
+- Prior over parameters $p(\theta)$ reflects baseline term weighting (e.g., uninformative priors on $\alpha$ and decay rates).
+- Calibration draws on historical query logs, click feedback, and corpus statistics to tune normalization constants and snippet window lengths.
+
+## Interfaces
+
+- **Inputs consumed**: Document ingestion streams, metadata filters, freshness signals, and live query text.
+- **Outputs produced**: Ranked `SearchResult` objects, per-term inverse document frequency traces, and snippet excerpts for observability dashboards.
+

--- a/tests_python/test_dynamic_search_engine.py
+++ b/tests_python/test_dynamic_search_engine.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dynamic_search_engine import Document, DynamicSearchEngine
+
+
+def test_document_validation() -> None:
+    with pytest.raises(ValueError):
+        Document(identifier=" ", content="Test content")
+    with pytest.raises(ValueError):
+        Document(identifier="alpha", content="   ")
+
+
+def test_search_ranks_relevant_documents() -> None:
+    engine = DynamicSearchEngine()
+    engine.add_documents(
+        [
+            Document(
+                identifier="one",
+                content="The quick brown fox jumps over the lazy dog.",
+            ),
+            Document(
+                identifier="two",
+                content="Dynamic strategies demand quick execution and adaptive playbooks.",
+            ),
+            Document(
+                identifier="three",
+                content="Meticulous research fuels disciplined capital deployment.",
+            ),
+        ]
+    )
+
+    results = engine.search("quick fox", limit=2)
+
+    assert [result.document.identifier for result in results] == ["one", "two"]
+    assert results[0].score >= results[1].score
+    assert results[0].snippet is not None
+
+
+def test_search_respects_filters_and_updates() -> None:
+    engine = DynamicSearchEngine()
+    doc = Document(
+        identifier="alpha",
+        content="Search pipelines thrive on well-indexed adaptive corpora.",
+    )
+    engine.add_document(doc)
+
+    results = engine.search("adaptive corpora")
+    assert results and results[0].document.identifier == "alpha"
+
+    filtered = engine.search("adaptive", filter=lambda item: item.identifier == "beta")
+    assert filtered == []
+
+    engine.add_document(
+        Document(
+            identifier="alpha",
+            content="Adaptive engines balance recall and precision dynamically.",
+        )
+    )
+    results = engine.search("adaptive precision")
+    assert results[0].document.identifier == "alpha"
+    assert "precision" in results[0].snippet.lower()
+
+    removed = engine.remove_document("alpha")
+    assert removed
+    assert engine.search("adaptive") == []
+
+
+def test_back_to_back_updates_preserve_consistency() -> None:
+    engine = DynamicSearchEngine()
+    engine.add_documents(
+        [
+            Document(identifier="d1", content="Alpha beta gamma dynamics."),
+            Document(identifier="d2", content="Gamma rays illuminate alpha pathways."),
+        ]
+    )
+
+    initial = engine.search("alpha gamma", limit=5)
+    assert {result.document.identifier for result in initial} == {"d1", "d2"}
+
+    # Back-to-back updates and removals should keep the engine coherent.
+    engine.add_document(
+        Document(identifier="d1", content="Alpha systems evolve with gamma harmonics."),
+    )
+    engine.add_document(
+        Document(identifier="d3", content="Beta channels amplify adaptive harmonics."),
+    )
+    engine.remove_document("d2")
+
+    refreshed = engine.search("alpha gamma", limit=5)
+    assert [result.document.identifier for result in refreshed] == ["d1"]
+    assert refreshed[0].score > 0
+    assert "gamma" in (refreshed[0].snippet or "").lower()
+
+
+def test_limit_zero_returns_empty() -> None:
+    engine = DynamicSearchEngine()
+    engine.add_document(Document(identifier="a", content="alpha beta"))
+
+    assert engine.search("alpha", limit=0) == []


### PR DESCRIPTION
## Summary
- cache normalized term weights to reduce redundant TF normalization during scoring
- short-circuit zero limits and restrict snippet work to the top-ranked documents for efficiency
- add regression tests covering back-to-back updates and limit handling for the dynamic search engine

## Testing
- pytest tests_python/test_dynamic_search_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68db94c8b5a48322b0083d77e2e72561