### PR TITLE
Enhance dynamic inventory listing

### DIFF
--- a/docs/dynamic_inventory.md
+++ b/docs/dynamic_inventory.md
@@ -1,6 +1,6 @@
 # Dynamic Inventory Knowledge Base
 
-_Last updated: 2025-09-28 (UTC)_
+_Last updated: 2025-09-30 (UTC)_
 
 This catalog summarizes the repository's `dynamic_` directories so you can
 explore related knowledge modules at a glance.
@@ -13,12 +13,13 @@ explore related knowledge modules at a glance.
 - [Potential uses for each module](#potential-uses-for-each-module)
 - [Next steps to enrich the knowledge base](#next-steps-to-enrich-the-knowledge-base)
 - [Complete alphabetical index](#complete-alphabetical-index)
+- [Command-line listing](#command-line-listing)
 
 ## Snapshot metrics
 
-- Total directories: 161
+- Total directories: 183 (based on the latest automated scan)
 - Domain groups: 11 (largest: Technology & Infrastructure with 54 modules)
-- Generation command: `ls -d dynamic_* | sort`
+- Generation helper: `npx tsx scripts/list-dynamic-inventory.ts`
 
 ## Domain overview
 
@@ -36,7 +37,6 @@ explore related knowledge modules at a glance.
 | Process & Workflow Tooling | 9 | Frameworks for orchestrating routines, bridges, and continuous cycles. |
 | Natural Systems & Sustainability | 5 | Biological and energy-oriented systems thinking. |
 | Conceptual & Experimental Frameworks | 4 | Abstract models, pillars, and exploratory mental scaffolds. |
-
 
 ## Domain-based catalog
 
@@ -331,3 +331,15 @@ The table below is sorted alphabetically from left to right for quick scanning.
 | `dynamic_wave` | `dynamic_web` | `dynamic_web3` | `dynamic_wisdom` |
 | `dynamic_zone` |  |  |  |
 
+## Command-line listing
+
+For an always up-to-date directory roster, run the helper script:
+
+```bash
+npx tsx scripts/list-dynamic-inventory.ts
+```
+
+The default output prints the current count (183 as of 2025-09-30) followed by
+every `dynamic_` module name. Automations can add `--json` for structured output
+or `--absolute` to emit full paths instead of repository-relative names, or
+`--recursive` to include nested matches outside the repository root.

--- a/scripts/list-dynamic-inventory.ts
+++ b/scripts/list-dynamic-inventory.ts
@@ -1,0 +1,208 @@
+import { readdir } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { error, info, success } from "./utils/friendly-logger.js";
+
+type OutputFormat = "json" | "text";
+
+interface CliOptions {
+  format: OutputFormat;
+  root: string;
+  absolute: boolean;
+  ignores: Set<string>;
+  showHelp: boolean;
+  recursive: boolean;
+}
+
+const DEFAULT_IGNORES = new Set<string>([
+  ".git",
+  "node_modules",
+  ".turbo",
+  ".next",
+  ".vercel",
+  "dist",
+  "build",
+  "coverage",
+  "tmp",
+  "vendor",
+]);
+
+interface CollectOptions {
+  ignores: Set<string>;
+  recursive: boolean;
+}
+
+async function collectDynamicDirectories(
+  root: string,
+  { ignores, recursive }: CollectOptions,
+) {
+  if (!recursive) {
+    const entries = await readdir(root, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory() && !ignores.has(entry.name))
+      .filter((entry) => entry.name.startsWith("dynamic_"))
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b));
+  }
+
+  const results: string[] = [];
+  const queue: string[] = [root];
+
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    const entries = await readdir(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (ignores.has(entry.name)) continue;
+
+      const fullPath = join(current, entry.name);
+      const relativePath = relative(root, fullPath) || entry.name;
+
+      if (entry.name.startsWith("dynamic_")) {
+        results.push(relativePath);
+      }
+
+      queue.push(fullPath);
+    }
+  }
+
+  return results.sort((a, b) => a.localeCompare(b));
+}
+
+function parseArgs(defaultRoot: string): CliOptions {
+  const args = process.argv.slice(2);
+  const ignores = new Set(DEFAULT_IGNORES);
+
+  let format: OutputFormat = "text";
+  let root = defaultRoot;
+  let absolute = false;
+  let showHelp = false;
+  let recursive = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--help":
+      case "-h": {
+        showHelp = true;
+        break;
+      }
+      case "--json": {
+        format = "json";
+        break;
+      }
+      case "--absolute": {
+        absolute = true;
+        break;
+      }
+      case "--root":
+      case "-r": {
+        const value = args.at(index + 1);
+        if (!value) {
+          throw new Error("--root requires a path argument");
+        }
+        root = resolve(defaultRoot, value);
+        index += 1;
+        break;
+      }
+      case "--ignore": {
+        const value = args.at(index + 1);
+        if (!value) {
+          throw new Error("--ignore requires a directory name");
+        }
+        ignores.add(value);
+        index += 1;
+        break;
+      }
+      case "--recursive": {
+        recursive = true;
+        break;
+      }
+      default: {
+        throw new Error(`Unknown argument: ${arg}`);
+      }
+    }
+  }
+
+  return { format, root, absolute, ignores, showHelp, recursive };
+}
+
+function printHelp(defaultRoot: string) {
+  info("List every dynamic_* directory in the repository.", {
+    details: [
+      "Usage: npx tsx scripts/list-dynamic-inventory.ts [options]",
+      "Options:",
+      "  -h, --help        Show this message",
+      "  --json            Emit a JSON payload instead of text",
+      "  --absolute        Print absolute paths",
+      "  -r, --root <dir>  Override the repository root",
+      "  --ignore <name>   Add an extra directory name to skip",
+      "  --recursive       Scan nested folders as well",
+      `Default root: ${defaultRoot}`,
+    ],
+  });
+}
+
+async function main() {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const defaultRoot = resolve(currentDir, "..");
+  let options: CliOptions;
+
+  try {
+    options = parseArgs(defaultRoot);
+  } catch (cause) {
+    error("Failed to parse arguments.", { details: cause });
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.showHelp) {
+    printHelp(defaultRoot);
+    return;
+  }
+
+  let directories: string[];
+  try {
+    directories = await collectDynamicDirectories(options.root, {
+      ignores: options.ignores,
+      recursive: options.recursive,
+    });
+  } catch (cause) {
+    error("Unable to scan for dynamic directories.", { details: cause });
+    process.exitCode = 1;
+    return;
+  }
+
+  const formattedDirectories = directories.map((directory) =>
+    options.absolute ? resolve(options.root, directory) : directory
+  );
+
+  if (options.format === "json") {
+    const payload = {
+      count: formattedDirectories.length,
+      directories: formattedDirectories,
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  if (formattedDirectories.length === 0) {
+    info("No dynamic_* directories were found.");
+    return;
+  }
+
+  const descriptors: string[] = [];
+  if (options.recursive) descriptors.push("recursive");
+  if (options.absolute) descriptors.push("absolute paths");
+  const suffix = descriptors.length > 0 ? ` (${descriptors.join(", ")})` : "";
+
+  success(`Found ${formattedDirectories.length} dynamic modules${suffix}:`);
+  for (const directory of formattedDirectories) {
+    console.log(` - ${directory}`);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- extend the dynamic inventory helper with option parsing, recursive scans, and JSON/absolute output modes
- add usage guidance and error handling so the script stays resilient when arguments are missing or invalid
- refresh the documentation with the current inventory count and describe the new CLI capabilities

## Testing
- npx tsx scripts/list-dynamic-inventory.ts
- npx tsx scripts/list-dynamic-inventory.ts --recursive --json


------
https://chatgpt.com/codex/tasks/task_e_68dbc0b946a48322a319c34bd446192c