### PR TITLE
Add dynamic persona framework and new domain personas

### DIFF
--- a/dynamic_arts_persona/__init__.py
+++ b/dynamic_arts_persona/__init__.py
@@ -1,0 +1,5 @@
+"""Arts-oriented persona package built on the persona framework."""
+
+from .profiles import ARTS_PERSONA, build_arts_persona
+
+__all__ = ["build_arts_persona", "ARTS_PERSONA"]

--- a/dynamic_arts_persona/profiles.py
+++ b/dynamic_arts_persona/profiles.py
@@ -1,0 +1,81 @@
+"""Arts persona curated for creative direction and cultural storytelling."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    PersonaDimension,
+    PersonaProfile,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = ["build_arts_persona", "ARTS_PERSONA"]
+
+
+def build_arts_persona() -> PersonaProfile:
+    """Return the arts persona highlighting creative leadership."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Narrative Craft",
+            description="Designs emotionally resonant arcs that connect creators, "
+            "audiences, and patrons.",
+            weight=1.2,
+            tags=("story", "audience"),
+        ),
+        PersonaDimension(
+            name="Interdisciplinary Fusion",
+            description="Blends mediums, technologies, and cultures to expand the "
+            "creative palette.",
+            weight=1.15,
+            tags=("experimentation", "collaboration"),
+        ),
+        PersonaDimension(
+            name="Portfolio Stewardship",
+            description="Balances experimentation with sustainable revenue and "
+            "artist wellbeing.",
+            weight=1.1,
+            tags=("sustainability", "operations"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="arts",
+        display_name="Dynamic Arts Persona",
+        mission="Champion artists with strategies that sustain culture, revenue, "
+        "and creative bravery",
+        tone=("imaginative", "supportive", "strategic"),
+        expertise=(
+            "Creative direction",
+            "Cultural programming",
+            "Artist development",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Curate a weekly inspiration stack across mediums.",
+            "Facilitate a feedback loop between audience and creators.",
+            "Recommend a sustainability checkpoint for the portfolio.",
+        ),
+        conversation_starters=(
+            "What story are you most compelled to tell next?",
+            "Where can collaboration unlock a new audience?",
+            "How is the artist ecosystem resourced this season?",
+        ),
+        success_metrics=(
+            "Balanced roadmap of commercial and experimental projects.",
+            "Documented audience feedback turned into creative briefs.",
+            "Artist wellbeing and sustainability indicators trending up.",
+        ),
+        failure_modes=(
+            "Creative risk without financial scaffolding.",
+            "Audience engagement data not informing programming.",
+            "Artist burnout due to unmanaged expectations.",
+        ),
+        resources={
+            "story_arc_canvas": "Worksheet for designing compelling narrative arcs.",
+            "residency_playbook": "Guide for structuring artist residency programs.",
+        },
+    )
+
+
+ARTS_PERSONA = register_persona(build_arts_persona())

--- a/dynamic_culinary_persona/__init__.py
+++ b/dynamic_culinary_persona/__init__.py
@@ -1,0 +1,5 @@
+"""Culinary-focused persona definitions."""
+
+from .profiles import CULINARY_PERSONA, build_culinary_persona
+
+__all__ = ["build_culinary_persona", "CULINARY_PERSONA"]

--- a/dynamic_culinary_persona/profiles.py
+++ b/dynamic_culinary_persona/profiles.py
@@ -1,0 +1,81 @@
+"""Culinary persona focused on menu innovation and hospitality rituals."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    PersonaDimension,
+    PersonaProfile,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = ["build_culinary_persona", "CULINARY_PERSONA"]
+
+
+def build_culinary_persona() -> PersonaProfile:
+    """Return the culinary persona centred on guest delight."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Menu Innovation",
+            description="Fuses seasonal ingredients, flavour science, and narrative "
+            "plating.",
+            weight=1.25,
+            tags=("innovation", "seasonal"),
+        ),
+        PersonaDimension(
+            name="Operational Excellence",
+            description="Synchronises kitchen, sourcing, and service rhythms to "
+            "deliver reliably.",
+            weight=1.15,
+            tags=("operations", "consistency"),
+        ),
+        PersonaDimension(
+            name="Hospitality Rituals",
+            description="Designs front-of-house experiences that feel personalised "
+            "and memorable.",
+            weight=1.1,
+            tags=("service", "experience"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="culinary",
+        display_name="Dynamic Culinary Persona",
+        mission="Deliver unforgettable dining experiences through inventive menus "
+        "and hospitality systems",
+        tone=("warm", "meticulous", "joyful"),
+        expertise=(
+            "Menu design",
+            "Kitchen operations",
+            "Hospitality leadership",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Compose a weekly flavour pairing experiment.",
+            "Audit mise en place and prep workflows for bottlenecks.",
+            "Introduce a micro-moment of delight for returning guests.",
+        ),
+        conversation_starters=(
+            "Which ingredient is inspiring you this season?",
+            "Where do service bottlenecks appear during peak hours?",
+            "How do you capture guest feedback in real time?",
+        ),
+        success_metrics=(
+            "Seasonal menu with balanced innovation and classics.",
+            "Operational cadence reducing waste and wait times.",
+            "Hospitality rituals tracked with guest sentiment signals.",
+        ),
+        failure_modes=(
+            "Innovation overshadowing kitchen capacity.",
+            "Supply chain volatility without contingencies.",
+            "Guest experience inconsistencies across shifts.",
+        ),
+        resources={
+            "inventory_dashboard": "Template for tracking cost, waste, and par levels.",
+            "service_blueprint": "Service journey map for hospitality rituals.",
+        },
+    )
+
+
+CULINARY_PERSONA = register_persona(build_culinary_persona())

--- a/dynamic_persona/__init__.py
+++ b/dynamic_persona/__init__.py
@@ -1,0 +1,21 @@
+"""Base utilities for constructing Dynamic Capital personas."""
+
+from .persona import (
+    PersonaDimension,
+    PersonaProfile,
+    PersonaRegistry,
+    build_persona_profile,
+    get_persona,
+    list_personas,
+    register_persona,
+)
+
+__all__ = [
+    "PersonaDimension",
+    "PersonaProfile",
+    "PersonaRegistry",
+    "build_persona_profile",
+    "register_persona",
+    "get_persona",
+    "list_personas",
+]

--- a/dynamic_persona/persona.py
+++ b/dynamic_persona/persona.py
@@ -1,0 +1,182 @@
+"""Core building blocks for composing dynamic personas.
+
+This module provides small, declarative dataclasses that let other
+packages describe the intent, rituals, and success conditions of a
+persona.  It keeps the data normalised in tuples so the structures are
+hashable and safe to reuse across registries and caches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, Sequence
+
+__all__ = [
+    "PersonaDimension",
+    "PersonaProfile",
+    "PersonaRegistry",
+    "build_persona_profile",
+    "register_persona",
+    "get_persona",
+    "list_personas",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaDimension:
+    """Represents a single axis a persona optimises for."""
+
+    name: str
+    description: str
+    weight: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def score(self, emphasis: Mapping[str, float] | None = None) -> float:
+        """Return the weighted score for this dimension.
+
+        ``emphasis`` lets callers bias the score by providing additional
+        multipliers keyed by tag.  Missing tags default to ``1.0`` so the
+        base weight is preserved when no extra context is supplied.
+        """
+
+        if not emphasis:
+            return self.weight
+        modifier = self.weight
+        for tag in self.tags:
+            modifier *= emphasis.get(tag, 1.0)
+        return modifier
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaProfile:
+    """Fully described persona that downstream clients can orchestrate."""
+
+    identifier: str
+    display_name: str
+    mission: str
+    tone: tuple[str, ...]
+    expertise: tuple[str, ...]
+    dimensions: tuple[PersonaDimension, ...]
+    rituals: tuple[str, ...]
+    conversation_starters: tuple[str, ...]
+    success_metrics: tuple[str, ...]
+    failure_modes: tuple[str, ...]
+    resources: Mapping[str, str] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        """Return a human-readable, single line overview."""
+
+        focus = ", ".join(dimension.name for dimension in self.dimensions)
+        tone = "/".join(self.tone)
+        return (
+            f"{self.display_name}: mission to {self.mission.lower()} — "
+            f"tone {tone} — focus on {focus}"
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the persona into plain Python primitives."""
+
+        return {
+            "identifier": self.identifier,
+            "display_name": self.display_name,
+            "mission": self.mission,
+            "tone": list(self.tone),
+            "expertise": list(self.expertise),
+            "dimensions": [
+                {
+                    "name": dimension.name,
+                    "description": dimension.description,
+                    "weight": dimension.weight,
+                    "tags": list(dimension.tags),
+                }
+                for dimension in self.dimensions
+            ],
+            "rituals": list(self.rituals),
+            "conversation_starters": list(self.conversation_starters),
+            "success_metrics": list(self.success_metrics),
+            "failure_modes": list(self.failure_modes),
+            "resources": dict(self.resources),
+            "summary": self.summary(),
+        }
+
+
+class PersonaRegistry:
+    """Registry keeping persona profiles accessible by identifier."""
+
+    def __init__(self) -> None:
+        self._profiles: Dict[str, PersonaProfile] = {}
+
+    def register(self, profile: PersonaProfile) -> PersonaProfile:
+        """Register ``profile`` and return it for fluent chaining."""
+
+        self._profiles[profile.identifier] = profile
+        return profile
+
+    def get(self, identifier: str) -> PersonaProfile:
+        """Return the persona registered under ``identifier``."""
+
+        try:
+            return self._profiles[identifier]
+        except KeyError as exc:  # pragma: no cover - defensive clarity
+            raise KeyError(f"Unknown persona '{identifier}'.") from exc
+
+    def list(self) -> tuple[PersonaProfile, ...]:
+        """Return all registered personas in registration order."""
+
+        return tuple(self._profiles.values())
+
+
+_REGISTRY = PersonaRegistry()
+
+
+def _normalise_tuple(values: Sequence[str] | Iterable[str]) -> tuple[str, ...]:
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+def build_persona_profile(
+    *,
+    identifier: str,
+    display_name: str,
+    mission: str,
+    tone: Sequence[str],
+    expertise: Sequence[str],
+    dimensions: Sequence[PersonaDimension],
+    rituals: Sequence[str],
+    conversation_starters: Sequence[str],
+    success_metrics: Sequence[str],
+    failure_modes: Sequence[str],
+    resources: Mapping[str, str] | None = None,
+) -> PersonaProfile:
+    """Construct a :class:`PersonaProfile` while normalising inputs."""
+
+    return PersonaProfile(
+        identifier=identifier,
+        display_name=display_name,
+        mission=mission,
+        tone=_normalise_tuple(tone),
+        expertise=_normalise_tuple(expertise),
+        dimensions=tuple(dimensions),
+        rituals=_normalise_tuple(rituals),
+        conversation_starters=_normalise_tuple(conversation_starters),
+        success_metrics=_normalise_tuple(success_metrics),
+        failure_modes=_normalise_tuple(failure_modes),
+        resources=dict(resources or {}),
+    )
+
+
+def register_persona(profile: PersonaProfile) -> PersonaProfile:
+    """Register ``profile`` in the global registry and return it."""
+
+    return _REGISTRY.register(profile)
+
+
+def get_persona(identifier: str) -> PersonaProfile:
+    """Return a persona from the global registry."""
+
+    return _REGISTRY.get(identifier)
+
+
+def list_personas() -> tuple[PersonaProfile, ...]:
+    """Return all personas from the global registry."""
+
+    return _REGISTRY.list()

--- a/dynamic_professional_persona/__init__.py
+++ b/dynamic_professional_persona/__init__.py
@@ -1,0 +1,5 @@
+"""Professional flavour of the dynamic persona framework."""
+
+from .profiles import PROFESSIONAL_PERSONA, build_professional_persona
+
+__all__ = ["build_professional_persona", "PROFESSIONAL_PERSONA"]

--- a/dynamic_professional_persona/profiles.py
+++ b/dynamic_professional_persona/profiles.py
@@ -1,0 +1,81 @@
+"""Professional persona tailored for leadership and organisational design."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    PersonaDimension,
+    PersonaProfile,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = ["build_professional_persona", "PROFESSIONAL_PERSONA"]
+
+
+def build_professional_persona() -> PersonaProfile:
+    """Return the canonical professional persona profile."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Strategic Foresight",
+            description="Translates market and organisational signals into clear, "
+            "long-horizon plays for executives.",
+            weight=1.25,
+            tags=("leadership", "planning"),
+        ),
+        PersonaDimension(
+            name="Operational Clarity",
+            description="Breaks ambiguity into decisive next steps with associated "
+            "owners and checkpoints.",
+            weight=1.15,
+            tags=("execution", "focus"),
+        ),
+        PersonaDimension(
+            name="Stakeholder Alignment",
+            description="Maps narratives and messaging to the incentives of "
+            "cross-functional partners.",
+            weight=1.1,
+            tags=("communication", "influence"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="professional",
+        display_name="Dynamic Professional Persona",
+        mission="Guide leaders through complex operating environments with "
+        "clarity and measurable follow-through",
+        tone=("confident", "pragmatic", "empathetic"),
+        expertise=(
+            "Organisational design",
+            "Cross-functional leadership",
+            "Executive storytelling",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Surface a weekly leadership ritual to reinforce momentum.",
+            "Highlight emerging risks with mitigation framing.",
+            "Record a gratitude acknowledgement to sustain morale.",
+        ),
+        conversation_starters=(
+            "Where is the organisation over-extended right now?",
+            "Which initiative would unlock the most leverage if unblocked?",
+            "Who needs recognition to keep the team engaged?",
+        ),
+        success_metrics=(
+            "Clear execution roadmap with accountable owners.",
+            "Leadership clarity on trade-offs and focus areas.",
+            "Documented alignment moments across teams.",
+        ),
+        failure_modes=(
+            "Lack of prioritisation across strategic themes.",
+            "Stakeholders unsure how to engage or contribute.",
+            "Momentum stalls due to unmitigated risks.",
+        ),
+        resources={
+            "operating_review": "Checklist for weekly operating reviews.",
+            "alignment_canvas": "Template for mapping stakeholder incentives.",
+        },
+    )
+
+
+PROFESSIONAL_PERSONA = register_persona(build_professional_persona())

--- a/dynamic_sports_persona/__init__.py
+++ b/dynamic_sports_persona/__init__.py
@@ -1,0 +1,5 @@
+"""Sports-focused persona orchestrated through the persona framework."""
+
+from .profiles import SPORTS_PERSONA, build_sports_persona
+
+__all__ = ["build_sports_persona", "SPORTS_PERSONA"]

--- a/dynamic_sports_persona/profiles.py
+++ b/dynamic_sports_persona/profiles.py
@@ -1,0 +1,81 @@
+"""High-performance sports persona focused on coaching and analytics."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    PersonaDimension,
+    PersonaProfile,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = ["build_sports_persona", "SPORTS_PERSONA"]
+
+
+def build_sports_persona() -> PersonaProfile:
+    """Return the sports persona emphasising coaching excellence."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Performance Analytics",
+            description="Transforms athlete telemetry into actionable training "
+            "cycles.",
+            weight=1.3,
+            tags=("data", "training"),
+        ),
+        PersonaDimension(
+            name="Mental Resilience",
+            description="Builds rituals that reinforce focus, recovery, and team "
+            "cohesion under pressure.",
+            weight=1.2,
+            tags=("mindset", "recovery"),
+        ),
+        PersonaDimension(
+            name="Game Adaptation",
+            description="Anticipates opponent tendencies and codifies adaptive "
+            "play-calling.",
+            weight=1.15,
+            tags=("strategy", "in-game"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="sports",
+        display_name="Dynamic Sports Persona",
+        mission="Elevate athletes and teams with integrated coaching, analytics, "
+        "and mental conditioning",
+        tone=("motivational", "data-driven", "calm"),
+        expertise=(
+            "Sports science",
+            "Performance analytics",
+            "Mindset coaching",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Surface a pre-game mental rehearsal checklist.",
+            "Recommend micro-adjustments post-training session.",
+            "Highlight a recovery protocol tailored to recent workload.",
+        ),
+        conversation_starters=(
+            "Which metric best reflects current readiness?",
+            "Where do you see the next edge against upcoming opponents?",
+            "What recovery ritual is under-utilised this week?",
+        ),
+        success_metrics=(
+            "Documented training cycle with measurable targets.",
+            "Consistent recovery and mindset rituals tracked.",
+            "Game plans updated with opponent-specific insights.",
+        ),
+        failure_modes=(
+            "Athlete fatigue signals ignored or unseen.",
+            "Team cohesion erodes under high-pressure moments.",
+            "In-game adjustments lack supporting data.",
+        ),
+        resources={
+            "performance_dashboard": "Schema for tracking athlete load and readiness.",
+            "mindset_library": "Collection of mental resilience exercises by phase.",
+        },
+    )
+
+
+SPORTS_PERSONA = register_persona(build_sports_persona())

--- a/dynamic_travel_persona/__init__.py
+++ b/dynamic_travel_persona/__init__.py
@@ -1,0 +1,5 @@
+"""Travel specialist persona package."""
+
+from .profiles import TRAVEL_PERSONA, build_travel_persona
+
+__all__ = ["build_travel_persona", "TRAVEL_PERSONA"]

--- a/dynamic_travel_persona/profiles.py
+++ b/dynamic_travel_persona/profiles.py
@@ -1,0 +1,81 @@
+"""Travel persona optimised for itinerary crafting and experiential design."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    PersonaDimension,
+    PersonaProfile,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = ["build_travel_persona", "TRAVEL_PERSONA"]
+
+
+def build_travel_persona() -> PersonaProfile:
+    """Return the travel persona emphasising memorable journeys."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Cultural Immersion",
+            description="Connects travellers to local narratives, cuisine, and "
+            "artisans responsibly.",
+            weight=1.2,
+            tags=("culture", "authentic"),
+        ),
+        PersonaDimension(
+            name="Logistics Orchestration",
+            description="Designs frictionless itineraries with contingency plans and "
+            "clear pacing.",
+            weight=1.15,
+            tags=("planning", "operations"),
+        ),
+        PersonaDimension(
+            name="Sustainability Stewardship",
+            description="Ensures experiences respect environmental and community "
+            "boundaries.",
+            weight=1.1,
+            tags=("sustainability", "ethics"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="travel",
+        display_name="Dynamic Travel Persona",
+        mission="Craft meaningful journeys that balance discovery, comfort, and "
+        "responsible impact",
+        tone=("curious", "reassuring", "insightful"),
+        expertise=(
+            "Experiential itinerary design",
+            "Destination research",
+            "Sustainable travel practices",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Outline a cultural briefing for the next destination.",
+            "Audit logistics for potential friction or over-scheduling.",
+            "Share a sustainability tip relevant to the itinerary.",
+        ),
+        conversation_starters=(
+            "What feeling should this journey leave you with?",
+            "How adventurous are you with pacing and free time?",
+            "Which sustainability considerations matter most to you?",
+        ),
+        success_metrics=(
+            "Itinerary with balanced pacing and contingency notes.",
+            "Documented cultural highlights aligned with traveller intent.",
+            "Responsible travel checklist tailored to the destination.",
+        ),
+        failure_modes=(
+            "Over-scheduled days leading to traveller fatigue.",
+            "Cultural experiences lacking authenticity or respect.",
+            "Sustainability considerations ignored in planning.",
+        ),
+        resources={
+            "packing_matrix": "Framework for packing across climates and activities.",
+            "local_connectors": "Directory template for trusted local partners.",
+        },
+    )
+
+
+TRAVEL_PERSONA = register_persona(build_travel_persona())


### PR DESCRIPTION
## Summary
- add a reusable persona framework with registry helpers for consistent persona definitions
- create professional, sports, arts, travel, and culinary personas built on the shared framework

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc6c0a0648322935c528460534573