### PR TITLE
test: fix deno fmt parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Explore the broader platform anatomy and contributor guides:
 
 - [Master meta-model reference](models/meta_model.md) — shared state/control/dynamics grammar with module index.
 - [Dynamic Capital ecosystem anatomy](docs/dynamic-capital-ecosystem-anatomy.md)
+- [Dynamic Capital flow chart](docs/dynamic-capital-flow-chart.md) — high-level CI/CD and runtime topology across GitHub, Vercel, Supabase, DigitalOcean, and TON.
 - [Dynamic AI overview](docs/dynamic-ai-overview.md)
 - [Dynamic Trading ALGO vs LOGIC](docs/dynamic-trading-algo-vs-logic.md)
 - [Model intelligence & infrastructure reference](docs/model-intelligence-infrastructure-reference.md)

--- a/docs/dynamic-capital-flow-chart.md
+++ b/docs/dynamic-capital-flow-chart.md
@@ -1,0 +1,105 @@
+# Dynamic Capital Flow Chart
+
+This document summarizes the production deployment flow for Dynamic Capital
+across GitHub, Vercel, Supabase, DigitalOcean, and the TON blockchain.
+
+## Architecture Overview
+
+```text
+        ┌───────────────┐
+        │   GitHub Repo │
+        └───────┬───────┘
+                │ CI/CD
+                ▼
+┌───────────────────────────────────┐
+│            Vercel (UI)            │
+│  - Next.js / React frontend       │
+│  - Calls Supabase APIs            │
+│  - Served via .ton + .com domain  │
+└───────────────────────────────────┘
+                │
+                ▼
+┌───────────────────────────────────┐
+│        Supabase (Core Hub)        │
+│  - Postgres DB (users, signals)   │
+│  - Auth (wallet/email login)      │
+│  - Edge Functions (scoring, DCT)  │
+│  - Realtime (live mentorship feed)│
+└───────────────────────────────────┘
+                │
+                ▼
+┌───────────────────────────────────┐
+│   DigitalOcean (Heavy Backend)    │
+│  - AI inference (GPU workloads)   │
+│  - Trading models, pipelines      │
+│  - Exposed via API → Supabase     │
+└───────────────────────────────────┘
+                │
+                ▼
+┌───────────────────────────────────┐
+│        TON Blockchain Layer       │
+│  - .ton domain DNS → Vercel       │
+│  - Smart contracts (DCT burn, pay)│
+│  - Events consumed by Supabase    │
+└───────────────────────────────────┘
+```
+
+## Component Responsibilities
+
+### GitHub Repository
+
+- Source of truth for application code, infrastructure as code, and
+  documentation.
+- Drives automated CI/CD workflows that deploy updated frontends to Vercel and
+  backend services to Supabase/DigitalOcean.
+
+### Vercel (UI Layer)
+
+- Hosts the Next.js/React web experience served from both `.ton` and `.com`
+  domains.
+- Performs client interactions, calling Supabase APIs for data access and
+  authentication.
+- Acts as the public entry point for the Telegram Mini App and investor
+  dashboards.
+
+### Supabase (Core Hub)
+
+- Manages the Postgres database for users, trading signals, and mentorship
+  content.
+- Provides authentication via wallet and email flows.
+- Runs edge functions that power scoring engines and Dynamic Capital Token (DCT)
+  logic.
+- Streams realtime mentorship and trading updates to the UI layer.
+
+### DigitalOcean (Heavy Backend)
+
+- Executes GPU-intensive inference, training pipelines, and quantitative trading
+  models.
+- Exposes REST and websocket APIs that Supabase edge functions invoke for
+  advanced analytics.
+- Scales independently from the UI to handle burst compute demand.
+
+### TON Blockchain Layer
+
+- Resolves `.ton` DNS entries to the Vercel-hosted frontend.
+- Maintains smart contracts responsible for DCT mint/burn events and treasury
+  payments.
+- Emits on-chain events that Supabase ingests to keep the internal ledger
+  synchronized.
+
+## End-to-End Flow
+
+1. Developers push changes to GitHub, triggering CI/CD pipelines.
+2. Successful builds deploy the frontend to Vercel and update backend services
+   via Supabase migrations or DigitalOcean rollouts.
+3. End users access the app via `.ton` or `.com` domains, hitting the
+   Vercel-hosted UI.
+4. The UI calls Supabase for authentication, data retrieval, and edge function
+   execution.
+5. Supabase orchestrates heavy computations by calling DigitalOcean APIs and
+   receives blockchain events from TON.
+6. TON smart contracts finalize token operations while Supabase reconciles
+   events and updates the UI in realtime.
+
+This flow ensures a cohesive pipeline from code commits through on-chain
+settlement, balancing developer velocity with operational resilience.

--- a/supabase/functions/_tests/helpers.ts
+++ b/supabase/functions/_tests/helpers.ts
@@ -12,9 +12,7 @@ export function setTestEnv(kv: Record<string, string>) {
 export async function makeTelegramInitData(
   user: Record<string, unknown>,
   botToken: string,
-  extra: Record<string, string> = {
-    await Promise.resolve(); // satisfy require-await
-},
+  extra: Record<string, string> = {},
 ) {
   // builds a valid WebApp initData for tests
   const enc = new TextEncoder();

--- a/supabase/functions/_tests/payments-flags.test.ts
+++ b/supabase/functions/_tests/payments-flags.test.ts
@@ -1,34 +1,44 @@
 import { assertEquals } from "std/testing/asserts.ts";
-import { setConfig, getFlag } from "../_shared/config.ts";
+import { getFlag, setConfig } from "../_shared/config.ts";
 
-async function applyAutoApprove(payment: {
-  await Promise.resolve(); // satisfy require-await
- method: string; status: string }) {
+interface Payment {
+  method: string;
+  status: string;
+}
+
+async function applyAutoApprove(payment: Payment) {
   const flag = await getFlag(`auto_approve_${payment.method}`, false);
   payment.status = flag ? "completed" : "awaiting_admin";
 }
 
 Deno.test("crypto auto-approval flag", async () => {
-  await setConfig("features:published", { data: { auto_approve_crypto: true } });
+  await setConfig("features:published", {
+    data: { auto_approve_crypto: true },
+  });
   const p1 = { method: "crypto", status: "pending" };
   await applyAutoApprove(p1);
   assertEquals(p1.status, "completed");
 
-  await setConfig("features:published", { data: { auto_approve_crypto: false } });
+  await setConfig("features:published", {
+    data: { auto_approve_crypto: false },
+  });
   const p2 = { method: "crypto", status: "pending" };
   await applyAutoApprove(p2);
   assertEquals(p2.status, "awaiting_admin");
 });
 
 Deno.test("bank transfer auto-approval flag", async () => {
-  await setConfig("features:published", { data: { auto_approve_bank_transfer: true } });
+  await setConfig("features:published", {
+    data: { auto_approve_bank_transfer: true },
+  });
   const p1 = { method: "bank_transfer", status: "pending" };
   await applyAutoApprove(p1);
   assertEquals(p1.status, "completed");
 
-  await setConfig("features:published", { data: { auto_approve_bank_transfer: false } });
+  await setConfig("features:published", {
+    data: { auto_approve_bank_transfer: false },
+  });
   const p2 = { method: "bank_transfer", status: "pending" };
   await applyAutoApprove(p2);
   assertEquals(p2.status, "awaiting_admin");
 });
-


### PR DESCRIPTION
## Summary
- remove invalid default parameter hack in the Telegram test helper so deno fmt can parse the file
- tidy the payments flag test by introducing a Payment interface and eliminating stray statements in the parameter list

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dc499261cc8322a4ae1f895653dd54