### PR TITLE
Add step-by-step loop equation narrative

### DIFF
--- a/dynamic_loop/__init__.py
+++ b/dynamic_loop/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from .engine import (
     DynamicLoopEngine,
     LoopEquation,
+    LoopEquationDelta,
+    LoopEquationTimelineEntry,
     LoopParameters,
     LoopRecommendation,
     LoopSignal,
@@ -14,6 +16,8 @@ from .engine import (
 __all__ = [
     "DynamicLoopEngine",
     "LoopEquation",
+    "LoopEquationDelta",
+    "LoopEquationTimelineEntry",
     "LoopParameters",
     "LoopRecommendation",
     "LoopSignal",


### PR DESCRIPTION
## Summary
- extend loop equation payloads with a step-by-step narrative of review and optimise stages
- generate descriptive review, optimise, and delta messages during back-to-back loop scoring
- assert the new thinking trail in the dynamic loop tests and payload serialization

## Testing
- pytest tests_python/test_dynamic_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3bb22eb08322946aba13fbee374b