### PR TITLE
refine dynamic corpus deduplication

### DIFF
--- a/dynamic_corpus_extraction/__init__.py
+++ b/dynamic_corpus_extraction/__init__.py
@@ -1,0 +1,15 @@
+"""Dynamic corpus extraction engine."""
+
+from .engine import (
+    CorpusDocument,
+    CorpusExtractionContext,
+    CorpusExtractionSummary,
+    DynamicCorpusExtractionEngine,
+)
+
+__all__ = [
+    "CorpusDocument",
+    "CorpusExtractionContext",
+    "CorpusExtractionSummary",
+    "DynamicCorpusExtractionEngine",
+]

--- a/dynamic_corpus_extraction/engine.py
+++ b/dynamic_corpus_extraction/engine.py
@@ -1,0 +1,349 @@
+"""Composable corpus extraction engine with deduplication and export helpers."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from time import monotonic
+from types import MappingProxyType
+from typing import Callable, Iterable, Literal, Mapping, MutableMapping, Sequence, cast
+
+__all__ = [
+    "CorpusDocument",
+    "CorpusExtractionContext",
+    "CorpusExtractionSummary",
+    "DynamicCorpusExtractionEngine",
+]
+
+@dataclass(slots=True)
+class CorpusDocument:
+    """Normalised representation of a corpus entry."""
+
+    identifier: str
+    content: str
+    source: str
+    metadata: MutableMapping[str, object] = field(default_factory=dict)
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.identifier = _normalise_identifier(self.identifier)
+        self.content = _normalise_text(self.content)
+        self.source = _normalise_identifier(self.source)
+        self.metadata = dict(self.metadata)
+        self.tags = _normalise_tags(self.tags)
+
+    def as_payload(self) -> MutableMapping[str, object]:
+        """Return a serialisable payload suitable for JSONL export."""
+
+        return {
+            "identifier": self.identifier,
+            "content": self.content,
+            "source": self.source,
+            "metadata": dict(self.metadata),
+            "tags": list(self.tags),
+        }
+
+
+@dataclass(slots=True)
+class CorpusExtractionContext:
+    """Context passed to source loaders with run level metadata."""
+
+    source: str
+    limit: int | None
+    metadata: Mapping[str, object]
+
+
+@dataclass(slots=True)
+class CorpusExtractionSummary:
+    """Summary returned after running an extraction cycle."""
+
+    documents: tuple[CorpusDocument, ...]
+    source_statistics: Mapping[str, int]
+    duplicate_count: int
+    elapsed_seconds: float
+
+    def as_dict(self) -> MutableMapping[str, object]:
+        return {
+            "documents": [document.as_payload() for document in self.documents],
+            "source_statistics": dict(self.source_statistics),
+            "duplicate_count": self.duplicate_count,
+            "elapsed_seconds": self.elapsed_seconds,
+        }
+
+    def export_jsonl(self, path: str | Path, *, ensure_ascii: bool = False) -> int:
+        """Write the extracted documents to ``path`` as JSONL and return count."""
+
+        handle_path = Path(path)
+        handle_path.parent.mkdir(parents=True, exist_ok=True)
+        count = 0
+        with handle_path.open("w", encoding="utf-8") as handle:
+            for document in self.documents:
+                json.dump(document.as_payload(), handle, ensure_ascii=ensure_ascii)
+                handle.write("\n")
+                count += 1
+        return count
+
+
+DeduplicateField = Literal["identifier", "content"]
+
+ExtractionLoader = Callable[[CorpusExtractionContext], Iterable[CorpusDocument | Mapping[str, object]]]
+
+
+@dataclass(slots=True)
+class _RegisteredSource:
+    name: str
+    loader: ExtractionLoader
+    tags: tuple[str, ...]
+    metadata: Mapping[str, object]
+
+
+class DynamicCorpusExtractionEngine:
+    """Coordinate multiple corpus loaders with configurable deduplication."""
+
+    def __init__(
+        self,
+        *,
+        deduplicate: bool = True,
+        deduplicate_fields: Sequence[str] | str = ("identifier", "content"),
+        attach_source_metadata: bool = True,
+    ) -> None:
+        self._deduplicate = deduplicate
+        self._deduplicate_fields: tuple[DeduplicateField, ...] = _normalise_deduplicate_fields(
+            deduplicate_fields
+        )
+        self._attach_source_metadata = attach_source_metadata
+        self._sources: dict[str, _RegisteredSource] = {}
+
+    # ---------------------------------------------------------------- register
+    def register_source(
+        self,
+        name: str,
+        loader: ExtractionLoader,
+        *,
+        tags: Sequence[str] | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> None:
+        """Register a new corpus source."""
+
+        key = _normalise_identifier(name)
+        if key in self._sources:
+            raise ValueError(f"source '{key}' is already registered")
+        self._sources[key] = _RegisteredSource(
+            name=key,
+            loader=loader,
+            tags=_normalise_tags(tags),
+            metadata=dict(metadata or {}),
+        )
+
+    def unregister_source(self, name: str) -> None:
+        key = _normalise_identifier(name)
+        self._sources.pop(key, None)
+
+    def list_sources(self) -> tuple[str, ...]:
+        return tuple(self._sources)
+
+    # ------------------------------------------------------------------- extract
+    def extract(
+        self,
+        *,
+        sources: Sequence[str] | None = None,
+        limit: int | None = None,
+        metadata: Mapping[str, object] | None = None,
+    ) -> CorpusExtractionSummary:
+        """Run extraction across selected sources and return a summary."""
+
+        selected = self._resolve_sources(sources)
+        run_metadata = dict(metadata or {})
+        context_metadata = MappingProxyType(run_metadata)
+        documents: list[CorpusDocument] = []
+        counts: Counter[str] = Counter()
+        duplicates = 0
+        trackers: dict[DeduplicateField, set[str]]
+        if self._deduplicate and self._deduplicate_fields:
+            trackers = {field: set() for field in self._deduplicate_fields}
+        else:
+            trackers = {}
+        start_time = monotonic()
+        remaining = limit
+
+        for source in selected:
+            context = CorpusExtractionContext(
+                source=source.name,
+                limit=remaining,
+                metadata=context_metadata,
+            )
+            try:
+                stream = source.loader(context)
+            except Exception as error:  # pragma: no cover - runtime safety net
+                raise RuntimeError(f"source '{source.name}' loader failed") from error
+            for raw_document in stream:
+                document = self._coerce_document(
+                    raw_document,
+                    source,
+                    run_metadata=run_metadata,
+                )
+                if trackers:
+                    field_values = {
+                        field: getattr(document, field)
+                        for field in trackers
+                    }
+                    if any(
+                        field_values[field] in seen
+                        for field, seen in trackers.items()
+                    ):
+                        duplicates += 1
+                        continue
+                    for field, seen in trackers.items():
+                        seen.add(field_values[field])
+                documents.append(document)
+                counts[source.name] += 1
+                if remaining is not None:
+                    remaining -= 1
+                    if remaining <= 0:
+                        elapsed = monotonic() - start_time
+                        return CorpusExtractionSummary(
+                            documents=tuple(documents),
+                            source_statistics=dict(counts),
+                            duplicate_count=duplicates,
+                            elapsed_seconds=elapsed,
+                        )
+        elapsed = monotonic() - start_time
+        return CorpusExtractionSummary(
+            documents=tuple(documents),
+            source_statistics=dict(counts),
+            duplicate_count=duplicates,
+            elapsed_seconds=elapsed,
+        )
+
+    # ------------------------------------------------------------------- helpers
+    def _resolve_sources(self, sources: Sequence[str] | None) -> tuple[_RegisteredSource, ...]:
+        if not sources:
+            return tuple(self._sources.values())
+        resolved: list[_RegisteredSource] = []
+        for name in sources:
+            key = _normalise_identifier(name)
+            if key not in self._sources:
+                raise KeyError(f"unknown source '{key}'")
+            resolved.append(self._sources[key])
+        return tuple(resolved)
+
+    def _coerce_document(
+        self,
+        payload: CorpusDocument | Mapping[str, object],
+        source: _RegisteredSource,
+        *,
+        run_metadata: Mapping[str, object],
+    ) -> CorpusDocument:
+        if isinstance(payload, CorpusDocument):
+            document = payload
+            if payload.source != source.name or source.tags:
+                document = replace(
+                    payload,
+                    source=source.name,
+                    tags=_merge_tags(payload.tags, source.tags),
+                )
+        else:
+            mapping = dict(payload)
+            identifier = str(mapping.get("identifier") or mapping.get("id") or "")
+            content = str(
+                mapping.get("content")
+                or mapping.get("text")
+                or mapping.get("body")
+                or mapping.get("response")
+                or ""
+            )
+            metadata = _normalise_metadata(mapping.get("metadata"))
+            tags = mapping.get("tags")
+            document = CorpusDocument(
+                identifier=identifier,
+                content=content,
+                source=source.name,
+                metadata=metadata,
+                tags=_merge_tags(tags, source.tags),
+            )
+        merged_metadata = self._merge_metadata(document.metadata, source.metadata, run_metadata)
+        if self._attach_source_metadata:
+            merged_metadata.setdefault("source", source.name)
+        document.metadata = merged_metadata
+        return document
+
+    @staticmethod
+    def _merge_metadata(
+        *sources: Mapping[str, object] | MutableMapping[str, object]
+    ) -> MutableMapping[str, object]:
+        merged: dict[str, object] = {}
+        for metadata in sources:
+            if metadata:
+                merged.update(metadata)
+        return merged
+
+
+def _normalise_identifier(value: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("identifier must not be empty")
+    return text
+
+
+def _normalise_text(value: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("content must not be empty")
+    return text
+
+
+def _normalise_tags(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    seen: set[str] = set()
+    result: list[str] = []
+    for tag in values:
+        candidate = tag.strip().lower()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        result.append(candidate)
+    return tuple(result)
+
+
+def _merge_tags(
+    values: Sequence[str] | None, defaults: Sequence[str] | None
+) -> tuple[str, ...]:
+    combined: list[str] = []
+    if defaults:
+        combined.extend(defaults)
+    if values:
+        combined.extend(values)
+    return _normalise_tags(combined)
+
+
+def _normalise_deduplicate_fields(
+    fields: Sequence[str] | str,
+) -> tuple[DeduplicateField, ...]:
+    if isinstance(fields, str):
+        normalised = (fields,)
+    else:
+        normalised = tuple(fields)
+    if not normalised:
+        return ()
+    allowed = {"identifier", "content"}
+    cleaned: list[str] = []
+    for field in normalised:
+        candidate = field.strip().lower()
+        if candidate not in allowed:
+            raise ValueError(
+                "deduplicate_fields must only include 'identifier' and/or 'content'"
+            )
+        if candidate not in cleaned:
+            cleaned.append(candidate)
+    return tuple(cast(DeduplicateField, candidate) for candidate in cleaned)
+
+
+def _normalise_metadata(metadata: object) -> MutableMapping[str, object]:
+    if metadata is None:
+        return {}
+    if isinstance(metadata, Mapping):
+        return dict(metadata)
+    raise TypeError("metadata must be a mapping if provided")

--- a/tests_python/test_dynamic_corpus_extraction_engine.py
+++ b/tests_python/test_dynamic_corpus_extraction_engine.py
@@ -1,0 +1,167 @@
+"""Tests for the dynamic corpus extraction engine."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from dynamic_corpus_extraction import (
+    CorpusDocument,
+    DynamicCorpusExtractionEngine,
+)
+
+
+def test_extracts_and_deduplicates(tmp_path: Path) -> None:
+    engine = DynamicCorpusExtractionEngine()
+    requested_limits: list[int | None] = []
+
+    def loader_alpha(context):
+        requested_limits.append(context.limit)
+        yield {"identifier": "alpha-1", "content": "Entry one"}
+        yield {"identifier": "alpha-2", "content": "Entry two"}
+
+    def loader_beta(context):
+        assert context.metadata["batch"] == "2024-11"
+        yield {"identifier": "alpha-2", "content": "Entry two"}  # duplicate id/content
+        yield CorpusDocument(
+            identifier="beta-1",
+            content="Entry three",
+            source=context.source,
+            tags=("News",),
+        )
+
+    engine.register_source("alpha", loader_alpha, tags=["Dictionary"])
+    engine.register_source("beta", loader_beta, tags=["News"])
+
+    summary = engine.extract(limit=3, metadata={"batch": "2024-11"})
+
+    assert [document.identifier for document in summary.documents] == [
+        "alpha-1",
+        "alpha-2",
+        "beta-1",
+    ]
+    assert summary.duplicate_count == 1
+    assert summary.source_statistics == {"alpha": 2, "beta": 1}
+    assert summary.documents[0].tags == ("dictionary",)
+    assert summary.documents[2].tags == ("news",)
+    assert summary.documents[2].metadata["source"] == "beta"
+    assert summary.documents[2].metadata["batch"] == "2024-11"
+    assert requested_limits[0] == 3
+
+    export_path = tmp_path / "corpus.jsonl"
+    count = summary.export_jsonl(export_path)
+    assert count == 3
+    lines = export_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 3
+    payload = json.loads(lines[0])
+    assert payload["identifier"] == "alpha-1"
+
+
+def test_registering_duplicate_source_raises() -> None:
+    engine = DynamicCorpusExtractionEngine()
+    engine.register_source("alpha", lambda context: ())
+    with pytest.raises(ValueError):
+        engine.register_source("alpha", lambda context: ())
+
+
+def test_limit_applies_globally() -> None:
+    engine = DynamicCorpusExtractionEngine()
+
+    def loader(context):
+        for index in range(5):
+            yield {"identifier": f"doc-{context.source}-{index}", "content": f"Body {index}"}
+
+    engine.register_source("alpha", loader)
+    engine.register_source("beta", loader)
+
+    summary = engine.extract(limit=2)
+
+    assert len(summary.documents) == 2
+    assert {document.source for document in summary.documents} == {"alpha"}
+
+
+def test_selecting_unknown_source_errors() -> None:
+    engine = DynamicCorpusExtractionEngine()
+    engine.register_source("alpha", lambda context: ())
+    with pytest.raises(KeyError):
+        engine.extract(sources=["beta"])
+
+
+def test_configurable_deduplication_fields() -> None:
+    engine = DynamicCorpusExtractionEngine(deduplicate_fields="identifier")
+
+    def alpha_loader(context):
+        yield {"identifier": "shared", "content": "Shared content"}
+
+    def beta_loader(context):
+        yield {"identifier": "shared", "content": "Unique beta"}
+        yield {"identifier": "beta-unique", "content": "Shared content"}
+
+    engine.register_source("alpha", alpha_loader)
+    engine.register_source("beta", beta_loader)
+
+    summary = engine.extract()
+
+    assert [document.identifier for document in summary.documents] == [
+        "shared",
+        "beta-unique",
+    ]
+    assert summary.duplicate_count == 1
+    assert summary.source_statistics == {"alpha": 1, "beta": 1}
+
+    engine_content = DynamicCorpusExtractionEngine(deduplicate_fields=["content"])
+    engine_content.register_source("alpha", alpha_loader)
+    engine_content.register_source("beta", beta_loader)
+
+    summary_content = engine_content.extract()
+
+    assert [document.identifier for document in summary_content.documents] == [
+        "shared",
+        "shared",
+    ]
+    assert summary_content.duplicate_count == 1
+    assert summary_content.source_statistics == {"alpha": 1, "beta": 1}
+
+
+def test_invalid_deduplicate_field_configuration() -> None:
+    with pytest.raises(ValueError):
+        DynamicCorpusExtractionEngine(deduplicate_fields=("identifier", "unknown"))
+
+
+def test_metadata_context_is_read_only() -> None:
+    engine = DynamicCorpusExtractionEngine()
+    mutation_errors: list[Exception] = []
+
+    def loader(context):
+        try:
+            context.metadata["new"] = "value"
+        except TypeError as error:  # MappingProxyType prevents mutation
+            mutation_errors.append(error)
+        yield {"identifier": "alpha", "content": "Body"}
+
+    engine.register_source("alpha", loader)
+
+    summary = engine.extract(metadata={"batch": "2024-12"})
+
+    assert len(summary.documents) == 1
+    assert mutation_errors and isinstance(mutation_errors[0], TypeError)
+
+
+def test_deduplication_can_be_disabled() -> None:
+    engine = DynamicCorpusExtractionEngine(deduplicate=False)
+
+    def loader(context):
+        yield {"identifier": "dup", "content": "shared"}
+        yield {"identifier": "dup", "content": "shared"}
+
+    engine.register_source("alpha", loader)
+
+    summary = engine.extract()
+
+    assert [document.identifier for document in summary.documents] == ["dup", "dup"]
+    assert summary.duplicate_count == 0


### PR DESCRIPTION
## Summary
- streamline deduplication tracking with reusable field-based trackers and annotate the configured fields for clarity
- expose extraction metadata through an immutable view so loaders cannot accidentally mutate shared run metadata
- add regression tests covering disabled deduplication and the new read-only context metadata behaviour

## Testing
- pytest tests_python/test_dynamic_corpus_extraction_engine.py
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dbd4cbd3f08322a0a9c92f20495f31