### PR TITLE
chore: add automation for ecosystem deployment checklist

### DIFF
--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -47,6 +47,7 @@ key.
 | 18       | [`NFT Collectible Launch Checklist`](./nft-collectible-launch-checklist.md)                           | End-to-end preparation for story-driven NFT drops                                | Plan concept, metadata, utility, and community execution for a new collection         | `nft-collectible`     |
 | 19       | [`Dynamic AI (DAI) Validation`](./dai-dagi-dct-dtl-dta-checklist-review.md#dynamic-ai-dai)            | Domain health checks for Dynamic AI telemetry, routing, and personas             | Run Dynamic AI regression tests before shipping Brain/orchestrator updates            | `dai`                 |
 | 20       | [`Dynamic AGI (DAGI) Oversight`](./dai-dagi-dct-dtl-dta-checklist-review.md#dynamic-agi-dagi)         | Orchestration, mentorship, and self-improvement verification for DAGI            | Exercise DAGI loops prior to infrastructure or governance changes                     | `dagi`                |
+| 21       | [`Dynamic Capital Ecosystem Deployment`](./dynamic-capital-ecosystem-deployment-checklist.md)        | Full-stack Supabase, Vercel, DigitalOcean, Telegram, and TON deployment readiness | Coordinate multi-surface go-lives with cross-team owners                                | `ecosystem-deployment` |
 
 ## Project delivery (priorities 1–3)
 
@@ -89,6 +90,8 @@ key.
 - **[`Vercel Production Checklist`](./VERCEL_PRODUCTION_CHECKLIST.md)** –
   applies the Vercel Well-Architected review to the hosted frontend. Ideal
   before handoffs or compliance reviews.
+- **[`Dynamic Capital Ecosystem Deployment Checklist`](./dynamic-capital-ecosystem-deployment-checklist.md)** –
+  orchestrates the Supabase, Vercel, DigitalOcean, Telegram, and TON go-live sequence with a single cross-team playbook.
 
 ## Specialized projects & integrations (priorities 9–12)
 

--- a/docs/dynamic-capital-ecosystem-deployment-checklist.md
+++ b/docs/dynamic-capital-ecosystem-deployment-checklist.md
@@ -1,0 +1,130 @@
+# Dynamic Capital Ecosystem Deployment Checklist
+
+Coordinate Supabase, Vercel, DigitalOcean, Telegram, and TON deliverables when
+launching or refreshing the Dynamic Capital ecosystem. Each section mirrors a
+platform owner. Complete every checkbox before marking the deployment ready.
+
+> **Automation:** Run `npm run checklists -- --checklist ecosystem-deployment`
+> to generate a progress report for this checklist.
+
+## Supabase Setup
+
+### Project Initialization
+
+- [ ] Create the Supabase project with the regional settings agreed on by the
+      infrastructure team.
+- [ ] Enable the managed Postgres database and Supabase Auth providers required
+      for the launch.
+- [ ] Configure row level security (RLS) policies so token-gated resources only
+      accept wallets with the required DCT balances.
+
+### Tables
+
+- [ ] Provision the `users` table with columns for wallet address, email, role,
+      and DCT balance.
+- [ ] Provision the `payments` table with columns for `tx_hash`, wallet, amount,
+      and `verified` status.
+- [ ] Provision the `mentorship_scores` table with columns for `user_id`,
+      `score`, and `timestamp`.
+- [ ] Provision the `signals` table with columns for asset, direction,
+      confidence, and timestamp.
+
+### Edge Functions
+
+- [ ] Implement `verifyPayment.ts` to validate TON transactions and update
+      `payments`.
+- [ ] Implement `scoreMentorship.ts` to run the AGI Oracle and update
+      `mentorship_scores`.
+- [ ] Implement `broadcastSignal.ts` to push new signals to Telegram and
+      Supabase Realtime channels.
+
+### Auth
+
+- [ ] Enable wallet-based login (TON Connect or the chosen custom provider).
+- [ ] Enable email/password login for administrator roles.
+
+## Vercel Frontend
+
+### UI Deployment
+
+- [ ] Connect the GitHub repository to Vercel and configure the production
+      branch.
+- [ ] Deploy the Next.js frontend.
+- [ ] Add the required `.env` variables, including Supabase keys and TON Connect
+      configuration.
+
+### API Integration
+
+- [ ] Call the Supabase Edge Functions responsible for scoring, payments, and
+      signals.
+- [ ] Subscribe to the `signals` and `mentorship_scores` channels through
+      Supabase Realtime.
+- [ ] Display dashboards, trading views, and mentorship tiers that reflect the
+      live Supabase data.
+
+### Domain Binding
+
+- [ ] Bind the `.ton` domain via TON DNS to the Vercel deployment.
+- [ ] (Optional) Add a `.com` or `.io` domain for universal access.
+- [ ] Configure redirects or dual entry points when multiple domains are active.
+
+## DigitalOcean Backend
+
+### AI Inference
+
+- [ ] Deploy the FastAPI or Node.js backend service.
+- [ ] Host the AGI Oracle, trading models, and mentorship scoring logic.
+- [ ] Expose `/predict`, `/oracle`, and `/burn` endpoints.
+
+### Supabase Integration
+
+- [ ] Ensure Supabase Edge Functions can call the DigitalOcean endpoints.
+- [ ] Secure the communication with API keys or JWT-based authentication.
+- [ ] Log inference and scoring results back into the Supabase database.
+
+### Infrastructure
+
+- [ ] Use DigitalOcean App Platform or managed Droplets for the deployment
+      target.
+- [ ] Enable HTTPS and configure firewall rules.
+- [ ] Monitor the service with uptime alerts.
+
+## Telegram Bot and Mini App
+
+### Bot Logic
+
+- [ ] Connect the Telegram bot to Supabase for user authentication and signal
+      delivery.
+- [ ] Trigger bot messages from the `broadcastSignal.ts` Edge Function.
+- [ ] Verify payments against TON smart contract events.
+
+### Mini App
+
+- [ ] Embed the frontend UI or mentorship dashboard inside the Telegram Mini
+      App.
+- [ ] Sync Mini App state with Supabase for live updates.
+- [ ] Enforce token-gated access using DCT balances.
+
+## TON Smart Contract Integration
+
+### Contract Deployment
+
+- [ ] Deploy the DCT token contract with burn and buyback logic.
+- [ ] Deploy the mentorship payment contract.
+- [ ] Emit events that Supabase services can consume.
+
+### Supabase Sync
+
+- [ ] Configure an Edge Function listener for TON transaction events.
+- [ ] Update the `payments` table and trigger mentorship scoring when new events
+      arrive.
+- [ ] (Optional) Trigger a DCT burn through the DigitalOcean backend when
+      thresholds are met.
+
+## Final Review
+
+- [ ] Confirm all services are deployed and connected end-to-end.
+- [ ] Verify domains resolve correctly across TON and conventional DNS entries.
+- [ ] Exercise each Edge Function to ensure authentication and input validation.
+- [ ] Confirm Realtime updates reach the frontend UI and Telegram bot.
+- [ ] Validate that smart contract events sync into Supabase without drift.

--- a/scripts/checklists/dynamic-capital-ecosystem-deployment.mjs
+++ b/scripts/checklists/dynamic-capital-ecosystem-deployment.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..");
+const DOC_RELATIVE_PATH =
+  "docs/dynamic-capital-ecosystem-deployment-checklist.md";
+const DOC_ABSOLUTE_PATH = path.join(PROJECT_ROOT, DOC_RELATIVE_PATH);
+
+const CHECKBOX_PATTERN = /^\s*-\s*\[(?<state>[ xX])\]\s*(?<text>.*)$/;
+
+function createSection(title) {
+  return {
+    title,
+    items: [],
+    subsections: [],
+  };
+}
+
+function createSubsection(title) {
+  return {
+    title,
+    items: [],
+  };
+}
+
+function finalizeItem(currentItem, target) {
+  if (!currentItem) {
+    return null;
+  }
+
+  const text = currentItem.text.trim();
+  if (text.length > 0) {
+    target.items.push({
+      status: currentItem.status,
+      text,
+    });
+  }
+
+  return null;
+}
+
+function parseDocument(content) {
+  const lines = content.split(/\r?\n/);
+
+  const sections = [];
+  let currentSection = null;
+  let currentSubsection = null;
+  let currentItem = null;
+
+  const pushSectionIfPresent = () => {
+    if (currentSection) {
+      currentItem = finalizeItem(
+        currentItem,
+        currentSubsection ?? currentSection,
+      );
+      sections.push(currentSection);
+    }
+  };
+
+  lines.forEach((rawLine) => {
+    const line = rawLine.trimEnd();
+
+    const sectionMatch = line.match(/^##\s+(?<title>.+)$/);
+    if (sectionMatch) {
+      if (
+        sectionMatch.groups.title ===
+          "Dynamic Capital Ecosystem Deployment Checklist"
+      ) {
+        return;
+      }
+
+      currentItem = finalizeItem(
+        currentItem,
+        currentSubsection ?? currentSection ?? createSection(""),
+      );
+      pushSectionIfPresent();
+      currentSection = createSection(sectionMatch.groups.title.trim());
+      currentSubsection = null;
+      return;
+    }
+
+    const subsectionMatch = line.match(/^###\s+(?<title>.+)$/);
+    if (subsectionMatch) {
+      currentItem = finalizeItem(
+        currentItem,
+        currentSubsection ?? currentSection ?? createSection(""),
+      );
+      if (!currentSection) {
+        throw new Error(
+          `Encountered subsection "${subsectionMatch.groups.title.trim()}" before any section heading.`,
+        );
+      }
+      currentSubsection = createSubsection(subsectionMatch.groups.title.trim());
+      currentSection.subsections.push(currentSubsection);
+      return;
+    }
+
+    const checkboxMatch = line.match(CHECKBOX_PATTERN);
+    if (checkboxMatch) {
+      if (!currentSection) {
+        throw new Error(
+          `Encountered checklist item "${checkboxMatch.groups.text.trim()}" before any section heading.`,
+        );
+      }
+
+      currentItem = finalizeItem(
+        currentItem,
+        currentSubsection ?? currentSection,
+      );
+
+      const status = checkboxMatch.groups.state.toLowerCase() === "x"
+        ? "complete"
+        : "open";
+      const target = currentSubsection ?? currentSection;
+      if (!target) {
+        throw new Error("Unable to resolve target for checklist item.");
+      }
+
+      currentItem = {
+        status,
+        text: checkboxMatch.groups.text.trim(),
+      };
+      return;
+    }
+
+    if (currentItem && line.trim() !== "") {
+      currentItem.text += ` ${line.trim()}`;
+    }
+  });
+
+  currentItem = finalizeItem(
+    currentItem,
+    currentSubsection ?? currentSection ?? createSection(""),
+  );
+  pushSectionIfPresent();
+
+  return sections;
+}
+
+function flattenItems(section) {
+  const sectionLevel = section.items ?? [];
+  const subsectionItems = section.subsections.flatMap((subsection) =>
+    subsection.items
+  );
+  return [...sectionLevel, ...subsectionItems];
+}
+
+function summarizeItems(items) {
+  const total = items.length;
+  const complete = items.filter((item) => item.status === "complete").length;
+  return {
+    total,
+    complete,
+    pending: total - complete,
+  };
+}
+
+function printSection(section) {
+  const allItems = flattenItems(section);
+  if (allItems.length === 0) {
+    console.log(`${section.title}: No checklist items detected.`);
+    console.log("");
+    return;
+  }
+
+  const summary = summarizeItems(allItems);
+  console.log(
+    `${section.title} — ${summary.total} task${summary.total === 1 ? "" : "s"}`,
+  );
+  console.log(`  Complete: ${summary.complete}`);
+  console.log(`  Pending: ${summary.pending}`);
+
+  if (section.items.length > 0) {
+    console.log("");
+    console.log("  Section tasks:");
+    section.items.forEach((item, index) => {
+      const statusLabel = item.status === "complete" ? "DONE" : "OPEN";
+      console.log(`    ${index + 1}. [${statusLabel}] ${item.text}`);
+    });
+  }
+
+  section.subsections.forEach((subsection) => {
+    if (subsection.items.length === 0) {
+      return;
+    }
+    const subsectionSummary = summarizeItems(subsection.items);
+    console.log("");
+    console.log(
+      `  ${subsection.title} — ${subsectionSummary.total} task${
+        subsectionSummary.total === 1 ? "" : "s"
+      }`,
+    );
+    console.log(`    Complete: ${subsectionSummary.complete}`);
+    console.log(`    Pending: ${subsectionSummary.pending}`);
+    subsection.items.forEach((item, index) => {
+      const statusLabel = item.status === "complete" ? "DONE" : "OPEN";
+      console.log(`      ${index + 1}. [${statusLabel}] ${item.text}`);
+    });
+  });
+
+  console.log("");
+}
+
+async function main() {
+  const content = await readFile(DOC_ABSOLUTE_PATH, "utf8");
+  const sections = parseDocument(content);
+
+  if (sections.length === 0) {
+    throw new Error(
+      `No sections found in ${DOC_RELATIVE_PATH}. Ensure it contains "##" headings.`,
+    );
+  }
+
+  console.log("Dynamic Capital ecosystem deployment checklist status");
+  console.log(`Source: ${DOC_RELATIVE_PATH}`);
+  console.log("");
+
+  sections.forEach(printSection);
+}
+
+main().catch((error) => {
+  console.error(error.message ?? error);
+  process.exitCode = 1;
+});

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -104,6 +104,17 @@ const TASK_LIBRARY = {
       "Parses the modular architecture document and reports the status of implementation and verification tasks.",
     ],
   },
+  "ecosystem-deployment-report": {
+    id: "ecosystem-deployment-report",
+    label:
+      "Summarize ecosystem deployment checklist (node scripts/checklists/dynamic-capital-ecosystem-deployment.mjs)",
+    command: "node scripts/checklists/dynamic-capital-ecosystem-deployment.mjs",
+    optional: false,
+    docs: ["docs/dynamic-capital-ecosystem-deployment-checklist.md"],
+    notes: [
+      "Parses the cross-surface deployment checklist and reports completion status by platform.",
+    ],
+  },
   "automated-trading-build-report": {
     id: "automated-trading-build-report",
     label:
@@ -409,6 +420,13 @@ const CHECKLISTS = {
       { task: "smoke-miniapp", optional: true },
       { task: "smoke-tunnel", optional: true },
     ],
+  },
+  "ecosystem-deployment": {
+    name: "Dynamic Capital Ecosystem Deployment Checklist",
+    doc: "docs/dynamic-capital-ecosystem-deployment-checklist.md",
+    description:
+      "Summarize progress across Supabase, Vercel, DigitalOcean, Telegram, and TON launch streams.",
+    tasks: ["ecosystem-deployment-report"],
   },
   "dynamic-modular-architecture": {
     name: "Dynamic Modular Architecture Checklist",


### PR DESCRIPTION
## Summary
- add a checklist reporting script for the Dynamic Capital ecosystem deployment guide
- expose the new `ecosystem-deployment` automation key in the runner and checklist directory
- document how to trigger the automation from the deployment checklist itself

## Testing
- npm run checklists -- --checklist ecosystem-deployment
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dc50b3f57083228a4a1b1aab506424