### PR TITLE
feat: add bank-to-dct supabase schema definitions

### DIFF
--- a/docs/bank-to-dct-conversion.md
+++ b/docs/bank-to-dct-conversion.md
@@ -1,0 +1,301 @@
+# Bank-to-DCT Conversion Strategy
+
+## Overview
+
+This document outlines the recommended architecture for converting fiat deposits
+in Maldivian bank accounts into on-chain DCT tokens. It prioritizes compliance,
+operational resilience, and a consistent user experience across the Dynamic
+Capital ecosystem.
+
+## Conversion Lanes
+
+1. **Direct On-Ramp (Gateway):** Integrate with a fiat-to-crypto payment
+   processor capable of settling in TON or USDT, then execute a market-maker
+   swap into DCT.
+2. **Exchange Bridge:** Route users through a centralized exchange (CEX) flow
+   where they deposit fiat, purchase USDT, transfer to TON, and swap to DCT from
+   within the mini app.
+3. **OTC/P2P with Escrow:** Authorize OTC dealers to receive bank transfers and
+   programmatically release DCT through an escrow smart contract upon
+   confirmation.
+4. **Bank Transfer with Invoice Reconciliation:** Accept local bank transfers
+   tagged with unique references, verify receipts in Supabase, and mint or
+   transfer DCT after confirmation.
+
+## Primary and Fallback Paths
+
+### Primary: Bank Transfer with Automated Reconciliation
+
+- **Rationale:** Minimal integration effort, support for local banking partners,
+  and full control within the Dynamic Capital stack.
+- **Implementation:** Issue a unique payment memo for each order, collect proof
+  of payment, and validate via Supabase edge functions before authorizing a DCT
+  transfer.
+
+### Fallback: USDT Bridge via Exchange
+
+- **Rationale:** Delegates fiat handling to trusted exchanges and reduces
+  exposure to chargeback or recall risk.
+- **Implementation:** Provide guided flows for purchasing USDT, initiating TON
+  transfers, and executing an automated DCT swap through the mini app.
+
+## Operational Flow
+
+### Purchase Initiation
+
+- **Order Record:** Insert `orders` entries with `user_id`, `amount_fiat`,
+  `target_dct`, `reference_code`, `status`, and `expires_at` fields so locks
+  can safely time out.
+- **Pricing Engine:** Quote DCT prices using a USDT peg with a configurable
+  spread and a short-term lock window. Cache each quote hash on the order so
+  later reconciliation can confirm that the delivered DCT matches the quote.
+- **Reference Allocation:** Generate a unique `reference_code` per order and
+  reserve it inside a `payment_references` table to prevent reuse or collisions.
+
+### Bank Payment Capture
+
+- **Unique Reference:** Display a distinctive memo/reference string for every
+  transfer request. Keep the reference visible across web, mobile, and email
+  confirmations to reduce user error.
+- **Proof Upload:** Allow users to attach receipts (PDF or image) tied to the
+  order record and store the uploaded asset metadata in a `receipt_uploads`
+  table with checksum fields for tamper detection.
+- **Webhook or Manual Review:** Match payments via bank webhooks when available
+  or queue them for expedited manual verification. The webhook handler should
+  insert raw payloads into a `bank_events_raw` table before any parsing to
+  provide a defensible audit trail.
+
+### Verification and Settlement
+
+- **Edge Function Validation:** Confirm amount, payer identity (name/IBAN),
+  timestamp tolerances, and check for duplicate submissions. Write evaluation
+  results to `verification_logs` with fields for rule outcomes and reviewer ID.
+- **Mint/Transfer:** Trigger the DCT treasury or market-maker wallet to transfer
+  tokens on-chain to the user's address. Persist the transaction hash and
+  signer public key in a `treasury_transfers` table.
+- **Finalize:** Update order status to `settled` and record immutable audit
+  entries. Post a corresponding ledger entry into `accounting_ledger` so fiat
+  and token balances reconcile end-to-end.
+
+### USDT Fallback Bridge
+
+- **Wallet Detection:** If a user prefers crypto, bypass bank flows and provide
+  a direct "Buy USDT → Swap to DCT" option.
+- **Automated Swap:** Use edge functions to coordinate swaps, monitor slippage,
+  and capture fee data.
+
+## Data Architecture
+
+```sql
+-- orders placed by end users
+create table orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  amount_fiat numeric(18,2) not null,
+  target_dct numeric(36,8) not null,
+  status text check (status in ('pending', 'awaiting_payment', 'verifying', 'settled', 'failed')),
+  reference_code text unique not null,
+  quote_hash text not null,
+  expires_at timestamptz not null,
+  created_at timestamptz default now()
+);
+
+create table payment_references (
+  reference_code text primary key,
+  order_id uuid references orders(id),
+  status text check (status in ('reserved', 'assigned', 'expired', 'consumed')),
+  created_at timestamptz default now()
+);
+
+create table receipt_uploads (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid references orders(id),
+  storage_path text not null,
+  checksum_sha256 text not null,
+  uploaded_by uuid not null,
+  created_at timestamptz default now()
+);
+
+create table verification_logs (
+  id bigint generated always as identity primary key,
+  order_id uuid references orders(id),
+  rule_name text not null,
+  result text check (result in ('pass', 'fail', 'manual_review')),
+  reviewer_id uuid,
+  notes text,
+  created_at timestamptz default now()
+);
+
+create table treasury_transfers (
+  id bigint generated always as identity primary key,
+  order_id uuid references orders(id),
+  tx_hash text unique not null,
+  signer_public_key text not null,
+  amount_dct numeric(36,8) not null,
+  network text not null,
+  created_at timestamptz default now()
+);
+
+create table audit_events (
+  id bigint generated always as identity primary key,
+  entity_type text not null,
+  entity_id text not null,
+  action text not null,
+  actor text not null,
+  payload jsonb,
+  created_at timestamptz default now()
+);
+```
+
+The schema favors append-only tables for forensic analysis. Do not mutate raw
+bank events or verification logs; instead, layer derived views for reporting.
+
+## Edge Functions and Automation
+
+- **`create-order` Function:** Validates user tiers, computes the quote, reserves
+  a payment reference, and inserts the order. Returns signed payment
+  instructions plus expiry metadata for the UI.
+- **`ingest-bank-event` Function:** Receives webhook payloads, validates source
+  signatures, stores raw JSON, and emits a Supabase Realtime event for the
+  reconciliation worker queue.
+- **`verify-payment` Function:** Runs deterministic rules (amount tolerance,
+  payer name similarity, duplicate reference detection) and schedules manual
+  review tasks when thresholds are exceeded.
+- **`settle-order` Function:** On successful verification, orchestrates the TON
+  transaction, logs the transfer, updates the order status, and writes ledger
+  entries. Emits metrics for settlement latency and hedging cost variance.
+- **`expire-orders` Task:** Cron-triggered process that marks orders past
+  `expires_at` as expired, releases reserved references, and notifies users to
+  initiate a fresh quote.
+
+## Reconciliation Workflow
+
+1. **Daily Bank Match:** Compare `orders` and confirmed `bank_events_raw`
+   entries by amount, reference code, and settlement date. Export mismatches to
+   the issue register for remediation.
+2. **Ledger Triangulation:** Ensure each settled order has matching ledger,
+   treasury transfer, and on-chain transaction hash. Trigger alerts when any
+   leg is missing for more than 30 minutes.
+3. **FX & Hedge Review:** Re-run the pricing engine with actual FX rates to
+   quantify slippage and hedge costs; feed results into the metric dashboard.
+4. **Access Review:** Weekly, confirm that only authorized operators have
+   ability to approve manual verifications or trigger settlements.
+
+## Security and Compliance Automation
+
+- **KYC Synchronization:** Sync KYC status from the provider nightly. Orders
+  auto-expire if KYC downgrades below Tier 1 mid-process.
+- **AML Orchestration:** Chain name-screening APIs with on-chain analytics and
+  store scored results in `verification_logs`. Require dual approval when scores
+  exceed defined thresholds.
+- **Retention Policies:** Configure row-level security (RLS) so users access
+  only their own orders and receipts, while compliance officers have full audit
+  visibility.
+- **Key Management:** Store TON signer keys inside an HSM or custodial service.
+  Edge functions should request signatures via a short-lived session token
+  rather than handling raw keys.
+
+## Compliance and Risk Controls
+
+### KYC Tiers
+
+- **Tier 0:** Wallet-verified users with low purchase limits.
+- **Tier 1:** Requires photo ID and selfie verification for higher limits.
+- **Tier 2:** Adds proof of address or business documentation for institutional
+  access.
+
+### AML Controls
+
+- **Sanctions Screening:** Screen bank transfer names and on-chain wallets
+  against sanctions and risk databases.
+- **Velocity and Amount Rules:** Flag suspicious transaction patterns for manual
+  review.
+
+### Chargeback and Recall Mitigation
+
+- **Delay Window:** Introduce a 1–3 hour hold on large orders or new users
+  before releasing DCT.
+- **Escrow Option:** Employ on-chain escrow contracts for OTC transactions,
+  releasing funds only after bank confirmation.
+
+### Pricing and Volatility Management
+
+- **USDT Peg:** Use a USDT reference rate, convert fiat to USDT via FX feeds,
+  and price DCT accordingly.
+- **Spread and Fees:** Maintain a transparent fee schedule displayed within the
+  application.
+
+### Audit Trail
+
+- **Immutable Logs:** Hash receipt artifacts and anchor them on-chain or within
+  notarized Supabase tables.
+- **Reconciliation Reports:** Generate daily reconciliations across orders, bank
+  statements, and blockchain transfers.
+
+### Optimization Feedback Loop
+
+- **Issue Register:** During each reconciliation cycle, log mismatches, manual
+  overrides, or settlement delays into a shared Supabase table with owner,
+  severity, and remediation deadline fields.
+- **Root-Cause Reviews:** Within 24 hours of a flagged incident, document the
+  underlying process, data, or partner failure and propose a preventive control
+  change.
+- **Metric Dashboard:** Plot daily settlement latency, reconciliation error
+  counts, and hedge cost variance so optimization effects are measurable.
+- **Back-to-Back Cadence:** Schedule optimization sprints immediately after each
+  audit cycle to ensure findings translate into implemented controls. Each sprint
+  should produce an implementation memo that references the originating audit
+  issue IDs and documents the deployed change.
+- **Continuous Tuning:** Prioritize fixes that reduce manual touch time, shrink
+  settlement latency, or lower hedging costs. Deploy improvements in small
+  batches and monitor their effect on the next audit run. Track win/loss ratios
+  for experiments to inform future prioritization.
+
+## Incident Response Playbooks
+
+- **Payment Received, Order Missing:** Auto-create a critical incident, freeze
+  associated references, and alert on-call operations. Provide a runbook to
+  insert the missing order while preserving the original payment timestamp.
+- **Verification Rule Failure Spike:** If failure rate exceeds baseline by 3×
+  within an hour, pause automated settlements, escalate to compliance, and
+  initiate a ruleset review before resuming.
+- **TON Transfer Delays:** After 10 minutes without on-chain confirmation,
+  trigger a fallback signer or reroute through a backup liquidity provider and
+  record the event for the next optimization sprint.
+
+## Tokenomics and Market Operations
+
+- **Treasury Policy:** Define clear mint allowances and prefer governed minting
+  or market-maker inventory over ad-hoc issuance.
+- **Buybacks:** Allocate a portion of fiat inflows to scheduled USDT buybacks to
+  maintain price stability.
+- **Burn Mechanics:** Burn a fixed DCT percentage linked to mentorship or oracle
+  services and publish burn events.
+- **Liquidity:** Maintain healthy DCT/USDT pools on TON with enforced slippage
+  bounds for automated swaps.
+- **Oracle Integrity:** Aggregate prices from multiple sources, apply medians,
+  and trigger circuit breakers on abnormal deviations.
+
+## User Experience Guidelines
+
+- **Calls to Action:** Offer "Pay by bank (fast)" with the reference code and
+  settlement ETA, plus "Pay by USDT (instant)" for crypto-native users.
+- **Status Updates:** Use Supabase real-time channels to broadcast status
+  changes—Received, Verifying, Settled.
+- **Receipts:** Send email or Telegram confirmations containing order IDs and
+  on-chain transaction links.
+- **Localized Trust:** Highlight Maldivian banking partners and clearly explain
+  the memo/reference step.
+- **Support:** Provide a one-tap contact option for payment disputes or
+  assistance.
+
+## Open Questions
+
+To finalize the build, provide:
+
+- **Banking Scope:** Target Maldivian banks and preferred transfer methods for
+  initial support.
+- **KYC Provider:** Preferred vendor or appetite for an in-house verification
+  workflow.
+- **Treasury Rules:** Desired mint allowances, burn percentages, and buyback
+  cadence.

--- a/docs/bank-to-dct-data-architecture.md
+++ b/docs/bank-to-dct-data-architecture.md
@@ -1,0 +1,271 @@
+# Bank-to-DCT Data Architecture
+
+## Purpose
+
+This document translates the conversion strategy into an end-to-end data
+architecture that supports fiat receipt capture, automated reconciliation, token
+settlement, and downstream analytics. It highlights the operational data store
+(ODS) layer inside Supabase, the analytical warehouse footprint, and the control
+planes that guarantee compliance and auditability.
+
+## Architectural Layers
+
+1. **Edge & Integration Layer**
+   - Bank webhooks, manual review portal uploads, and TON/USDT swap callbacks.
+   - Events ingested through Supabase Edge Functions with signature validation
+     and payload hashing.
+2. **Operational Data Store (Postgres/Supabase)**
+   - Normalized schema for orders, payment signals, verification, and on-chain
+     settlements.
+   - Row Level Security (RLS) policies segregate customer data from ops/finance
+     teams.
+3. **Analytics & Warehouse Layer**
+   - Nightly ELT from Supabase into the analytics warehouse (e.g., BigQuery or
+     Snowflake) via managed pipelines (Fivetran/Supabase Log Drains).
+   - Modeled marts for treasury, compliance, and product metrics.
+4. **Observability & Audit Layer**
+   - Immutable append-only logs with cryptographic sealing.
+   - Scheduled reconciliations and anomaly detection metrics pushed to Grafana
+     and PagerDuty.
+
+## Entity Relationship Model
+
+```
++----------------+     +---------------------+     +--------------------+
+|   users        |     |     orders           |     | treasury_transfers |
+|----------------|     |----------------------|     |--------------------|
+| id (PK)        | 1  n| id (PK)              |1   1| id (PK)            |
+| tier           |-----| user_id (FK->users)  |-----| order_id (FK)      |
+| risk_flags     |     | amount_fiat          |     | tx_hash            |
++----------------+     | target_dct           |     | amount_dct         |
+                       | reference_code (FK)  |     | network            |
+                       | quote_hash           |     +--------------------+
+                       | status               |               |
+                       | expires_at           |               |
+                       +----------+-----------+               |
+                                  |1                              n
+                                  |                               |
+                                  v                               v
+                         +-------------------+        +----------------------+
+                         | payment_references|        | verification_logs    |
+                         |-------------------|        |----------------------|
+                         | reference_code PK |        | id PK               |
+                         | order_id FK       |        | order_id FK         |
+                         | status            |        | rule_name           |
+                         | reserved_at       |        | result              |
+                         +-------------------+        | reviewer_id         |
+                                                      | notes               |
+                                                      +----------------------+
+```
+
+Additional supporting tables:
+
+- `receipt_uploads` – references storage bucket metadata and checksum values.
+- `bank_events_raw` – immutable ledger of webhook payloads with verification
+  signatures.
+- `bank_events_normalized` – parsed view keyed by `reference_code` and
+  transaction identifiers for reconciliation joins.
+- `accounting_ledger` – double-entry ledger bridging fiat accounts and on-chain
+  treasury balances.
+
+## Supabase Schema Definition
+
+```sql
+create table users (
+  id uuid primary key default gen_random_uuid(),
+  tier text not null check (tier in ('tier_0', 'tier_1', 'tier_2')),
+  risk_flags jsonb default '[]'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references users(id),
+  amount_fiat numeric(18,2) not null,
+  target_dct numeric(36,8) not null,
+  status text not null check (status in (
+    'draft','pending','awaiting_payment','verifying','settled','failed','cancelled'
+  )),
+  reference_code text unique not null,
+  quote_hash text not null,
+  expires_at timestamptz not null,
+  pricing_locked_at timestamptz not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table payment_references (
+  reference_code text primary key,
+  order_id uuid references orders(id),
+  status text not null check (status in ('reserved','assigned','expired','consumed')),
+  reserved_at timestamptz default now(),
+  consumed_at timestamptz,
+  unique (order_id)
+);
+
+create table receipt_uploads (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references orders(id),
+  storage_path text not null,
+  checksum_sha256 text not null,
+  file_bytes bigint not null,
+  uploaded_by uuid not null,
+  uploaded_at timestamptz default now(),
+  constraint receipt_unique_per_order unique (order_id, uploaded_by)
+);
+
+create table bank_events_raw (
+  id bigint generated always as identity primary key,
+  provider text not null,
+  payload jsonb not null,
+  signature text not null,
+  received_at timestamptz default now(),
+  hash_sha256 text not null unique
+);
+
+create table bank_events_normalized (
+  id bigint generated always as identity primary key,
+  raw_event_id bigint not null references bank_events_raw(id),
+  reference_code text not null,
+  sender_account text,
+  sender_name text,
+  amount_fiat numeric(18,2) not null,
+  currency text not null,
+  transaction_date timestamptz not null,
+  status text not null,
+  unique(reference_code, sender_account, transaction_date)
+);
+
+create table verification_logs (
+  id bigint generated always as identity primary key,
+  order_id uuid not null references orders(id),
+  rule_name text not null,
+  result text not null check (result in ('pass','fail','manual_review')),
+  reviewer_id uuid,
+  notes text,
+  created_at timestamptz default now()
+);
+
+create table treasury_transfers (
+  id bigint generated always as identity primary key,
+  order_id uuid not null references orders(id),
+  tx_hash text not null unique,
+  signer_public_key text not null,
+  amount_dct numeric(36,8) not null,
+  fee_dct numeric(36,8) default 0,
+  network text not null,
+  settled_at timestamptz default now()
+);
+
+create table accounting_ledger (
+  id bigint generated always as identity primary key,
+  entry_type text not null check (entry_type in ('fiat','token','fee','adjustment')),
+  reference_id uuid not null,
+  reference_table text not null,
+  debit numeric(36,8) default 0,
+  credit numeric(36,8) default 0,
+  currency text not null,
+  memo text,
+  occurred_at timestamptz default now()
+);
+
+create table audit_events (
+  id bigint generated always as identity primary key,
+  entity_type text not null,
+  entity_id text not null,
+  action text not null,
+  actor text not null,
+  payload jsonb,
+  created_at timestamptz default now()
+);
+
+create materialized view reconciliation_dashboard as
+select
+  o.id as order_id,
+  o.status,
+  o.amount_fiat,
+  o.target_dct,
+  o.reference_code,
+  be.transaction_date,
+  be.amount_fiat as bank_amount,
+  tt.amount_dct,
+  tt.tx_hash,
+  greatest(o.updated_at, coalesce(tt.settled_at, o.updated_at)) as last_touch
+from orders o
+left join bank_events_normalized be on be.reference_code = o.reference_code
+left join treasury_transfers tt on tt.order_id = o.id;
+```
+
+## Data Processing Pipelines
+
+### Ingestion
+
+- **Edge Function `ingest-bank-event`:** Validates headers, hashes payloads, and
+  inserts into `bank_events_raw` with conflict handling for replays.
+- **Manual Review UI:** Inserts metadata into `receipt_uploads` and enqueues a
+  `verification_jobs` task (handled by Supabase Functions or external worker).
+- **TON Settlement Listener:** Listens to treasury wallet events, enriches with
+  gas costs, and upserts `treasury_transfers` rows.
+
+### Reconciliation Workflow
+
+1. `orders` with status `awaiting_payment` are matched against normalized bank
+   events every 5 minutes via a background worker.
+2. Matches trigger verification rule evaluation; results flow into
+   `verification_logs` and update order status to `verifying`.
+3. On success, settlement job creates `treasury_transfers` rows and posts
+   double-entry lines in `accounting_ledger`.
+4. Any mismatch moves the order to `manual_review` and notifies the operations
+   queue through Supabase Realtime channels.
+
+### Analytics Sync
+
+- **Change Data Capture:** Supabase Log Drains export WAL changes to object
+  storage. Fivetran/Snowpipe ingests into the warehouse hourly.
+- **Data Modeling:** dbt project defines marts `mart_revenue`, `mart_liquidity`,
+  and `mart_compliance_flags` built on top of staging tables.
+- **BI/Reporting:** Looker/Metabase dashboards use the materialized mart tables
+  with row-level filters for finance vs. compliance audiences.
+
+## Security and Governance
+
+- **Row-Level Security:**
+  - Users can only select from `orders` where `user_id = auth.uid()`.
+  - Operations role has read access to `orders`, `payment_references`, and
+    `bank_events_normalized` via dedicated policies.
+- **Secrets Management:** Bank API secrets stored in Supabase Vault; edge
+  functions read via sealed secrets with rotation every 90 days.
+- **Access Control:**
+  - Finance role: write to `treasury_transfers`, read-only on `bank_events_raw`.
+  - Compliance role: full read on audit and ledger tables.
+  - Engineering role: manage schema migrations via migration pipelines.
+- **Data Retention:**
+  - `bank_events_raw` retained indefinitely with quarterly archival to cold
+    storage.
+  - Receipts older than 24 months moved to encrypted cold storage with hash
+    references kept in `receipt_uploads`.
+- **Backups:** Nightly logical backups via `pg_dump` and hourly WAL archival to
+  cloud storage buckets with 35-day retention.
+
+## Monitoring and Quality Controls
+
+- **Reconciliation Metrics:** Delta between bank amounts and token settlements,
+  flagged when deviation exceeds 0.5% or 100 MVR.
+- **Throughput Dashboards:** Orders per hour, settlement latency, and manual
+  review queue length.
+- **Data Quality Tests:**
+  - dbt tests for uniqueness of `reference_code`, non-null `tx_hash`, and valid
+    status transitions.
+  - Great Expectations suite validating currency codes and numeric ranges.
+- **Alerts:** PagerDuty alerts for stalled reconciliation jobs, high manual
+  review backlog, or repeated verification failures from the same account.
+
+## Future Extensions
+
+- **Multi-Currency Support:** Add `currency` fields to `orders` and convert
+  using FX rate tables keyed by provider feeds.
+- **Token Buyback Automation:** Extend `treasury_transfers` with `direction`
+  flag to handle buybacks and integrate with on-chain DEX liquidity metrics.
+- **Machine Learning Scoring:** Introduce `risk_scores` table storing model
+  inferences for anomaly detection, including feature importance artifacts for
+  compliance review.

--- a/supabase/functions/_shared/order-users.ts
+++ b/supabase/functions/_shared/order-users.ts
@@ -1,0 +1,72 @@
+import { createClient, createSupabaseClient } from "./client.ts";
+import { getEnv } from "./env.ts";
+import { verifyInitDataAndGetUser } from "./telegram.ts";
+
+type ServiceClient = ReturnType<typeof createClient>;
+
+type ExplicitId = string | number | null | undefined;
+
+export async function resolveTelegramId(
+  req: Request,
+  initData?: string,
+  explicit?: ExplicitId,
+): Promise<string | null> {
+  if (explicit) return String(explicit);
+
+  const authHeader = req.headers.get("Authorization");
+  if (authHeader) {
+    try {
+      const supaAuth = createSupabaseClient(
+        getEnv("SUPABASE_URL"),
+        getEnv("SUPABASE_ANON_KEY"),
+        {
+          global: { headers: { Authorization: authHeader } },
+          auth: { persistSession: false },
+        },
+      );
+      const { data: { user } } = await supaAuth.auth.getUser();
+      if (user) {
+        const tgId = user.user_metadata?.telegram_id || user.id;
+        if (tgId) return String(tgId);
+      }
+    } catch (err) {
+      console.warn("resolveTelegramId auth fallback failed", err);
+    }
+  }
+
+  if (initData) {
+    const tgUser = await verifyInitDataAndGetUser(initData);
+    if (tgUser) return String(tgUser.id);
+  }
+
+  return null;
+}
+
+export async function ensureUserId(
+  supa: ServiceClient,
+  telegramId: string,
+): Promise<string> {
+  const { data: existing, error: fetchError } = await supa
+    .from("users")
+    .select("id")
+    .eq("telegram_id", telegramId)
+    .maybeSingle();
+
+  if (fetchError) {
+    console.error("ensureUserId lookup failed", fetchError);
+  }
+
+  if (existing?.id) return existing.id as string;
+
+  const { data, error } = await supa
+    .from("users")
+    .insert({ telegram_id: telegramId })
+    .select("id")
+    .maybeSingle();
+
+  if (error || !data?.id) {
+    throw new Error(`Failed to upsert user: ${error?.message ?? "unknown"}`);
+  }
+
+  return data.id as string;
+}

--- a/supabase/functions/bank-order-init/index.ts
+++ b/supabase/functions/bank-order-init/index.ts
@@ -1,0 +1,190 @@
+import { createClient } from "../_shared/client.ts";
+import { bad, corsHeaders, mna, ok, oops, unauth } from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+import { ensureUserId, resolveTelegramId } from "../_shared/order-users.ts";
+
+const REFERENCE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
+
+function generateReference(): string {
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  let ref = "DC";
+  for (const b of bytes) {
+    ref += REFERENCE_ALPHABET[b % REFERENCE_ALPHABET.length];
+  }
+  return ref;
+}
+
+type RequestBody = {
+  amount_fiat?: number;
+  target_dct?: number;
+  quote_hash?: string;
+  pricing_locked_at?: string;
+  expires_at?: string;
+  initData?: string;
+  telegram_id?: string | number;
+};
+
+export const handler = registerHandler(async (req) => {
+  const headers = corsHeaders(req, "POST,OPTIONS");
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers });
+  }
+
+  if (req.method !== "POST") {
+    return mna();
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return bad("Invalid JSON payload", undefined, req);
+  }
+
+  const telegramId = await resolveTelegramId(
+    req,
+    body.initData,
+    body.telegram_id,
+  );
+  if (!telegramId) {
+    return unauth("Unable to resolve user", req);
+  }
+
+  const amount = Number(body.amount_fiat);
+  const target = Number(body.target_dct);
+  const quoteHash = String(body.quote_hash || "").trim();
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return bad("amount_fiat must be a positive number", undefined, req);
+  }
+
+  if (!Number.isFinite(target) || target <= 0) {
+    return bad("target_dct must be a positive number", undefined, req);
+  }
+
+  if (!quoteHash) {
+    return bad("quote_hash is required", undefined, req);
+  }
+
+  const nowIso = new Date().toISOString();
+  let pricingLockedAt: string;
+  if (body.pricing_locked_at) {
+    const dt = new Date(body.pricing_locked_at);
+    if (Number.isNaN(dt.getTime())) {
+      return bad("Invalid pricing_locked_at", undefined, req);
+    }
+    pricingLockedAt = dt.toISOString();
+  } else {
+    pricingLockedAt = nowIso;
+  }
+
+  let expiresAt: string;
+  if (body.expires_at) {
+    const dt = new Date(body.expires_at);
+    if (Number.isNaN(dt.getTime())) {
+      return bad("Invalid expires_at", undefined, req);
+    }
+    expiresAt = dt.toISOString();
+  } else {
+    const expiry = new Date(pricingLockedAt);
+    expiry.setMinutes(expiry.getMinutes() + 45);
+    expiresAt = expiry.toISOString();
+  }
+
+  const supa = createClient("service");
+
+  let userId: string;
+  try {
+    userId = await ensureUserId(supa, telegramId);
+  } catch (err) {
+    console.error("bank-order-init ensureUserId failed", err);
+    return oops(
+      "Unable to resolve user profile",
+      err instanceof Error ? err.message : err,
+      req,
+    );
+  }
+
+  let referenceCode = "";
+  let orderId: string | null = null;
+  const maxAttempts = 5;
+
+  for (let attempt = 0; attempt < maxAttempts && !orderId; attempt++) {
+    referenceCode = generateReference();
+    const { data, error } = await supa
+      .from("orders")
+      .insert({
+        user_id: userId,
+        amount_fiat: amount,
+        target_dct: target,
+        status: "awaiting_payment",
+        reference_code: referenceCode,
+        quote_hash: quoteHash,
+        expires_at: expiresAt,
+        pricing_locked_at: pricingLockedAt,
+      })
+      .select("id,reference_code,expires_at,created_at")
+      .maybeSingle();
+
+    if (error) {
+      if ((error as { code?: string }).code === "23505") {
+        continue;
+      }
+      console.error("bank-order-init insert error", error);
+      return oops("Failed to create order", error, req);
+    }
+
+    if (data?.id) {
+      orderId = data.id as string;
+    }
+  }
+
+  if (!orderId) {
+    return oops("Unable to allocate unique reference", undefined, req);
+  }
+
+  const reserveStatus = {
+    reference_code: referenceCode,
+    order_id: orderId,
+    status: "assigned" as const,
+    reserved_at: new Date().toISOString(),
+  };
+
+  const { error: refError } = await supa
+    .from("payment_references")
+    .insert(reserveStatus)
+    .onConflict("reference_code")
+    .ignore();
+
+  if (refError) {
+    console.error("bank-order-init payment_references error", refError);
+  }
+
+  await supa.from("audit_events").insert({
+    entity_type: "order",
+    entity_id: orderId,
+    action: "created",
+    actor: `telegram:${telegramId}`,
+    payload: {
+      amount_fiat: amount,
+      target_dct: target,
+      reference_code: referenceCode,
+      quote_hash: quoteHash,
+    },
+  }).catch((err) => {
+    console.warn("bank-order-init audit event failed", err);
+  });
+
+  return ok({
+    order_id: orderId,
+    reference_code: referenceCode,
+    expires_at: expiresAt,
+    pricing_locked_at: pricingLockedAt,
+    amount_fiat: amount,
+    target_dct: target,
+  }, req);
+});
+
+export default handler;

--- a/supabase/functions/bank-order-status/index.ts
+++ b/supabase/functions/bank-order-status/index.ts
@@ -1,0 +1,144 @@
+import { createClient } from "../_shared/client.ts";
+import { ensureUserId, resolveTelegramId } from "../_shared/order-users.ts";
+import {
+  bad,
+  corsHeaders,
+  mna,
+  nf,
+  ok,
+  oops,
+  unauth,
+} from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+type RequestBody = {
+  order_id?: string;
+  reference_code?: string;
+  initData?: string;
+  telegram_id?: string | number;
+};
+
+export const handler = registerHandler(async (req) => {
+  const headers = corsHeaders(req, "POST,OPTIONS");
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers });
+  }
+
+  if (req.method !== "POST") {
+    return mna();
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return bad("Invalid JSON payload", undefined, req);
+  }
+
+  if (!body.order_id && !body.reference_code) {
+    return bad("order_id or reference_code is required", undefined, req);
+  }
+
+  const telegramId = await resolveTelegramId(
+    req,
+    body.initData,
+    body.telegram_id,
+  );
+  if (!telegramId) {
+    return unauth("Unable to resolve user", req);
+  }
+
+  const supa = createClient("service");
+
+  let userId: string;
+  try {
+    userId = await ensureUserId(supa, telegramId);
+  } catch (err) {
+    console.error("bank-order-status ensureUserId failed", err);
+    return oops(
+      "Unable to resolve user",
+      err instanceof Error ? err.message : err,
+      req,
+    );
+  }
+
+  const query = supa
+    .from("orders")
+    .select(
+      "id,user_id,amount_fiat,target_dct,status,reference_code,quote_hash,expires_at,pricing_locked_at,created_at,updated_at",
+    )
+    .limit(1);
+
+  if (body.order_id) {
+    query.eq("id", body.order_id);
+  } else if (body.reference_code) {
+    query.eq("reference_code", body.reference_code);
+  }
+
+  const { data: order, error: orderError } = await query.maybeSingle();
+  if (orderError) {
+    console.error("bank-order-status order lookup error", orderError);
+    return oops("Failed to load order", orderError, req);
+  }
+
+  if (!order) {
+    return nf("Order not found", req);
+  }
+
+  if (order.user_id !== userId) {
+    return unauth("Order does not belong to user", req);
+  }
+
+  const orderId = order.id as string;
+
+  const [receiptsRes, verificationsRes, transfersRes, bankEventsRes] =
+    await Promise.all([
+      supa
+        .from("receipt_uploads")
+        .select("id,storage_path,checksum_sha256,file_bytes,uploaded_at")
+        .eq("order_id", orderId)
+        .order("uploaded_at", { ascending: false }),
+      supa
+        .from("verification_logs")
+        .select("rule_name,result,notes,created_at,reviewer_id")
+        .eq("order_id", orderId)
+        .order("created_at", { ascending: false }),
+      supa
+        .from("treasury_transfers")
+        .select("tx_hash,amount_dct,fee_dct,network,settled_at")
+        .eq("order_id", orderId)
+        .order("settled_at", { ascending: false }),
+      supa
+        .from("bank_events_normalized")
+        .select(
+          "amount_fiat,currency,status,transaction_date,sender_name,sender_account",
+        )
+        .eq("reference_code", order.reference_code)
+        .order("transaction_date", { ascending: false })
+        .limit(5),
+    ]);
+
+  const response = {
+    order: {
+      id: order.id,
+      status: order.status,
+      amount_fiat: order.amount_fiat,
+      target_dct: order.target_dct,
+      reference_code: order.reference_code,
+      quote_hash: order.quote_hash,
+      pricing_locked_at: order.pricing_locked_at,
+      expires_at: order.expires_at,
+      created_at: order.created_at,
+      updated_at: order.updated_at,
+    },
+    receipts: receiptsRes.data ?? [],
+    verification_logs: verificationsRes.data ?? [],
+    treasury_transfers: transfersRes.data ?? [],
+    bank_events: bankEventsRes.data ?? [],
+  };
+
+  return ok(response, req);
+});
+
+export default handler;

--- a/supabase/functions/ingest-bank-event/index.ts
+++ b/supabase/functions/ingest-bank-event/index.ts
@@ -1,0 +1,252 @@
+import { createClient } from "../_shared/client.ts";
+import { bad, corsHeaders, mna, ok, oops, unauth } from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+const encoder = new TextEncoder();
+
+function toHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function computeHash(payload: string) {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(payload));
+  return toHex(digest);
+}
+
+async function verifySignature(
+  secret: string,
+  payload: string,
+  signature: string,
+) {
+  const normalized = signature.replace(/^sha256=/i, "").trim().toLowerCase();
+  if (!normalized) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signed = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  const computed = toHex(signed).toLowerCase();
+  return computed === normalized;
+}
+
+type NormalizedEvent = {
+  reference_code?: string;
+  sender_account?: string | null;
+  sender_name?: string | null;
+  amount_fiat?: number;
+  currency?: string;
+  transaction_date?: string;
+  status?: string;
+};
+
+const AMOUNT_TOLERANCE = 1;
+
+export const handler = registerHandler(async (req) => {
+  const headers = corsHeaders(req, "POST,OPTIONS");
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers });
+  }
+
+  if (req.method !== "POST") {
+    return mna();
+  }
+
+  const secret = Deno.env.get("BANK_WEBHOOK_SECRET");
+  if (!secret) {
+    console.error("BANK_WEBHOOK_SECRET is not configured");
+    return oops("bank webhook secret missing");
+  }
+
+  const signatureHeader = req.headers.get("x-bank-signature") ||
+    req.headers.get("x-signature") || "";
+  if (!signatureHeader) {
+    return unauth("Missing signature header");
+  }
+
+  const rawBody = await req.text();
+  if (!rawBody) {
+    return bad("Empty payload");
+  }
+
+  const isValid = await verifySignature(secret, rawBody, signatureHeader);
+  if (!isValid) {
+    return unauth("Invalid signature");
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch (err) {
+    console.error("ingest-bank-event JSON parse error", err);
+    return bad("Invalid JSON payload");
+  }
+
+  const provider = typeof parsed.provider === "string" && parsed.provider
+    ? parsed.provider
+    : "bank_webhook";
+
+  const normalized: NormalizedEvent = {
+    reference_code: typeof parsed.reference_code === "string"
+      ? parsed.reference_code
+      : undefined,
+    sender_account: typeof parsed.sender_account === "string"
+      ? parsed.sender_account
+      : null,
+    sender_name: typeof parsed.sender_name === "string"
+      ? parsed.sender_name
+      : null,
+    amount_fiat: Number(parsed.amount_fiat),
+    currency: typeof parsed.currency === "string" ? parsed.currency : undefined,
+    transaction_date: typeof parsed.transaction_date === "string"
+      ? new Date(parsed.transaction_date).toISOString()
+      : undefined,
+    status: typeof parsed.status === "string" ? parsed.status : undefined,
+  };
+
+  if (
+    normalized.amount_fiat !== undefined &&
+    !Number.isFinite(normalized.amount_fiat)
+  ) {
+    normalized.amount_fiat = undefined;
+  }
+
+  const supa = createClient("service");
+
+  const hash = await computeHash(rawBody);
+
+  let rawEventId: number | null = null;
+  let duplicate = false;
+
+  const { data: inserted, error: insertError } = await supa
+    .from("bank_events_raw")
+    .insert({
+      provider,
+      payload: parsed,
+      signature: signatureHeader,
+      hash_sha256: hash,
+    })
+    .select("id")
+    .maybeSingle();
+
+  if (insertError) {
+    if ((insertError as { code?: string }).code === "23505") {
+      duplicate = true;
+      const { data: existing } = await supa
+        .from("bank_events_raw")
+        .select("id")
+        .eq("hash_sha256", hash)
+        .maybeSingle();
+      rawEventId = existing?.id ?? null;
+    } else {
+      console.error("ingest-bank-event insert error", insertError);
+      return oops("Failed to persist bank event", insertError);
+    }
+  } else {
+    rawEventId = inserted?.id ?? null;
+  }
+
+  if (
+    rawEventId && normalized.reference_code &&
+    normalized.amount_fiat !== undefined && normalized.currency &&
+    normalized.transaction_date
+  ) {
+    const normalizedPayload = {
+      raw_event_id: rawEventId,
+      reference_code: normalized.reference_code,
+      sender_account: normalized.sender_account,
+      sender_name: normalized.sender_name,
+      amount_fiat: normalized.amount_fiat,
+      currency: normalized.currency,
+      transaction_date: normalized.transaction_date,
+      status: normalized.status ?? "received",
+    };
+
+    const { error: normError } = await supa
+      .from("bank_events_normalized")
+      .upsert(normalizedPayload, {
+        onConflict: "reference_code,sender_account,transaction_date",
+      });
+
+    if (normError) {
+      console.error("ingest-bank-event normalized upsert error", normError);
+    }
+  }
+
+  let matchedOrderId: string | null = null;
+  let matchStatus: "matched" | "mismatch" | "not_found" = "not_found";
+
+  if (normalized.reference_code) {
+    const { data: order } = await supa
+      .from("orders")
+      .select("id,amount_fiat,status")
+      .eq("reference_code", normalized.reference_code)
+      .maybeSingle();
+
+    if (order?.id) {
+      matchedOrderId = order.id as string;
+      const expectedAmount = Number(order.amount_fiat);
+      const receivedAmount = normalized.amount_fiat ?? NaN;
+      const amountMatches = Number.isFinite(expectedAmount) &&
+        Number.isFinite(receivedAmount) &&
+        Math.abs(expectedAmount - receivedAmount) <= AMOUNT_TOLERANCE;
+
+      if (amountMatches) {
+        matchStatus = "matched";
+        await supa
+          .from("orders")
+          .update({ status: "verifying" })
+          .eq("id", order.id)
+          .in("status", ["awaiting_payment", "pending"]);
+
+        await supa.from("verification_logs").insert({
+          order_id: order.id,
+          rule_name: "bank_amount_match",
+          result: "pass",
+          notes: `Bank event ${hash} matched amount ${receivedAmount}`,
+        }).catch((err) => {
+          console.warn("verification log insert failed", err);
+        });
+      } else {
+        matchStatus = "mismatch";
+        await supa.from("verification_logs").insert({
+          order_id: order.id,
+          rule_name: "bank_amount_match",
+          result: "fail",
+          notes:
+            `Expected ${expectedAmount}, received ${normalized.amount_fiat}`,
+        }).catch((err) => {
+          console.warn("verification log insert failed", err);
+        });
+      }
+    }
+  }
+
+  await supa.from("audit_events").insert({
+    entity_type: "bank_event",
+    entity_id: rawEventId ? String(rawEventId) : hash,
+    action: duplicate ? "duplicate" : "ingested",
+    actor: "bank_webhook",
+    payload: {
+      reference_code: normalized.reference_code ?? null,
+      matched_order_id: matchedOrderId,
+      match_status: matchStatus,
+      provider,
+    },
+  }).catch((err) => {
+    console.warn("audit event insert failed", err);
+  });
+
+  return ok({
+    raw_event_id: rawEventId,
+    duplicate,
+    match_status: matchStatus,
+    matched_order_id: matchedOrderId,
+  }, req);
+});
+
+export default handler;

--- a/supabase/functions/settle-order/index.ts
+++ b/supabase/functions/settle-order/index.ts
@@ -1,0 +1,214 @@
+import { createClient } from "../_shared/client.ts";
+import { getEnv } from "../_shared/env.ts";
+import {
+  bad,
+  corsHeaders,
+  mna,
+  nf,
+  ok,
+  oops,
+  unauth,
+} from "../_shared/http.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+const DEFAULT_FIAT_CURRENCY = "MVR";
+
+type RequestBody = {
+  order_id?: string;
+  tx_hash?: string;
+  amount_dct?: number;
+  fee_dct?: number;
+  network?: string;
+  signer_public_key?: string;
+  memo?: string;
+  actor?: string;
+};
+
+export const handler = registerHandler(async (req) => {
+  const headers = corsHeaders(req, "POST,OPTIONS");
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers });
+  }
+
+  if (req.method !== "POST") {
+    return mna();
+  }
+
+  const adminSecret = getEnv("ADMIN_API_SECRET");
+  if (!adminSecret) {
+    console.error("ADMIN_API_SECRET not configured");
+    return oops("Admin secret not configured");
+  }
+
+  const headerSecret = req.headers.get("X-Admin-Secret") || "";
+  if (headerSecret !== adminSecret) {
+    return unauth("Invalid admin secret");
+  }
+
+  let body: RequestBody;
+  try {
+    body = await req.json();
+  } catch {
+    return bad("Invalid JSON payload", undefined, req);
+  }
+
+  if (!body.order_id) return bad("order_id is required", undefined, req);
+  if (!body.tx_hash) return bad("tx_hash is required", undefined, req);
+  if (!body.amount_dct || Number(body.amount_dct) <= 0) {
+    return bad("amount_dct must be positive", undefined, req);
+  }
+  if (!body.network) return bad("network is required", undefined, req);
+  if (!body.signer_public_key) {
+    return bad("signer_public_key is required", undefined, req);
+  }
+
+  const supa = createClient("service");
+
+  const { data: order, error: orderError } = await supa
+    .from("orders")
+    .select("id,status,amount_fiat,reference_code")
+    .eq("id", body.order_id)
+    .maybeSingle();
+
+  if (orderError) {
+    console.error("settle-order order lookup error", orderError);
+    return oops("Failed to load order", orderError, req);
+  }
+
+  if (!order?.id) {
+    return nf("Order not found", req);
+  }
+
+  const { data: existingTransfer } = await supa
+    .from("treasury_transfers")
+    .select("id")
+    .eq("tx_hash", body.tx_hash)
+    .maybeSingle();
+
+  if (existingTransfer?.id) {
+    return ok(
+      { duplicate: true, treasury_transfer_id: existingTransfer.id },
+      req,
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+  const amountDct = Number(body.amount_dct);
+  const fiatAmount = Number(order.amount_fiat);
+  if (!Number.isFinite(fiatAmount) || fiatAmount <= 0) {
+    return oops("Order amount is invalid", undefined, req);
+  }
+  const feeDctRaw = body.fee_dct !== undefined && body.fee_dct !== null
+    ? Number(body.fee_dct)
+    : 0;
+  const feeDct = Number.isFinite(feeDctRaw) && feeDctRaw > 0 ? feeDctRaw : 0;
+
+  const { data: transfer, error: transferError } = await supa
+    .from("treasury_transfers")
+    .insert({
+      order_id: order.id,
+      tx_hash: body.tx_hash,
+      signer_public_key: body.signer_public_key,
+      amount_dct: amountDct,
+      fee_dct: feeDct || 0,
+      network: body.network,
+      settled_at: nowIso,
+    })
+    .select("id")
+    .maybeSingle();
+
+  if (transferError) {
+    console.error("settle-order transfer insert error", transferError);
+    return oops("Failed to record treasury transfer", transferError, req);
+  }
+
+  await supa
+    .from("orders")
+    .update({ status: "settled" })
+    .eq("id", order.id);
+
+  await supa
+    .from("payment_references")
+    .update({ status: "consumed", consumed_at: nowIso })
+    .eq("order_id", order.id)
+    .eq("status", "assigned")
+    .catch((err) => {
+      console.warn("payment reference update failed", err);
+    });
+
+  const ledgerEntries = [
+    {
+      entry_type: "fiat" as const,
+      reference_id: order.id,
+      reference_table: "orders",
+      debit: 0,
+      credit: fiatAmount,
+      currency: DEFAULT_FIAT_CURRENCY,
+      memo: body.memo ?? `Fiat settlement for ${order.reference_code}`,
+      occurred_at: nowIso,
+    },
+    {
+      entry_type: "token" as const,
+      reference_id: order.id,
+      reference_table: "orders",
+      debit: amountDct,
+      credit: 0,
+      currency: "DCT",
+      memo: `DCT transfer ${body.tx_hash}`,
+      occurred_at: nowIso,
+    },
+  ];
+
+  if (feeDct > 0) {
+    ledgerEntries.push({
+      entry_type: "fee" as const,
+      reference_id: order.id,
+      reference_table: "orders",
+      debit: feeDct,
+      credit: 0,
+      currency: "DCT",
+      memo: `Network fee for ${body.tx_hash}`,
+      occurred_at: nowIso,
+    });
+  }
+
+  const { error: ledgerError } = await supa
+    .from("accounting_ledger")
+    .insert(ledgerEntries);
+
+  if (ledgerError) {
+    console.error("settle-order ledger insert error", ledgerError);
+  }
+
+  await supa.from("verification_logs").insert({
+    order_id: order.id,
+    rule_name: "settlement_recorded",
+    result: "pass",
+    notes: `Treasury transfer ${body.tx_hash} recorded`,
+  }).catch((err) => {
+    console.warn("verification log settlement insert failed", err);
+  });
+
+  await supa.from("audit_events").insert({
+    entity_type: "order",
+    entity_id: order.id,
+    action: "settled",
+    actor: body.actor ?? "treasury_bot",
+    payload: {
+      tx_hash: body.tx_hash,
+      amount_dct: amountDct,
+      fee_dct: feeDct,
+      network: body.network,
+    },
+  }).catch((err) => {
+    console.warn("audit event settlement failed", err);
+  });
+
+  return ok({
+    treasury_transfer_id: transfer?.id,
+    order_id: order.id,
+  }, req);
+});
+
+export default handler;

--- a/supabase/migrations/20251105090000_bank_to_dct_core.sql
+++ b/supabase/migrations/20251105090000_bank_to_dct_core.sql
@@ -1,0 +1,359 @@
+-- Core schema for bank-to-DCT conversion pipeline
+
+-- Ensure public.users exists with required governance fields
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+  ) THEN
+    CREATE TABLE public.users (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      telegram_id text UNIQUE,
+      tier text NOT NULL DEFAULT 'tier_0',
+      risk_flags jsonb NOT NULL DEFAULT '[]'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  ELSE
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'users'
+        AND column_name = 'telegram_id'
+    ) THEN
+      ALTER TABLE public.users
+        ADD COLUMN telegram_id text;
+      CREATE UNIQUE INDEX IF NOT EXISTS users_telegram_id_key
+        ON public.users(telegram_id);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'users'
+        AND column_name = 'tier'
+    ) THEN
+      ALTER TABLE public.users
+        ADD COLUMN tier text NOT NULL DEFAULT 'tier_0';
+    ELSE
+      ALTER TABLE public.users
+        ALTER COLUMN tier SET DEFAULT 'tier_0';
+      UPDATE public.users SET tier = 'tier_0' WHERE tier IS NULL;
+      ALTER TABLE public.users
+        ALTER COLUMN tier SET NOT NULL;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'users'
+        AND column_name = 'risk_flags'
+    ) THEN
+      ALTER TABLE public.users
+        ADD COLUMN risk_flags jsonb NOT NULL DEFAULT '[]'::jsonb;
+    END IF;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'users_tier_check'
+      AND conrelid = 'public.users'::regclass
+  ) THEN
+    ALTER TABLE public.users
+      ADD CONSTRAINT users_tier_check
+      CHECK (tier IN ('tier_0', 'tier_1', 'tier_2'));
+  END IF;
+END$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS users_telegram_id_key
+  ON public.users(telegram_id);
+
+CREATE TABLE IF NOT EXISTS public.orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.users(id),
+  amount_fiat numeric(18,2) NOT NULL,
+  target_dct numeric(36,8) NOT NULL,
+  status text NOT NULL CHECK (status IN (
+    'draft','pending','awaiting_payment','verifying','manual_review','settled','failed','cancelled'
+  )),
+  reference_code text NOT NULL UNIQUE,
+  quote_hash text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  pricing_locked_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS orders_user_status_idx
+  ON public.orders (user_id, status);
+CREATE INDEX IF NOT EXISTS orders_reference_idx
+  ON public.orders (reference_code);
+
+CREATE TABLE IF NOT EXISTS public.payment_references (
+  reference_code text PRIMARY KEY,
+  order_id uuid REFERENCES public.orders(id),
+  status text NOT NULL CHECK (status IN ('reserved','assigned','expired','consumed')),
+  reserved_at timestamptz NOT NULL DEFAULT now(),
+  consumed_at timestamptz,
+  UNIQUE (order_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.receipt_uploads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL REFERENCES public.orders(id),
+  storage_path text NOT NULL,
+  checksum_sha256 text NOT NULL,
+  file_bytes bigint NOT NULL,
+  uploaded_by uuid NOT NULL,
+  uploaded_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT receipt_unique_per_order UNIQUE (order_id, uploaded_by)
+);
+
+CREATE TABLE IF NOT EXISTS public.bank_events_raw (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  provider text NOT NULL,
+  payload jsonb NOT NULL,
+  signature text NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  hash_sha256 text NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS public.bank_events_normalized (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  raw_event_id bigint NOT NULL REFERENCES public.bank_events_raw(id) ON DELETE CASCADE,
+  reference_code text NOT NULL,
+  sender_account text,
+  sender_name text,
+  amount_fiat numeric(18,2) NOT NULL,
+  currency text NOT NULL,
+  transaction_date timestamptz NOT NULL,
+  status text NOT NULL,
+  UNIQUE (reference_code, sender_account, transaction_date)
+);
+
+CREATE INDEX IF NOT EXISTS bank_events_normalized_ref_idx
+  ON public.bank_events_normalized (reference_code);
+
+CREATE TABLE IF NOT EXISTS public.verification_logs (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  order_id uuid NOT NULL REFERENCES public.orders(id),
+  rule_name text NOT NULL,
+  result text NOT NULL CHECK (result IN ('pass','fail','manual_review')),
+  reviewer_id uuid,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS verification_logs_order_idx
+  ON public.verification_logs (order_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.treasury_transfers (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  order_id uuid NOT NULL REFERENCES public.orders(id),
+  tx_hash text NOT NULL UNIQUE,
+  signer_public_key text NOT NULL,
+  amount_dct numeric(36,8) NOT NULL,
+  fee_dct numeric(36,8) DEFAULT 0,
+  network text NOT NULL,
+  settled_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS treasury_transfers_order_idx
+  ON public.treasury_transfers (order_id);
+
+CREATE TABLE IF NOT EXISTS public.accounting_ledger (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  entry_type text NOT NULL CHECK (entry_type IN ('fiat','token','fee','adjustment')),
+  reference_id uuid NOT NULL,
+  reference_table text NOT NULL,
+  debit numeric(36,8) DEFAULT 0,
+  credit numeric(36,8) DEFAULT 0,
+  currency text NOT NULL,
+  memo text,
+  occurred_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS accounting_ledger_reference_idx
+  ON public.accounting_ledger (reference_table, reference_id);
+
+CREATE TABLE IF NOT EXISTS public.audit_events (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  entity_type text NOT NULL,
+  entity_id text NOT NULL,
+  action text NOT NULL,
+  actor text NOT NULL,
+  payload jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS audit_events_entity_idx
+  ON public.audit_events (entity_type, entity_id);
+
+CREATE OR REPLACE FUNCTION public.orders_set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_orders_updated_at ON public.orders;
+CREATE TRIGGER set_orders_updated_at
+BEFORE UPDATE ON public.orders
+FOR EACH ROW
+EXECUTE FUNCTION public.orders_set_updated_at();
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.reconciliation_dashboard AS
+SELECT
+  o.id AS order_id,
+  o.status,
+  o.amount_fiat,
+  o.target_dct,
+  o.reference_code,
+  o.updated_at,
+  be.transaction_date,
+  be.amount_fiat AS bank_amount,
+  be.currency,
+  tt.amount_dct,
+  tt.tx_hash,
+  GREATEST(o.updated_at, COALESCE(tt.settled_at, o.updated_at)) AS last_touch
+FROM public.orders o
+LEFT JOIN public.bank_events_normalized be ON be.reference_code = o.reference_code
+LEFT JOIN public.treasury_transfers tt ON tt.order_id = o.id;
+
+-- Row Level Security
+ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.orders FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.payment_references ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.payment_references FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.receipt_uploads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.receipt_uploads FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.bank_events_raw ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bank_events_raw FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.bank_events_normalized ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bank_events_normalized FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.verification_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.verification_logs FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.treasury_transfers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.treasury_transfers FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.accounting_ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.accounting_ledger FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE public.audit_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.audit_events FORCE ROW LEVEL SECURITY;
+
+-- Policies for service role
+CREATE POLICY IF NOT EXISTS orders_service_manage
+  ON public.orders
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS payment_references_service_manage
+  ON public.payment_references
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS receipt_uploads_service_manage
+  ON public.receipt_uploads
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS bank_events_raw_service_manage
+  ON public.bank_events_raw
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS bank_events_normalized_service_manage
+  ON public.bank_events_normalized
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS verification_logs_service_manage
+  ON public.verification_logs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS treasury_transfers_service_manage
+  ON public.treasury_transfers
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS accounting_ledger_service_manage
+  ON public.accounting_ledger
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY IF NOT EXISTS audit_events_service_manage
+  ON public.audit_events
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Authenticated users can view their own orders, receipts, and settlements
+CREATE POLICY IF NOT EXISTS orders_authenticated_select
+  ON public.orders
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY IF NOT EXISTS receipt_uploads_authenticated_select
+  ON public.receipt_uploads
+  FOR SELECT
+  TO authenticated
+  USING (uploaded_by = auth.uid());
+
+CREATE POLICY IF NOT EXISTS treasury_transfers_authenticated_select
+  ON public.treasury_transfers
+  FOR SELECT
+  TO authenticated
+  USING (order_id IN (
+    SELECT id FROM public.orders WHERE user_id = auth.uid()
+  ));
+
+CREATE POLICY IF NOT EXISTS verification_logs_authenticated_select
+  ON public.verification_logs
+  FOR SELECT
+  TO authenticated
+  USING (order_id IN (
+    SELECT id FROM public.orders WHERE user_id = auth.uid()
+  ));
+
+-- Allow authenticated users to insert receipt metadata for their orders
+CREATE POLICY IF NOT EXISTS receipt_uploads_authenticated_insert
+  ON public.receipt_uploads
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (uploaded_by = auth.uid());

--- a/supabase/resource-plan.ts
+++ b/supabase/resource-plan.ts
@@ -567,6 +567,884 @@ export const resourcePlan: ResourcePlan = {
         "CREATE TRIGGER course_progress_set_updated_at\nBEFORE UPDATE ON public.course_progress\nFOR EACH ROW EXECUTE FUNCTION public.set_course_progress_updated_at();",
       ],
     },
+    {
+      schema: "public",
+      name: "users",
+      comment:
+        "Lightweight profile records that map Telegram accounts to conversion users.",
+      columns: [
+        {
+          name: "id",
+          type: "uuid",
+          nullable: false,
+          default: "gen_random_uuid()",
+          comment: "Primary key for the conversion user profile.",
+        },
+        {
+          name: "telegram_id",
+          type: "text",
+          unique: true,
+          comment:
+            "Telegram identifier linked to the Dynamic mini app session.",
+        },
+        {
+          name: "tier",
+          type: "text",
+          nullable: false,
+          default: "'tier_0'",
+          comment: "Assigned KYC tier controlling order limits.",
+        },
+        {
+          name: "risk_flags",
+          type: "jsonb",
+          nullable: false,
+          default: "'[]'::jsonb",
+          comment: "Compliance risk markers collected during reviews.",
+        },
+        {
+          name: "created_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the profile row was created.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      checks: [
+        {
+          name: "users_tier_check",
+          expression: "tier IN ('tier_0','tier_1','tier_2')",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "users_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment:
+            "Allow backend services to manage Telegram profile mappings.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "orders",
+      comment:
+        "Fiat-to-DCT conversion orders awaiting payment confirmation and settlement.",
+      columns: [
+        {
+          name: "id",
+          type: "uuid",
+          nullable: false,
+          default: "gen_random_uuid()",
+          comment: "Primary key for the conversion order.",
+        },
+        {
+          name: "user_id",
+          type: "uuid",
+          nullable: false,
+          references: {
+            schema: "public",
+            table: "users",
+            column: "id",
+          },
+          comment: "Conversion user that initiated the order.",
+        },
+        {
+          name: "amount_fiat",
+          type: "numeric(18,2)",
+          nullable: false,
+          comment: "Fiat amount the user will transfer via bank rails.",
+        },
+        {
+          name: "target_dct",
+          type: "numeric(36,8)",
+          nullable: false,
+          comment:
+            "Quoted quantity of DCT that will be delivered on settlement.",
+        },
+        {
+          name: "status",
+          type: "text",
+          nullable: false,
+          check:
+            "status IN ('draft','pending','awaiting_payment','verifying','manual_review','settled','failed','cancelled')",
+          comment: "Lifecycle state for the conversion order.",
+        },
+        {
+          name: "reference_code",
+          type: "text",
+          nullable: false,
+          unique: true,
+          comment: "Human-visible payment reference shared with the user.",
+        },
+        {
+          name: "quote_hash",
+          type: "text",
+          nullable: false,
+          comment:
+            "Hash of the pricing quote used to lock the conversion rate.",
+        },
+        {
+          name: "expires_at",
+          type: "timestamptz",
+          nullable: false,
+          comment:
+            "Timestamp when the quote expires and payment is no longer guaranteed.",
+        },
+        {
+          name: "pricing_locked_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the quote was locked for the user.",
+        },
+        {
+          name: "created_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the order was created.",
+        },
+        {
+          name: "updated_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the order last changed state.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "orders_user_status_idx",
+          expression: "(user_id, status)",
+        },
+        {
+          name: "orders_reference_idx",
+          expression: "(reference_code)",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "orders_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Allow trusted automation to manage order lifecycles.",
+        },
+        {
+          name: "orders_authenticated_select",
+          command: "SELECT",
+          roles: ["authenticated"],
+          using: "(user_id = auth.uid())",
+          comment: "Authenticated users can view their own conversion orders.",
+        },
+      ],
+      postDeploymentSql: [
+        "ALTER TABLE public.orders ALTER COLUMN updated_at SET DEFAULT now();",
+        "CREATE OR REPLACE FUNCTION public.orders_set_updated_at()\nRETURNS TRIGGER\nLANGUAGE plpgsql AS $$\nBEGIN\n  NEW.updated_at := now();\n  RETURN NEW;\nEND;\n$$;",
+        "DROP TRIGGER IF EXISTS set_orders_updated_at ON public.orders;",
+        "CREATE TRIGGER set_orders_updated_at\nBEFORE UPDATE ON public.orders\nFOR EACH ROW EXECUTE FUNCTION public.orders_set_updated_at();",
+      ],
+    },
+    {
+      schema: "public",
+      name: "payment_references",
+      comment:
+        "Holds bank transfer reference codes that are assigned to active orders.",
+      columns: [
+        {
+          name: "reference_code",
+          type: "text",
+          nullable: false,
+          comment: "Payment memo string communicated to the user.",
+        },
+        {
+          name: "order_id",
+          type: "uuid",
+          references: {
+            schema: "public",
+            table: "orders",
+            column: "id",
+          },
+          comment: "Order that currently reserves the payment reference.",
+        },
+        {
+          name: "status",
+          type: "text",
+          nullable: false,
+          check: "status IN ('reserved','assigned','expired','consumed')",
+          comment: "Lifecycle for the reference allocation.",
+        },
+        {
+          name: "reserved_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the reference was reserved.",
+        },
+        {
+          name: "consumed_at",
+          type: "timestamptz",
+          comment:
+            "Timestamp when the reference was consumed during settlement.",
+        },
+      ],
+      primaryKey: {
+        columns: ["reference_code"],
+      },
+      indexes: [
+        {
+          name: "payment_references_order_unique",
+          expression: "(order_id)",
+          unique: true,
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "payment_references_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Automation can manage payment reference lifecycles.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "receipt_uploads",
+      comment:
+        "Normalized record of receipt files uploaded as payment evidence for orders.",
+      columns: [
+        {
+          name: "id",
+          type: "uuid",
+          nullable: false,
+          default: "gen_random_uuid()",
+          comment: "Primary key for the uploaded receipt artifact.",
+        },
+        {
+          name: "order_id",
+          type: "uuid",
+          nullable: false,
+          references: {
+            schema: "public",
+            table: "orders",
+            column: "id",
+            onDelete: "CASCADE",
+          },
+          comment: "Order the receipt upload is associated with.",
+        },
+        {
+          name: "storage_path",
+          type: "text",
+          nullable: false,
+          comment: "Path inside Supabase Storage where the file resides.",
+        },
+        {
+          name: "checksum_sha256",
+          type: "text",
+          nullable: false,
+          comment: "SHA-256 checksum to deduplicate uploads.",
+        },
+        {
+          name: "file_bytes",
+          type: "bigint",
+          nullable: false,
+          comment: "File size in bytes for auditing limits.",
+        },
+        {
+          name: "uploaded_by",
+          type: "uuid",
+          nullable: false,
+          comment: "User that submitted the receipt file.",
+        },
+        {
+          name: "uploaded_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the file was uploaded.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "receipt_uploads_order_uploaded_by_key",
+          expression: "(order_id, uploaded_by)",
+          unique: true,
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "receipt_uploads_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Allow automation to manage uploaded receipts.",
+        },
+        {
+          name: "receipt_uploads_authenticated_select",
+          command: "SELECT",
+          roles: ["authenticated"],
+          using: "(uploaded_by = auth.uid())",
+          comment: "Users can view receipt uploads they submitted.",
+        },
+        {
+          name: "receipt_uploads_authenticated_insert",
+          command: "INSERT",
+          roles: ["authenticated"],
+          withCheck: "(uploaded_by = auth.uid())",
+          comment: "Users may attach receipt uploads for their own orders.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "bank_events_raw",
+      comment:
+        "Immutable store of raw webhook payloads received from partner banks.",
+      columns: [
+        {
+          name: "id",
+          type: "bigint",
+          nullable: false,
+          identity: "always",
+          comment: "Sequence identifier for the inbound webhook payload.",
+        },
+        {
+          name: "provider",
+          type: "text",
+          nullable: false,
+          comment: "Bank or webhook provider that delivered the event.",
+        },
+        {
+          name: "payload",
+          type: "jsonb",
+          nullable: false,
+          comment: "Raw JSON payload as delivered by the provider.",
+        },
+        {
+          name: "signature",
+          type: "text",
+          nullable: false,
+          comment: "Signature string used to verify authenticity.",
+        },
+        {
+          name: "received_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the webhook was processed.",
+        },
+        {
+          name: "hash_sha256",
+          type: "text",
+          nullable: false,
+          unique: true,
+          comment: "Deterministic hash of the payload for de-duplication.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+        name: "bank_events_raw_pkey",
+      },
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "bank_events_raw_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment:
+            "Allow secure ingestion workers to manage raw bank payloads.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "bank_events_normalized",
+      comment:
+        "Structured bank transaction data extracted from raw webhook events.",
+      columns: [
+        {
+          name: "id",
+          type: "bigint",
+          nullable: false,
+          identity: "always",
+          comment: "Primary key for the normalized bank event.",
+        },
+        {
+          name: "raw_event_id",
+          type: "bigint",
+          nullable: false,
+          references: {
+            schema: "public",
+            table: "bank_events_raw",
+            column: "id",
+            onDelete: "CASCADE",
+          },
+          comment: "Foreign key back to the raw webhook payload.",
+        },
+        {
+          name: "reference_code",
+          type: "text",
+          nullable: false,
+          comment: "Reference string parsed from the bank transfer memo.",
+        },
+        {
+          name: "sender_account",
+          type: "text",
+          comment: "Account number reported by the sending bank.",
+        },
+        {
+          name: "sender_name",
+          type: "text",
+          comment: "Name of the remitting customer.",
+        },
+        {
+          name: "amount_fiat",
+          type: "numeric(18,2)",
+          nullable: false,
+          comment: "Fiat amount received per the bank event.",
+        },
+        {
+          name: "currency",
+          type: "text",
+          nullable: false,
+          comment: "Currency of the bank transfer.",
+        },
+        {
+          name: "transaction_date",
+          type: "timestamptz",
+          nullable: false,
+          comment: "Timestamp when the bank recorded the transaction.",
+        },
+        {
+          name: "status",
+          type: "text",
+          nullable: false,
+          comment: "Normalization status for the matched payment.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+        name: "bank_events_normalized_pkey",
+      },
+      indexes: [
+        {
+          name: "bank_events_normalized_reference_unique",
+          expression: "(reference_code, sender_account, transaction_date)",
+          unique: true,
+        },
+        {
+          name: "bank_events_normalized_ref_idx",
+          expression: "(reference_code)",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "bank_events_normalized_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment:
+            "Allow secure ingestion workers to manage normalized events.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "verification_logs",
+      comment:
+        "Rule evaluation trail that captures automated and manual payment checks.",
+      columns: [
+        {
+          name: "id",
+          type: "bigint",
+          nullable: false,
+          identity: "always",
+          comment: "Primary key for the verification log entry.",
+        },
+        {
+          name: "order_id",
+          type: "uuid",
+          nullable: false,
+          references: {
+            schema: "public",
+            table: "orders",
+            column: "id",
+            onDelete: "CASCADE",
+          },
+          comment: "Order that the verification rule evaluated.",
+        },
+        {
+          name: "rule_name",
+          type: "text",
+          nullable: false,
+          comment: "Identifier for the verification rule or procedure.",
+        },
+        {
+          name: "result",
+          type: "text",
+          nullable: false,
+          check: "result IN ('pass','fail','manual_review')",
+          comment: "Outcome of the verification rule.",
+        },
+        {
+          name: "reviewer_id",
+          type: "uuid",
+          comment: "Optional reviewer that recorded the result.",
+        },
+        {
+          name: "notes",
+          type: "text",
+          comment: "Additional context captured for the verification.",
+        },
+        {
+          name: "created_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the verification log was recorded.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "verification_logs_order_idx",
+          expression: "(order_id, created_at DESC)",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "verification_logs_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Allow automation to manage verification evidence.",
+        },
+        {
+          name: "verification_logs_authenticated_select",
+          command: "SELECT",
+          roles: ["authenticated"],
+          using:
+            "(order_id IN (SELECT id FROM public.orders WHERE user_id = auth.uid()))",
+          comment:
+            "Users can review verification history for their own orders.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "treasury_transfers",
+      comment:
+        "Settlements executed by the treasury wallet to deliver DCT for orders.",
+      columns: [
+        {
+          name: "id",
+          type: "bigint",
+          nullable: false,
+          identity: "always",
+          comment: "Primary key for the treasury transfer.",
+        },
+        {
+          name: "order_id",
+          type: "uuid",
+          nullable: false,
+          references: {
+            schema: "public",
+            table: "orders",
+            column: "id",
+            onDelete: "CASCADE",
+          },
+          comment: "Order that the transfer settles.",
+        },
+        {
+          name: "tx_hash",
+          type: "text",
+          nullable: false,
+          unique: true,
+          comment: "Blockchain transaction hash for the settlement.",
+        },
+        {
+          name: "signer_public_key",
+          type: "text",
+          nullable: false,
+          comment: "Public key of the signer that authorized the transfer.",
+        },
+        {
+          name: "amount_dct",
+          type: "numeric(36,8)",
+          nullable: false,
+          comment: "Amount of DCT delivered to the user.",
+        },
+        {
+          name: "fee_dct",
+          type: "numeric(36,8)",
+          default: "0",
+          comment: "DCT paid in network fees for the settlement.",
+        },
+        {
+          name: "network",
+          type: "text",
+          nullable: false,
+          comment: "Blockchain network where the transfer was executed.",
+        },
+        {
+          name: "settled_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the transfer settled on-chain.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "treasury_transfers_order_idx",
+          expression: "(order_id)",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "treasury_transfers_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Allow treasury automation to manage settlement records.",
+        },
+        {
+          name: "treasury_transfers_authenticated_select",
+          command: "SELECT",
+          roles: ["authenticated"],
+          using:
+            "(order_id IN (SELECT id FROM public.orders WHERE user_id = auth.uid()))",
+          comment: "Users can view settlement transfers for their orders.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "accounting_ledger",
+      comment:
+        "Double-entry style ledger capturing fiat and token side effects per order.",
+      columns: [
+        {
+          name: "id",
+          type: "bigint",
+          nullable: false,
+          identity: "always",
+          comment: "Primary key for the accounting entry.",
+        },
+        {
+          name: "entry_type",
+          type: "text",
+          nullable: false,
+          check: "entry_type IN ('fiat','token','fee','adjustment')",
+          comment: "Category of ledger entry recorded.",
+        },
+        {
+          name: "reference_id",
+          type: "uuid",
+          nullable: false,
+          comment: "Identifier of the entity the ledger entry is linked to.",
+        },
+        {
+          name: "reference_table",
+          type: "text",
+          nullable: false,
+          comment:
+            "Table name for the referenced entity (orders, treasury_transfers, etc.).",
+        },
+        {
+          name: "debit",
+          type: "numeric(36,8)",
+          default: "0",
+          comment: "Debit amount recorded for the entry.",
+        },
+        {
+          name: "credit",
+          type: "numeric(36,8)",
+          default: "0",
+          comment: "Credit amount recorded for the entry.",
+        },
+        {
+          name: "currency",
+          type: "text",
+          nullable: false,
+          comment: "Currency denomination for the ledger amounts.",
+        },
+        {
+          name: "memo",
+          type: "text",
+          comment: "Optional contextual memo for auditors.",
+        },
+        {
+          name: "occurred_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the ledger entry occurred.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "accounting_ledger_reference_idx",
+          expression: "(reference_table, reference_id)",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "accounting_ledger_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Allow finance automation to manage ledger postings.",
+        },
+      ],
+    },
+    {
+      schema: "public",
+      name: "audit_events",
+      comment:
+        "Immutable audit log capturing significant actions across the conversion pipeline.",
+      columns: [
+        {
+          name: "id",
+          type: "bigint",
+          nullable: false,
+          identity: "always",
+          comment: "Primary key for the audit event.",
+        },
+        {
+          name: "entity_type",
+          type: "text",
+          nullable: false,
+          comment: "Domain entity category that triggered the audit entry.",
+        },
+        {
+          name: "entity_id",
+          type: "text",
+          nullable: false,
+          comment: "Identifier of the entity instance being audited.",
+        },
+        {
+          name: "action",
+          type: "text",
+          nullable: false,
+          comment: "Action verb describing what occurred.",
+        },
+        {
+          name: "actor",
+          type: "text",
+          nullable: false,
+          comment:
+            "Actor that performed the action (user, automation, webhook).",
+        },
+        {
+          name: "payload",
+          type: "jsonb",
+          comment: "Structured contextual metadata for the event.",
+        },
+        {
+          name: "created_at",
+          type: "timestamptz",
+          nullable: false,
+          default: "now()",
+          comment: "Timestamp when the audit event was recorded.",
+        },
+      ],
+      primaryKey: {
+        columns: ["id"],
+      },
+      indexes: [
+        {
+          name: "audit_events_entity_idx",
+          expression: "(entity_type, entity_id)",
+        },
+      ],
+      rowLevelSecurity: {
+        enable: true,
+        force: true,
+      },
+      policies: [
+        {
+          name: "audit_events_service_manage",
+          command: "ALL",
+          roles: ["service_role"],
+          using: "true",
+          withCheck: "true",
+          comment: "Allow secure automation to append audit trail entries.",
+        },
+      ],
+    },
+  ],
+  sql: [
+    {
+      name: "reconciliation_dashboard",
+      statement:
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS public.reconciliation_dashboard AS\nSELECT\n  o.id AS order_id,\n  o.status,\n  o.amount_fiat,\n  o.target_dct,\n  o.reference_code,\n  o.updated_at,\n  be.transaction_date,\n  be.amount_fiat AS bank_amount,\n  be.currency,\n  tt.amount_dct,\n  tt.tx_hash,\n  GREATEST(o.updated_at, COALESCE(tt.settled_at, o.updated_at)) AS last_touch\nFROM public.orders o\nLEFT JOIN public.bank_events_normalized be ON be.reference_code = o.reference_code\nLEFT JOIN public.treasury_transfers tt ON tt.order_id = o.id;",
+    },
   ],
   storage: {
     enableRowLevelSecurity: true,


### PR DESCRIPTION
## Summary
- add resource plan definitions for the conversion users table plus orders, references, receipts, bank events, verification logs, treasury transfers, accounting ledger, and audit events with row-level policies
- register the reconciliation dashboard materialized view in the Supabase resource plan

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc6287336c832295e960ccadd57cdd