### PR TITLE
Refine cosmological expansion calibration

### DIFF
--- a/docs/fundamental-forces-and-cosmology.md
+++ b/docs/fundamental-forces-and-cosmology.md
@@ -82,6 +82,47 @@ Einstein's field equations explain how matter and energy curve spacetime:
 - **Control optimization:** Solve a quadratic program minimizing curvature
   variance subject to cash runway constraints before approving capital moves.
 
+### Dark Energy → Expansion Pace & Treasury Runway Pressure
+
+The cosmological constant and the dark energy equation of state introduce a
+baseline acceleration in general relativity:
+
+\[ R_{\mu\nu} - \tfrac{1}{2} R g_{\mu\nu} + \Lambda g_{\mu\nu} = \frac{8 \pi
+G}{c^4} T_{\mu\nu}, \qquad p = w \rho. \]
+
+- **Cosmological constant (\(\Lambda\)) → Fixed runway drag:** Treat recurring
+  operational burn, compliance overhead, and required community incentives as an
+  immutable background term. Even when no new initiatives are funded, that
+  pressure accelerates cash consumption.
+- **Equation of state (\(w\)) → Growth posture:** Aggressive expansion modes
+  (marketing pushes, new chain deployments) behave like \(w < -1/3\), creating
+  negative pressure that speeds up treasury drawdown. A conservative posture
+  keeps \(w \approx -1\), ensuring burn is offset by yield or fee revenue.
+- **Friedmann acceleration (\(\ddot{a}/a = -\frac{4\pi G}{3c^2} (\rho + 3p)\)) →
+  Liquidity slope:** Translate the acceleration term into a KPI that tracks how
+  fast available liquidity changes under the current burn and revenue profile.
+  Positive acceleration signals unsustainable momentum—trigger a slowdown before
+  reserves fall below guardrails.
+- **Continuity (\( \dot{\rho}_{\text{DE}} + 3 H (\rho_{\text{DE}} +
+  p_{\text{DE}}) = 0 \)) → Forecast discipline:** Weekly runway models must
+  reconcile inflows, burn, and expansion bets. If "dark energy" initiatives are
+  assumed constant, enforce \(p_{\text{DE}} = -\rho_{\text{DE}}\) by earmarking
+  offsetting yield streams or trimming discretionary scope.
+- **Network density calibration → Resilience modifier:** Treat bridge-per-
+  phenomenon density around 1.0 as the neutral point. Higher densities increase
+  the expansion drag term, while sparse networks dampen it. The dynamic cosmic
+  engine now folds this calibration into a bounded stability multiplier so
+  treasury actions nudge resilience rather than whipsawing it.
+
+**Operational loop**
+
+1. **Review:** Publish a "cosmic constant" dashboard that compares observed burn
+   against the assumed \(\Lambda\) baseline and highlights when \(w\) deviates
+   from planned posture.
+2. **Optimize:** Adjust hiring, vendor spend, or incentive programs to return
+   \(w\) to the target band. Pair each change with a treasury hedging update so
+   long-horizon commitments stay solvent even under accelerated expansion.
+
 ## Electromagnetism → Signal Routing & Data Hygiene
 
 Maxwell's equations capture how electric and magnetic fields interact:

--- a/dynamic_agents/cosmic.py
+++ b/dynamic_agents/cosmic.py
@@ -59,12 +59,27 @@ class DynamicCosmicAgent:
         bridges = snapshot.get("bridges", [])
         events = snapshot.get("events", [])
         resilience = float(snapshot.get("resilience", 0.0) or 0.0)
+        expansion = snapshot.get("expansion", {}) if isinstance(snapshot, Mapping) else {}
         metrics = {
             "phenomena": float(len(phenomena)),
             "bridges": float(len(bridges)),
             "events": float(len(events)),
             "resilience": resilience,
         }
+        if isinstance(expansion, Mapping):
+            friedmann = float(expansion.get("friedmann_acceleration", 0.0) or 0.0)
+            continuity = float(expansion.get("continuity_residual", 0.0) or 0.0)
+            modifier = float(expansion.get("stability_modifier", 0.0) or 0.0)
+            metrics.update(
+                {
+                    "friedmann_acceleration": friedmann,
+                    "continuity_residual": continuity,
+                    "stability_modifier": modifier or 1.0,
+                }
+            )
+            equation_of_state = expansion.get("equation_of_state")
+            if isinstance(equation_of_state, (int, float)):
+                metrics["equation_of_state"] = float(equation_of_state)
         highlights: list[str] = []
         if phenomena:
             dominant = max(phenomena, key=lambda item: item.get("magnitude", 0.0))
@@ -73,6 +88,13 @@ class DynamicCosmicAgent:
             )
         if bridges:
             highlights.append(f"Network bridges active: {len(bridges)}")
+        if isinstance(expansion, Mapping):
+            friedmann = float(expansion.get("friedmann_acceleration", 0.0) or 0.0)
+            continuity = float(expansion.get("continuity_residual", 0.0) or 0.0)
+            if friedmann > 0.05:
+                highlights.append(f"Expansion acceleration {friedmann:.2f}")
+            if continuity > 0.05:
+                highlights.append(f"Runway drag index {continuity:.2f}")
         details = {"snapshot": snapshot}
         return AgentInsight(
             domain=self.domain,

--- a/dynamic_cosmic/__init__.py
+++ b/dynamic_cosmic/__init__.py
@@ -3,6 +3,7 @@
 from .cosmic import (
     CosmicBridge,
     CosmicCoordinate,
+    CosmicExpansionModel,
     CosmicPhenomenon,
     CosmicSignal,
     CosmicTimelineEvent,
@@ -12,6 +13,7 @@ from .cosmic import (
 __all__ = [
     "CosmicBridge",
     "CosmicCoordinate",
+    "CosmicExpansionModel",
     "CosmicPhenomenon",
     "CosmicSignal",
     "CosmicTimelineEvent",

--- a/dynamic_cosmic/__main__.py
+++ b/dynamic_cosmic/__main__.py
@@ -212,7 +212,12 @@ def _load_config(path: Path) -> Mapping[str, Any]:
 def build_engine(config: Mapping[str, Any]) -> DynamicCosmic:
     history_limit = int(config.get("history_limit", 500))
     phenomena = _build_phenomena(config.get("phenomena", []))
-    engine = DynamicCosmic(phenomena=phenomena, history_limit=history_limit)
+    expansion_config = config.get("expansion_model")
+    engine = DynamicCosmic(
+        phenomena=phenomena,
+        history_limit=history_limit,
+        expansion_model=expansion_config,
+    )
     _build_bridges(config.get("bridges", []), engine)
     _build_events(config.get("events", []), engine)
 
@@ -251,6 +256,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "phenomena": snapshot.get("phenomena", []),
         "bridges": snapshot.get("bridges", []),
         "events": snapshot.get("events", []),
+        "expansion": snapshot.get("expansion", {}),
     }
 
     if args.pretty:

--- a/supabase/functions/_tests/helpers.ts
+++ b/supabase/functions/_tests/helpers.ts
@@ -12,9 +12,7 @@ export function setTestEnv(kv: Record<string, string>) {
 export async function makeTelegramInitData(
   user: Record<string, unknown>,
   botToken: string,
-  extra: Record<string, string> = {
-    await Promise.resolve(); // satisfy require-await
-},
+  extra: Record<string, string> = {},
 ) {
   // builds a valid WebApp initData for tests
   const enc = new TextEncoder();

--- a/supabase/functions/_tests/payments-flags.test.ts
+++ b/supabase/functions/_tests/payments-flags.test.ts
@@ -1,34 +1,42 @@
 import { assertEquals } from "std/testing/asserts.ts";
-import { setConfig, getFlag } from "../_shared/config.ts";
+import { getFlag, setConfig } from "../_shared/config.ts";
 
 async function applyAutoApprove(payment: {
-  await Promise.resolve(); // satisfy require-await
- method: string; status: string }) {
+  method: string;
+  status: string;
+}) {
   const flag = await getFlag(`auto_approve_${payment.method}`, false);
   payment.status = flag ? "completed" : "awaiting_admin";
 }
 
 Deno.test("crypto auto-approval flag", async () => {
-  await setConfig("features:published", { data: { auto_approve_crypto: true } });
+  await setConfig("features:published", {
+    data: { auto_approve_crypto: true },
+  });
   const p1 = { method: "crypto", status: "pending" };
   await applyAutoApprove(p1);
   assertEquals(p1.status, "completed");
 
-  await setConfig("features:published", { data: { auto_approve_crypto: false } });
+  await setConfig("features:published", {
+    data: { auto_approve_crypto: false },
+  });
   const p2 = { method: "crypto", status: "pending" };
   await applyAutoApprove(p2);
   assertEquals(p2.status, "awaiting_admin");
 });
 
 Deno.test("bank transfer auto-approval flag", async () => {
-  await setConfig("features:published", { data: { auto_approve_bank_transfer: true } });
+  await setConfig("features:published", {
+    data: { auto_approve_bank_transfer: true },
+  });
   const p1 = { method: "bank_transfer", status: "pending" };
   await applyAutoApprove(p1);
   assertEquals(p1.status, "completed");
 
-  await setConfig("features:published", { data: { auto_approve_bank_transfer: false } });
+  await setConfig("features:published", {
+    data: { auto_approve_bank_transfer: false },
+  });
   const p2 = { method: "bank_transfer", status: "pending" };
   await applyAutoApprove(p2);
   assertEquals(p2.status, "awaiting_admin");
 });
-

--- a/tests/test_dynamic_cosmic_engine.py
+++ b/tests/test_dynamic_cosmic_engine.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from dynamic_cosmic import (
+    CosmicBridge,
+    CosmicCoordinate,
+    CosmicExpansionModel,
+    CosmicPhenomenon,
+    CosmicSignal,
+    CosmicTimelineEvent,
+    DynamicCosmic,
+)
+
+
+def _phenomenon(identifier: str, magnitude: float, volatility: float) -> CosmicPhenomenon:
+    return CosmicPhenomenon(
+        identifier=identifier,
+        location=CosmicCoordinate(0.0, 0.0, magnitude - 5.0),
+        magnitude=magnitude,
+        volatility=volatility,
+        signals=(
+            CosmicSignal(
+                identifier=f"{identifier}-beam",
+                wavelength_nm=520.0 + magnitude,
+                amplitude=3.2 + magnitude * 0.2,
+                coherence=0.7,
+                origin="Observatory",
+            ),
+        ),
+        tags=("cosmic", identifier),
+        metadata={"tier": magnitude},
+    )
+
+
+def test_cosmic_expansion_model_derivations() -> None:
+    model = CosmicExpansionModel(
+        cosmological_constant=0.72,
+        equation_of_state=-1.0,
+        matter_density=0.28,
+        hubble_constant=70.0,
+    )
+
+    telemetry = model.telemetry(network_density=1.5)
+
+    assert pytest.approx(telemetry["energy_density"], rel=1e-6) == 1.0
+    assert pytest.approx(telemetry["dark_energy_pressure"], rel=1e-6) == -0.72
+    assert telemetry["friedmann_acceleration"] > 0.0
+    assert 0.75 < telemetry["stability_modifier"] < 1.5
+    assert telemetry["continuity_residual"] != 0.0
+
+
+def test_dynamic_cosmic_resilience_modulated_by_expansion_profile() -> None:
+    base_model = CosmicExpansionModel(
+        cosmological_constant=0.6,
+        equation_of_state=-0.9,
+        matter_density=0.35,
+        hubble_constant=62.0,
+    )
+    tuned_model = CosmicExpansionModel(
+        cosmological_constant=1.05,
+        equation_of_state=-1.15,
+        matter_density=0.25,
+        hubble_constant=78.0,
+    )
+
+    phenomena = [
+        _phenomenon("aurora-core", 7.2, 0.24),
+        _phenomenon("quantum-halo", 6.8, 0.31),
+        _phenomenon("nebula-resonance", 6.5, 0.29),
+    ]
+    bridges = [
+        CosmicBridge(
+            source="aurora-core",
+            target="quantum-halo",
+            stability=0.74,
+            flux=4.4,
+            route_length=1.6,
+        ),
+        CosmicBridge(
+            source="quantum-halo",
+            target="nebula-resonance",
+            stability=0.69,
+            flux=4.1,
+            route_length=2.1,
+        ),
+    ]
+
+    base_engine = DynamicCosmic(phenomena=phenomena, bridges=bridges, expansion_model=base_model)
+    tuned_engine = DynamicCosmic(phenomena=phenomena, bridges=bridges, expansion_model=tuned_model)
+
+    base_resilience = base_engine.evaluate_resilience()
+    tuned_resilience = tuned_engine.evaluate_resilience()
+
+    assert base_resilience != pytest.approx(tuned_resilience)
+
+    base_snapshot = base_engine.snapshot()
+    tuned_snapshot = tuned_engine.snapshot()
+
+    assert pytest.approx(base_snapshot["resilience"]) == base_resilience
+    assert pytest.approx(tuned_snapshot["resilience"]) == tuned_resilience
+    assert base_snapshot["expansion"]["stability_modifier"] != pytest.approx(
+        tuned_snapshot["expansion"]["stability_modifier"]
+    )
+    assert base_snapshot["expansion"]["friedmann_acceleration"] > 0.0
+    assert tuned_snapshot["expansion"]["friedmann_acceleration"] > 0.0
+
+    base_engine.record_event(
+        CosmicTimelineEvent(
+            description="Calibration sweep",
+            impact=0.42,
+            timestamp=datetime(2024, 1, 12, 15, 30, tzinfo=timezone.utc),
+        )
+    )
+    tuned_engine.record_event(
+        CosmicTimelineEvent(
+            description="Stability pulse",
+            impact=0.37,
+            timestamp=datetime(2024, 2, 4, 10, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    assert base_engine.history_size == 1
+    assert tuned_engine.history_size == 1
+
+
+def test_configure_expansion_accepts_reset() -> None:
+    engine = DynamicCosmic()
+    custom = engine.configure_expansion({"cosmological_constant": 0.9, "matter_density": 0.2})
+    assert isinstance(custom, CosmicExpansionModel)
+    assert custom.cosmological_constant == 0.9
+
+    reset_model = engine.configure_expansion(None)
+    assert isinstance(reset_model, CosmicExpansionModel)
+    assert reset_model.cosmological_constant == pytest.approx(0.7)


### PR DESCRIPTION
## Summary
- smooth the CosmicExpansionModel dynamics with a bounded sigmoid response and density-neutral continuity term
- allow DynamicCosmic.configure_expansion to reset to defaults and document the network-density review/optimise cadence
- extend the expansion engine tests to cover reset behaviour and updated telemetry expectations

## Testing
- npm run format
- pytest tests/test_dynamic_cosmic_engine.py


------
https://chatgpt.com/codex/tasks/task_e_68dc48a9995883228a7639578987c385