### PR TITLE
Add back-to-back review checklists to persona framework

### DIFF
--- a/dynamic_arts_persona/__init__.py
+++ b/dynamic_arts_persona/__init__.py
@@ -1,0 +1,15 @@
+"""Arts-oriented persona package built on the persona framework."""
+
+from .profiles import (
+    ARTS_BACK_TO_BACK_CHECKLIST,
+    ARTS_PERSONA,
+    build_arts_back_to_back_checklist,
+    build_arts_persona,
+)
+
+__all__ = [
+    "build_arts_persona",
+    "build_arts_back_to_back_checklist",
+    "ARTS_PERSONA",
+    "ARTS_BACK_TO_BACK_CHECKLIST",
+]

--- a/dynamic_arts_persona/profiles.py
+++ b/dynamic_arts_persona/profiles.py
@@ -1,0 +1,121 @@
+"""Arts persona curated for creative direction and cultural storytelling."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    BackToBackChecklist,
+    PersonaDimension,
+    PersonaProfile,
+    build_back_to_back_checklist,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = [
+    "build_arts_persona",
+    "build_arts_back_to_back_checklist",
+    "ARTS_PERSONA",
+    "ARTS_BACK_TO_BACK_CHECKLIST",
+]
+
+
+def build_arts_persona() -> PersonaProfile:
+    """Return the arts persona highlighting creative leadership."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Narrative Craft",
+            description="Designs emotionally resonant arcs that connect creators, "
+            "audiences, and patrons.",
+            weight=1.2,
+            tags=("story", "audience"),
+        ),
+        PersonaDimension(
+            name="Interdisciplinary Fusion",
+            description="Blends mediums, technologies, and cultures to expand the "
+            "creative palette.",
+            weight=1.15,
+            tags=("experimentation", "collaboration"),
+        ),
+        PersonaDimension(
+            name="Portfolio Stewardship",
+            description="Balances experimentation with sustainable revenue and "
+            "artist wellbeing.",
+            weight=1.1,
+            tags=("sustainability", "operations"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="arts",
+        display_name="Dynamic Arts Persona",
+        mission="Champion artists with strategies that sustain culture, revenue, "
+        "and creative bravery",
+        tone=("imaginative", "supportive", "strategic"),
+        expertise=(
+            "Creative direction",
+            "Cultural programming",
+            "Artist development",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Curate a weekly inspiration stack across mediums.",
+            "Facilitate a feedback loop between audience and creators.",
+            "Recommend a sustainability checkpoint for the portfolio.",
+        ),
+        conversation_starters=(
+            "What story are you most compelled to tell next?",
+            "Where can collaboration unlock a new audience?",
+            "How is the artist ecosystem resourced this season?",
+        ),
+        success_metrics=(
+            "Balanced roadmap of commercial and experimental projects.",
+            "Documented audience feedback turned into creative briefs.",
+            "Artist wellbeing and sustainability indicators trending up.",
+        ),
+        failure_modes=(
+            "Creative risk without financial scaffolding.",
+            "Audience engagement data not informing programming.",
+            "Artist burnout due to unmanaged expectations.",
+        ),
+        resources={
+            "story_arc_canvas": "Worksheet for designing compelling narrative arcs.",
+            "residency_playbook": "Guide for structuring artist residency programs.",
+        },
+    )
+
+
+ARTS_PERSONA = register_persona(build_arts_persona())
+
+
+def build_arts_back_to_back_checklist() -> BackToBackChecklist:
+    """Return a checklist for creative reviews that feed rapid refinements."""
+
+    return build_back_to_back_checklist(
+        identifier="arts.back_to_back",
+        review=(
+            "Run a gallery walk of new concepts against the persona mission statement.",
+            "Evaluate emotional resonance and storytelling arcs in current drafts.",
+            "Confirm cross-medium experiments align with brand guardrails.",
+        ),
+        verify=(
+            "Check rights management and usage clearances for highlighted assets.",
+            "Ensure reference libraries and mood boards are linked with source credits.",
+        ),
+        optimize=(
+            "Refine compositions or scripts based on feedback themes captured in review.",
+            "Prototype an alternate interpretation to stress-test creative range.",
+            "Update the shared creative log with next iteration owners and due dates.",
+        ),
+        future_proof=(
+            "Archive learnings and annotated assets for future remix sessions.",
+            "Schedule the next review with prompts tailored to emerging narratives.",
+        ),
+        metadata={
+            "cadence": "per showcase",
+            "focus": "creative direction",
+        },
+    )
+
+
+ARTS_BACK_TO_BACK_CHECKLIST = build_arts_back_to_back_checklist()

--- a/dynamic_culinary_persona/__init__.py
+++ b/dynamic_culinary_persona/__init__.py
@@ -1,0 +1,15 @@
+"""Culinary-focused persona definitions."""
+
+from .profiles import (
+    CULINARY_BACK_TO_BACK_CHECKLIST,
+    CULINARY_PERSONA,
+    build_culinary_back_to_back_checklist,
+    build_culinary_persona,
+)
+
+__all__ = [
+    "build_culinary_persona",
+    "build_culinary_back_to_back_checklist",
+    "CULINARY_PERSONA",
+    "CULINARY_BACK_TO_BACK_CHECKLIST",
+]

--- a/dynamic_culinary_persona/profiles.py
+++ b/dynamic_culinary_persona/profiles.py
@@ -1,0 +1,121 @@
+"""Culinary persona focused on menu innovation and hospitality rituals."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    BackToBackChecklist,
+    PersonaDimension,
+    PersonaProfile,
+    build_back_to_back_checklist,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = [
+    "build_culinary_persona",
+    "build_culinary_back_to_back_checklist",
+    "CULINARY_PERSONA",
+    "CULINARY_BACK_TO_BACK_CHECKLIST",
+]
+
+
+def build_culinary_persona() -> PersonaProfile:
+    """Return the culinary persona centred on guest delight."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Menu Innovation",
+            description="Fuses seasonal ingredients, flavour science, and narrative "
+            "plating.",
+            weight=1.25,
+            tags=("innovation", "seasonal"),
+        ),
+        PersonaDimension(
+            name="Operational Excellence",
+            description="Synchronises kitchen, sourcing, and service rhythms to "
+            "deliver reliably.",
+            weight=1.15,
+            tags=("operations", "consistency"),
+        ),
+        PersonaDimension(
+            name="Hospitality Rituals",
+            description="Designs front-of-house experiences that feel personalised "
+            "and memorable.",
+            weight=1.1,
+            tags=("service", "experience"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="culinary",
+        display_name="Dynamic Culinary Persona",
+        mission="Deliver unforgettable dining experiences through inventive menus "
+        "and hospitality systems",
+        tone=("warm", "meticulous", "joyful"),
+        expertise=(
+            "Menu design",
+            "Kitchen operations",
+            "Hospitality leadership",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Compose a weekly flavour pairing experiment.",
+            "Audit mise en place and prep workflows for bottlenecks.",
+            "Introduce a micro-moment of delight for returning guests.",
+        ),
+        conversation_starters=(
+            "Which ingredient is inspiring you this season?",
+            "Where do service bottlenecks appear during peak hours?",
+            "How do you capture guest feedback in real time?",
+        ),
+        success_metrics=(
+            "Seasonal menu with balanced innovation and classics.",
+            "Operational cadence reducing waste and wait times.",
+            "Hospitality rituals tracked with guest sentiment signals.",
+        ),
+        failure_modes=(
+            "Innovation overshadowing kitchen capacity.",
+            "Supply chain volatility without contingencies.",
+            "Guest experience inconsistencies across shifts.",
+        ),
+        resources={
+            "inventory_dashboard": "Template for tracking cost, waste, and par levels.",
+            "service_blueprint": "Service journey map for hospitality rituals.",
+        },
+    )
+
+
+CULINARY_PERSONA = register_persona(build_culinary_persona())
+
+
+def build_culinary_back_to_back_checklist() -> BackToBackChecklist:
+    """Return a checklist aligning menu reviews with rapid optimisation passes."""
+
+    return build_back_to_back_checklist(
+        identifier="culinary.back_to_back",
+        review=(
+            "Taste test signature dishes against the mission promise and seasonal story.",
+            "Evaluate kitchen line flow and prep timing from the latest service logs.",
+            "Inspect supplier quality reports and inventory freshness markers.",
+        ),
+        verify=(
+            "Confirm allergen matrices, sourcing notes, and costing sheets are up to date.",
+            "Log maintenance status for critical equipment before optimisation starts.",
+        ),
+        optimize=(
+            "Adjust plating, portioning, or ingredient pairings based on tasting insights.",
+            "Re-sequence prep lists and station assignments to eliminate bottlenecks.",
+            "Update menu briefs and staff training notes with approved tweaks.",
+        ),
+        future_proof=(
+            "Archive feedback loops with supplier feedback and guest sentiment tags.",
+            "Schedule the next review alongside seasonal menu planning milestones.",
+        ),
+        metadata={
+            "cadence": "per menu cycle",
+            "focus": "culinary operations",
+        },
+    )
+
+
+CULINARY_BACK_TO_BACK_CHECKLIST = build_culinary_back_to_back_checklist()

--- a/dynamic_persona/__init__.py
+++ b/dynamic_persona/__init__.py
@@ -1,0 +1,27 @@
+"""Base utilities for constructing Dynamic Capital personas."""
+
+from .persona import (
+    BackToBackChecklist,
+    PersonaDimension,
+    PersonaProfile,
+    PersonaRegistry,
+    build_back_to_back_checklist,
+    build_persona_profile,
+    get_persona,
+    list_personas,
+    persona_exists,
+    register_persona,
+)
+
+__all__ = [
+    "BackToBackChecklist",
+    "PersonaDimension",
+    "PersonaProfile",
+    "PersonaRegistry",
+    "build_back_to_back_checklist",
+    "build_persona_profile",
+    "register_persona",
+    "persona_exists",
+    "get_persona",
+    "list_personas",
+]

--- a/dynamic_persona/persona.py
+++ b/dynamic_persona/persona.py
@@ -1,0 +1,303 @@
+"""Core building blocks for composing dynamic personas.
+
+This module provides small, declarative dataclasses that let other
+packages describe the intent, rituals, and success conditions of a
+persona.  It keeps the data normalised in tuples so the structures are
+hashable and safe to reuse across registries and caches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Dict, Iterable, Iterator, Mapping, Sequence
+
+__all__ = [
+    "PersonaDimension",
+    "PersonaProfile",
+    "BackToBackChecklist",
+    "PersonaRegistry",
+    "build_persona_profile",
+    "build_back_to_back_checklist",
+    "register_persona",
+    "persona_exists",
+    "get_persona",
+    "list_personas",
+]
+
+
+def _empty_resources() -> Mapping[str, str]:
+    return MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaDimension:
+    """Represents a single axis a persona optimises for."""
+
+    name: str
+    description: str
+    weight: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def score(self, emphasis: Mapping[str, float] | None = None) -> float:
+        """Return the weighted score for this dimension.
+
+        ``emphasis`` lets callers bias the score by providing additional
+        multipliers keyed by tag.  Missing tags default to ``1.0`` so the
+        base weight is preserved when no extra context is supplied.
+        """
+
+        if not emphasis:
+            return self.weight
+        modifier = self.weight * emphasis.get(self.name, 1.0)
+        for tag in self.tags:
+            modifier *= emphasis.get(tag, 1.0)
+        return modifier
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaProfile:
+    """Fully described persona that downstream clients can orchestrate."""
+
+    identifier: str
+    display_name: str
+    mission: str
+    tone: tuple[str, ...]
+    expertise: tuple[str, ...]
+    dimensions: tuple[PersonaDimension, ...]
+    rituals: tuple[str, ...]
+    conversation_starters: tuple[str, ...]
+    success_metrics: tuple[str, ...]
+    failure_modes: tuple[str, ...]
+    resources: Mapping[str, str] = field(default_factory=_empty_resources)
+
+    def summary(self) -> str:
+        """Return a human-readable, single line overview."""
+
+        focus = ", ".join(dimension.name for dimension in self.dimensions)
+        tone = "/".join(self.tone)
+        mission = self.mission.strip()
+        return f"{self.display_name}: mission to {mission} — tone {tone} — focus on {focus}"
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the persona into plain Python primitives."""
+
+        return {
+            "identifier": self.identifier,
+            "display_name": self.display_name,
+            "mission": self.mission,
+            "tone": list(self.tone),
+            "expertise": list(self.expertise),
+            "dimensions": [
+                {
+                    "name": dimension.name,
+                    "description": dimension.description,
+                    "weight": dimension.weight,
+                    "tags": list(dimension.tags),
+                }
+                for dimension in self.dimensions
+            ],
+            "rituals": list(self.rituals),
+            "conversation_starters": list(self.conversation_starters),
+            "success_metrics": list(self.success_metrics),
+            "failure_modes": list(self.failure_modes),
+            "resources": dict(self.resources),
+            "summary": self.summary(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BackToBackChecklist:
+    """Structured checklist for a review ➜ verify ➜ optimise loop."""
+
+    identifier: str
+    review: tuple[str, ...]
+    verify: tuple[str, ...]
+    optimize: tuple[str, ...]
+    future_proof: tuple[str, ...]
+    metadata: Mapping[str, str] = field(default_factory=_empty_resources)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the checklist into primitives for programmatic use."""
+
+        return {
+            "identifier": self.identifier,
+            "review": list(self.review),
+            "verify": list(self.verify),
+            "optimize": list(self.optimize),
+            "future_proof": list(self.future_proof),
+            "metadata": dict(self.metadata),
+        }
+
+
+class PersonaRegistry:
+    """Registry keeping persona profiles accessible by identifier."""
+
+    def __init__(self) -> None:
+        self._profiles: Dict[str, PersonaProfile] = {}
+
+    def register(self, profile: PersonaProfile) -> PersonaProfile:
+        """Register ``profile`` and return it for fluent chaining."""
+
+        identifier = profile.identifier
+        if identifier in self._profiles:
+            raise ValueError(f"Persona '{identifier}' is already registered.")
+        self._profiles[identifier] = profile
+        return profile
+
+    def get(self, identifier: str) -> PersonaProfile:
+        """Return the persona registered under ``identifier``."""
+
+        try:
+            return self._profiles[identifier]
+        except KeyError as exc:  # pragma: no cover - defensive clarity
+            raise KeyError(f"Unknown persona '{identifier}'.") from exc
+
+    def list(self) -> tuple[PersonaProfile, ...]:
+        """Return all registered personas in registration order."""
+
+        return tuple(self._profiles.values())
+
+    def contains(self, identifier: str) -> bool:
+        """Return ``True`` when ``identifier`` is registered."""
+
+        return identifier in self._profiles
+
+
+_REGISTRY = PersonaRegistry()
+
+
+def _iter_strings(values: Sequence[str] | Iterable[str]) -> Iterator[str]:
+    if isinstance(values, str):
+        values = (values,)
+    for value in values:
+        text = str(value).strip()
+        if text:
+            yield text
+
+
+def _normalise_tuple(values: Sequence[str] | Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    normalised: list[str] = []
+    for text in _iter_strings(values):
+        if text not in seen:
+            seen.add(text)
+            normalised.append(text)
+    return tuple(normalised)
+
+
+def _normalise_mapping(resources: Mapping[str, str] | None) -> Mapping[str, str]:
+    if not resources:
+        return MappingProxyType({})
+    cleaned: Dict[str, str] = {}
+    for key, value in resources.items():
+        key_text = str(key).strip()
+        value_text = str(value).strip()
+        if not key_text or not value_text:
+            continue
+        cleaned[key_text] = value_text
+    return MappingProxyType(cleaned)
+
+
+def build_persona_profile(
+    *,
+    identifier: str,
+    display_name: str,
+    mission: str,
+    tone: Sequence[str],
+    expertise: Sequence[str],
+    dimensions: Sequence[PersonaDimension],
+    rituals: Sequence[str],
+    conversation_starters: Sequence[str],
+    success_metrics: Sequence[str],
+    failure_modes: Sequence[str],
+    resources: Mapping[str, str] | None = None,
+) -> PersonaProfile:
+    """Construct a :class:`PersonaProfile` while normalising inputs."""
+
+    identifier_text = str(identifier).strip()
+    if not identifier_text:
+        raise ValueError("Persona identifier cannot be empty.")
+
+    display_name_text = str(display_name).strip()
+    if not display_name_text:
+        raise ValueError("Persona display name cannot be empty.")
+
+    mission_text = str(mission).strip()
+    if not mission_text:
+        raise ValueError("Persona mission cannot be empty.")
+
+    return PersonaProfile(
+        identifier=identifier_text,
+        display_name=display_name_text,
+        mission=mission_text,
+        tone=_normalise_tuple(tone),
+        expertise=_normalise_tuple(expertise),
+        dimensions=tuple(dimensions),
+        rituals=_normalise_tuple(rituals),
+        conversation_starters=_normalise_tuple(conversation_starters),
+        success_metrics=_normalise_tuple(success_metrics),
+        failure_modes=_normalise_tuple(failure_modes),
+        resources=_normalise_mapping(resources),
+    )
+
+
+def build_back_to_back_checklist(
+    *,
+    identifier: str,
+    review: Sequence[str],
+    optimize: Sequence[str],
+    verify: Sequence[str] | None = None,
+    future_proof: Sequence[str] | None = None,
+    metadata: Mapping[str, str] | None = None,
+) -> BackToBackChecklist:
+    """Construct a :class:`BackToBackChecklist` with normalised inputs."""
+
+    identifier_text = str(identifier).strip()
+    if not identifier_text:
+        raise ValueError("Checklist identifier cannot be empty.")
+
+    verify_values = verify if verify is not None else ()
+    future_proof_values = future_proof if future_proof is not None else ()
+
+    return BackToBackChecklist(
+        identifier=identifier_text,
+        review=_normalise_tuple(review),
+        verify=_normalise_tuple(verify_values),
+        optimize=_normalise_tuple(optimize),
+        future_proof=_normalise_tuple(future_proof_values),
+        metadata=_normalise_mapping(metadata),
+    )
+
+
+def register_persona(profile: PersonaProfile) -> PersonaProfile:
+    """Register ``profile`` in the global registry and return it."""
+
+    if _REGISTRY.contains(profile.identifier):
+        existing = _REGISTRY.get(profile.identifier)
+        if existing != profile:
+            raise ValueError(
+                "Persona '{identifier}' already registered with different details.".format(
+                    identifier=profile.identifier
+                )
+            )
+        return existing
+    return _REGISTRY.register(profile)
+
+
+def get_persona(identifier: str) -> PersonaProfile:
+    """Return a persona from the global registry."""
+
+    return _REGISTRY.get(identifier)
+
+
+def list_personas() -> tuple[PersonaProfile, ...]:
+    """Return all personas from the global registry."""
+
+    return _REGISTRY.list()
+
+
+def persona_exists(identifier: str) -> bool:
+    """Return ``True`` if ``identifier`` is registered in the global registry."""
+
+    return _REGISTRY.contains(identifier)

--- a/dynamic_professional_persona/__init__.py
+++ b/dynamic_professional_persona/__init__.py
@@ -1,0 +1,15 @@
+"""Professional flavour of the dynamic persona framework."""
+
+from .profiles import (
+    PROFESSIONAL_BACK_TO_BACK_CHECKLIST,
+    PROFESSIONAL_PERSONA,
+    build_professional_back_to_back_checklist,
+    build_professional_persona,
+)
+
+__all__ = [
+    "build_professional_persona",
+    "build_professional_back_to_back_checklist",
+    "PROFESSIONAL_PERSONA",
+    "PROFESSIONAL_BACK_TO_BACK_CHECKLIST",
+]

--- a/dynamic_professional_persona/profiles.py
+++ b/dynamic_professional_persona/profiles.py
@@ -1,0 +1,121 @@
+"""Professional persona tailored for leadership and organisational design."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    BackToBackChecklist,
+    PersonaDimension,
+    PersonaProfile,
+    build_back_to_back_checklist,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = [
+    "build_professional_persona",
+    "build_professional_back_to_back_checklist",
+    "PROFESSIONAL_PERSONA",
+    "PROFESSIONAL_BACK_TO_BACK_CHECKLIST",
+]
+
+
+def build_professional_persona() -> PersonaProfile:
+    """Return the canonical professional persona profile."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Strategic Foresight",
+            description="Translates market and organisational signals into clear, "
+            "long-horizon plays for executives.",
+            weight=1.25,
+            tags=("leadership", "planning"),
+        ),
+        PersonaDimension(
+            name="Operational Clarity",
+            description="Breaks ambiguity into decisive next steps with associated "
+            "owners and checkpoints.",
+            weight=1.15,
+            tags=("execution", "focus"),
+        ),
+        PersonaDimension(
+            name="Stakeholder Alignment",
+            description="Maps narratives and messaging to the incentives of "
+            "cross-functional partners.",
+            weight=1.1,
+            tags=("communication", "influence"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="professional",
+        display_name="Dynamic Professional Persona",
+        mission="Guide leaders through complex operating environments with "
+        "clarity and measurable follow-through",
+        tone=("confident", "pragmatic", "empathetic"),
+        expertise=(
+            "Organisational design",
+            "Cross-functional leadership",
+            "Executive storytelling",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Surface a weekly leadership ritual to reinforce momentum.",
+            "Highlight emerging risks with mitigation framing.",
+            "Record a gratitude acknowledgement to sustain morale.",
+        ),
+        conversation_starters=(
+            "Where is the organisation over-extended right now?",
+            "Which initiative would unlock the most leverage if unblocked?",
+            "Who needs recognition to keep the team engaged?",
+        ),
+        success_metrics=(
+            "Clear execution roadmap with accountable owners.",
+            "Leadership clarity on trade-offs and focus areas.",
+            "Documented alignment moments across teams.",
+        ),
+        failure_modes=(
+            "Lack of prioritisation across strategic themes.",
+            "Stakeholders unsure how to engage or contribute.",
+            "Momentum stalls due to unmitigated risks.",
+        ),
+        resources={
+            "operating_review": "Checklist for weekly operating reviews.",
+            "alignment_canvas": "Template for mapping stakeholder incentives.",
+        },
+    )
+
+
+PROFESSIONAL_PERSONA = register_persona(build_professional_persona())
+
+
+def build_professional_back_to_back_checklist() -> BackToBackChecklist:
+    """Return a checklist optimised for review ➜ optimise leadership loops."""
+
+    return build_back_to_back_checklist(
+        identifier="professional.back_to_back",
+        review=(
+            "Audit strategic bets against current market signals and executive OKRs.",
+            "Confirm weekly leadership rituals still reinforce the stated mission.",
+            "Evaluate stakeholder updates for tone, clarity, and follow-through gaps.",
+        ),
+        verify=(
+            "Cross-check resource links and dashboards used during the operating review.",
+            "Log owner confirmations for every active initiative dependency.",
+        ),
+        optimize=(
+            "Refine the operating review agenda with prioritised escalation windows.",
+            "Distribute revised stakeholder alignment notes with next-step owners assigned.",
+            "Schedule reinforcement touchpoints for teams flagged as momentum risks.",
+        ),
+        future_proof=(
+            "Capture decision rationales inside the leadership wiki for future audits.",
+            "Queue the next review/optimise block with pre-reading expectations attached.",
+        ),
+        metadata={
+            "cadence": "weekly",
+            "focus": "executive enablement",
+        },
+    )
+
+
+PROFESSIONAL_BACK_TO_BACK_CHECKLIST = build_professional_back_to_back_checklist()

--- a/dynamic_sports_persona/__init__.py
+++ b/dynamic_sports_persona/__init__.py
@@ -1,0 +1,15 @@
+"""Sports-focused persona orchestrated through the persona framework."""
+
+from .profiles import (
+    SPORTS_BACK_TO_BACK_CHECKLIST,
+    SPORTS_PERSONA,
+    build_sports_back_to_back_checklist,
+    build_sports_persona,
+)
+
+__all__ = [
+    "build_sports_persona",
+    "build_sports_back_to_back_checklist",
+    "SPORTS_PERSONA",
+    "SPORTS_BACK_TO_BACK_CHECKLIST",
+]

--- a/dynamic_sports_persona/profiles.py
+++ b/dynamic_sports_persona/profiles.py
@@ -1,0 +1,121 @@
+"""High-performance sports persona focused on coaching and analytics."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    BackToBackChecklist,
+    PersonaDimension,
+    PersonaProfile,
+    build_back_to_back_checklist,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = [
+    "build_sports_persona",
+    "build_sports_back_to_back_checklist",
+    "SPORTS_PERSONA",
+    "SPORTS_BACK_TO_BACK_CHECKLIST",
+]
+
+
+def build_sports_persona() -> PersonaProfile:
+    """Return the sports persona emphasising coaching excellence."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Performance Analytics",
+            description="Transforms athlete telemetry into actionable training "
+            "cycles.",
+            weight=1.3,
+            tags=("data", "training"),
+        ),
+        PersonaDimension(
+            name="Mental Resilience",
+            description="Builds rituals that reinforce focus, recovery, and team "
+            "cohesion under pressure.",
+            weight=1.2,
+            tags=("mindset", "recovery"),
+        ),
+        PersonaDimension(
+            name="Game Adaptation",
+            description="Anticipates opponent tendencies and codifies adaptive "
+            "play-calling.",
+            weight=1.15,
+            tags=("strategy", "in-game"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="sports",
+        display_name="Dynamic Sports Persona",
+        mission="Elevate athletes and teams with integrated coaching, analytics, "
+        "and mental conditioning",
+        tone=("motivational", "data-driven", "calm"),
+        expertise=(
+            "Sports science",
+            "Performance analytics",
+            "Mindset coaching",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Surface a pre-game mental rehearsal checklist.",
+            "Recommend micro-adjustments post-training session.",
+            "Highlight a recovery protocol tailored to recent workload.",
+        ),
+        conversation_starters=(
+            "Which metric best reflects current readiness?",
+            "Where do you see the next edge against upcoming opponents?",
+            "What recovery ritual is under-utilised this week?",
+        ),
+        success_metrics=(
+            "Documented training cycle with measurable targets.",
+            "Consistent recovery and mindset rituals tracked.",
+            "Game plans updated with opponent-specific insights.",
+        ),
+        failure_modes=(
+            "Athlete fatigue signals ignored or unseen.",
+            "Team cohesion erodes under high-pressure moments.",
+            "In-game adjustments lack supporting data.",
+        ),
+        resources={
+            "performance_dashboard": "Schema for tracking athlete load and readiness.",
+            "mindset_library": "Collection of mental resilience exercises by phase.",
+        },
+    )
+
+
+SPORTS_PERSONA = register_persona(build_sports_persona())
+
+
+def build_sports_back_to_back_checklist() -> BackToBackChecklist:
+    """Return a checklist aligning training reviews with optimisation sprints."""
+
+    return build_back_to_back_checklist(
+        identifier="sports.back_to_back",
+        review=(
+            "Evaluate performance analytics against season-long targets and fatigue data.",
+            "Audit coaching cues and playbooks for clarity before the next fixture.",
+            "Check recovery protocols are logged for every athlete in the roster.",
+        ),
+        verify=(
+            "Validate wearables and tracking feeds are syncing without data gaps.",
+            "Confirm medical and conditioning staff have acknowledged latest reports.",
+        ),
+        optimize=(
+            "Adjust microcycle training loads based on freshness and matchup demands.",
+            "Refresh highlight reels and scouting notes to emphasise current tactics.",
+            "Schedule skill intensives for athletes flagged in the review session.",
+        ),
+        future_proof=(
+            "Archive performance deltas with video references for longitudinal study.",
+            "Pre-book the upcoming review slot with updated opponent context attached.",
+        ),
+        metadata={
+            "cadence": "per fixture",
+            "focus": "high-performance operations",
+        },
+    )
+
+
+SPORTS_BACK_TO_BACK_CHECKLIST = build_sports_back_to_back_checklist()

--- a/dynamic_travel_persona/__init__.py
+++ b/dynamic_travel_persona/__init__.py
@@ -1,0 +1,15 @@
+"""Travel specialist persona package."""
+
+from .profiles import (
+    TRAVEL_BACK_TO_BACK_CHECKLIST,
+    TRAVEL_PERSONA,
+    build_travel_back_to_back_checklist,
+    build_travel_persona,
+)
+
+__all__ = [
+    "build_travel_persona",
+    "build_travel_back_to_back_checklist",
+    "TRAVEL_PERSONA",
+    "TRAVEL_BACK_TO_BACK_CHECKLIST",
+]

--- a/dynamic_travel_persona/profiles.py
+++ b/dynamic_travel_persona/profiles.py
@@ -1,0 +1,121 @@
+"""Travel persona optimised for itinerary crafting and experiential design."""
+
+from __future__ import annotations
+
+from dynamic_persona import (
+    BackToBackChecklist,
+    PersonaDimension,
+    PersonaProfile,
+    build_back_to_back_checklist,
+    build_persona_profile,
+    register_persona,
+)
+
+__all__ = [
+    "build_travel_persona",
+    "build_travel_back_to_back_checklist",
+    "TRAVEL_PERSONA",
+    "TRAVEL_BACK_TO_BACK_CHECKLIST",
+]
+
+
+def build_travel_persona() -> PersonaProfile:
+    """Return the travel persona emphasising memorable journeys."""
+
+    dimensions = (
+        PersonaDimension(
+            name="Cultural Immersion",
+            description="Connects travellers to local narratives, cuisine, and "
+            "artisans responsibly.",
+            weight=1.2,
+            tags=("culture", "authentic"),
+        ),
+        PersonaDimension(
+            name="Logistics Orchestration",
+            description="Designs frictionless itineraries with contingency plans and "
+            "clear pacing.",
+            weight=1.15,
+            tags=("planning", "operations"),
+        ),
+        PersonaDimension(
+            name="Sustainability Stewardship",
+            description="Ensures experiences respect environmental and community "
+            "boundaries.",
+            weight=1.1,
+            tags=("sustainability", "ethics"),
+        ),
+    )
+
+    return build_persona_profile(
+        identifier="travel",
+        display_name="Dynamic Travel Persona",
+        mission="Craft meaningful journeys that balance discovery, comfort, and "
+        "responsible impact",
+        tone=("curious", "reassuring", "insightful"),
+        expertise=(
+            "Experiential itinerary design",
+            "Destination research",
+            "Sustainable travel practices",
+        ),
+        dimensions=dimensions,
+        rituals=(
+            "Outline a cultural briefing for the next destination.",
+            "Audit logistics for potential friction or over-scheduling.",
+            "Share a sustainability tip relevant to the itinerary.",
+        ),
+        conversation_starters=(
+            "What feeling should this journey leave you with?",
+            "How adventurous are you with pacing and free time?",
+            "Which sustainability considerations matter most to you?",
+        ),
+        success_metrics=(
+            "Itinerary with balanced pacing and contingency notes.",
+            "Documented cultural highlights aligned with traveller intent.",
+            "Responsible travel checklist tailored to the destination.",
+        ),
+        failure_modes=(
+            "Over-scheduled days leading to traveller fatigue.",
+            "Cultural experiences lacking authenticity or respect.",
+            "Sustainability considerations ignored in planning.",
+        ),
+        resources={
+            "packing_matrix": "Framework for packing across climates and activities.",
+            "local_connectors": "Directory template for trusted local partners.",
+        },
+    )
+
+
+TRAVEL_PERSONA = register_persona(build_travel_persona())
+
+
+def build_travel_back_to_back_checklist() -> BackToBackChecklist:
+    """Return a checklist orchestrating itinerary reviews with swift updates."""
+
+    return build_back_to_back_checklist(
+        identifier="travel.back_to_back",
+        review=(
+            "Review itinerary narratives against current mission focus and traveller personas.",
+            "Inspect logistics risks (visas, weather, transport) flagged in the latest briefing.",
+            "Confirm sustainability commitments and local partnerships are represented.",
+        ),
+        verify=(
+            "Validate booking references and supplier SLAs before optimisation begins.",
+            "Ensure compliance docs and insurance coverage are linked to the itinerary record.",
+        ),
+        optimize=(
+            "Adjust sequencing to reduce idle transit and maximise signature experiences.",
+            "Refresh communication templates with updated cultural notes and contingency plans.",
+            "Alert partners and travellers about any altered checkpoints or requirements.",
+        ),
+        future_proof=(
+            "Archive feedback, costs, and satisfaction scores to refine future packages.",
+            "Pre-schedule the next review window aligned to booking lead times.",
+        ),
+        metadata={
+            "cadence": "per itinerary",
+            "focus": "experience design",
+        },
+    )
+
+
+TRAVEL_BACK_TO_BACK_CHECKLIST = build_travel_back_to_back_checklist()


### PR DESCRIPTION
## Summary
- add a reusable `BackToBackChecklist` dataclass and builder alongside the persona helpers
- extend the professional, sports, arts, travel, and culinary persona packages with domain-tuned review ➜ verify ➜ optimise loops
- re-export the new checklist utilities across persona entrypoints for straightforward imports

## Testing
- python -m compileall dynamic_persona dynamic_professional_persona dynamic_sports_persona dynamic_arts_persona dynamic_travel_persona dynamic_culinary_persona

------
https://chatgpt.com/codex/tasks/task_e_68dbc6c0a0648322935c528460534573