### PR TITLE
Add documentation summarizing influential quantitative finance works

### DIFF
--- a/docs/quantitative-finance-influential-works.md
+++ b/docs/quantitative-finance-influential-works.md
@@ -24,10 +24,10 @@ Gregory Zuckerman profiles Jim Simons’s transition from academic mathematics t
 ### Principal Models and Approaches
 Renaissance prioritized massive data ingestion, pattern discovery, and algorithmic execution. Hidden Markov models, Bayesian inference, and machine-learning ensembles were layered into thousands of short-lived signals that demanded continuous monitoring.
 
-### Practitioner Implications
-- Sustain a research feedback loop that links scientists, engineers, and trading operations.
-- Rotate or retire signals before crowding erodes their edge.
-- Bake risk controls into infrastructure so drawdown limits and stress tests run automatically.
+### Practitioner Checklist
+- [ ] Sustain a research feedback loop that links scientists, engineers, and trading operations.
+- [ ] Rotate or retire signals before crowding erodes their edge.
+- [ ] Bake risk controls into infrastructure so drawdown limits and stress tests run automatically.
 
 ## 2. _The Physics of Finance_
 
@@ -37,10 +37,10 @@ James Owen Weatherall explains how physicists imported statistical mechanics, ch
 ### Principal Models and Approaches
 Weatherall analyzes random walks, diffusion processes, fractals, and agent-based simulations. These frameworks reveal volatility clustering, fat tails, and feedback loops that classical equilibrium models miss.
 
-### Practitioner Implications
-- Expect non-linear dynamics and design stress scenarios that extend beyond Gaussian assumptions.
-- Monitor feedback effects—herding, reflexivity, liquidity spirals—that can destabilize strategies.
-- Combine structural knowledge of market microstructure with quantitative validation.
+### Practitioner Checklist
+- [ ] Expect non-linear dynamics and design stress scenarios that extend beyond Gaussian assumptions.
+- [ ] Monitor feedback effects—herding, reflexivity, liquidity spirals—that can destabilize strategies.
+- [ ] Combine structural knowledge of market microstructure with quantitative validation.
 
 ## 3. _The Statistical Mechanics of Financial Markets_
 
@@ -50,10 +50,10 @@ Jürgen Voigt provides a technical foundation for econophysics, modeling markets
 ### Principal Models and Approaches
 The text deploys stochastic calculus, Fokker–Planck equations, and ensemble averages to study return distributions and volatility regimes. It highlights self-organized criticality and the prevalence of leptokurtic tails.
 
-### Practitioner Implications
-- Track higher-order moments (skewness, kurtosis) as early warning indicators.
-- Use ensemble modeling to capture heterogeneous behavior across market participants.
-- Pair analytic derivations with frequent empirical recalibration to prevent model drift.
+### Practitioner Checklist
+- [ ] Track higher-order moments (skewness, kurtosis) as early warning indicators.
+- [ ] Use ensemble modeling to capture heterogeneous behavior across market participants.
+- [ ] Pair analytic derivations with frequent empirical recalibration to prevent model drift.
 
 ## 4. "The Pricing of Options and Corporate Liabilities"
 
@@ -63,10 +63,10 @@ Fischer Black and Myron Scholes introduced a closed-form formula for pricing Eur
 ### Principal Models and Approaches
 Assuming stock prices follow geometric Brownian motion, the authors derived the Black–Scholes partial differential equation. Solving it with continuous hedging yields option prices that, under ideal conditions, eliminate arbitrage.
 
-### Practitioner Implications
-- Document sources of hedging slippage—transaction costs, jumps, discrete rebalancing—to avoid false precision.
-- Use implied volatility surfaces to diagnose model misspecification.
-- Extend the framework with stochastic volatility or jump processes when empirical data demands it.
+### Practitioner Checklist
+- [ ] Document sources of hedging slippage—transaction costs, jumps, discrete rebalancing—to avoid false precision.
+- [ ] Use implied volatility surfaces to diagnose model misspecification.
+- [ ] Extend the framework with stochastic volatility or jump processes when empirical data demands it.
 
 ## 5. "Medallion Fund: The Ultimate Counterexample?"
 
@@ -76,10 +76,10 @@ Bradford Cornell questions how Medallion’s decades-long outperformance fits wi
 ### Principal Models and Approaches
 Cornell studies return distributions, drawdowns, and factor exposures, searching for conventional risk premia explanations. He emphasizes the role of organizational advantages—talent density, secrecy, and incentive alignment.
 
-### Practitioner Implications
-- Audit strategies against known risk factors before attributing residual returns to true alpha.
-- Treat extreme outperformance as evidence of real-world frictions that limit arbitrage.
-- Recognize that operational moats, not just models, can preserve edge.
+### Practitioner Checklist
+- [ ] Audit strategies against known risk factors before attributing residual returns to true alpha.
+- [ ] Treat extreme outperformance as evidence of real-world frictions that limit arbitrage.
+- [ ] Recognize that operational moats, not just models, can preserve edge.
 
 ## Historical Context and Evolution
 
@@ -107,11 +107,17 @@ The path to quantitative finance predates these works. Early efforts by Louis Ba
 
 ## Implementation Checklist
 
-1. **Data Pipeline Review:** Confirm ingestion, cleaning, and feature stores support rapid experimentation.
-2. **Model Audit:** Document assumptions—distributional, structural, behavioral—and link them to monitoring alerts.
-3. **Risk Controls:** Align hedging, leverage, and drawdown limits with observed tail risks and liquidity constraints.
-4. **Knowledge Transfer:** Schedule cross-functional reviews so research insights migrate into production playbooks.
-5. **Post-Mortem Cadence:** Conduct retrospectives after market dislocations to recalibrate models and operating procedures.
+- [ ] **Data Pipeline Review:** Confirm ingestion, cleaning, and feature stores support rapid experimentation.
+- [ ] **Model Audit:** Document assumptions—distributional, structural, behavioral—and link them to monitoring alerts.
+- [ ] **Risk Controls:** Align hedging, leverage, and drawdown limits with observed tail risks and liquidity constraints.
+- [ ] **Knowledge Transfer:** Schedule cross-functional reviews so research insights migrate into production playbooks.
+- [ ] **Post-Mortem Cadence:** Conduct retrospectives after market dislocations to recalibrate models and operating procedures.
+
+## Cross-Book Action Items
+
+- [ ] Map each strategy’s assumptions to observed market regimes and flag divergence alerts.
+- [ ] Maintain a shared backlog of model enhancements inspired by the five works to prioritize R&D sprints.
+- [ ] Pair quantitative researchers with operations leads to validate deployment readiness before production releases.
 
 ## Further Reading
 


### PR DESCRIPTION
## Summary
- add a documentation page consolidating insights from five influential quantitative finance publications
- capture key methods, lessons, and cross-cutting themes to guide practitioners applying quantitative models

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dbaf8bb28c8322b568963d924b7e06