### PR TITLE
Add DigitalOcean alias for qazf2 domain

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -11,6 +11,10 @@ spec:
       type: PRIMARY
       wildcard: false
       zone: dynamic-capital.ondigitalocean.app
+    - domain: dynamic-capital-qazf2.ondigitalocean.app
+      type: ALIAS
+      wildcard: false
+      zone: ondigitalocean.app
     - domain: dynamic-capital.vercel.app
       type: ALIAS
       wildcard: false
@@ -28,6 +32,13 @@ spec:
             exact: dynamic-capital.ondigitalocean.app
           path:
             prefix: /
+      - component:
+          name: dynamic-capital
+        match:
+          authority:
+            exact: dynamic-capital-qazf2.ondigitalocean.app
+          path:
+            prefix: /
   envs:
     - key: NODE_ENV
       value: production
@@ -42,7 +53,7 @@ spec:
       value: https://dynamic-capital.ondigitalocean.app
       scope: RUN_AND_BUILD_TIME
     - key: ALLOWED_ORIGINS
-      value: https://dynamic-capital.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app
+      value: https://dynamic-capital.ondigitalocean.app,https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app
       scope: RUN_AND_BUILD_TIME
     - key: MINIAPP_ORIGIN
       value: https://dynamic-capital.ondigitalocean.app
@@ -91,7 +102,7 @@ spec:
           value: https://dynamic-capital.ondigitalocean.app
           scope: RUN_AND_BUILD_TIME
         - key: ALLOWED_ORIGINS
-          value: https://dynamic-capital.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app
+          value: https://dynamic-capital.ondigitalocean.app,https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app
           scope: RUN_AND_BUILD_TIME
         - key: MINIAPP_ORIGIN
           value: https://dynamic-capital.ondigitalocean.app

--- a/project.toml
+++ b/project.toml
@@ -30,7 +30,7 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://dynamic-capital.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
+    value = "https://dynamic-capital.ondigitalocean.app,https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
 
   [[build.env]]
     name = "SITE_URL"

--- a/scripts/digitalocean/site-config-utils.mjs
+++ b/scripts/digitalocean/site-config-utils.mjs
@@ -2,6 +2,7 @@ import { URL } from "node:url";
 
 export const PRODUCTION_ALLOWED_ORIGINS = [
   "https://dynamic-capital.ondigitalocean.app",
+  "https://dynamic-capital-qazf2.ondigitalocean.app",
   "https://dynamic.capital",
   "https://dynamic-capital.vercel.app",
   "https://dynamic-capital.lovable.app",

--- a/scripts/utils/branding-env.mjs
+++ b/scripts/utils/branding-env.mjs
@@ -3,6 +3,7 @@ export const PRODUCTION_ORIGIN =
 
 export const PRODUCTION_ALLOWED_ORIGIN_LIST = [
   "https://dynamic-capital.ondigitalocean.app",
+  "https://dynamic-capital-qazf2.ondigitalocean.app",
   "https://dynamic.capital",
   "https://dynamic-capital.vercel.app",
   "https://dynamic-capital.lovable.app",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -4,6 +4,7 @@ project_id = "your-project-ref"
   site_url = "https://dynamic-capital.ondigitalocean.app"
   additional_redirect_urls = [
     "https://dynamic-capital.ondigitalocean.app",
+    "https://dynamic-capital-qazf2.ondigitalocean.app",
     "https://dynamic.capital",
     "https://dynamic-capital.vercel.app",
     "https://dynamic-capital.lovable.app",
@@ -13,6 +14,6 @@ project_id = "your-project-ref"
   [functions.env]
     SITE_URL = "https://dynamic-capital.ondigitalocean.app"
     NEXT_PUBLIC_SITE_URL = "https://dynamic-capital.ondigitalocean.app"
-    ALLOWED_ORIGINS = "https://dynamic-capital.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
+    ALLOWED_ORIGINS = "https://dynamic-capital.ondigitalocean.app,https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app"
     MINIAPP_ORIGIN = "https://dynamic-capital.ondigitalocean.app"
     TELEGRAM_WEBHOOK_URL = "https://dynamic-capital.ondigitalocean.app/webhook"


### PR DESCRIPTION
## Summary
- add the dynamic-capital-qazf2.ondigitalocean.app alias to the DigitalOcean app spec and ingress rules
- propagate the new alias through allowed origin lists used by build, Supabase, and deployment tooling

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbbb584ef8832280dee27f026c62bb