### PR TITLE
Add Dynamic Capital legal policy documentation

### DIFF
--- a/docs/legal/cookie-and-tracking-policy.md
+++ b/docs/legal/cookie-and-tracking-policy.md
@@ -1,0 +1,68 @@
+# Cookie and Tracking Policy
+
+_Last updated: October 2024_
+
+This Cookie and Tracking Policy explains how Dynamic Capital uses cookies,
+pixels, software development kits (SDKs), and similar technologies (collectively
+"cookies") when you visit our websites, use our applications, or interact with
+our online services. It also describes the options available to manage your
+preferences.
+
+## 1. What Are Cookies?
+
+Cookies are small data files placed on your device when you visit a website or
+use an application. They help remember your preferences, enable core
+functionality, and provide analytics about how users interact with our services.
+Related technologies, such as local storage, web beacons, and tracking pixels,
+serve similar purposes.
+
+## 2. Types of Cookies We Use
+
+- **Strictly necessary cookies:** Required for core functionality such as
+  account authentication, security, and load balancing. These cookies cannot be
+  disabled without impacting service availability.
+- **Performance and analytics cookies:** Collect information about how visitors
+  use our services, including page views, navigation patterns, and error logs.
+  We use this data to improve reliability and user experience.
+- **Functionality cookies:** Remember user preferences, such as language,
+  timezone, or saved dashboards, to provide a personalized experience.
+- **Marketing cookies:** Track engagement with campaigns, landing pages, and
+  referral sources. Marketing cookies are used only with appropriate consent and
+  may be managed through our preference center.
+
+## 3. Third-Party Cookies
+
+Dynamic Capital partners with trusted service providers that may set cookies on
+our behalf. These providers support analytics, customer support, security, and
+marketing functions. We review vendor privacy practices and require contractual
+commitments to safeguard data.
+
+## 4. Managing Preferences
+
+- Use the in-product cookie banner or preference center to accept, decline, or
+  adjust categories of cookies.
+- Modify browser settings to block or delete cookies. Note that disabling
+  strictly necessary cookies may affect functionality.
+- For mobile applications, adjust tracking settings within the device’s privacy
+  controls or through the application’s settings page.
+- Opt out of third-party analytics or marketing partners using the links
+  provided within the preference center or through industry opt-out mechanisms
+  such as the Network Advertising Initiative (NAI) or Digital Advertising
+  Alliance (DAA).
+
+## 5. Do Not Track
+
+Some browsers support a “Do Not Track” (DNT) signal. Because there is no common
+industry standard, Dynamic Capital does not currently respond to DNT signals.
+Users can manage tracking preferences using the tools described above.
+
+## 6. Updates to This Policy
+
+We may update this Cookie and Tracking Policy to reflect changes in technology,
+applicable law, or our business practices. Updates will be posted on this page
+with an updated “Last updated” date.
+
+## 7. Contact
+
+If you have questions about our use of cookies, contact
+`privacy@dynamic.capital`.

--- a/docs/legal/dynamic-capital-privacy-notice.md
+++ b/docs/legal/dynamic-capital-privacy-notice.md
@@ -1,0 +1,141 @@
+# Dynamic Capital Privacy Notice
+
+_Last updated: October 2024_
+
+Dynamic Capital values the privacy of every client, partner, and visitor who
+interacts with our products, services, and marketing channels. This Privacy
+Notice explains how we collect, use, disclose, and protect personal data. It
+also outlines the rights available to individuals under applicable privacy laws.
+
+## 1. Scope
+
+This Privacy Notice applies to:
+
+- The Dynamic Capital web properties, including logged-in dashboards and public
+  marketing pages.
+- Mobile, desktop, and API clients that integrate with the Dynamic Capital
+  platform.
+- Communications and support interactions across email, chat, or voice.
+- Prospective customers who engage with events, webinars, or marketing
+  campaigns.
+
+Internal human resources processing for employees and contractors is covered by
+separate workforce privacy documentation available through the People Operations
+portal.
+
+## 2. Data We Collect
+
+We collect personal data in the following categories:
+
+- **Account and contact details:** Names, email addresses, company affiliation,
+  and authentication credentials provided during registration or onboarding.
+- **Financial profile information:** Know-your-customer (KYC) data, beneficial
+  ownership attestations, and risk assessments when required for regulatory
+  compliance.
+- **Usage and telemetry data:** Device information, IP addresses, browser type,
+  access logs, feature usage metrics, and error diagnostics to maintain platform
+  reliability.
+- **Communications:** Support tickets, feedback, recordings (with notice), and
+  other correspondence with our teams.
+- **Marketing preferences:** Newsletter opt-ins, campaign responses, and event
+  participation history.
+
+We do not knowingly collect personal data from children under the age of 16. If
+we learn that such data has been provided, we will delete it and take steps to
+prevent future collection.
+
+## 3. How We Use Personal Data
+
+Dynamic Capital processes personal data for legitimate business purposes,
+including to:
+
+1. Provide, operate, and improve our products and services.
+2. Verify identity, manage customer due diligence, and satisfy regulatory
+   obligations.
+3. Deliver personalized content, product recommendations, and marketing
+   communications based on consent or applicable law.
+4. Detect, investigate, and prevent fraud, abuse, or security incidents.
+5. Respond to inquiries, provide customer support, and fulfill contractual
+   commitments.
+6. Perform analytics, conduct research, and develop new features.
+7. Comply with legal obligations, enforce agreements, and protect the rights of
+   Dynamic Capital and our users.
+
+## 4. Sharing and Disclosure
+
+We share personal data with:
+
+- **Service providers:** Cloud hosting, analytics, communications, payment, and
+  security vendors that process data on our behalf under written agreements.
+- **Regulators and legal authorities:** When required by law, subpoena, or legal
+  process, or to protect our rights and the safety of others.
+- **Corporate transactions:** Potential buyers, advisors, or counterparties in
+  the context of mergers, acquisitions, financing, or restructuring events. Any
+  transfer of personal data remains subject to this Privacy Notice or an updated
+  notice that provides equivalent protection.
+
+Dynamic Capital does not sell personal data or share it with third parties for
+cross-context behavioral advertising without consent.
+
+## 5. International Data Transfers
+
+Personal data may be transferred to countries outside of the jurisdiction in
+which it was collected. When we transfer data internationally, we rely on
+adequate safeguards such as Standard Contractual Clauses, intra-group data
+transfer agreements, or other mechanisms recognized by applicable law.
+
+## 6. Data Retention
+
+We retain personal data for as long as necessary to fulfill the purposes
+outlined in this Privacy Notice, comply with legal obligations, resolve
+disputes, and enforce agreements. Retention schedules are reviewed annually and
+aligned with regulatory requirements in the jurisdictions where we operate.
+
+## 7. Individual Rights
+
+Depending on your location, you may have the right to:
+
+- Access, correct, or delete personal data we hold about you.
+- Object to or restrict certain processing activities.
+- Receive a portable copy of your data.
+- Opt out of marketing communications or withdraw consent when processing is
+  based on consent.
+
+Submit privacy requests through our dedicated portal at
+<https://dynamic.capital/privacy-requests> or by emailing
+`privacy@dynamic.capital`. We verify identity before fulfilling requests and aim
+to respond within one month or the timeframe required by law.
+
+## 8. Security
+
+We implement technical and organizational measures to safeguard personal data,
+including encryption in transit and at rest, access controls, continuous
+monitoring, and regular security assessments. Incident response procedures
+ensure that suspected breaches are investigated promptly and reported to
+authorities and affected individuals when required.
+
+## 9. Cookies and Tracking Technologies
+
+We use cookies, pixels, and similar technologies to operate our sites, measure
+performance, and tailor experiences. Detailed information about these tools and
+choices for managing preferences is available in the
+[Cookie and Tracking Policy](cookie-and-tracking-policy.md).
+
+## 10. Changes to This Notice
+
+We will update this Privacy Notice when necessary to reflect changes in our
+practices, technology, or legal requirements. The “Last updated” date at the top
+of the document indicates when it was most recently revised. Material changes
+will be communicated through in-product notifications or email.
+
+## 11. Contact Us
+
+For questions or concerns about this Privacy Notice or our privacy practices,
+please contact:
+
+- Email: `privacy@dynamic.capital`
+- Mail: Dynamic Capital, Inc., Attn: Privacy Office, 548 Market St., PMB 12345,
+  San Francisco, CA 94104, USA
+
+Individuals within the European Economic Area may also contact our EU
+representative at `gdpr@eurotrustcompliance.eu`.

--- a/docs/legal/dynamic-capital-terms-of-use.md
+++ b/docs/legal/dynamic-capital-terms-of-use.md
@@ -1,0 +1,144 @@
+# Dynamic Capital Terms of Use
+
+_Last updated: October 2024_
+
+These Terms of Use ("Terms") govern access to and use of Dynamic Capital
+products, services, mobile applications, websites, and any related content or
+APIs (collectively, the "Services"). By accessing or using the Services, you
+agree to be bound by these Terms and any policies referenced herein. If you do
+not agree, do not use the Services.
+
+## 1. Eligibility and Account Registration
+
+- You must be at least 18 years old and capable of entering into legally binding
+  agreements to use the Services.
+- Account registration requires providing accurate, complete, and up-to-date
+  information. You are responsible for maintaining the confidentiality of your
+  credentials and for all activities that occur under your account.
+- Dynamic Capital reserves the right to decline, suspend, or terminate accounts
+  if information is inaccurate, fraudulent, or violates these Terms.
+
+## 2. Permitted Use
+
+- The Services may be used only for lawful purposes and in accordance with all
+  applicable laws, regulations, and contractual obligations.
+- You may not copy, modify, distribute, reverse engineer, or create derivative
+  works of the Services except as expressly permitted in writing by Dynamic
+  Capital.
+- Automated access (such as bots or scripts) is permitted solely through
+  documented APIs and in compliance with any rate limits or usage restrictions.
+
+## 3. Subscription Plans and Payment
+
+- Fees, billing cycles, and payment methods are described in the applicable
+  order form or subscription agreement. Unless stated otherwise, plans renew
+  automatically at the end of each term.
+- You authorize Dynamic Capital or its payment processors to charge all
+  applicable fees using the payment method on file. Late payments may incur
+  interest or suspension of service.
+- Except where prohibited by law, fees are non-refundable. Certain plans may
+  include trial periods or service-level guarantees described in separate terms.
+
+## 4. Intellectual Property
+
+- All software, documentation, logos, and content made available through the
+  Services are owned by Dynamic Capital or its licensors and are protected by
+  intellectual property laws.
+- Subject to your compliance with these Terms, Dynamic Capital grants a limited,
+  non-exclusive, non-transferable license to use the Services for your internal
+  business purposes.
+- Feedback or suggestions provided to Dynamic Capital may be used without
+  restriction, compensation, or obligation.
+
+## 5. Confidentiality
+
+- Certain areas of the Services may expose confidential information, including
+  research, trading strategies, product roadmaps, or non-public metrics.
+- You agree to protect confidential information with the same level of care used
+  for your own sensitive information and to use it solely as permitted by these
+  Terms or applicable agreements.
+
+## 6. Compliance Obligations
+
+- You are responsible for meeting any regulatory requirements associated with
+  your use of the Services, including financial, tax, data protection, and
+  reporting obligations.
+- Dynamic Capital may require additional information or documentation to fulfill
+  compliance obligations such as KYC/AML checks or export control screenings.
+
+## 7. Third-Party Services
+
+- The Services may integrate with or reference third-party products. Third-party
+  terms and privacy notices apply to your use of those products.
+- Dynamic Capital is not responsible for third-party services, and the inclusion
+  of integrations does not constitute an endorsement.
+
+## 8. Service Availability and Support
+
+- Dynamic Capital aims to provide continuous access to the Services but does not
+  guarantee uninterrupted or error-free operation.
+- Scheduled maintenance or updates may temporarily affect availability. Dynamic
+  Capital will provide reasonable notice of planned downtime when practicable.
+- Support services, response times, and service-level objectives are defined in
+  the applicable support plan or customer agreement.
+
+## 9. Disclaimers
+
+- The Services are provided on an "as is" and "as available" basis without
+  warranties of any kind, express or implied, including warranties of
+  merchantability, fitness for a particular purpose, or non-infringement.
+- Dynamic Capital does not provide investment, legal, or tax advice. Any
+  financial information or market data is for informational purposes only and
+  should not be construed as a recommendation.
+
+## 10. Limitation of Liability
+
+- To the maximum extent permitted by law, Dynamic Capital is not liable for any
+  indirect, incidental, special, consequential, or punitive damages, or any loss
+  of profits, revenue, data, or goodwill arising from or related to your use of
+  the Services.
+- Dynamic Capital’s aggregate liability for claims under these Terms is limited
+  to the greater of (a) fees paid by you in the twelve months preceding the
+  claim or (b) one hundred U.S. dollars (USD $100).
+
+## 11. Indemnification
+
+You agree to indemnify, defend, and hold harmless Dynamic Capital, its officers,
+directors, employees, and agents from any claims, liabilities, damages, losses,
+and expenses (including legal fees) arising out of or related to your use of the
+Services, violation of these Terms, or infringement of any third-party rights.
+
+## 12. Termination
+
+- Either party may terminate access to the Services upon written notice if the
+  other party materially breaches these Terms and fails to cure within thirty
+  days.
+- Dynamic Capital may suspend or terminate access immediately in response to
+  security threats, suspected fraud, legal requests, or misuse of the Services.
+- Upon termination, all rights granted to you under these Terms cease, and you
+  must discontinue use of the Services. Sections intended to survive termination
+  (including intellectual property, confidentiality, disclaimers, limitation of
+  liability, and indemnification) remain in effect.
+
+## 13. Modifications
+
+Dynamic Capital may update these Terms from time to time. Changes become
+effective upon posting to the Services or other communication method identified
+at the time of update. Continued use of the Services after changes take effect
+constitutes acceptance of the revised Terms.
+
+## 14. Governing Law and Dispute Resolution
+
+- These Terms are governed by the laws of the State of Delaware, without regard
+  to conflict of law principles.
+- Disputes will first be addressed through good-faith negotiations between the
+  parties. If unresolved within thirty days, disputes will be submitted to
+  binding arbitration under the rules of the American Arbitration Association in
+  Wilmington, Delaware, unless another venue is required by applicable law.
+- Nothing in this section prevents either party from seeking injunctive or other
+  equitable relief in court to protect intellectual property or confidential
+  information.
+
+## 15. Contact Information
+
+Please direct questions about these Terms to `legal@dynamic.capital`.

--- a/docs/legal/general-risk-warning.md
+++ b/docs/legal/general-risk-warning.md
@@ -1,0 +1,77 @@
+# General Risk Warning
+
+The information, analytics, and tools provided by Dynamic Capital are intended
+for sophisticated users who understand the risks associated with digital assets,
+financial markets, and algorithmic strategies. This General Risk Warning
+highlights key considerations and limitations. It does not replace independent
+professional advice tailored to your specific circumstances.
+
+## Market and Investment Risk
+
+- Digital assets and other alternative investments are highly volatile and may
+  experience rapid price movements or complete loss of value.
+- Past performance, backtests, or simulated results generated through Dynamic
+  Capital tools do not guarantee future outcomes.
+- Liquidity constraints, market gaps, and counterparty failures can prevent
+  execution at expected prices or cause significant slippage.
+
+## Regulatory and Legal Risk
+
+- Regulatory frameworks for digital assets continue to evolve. Jurisdictional
+  changes may restrict access to certain products, impose new compliance
+  obligations, or require divestment.
+- Users are responsible for ensuring their activities comply with applicable
+  laws, including securities, derivatives, commodities, tax, and data protection
+  regulations.
+- Dynamic Capital does not represent that any particular strategy or product is
+  authorized in your jurisdiction.
+
+## Technology and Operational Risk
+
+- Trading systems, APIs, and infrastructure may experience outages, latency, or
+  unexpected behavior due to software defects, cyberattacks, or third-party
+  service disruptions.
+- Automated strategies can generate unintended orders or positions if
+  configurations are incorrect or market conditions change rapidly. Implement
+  appropriate safeguards, such as circuit breakers and manual overrides.
+- Users are responsible for maintaining secure access controls, protecting API
+  keys, and monitoring their accounts for unauthorized activity.
+
+## Counterparty and Custodial Risk
+
+- Storing assets with third-party custodians or trading venues introduces risk
+  of insolvency, security breaches, or operational failures at those
+  institutions.
+- Conduct independent due diligence on counterparties and understand the terms
+  of custody, including segregation of assets, insurance coverage, and recovery
+  procedures.
+
+## Leverage and Derivatives Risk
+
+- Leverage amplifies both gains and losses. Small market moves can trigger
+  margin calls, forced liquidations, or negative account balances.
+- Complex derivatives, structured products, or perpetual swaps may involve
+  embedded risks such as funding rate fluctuations, basis risk, or mandatory
+  settlement events.
+
+## No Personalized Advice
+
+Dynamic Capital provides general information, analytics, and infrastructure. We
+are not acting as an investment adviser, broker, fiduciary, or tax advisor for
+any user. You should consult qualified professionals before making investment or
+trading decisions.
+
+## User Responsibilities
+
+- Evaluate your financial objectives, experience, and risk tolerance before
+  using Dynamic Capital tools.
+- Test strategies in simulated or sandbox environments prior to deploying live
+  capital.
+- Maintain appropriate capital reserves and risk controls to withstand adverse
+  market movements.
+
+## Acknowledgement
+
+By using Dynamic Capital products or services, you acknowledge that you
+understand and accept the risks described in this warning and agree to use the
+platform responsibly.

--- a/docs/legal/licenses-registrations-and-legal-matters.md
+++ b/docs/legal/licenses-registrations-and-legal-matters.md
@@ -1,0 +1,108 @@
+# Licenses, Registrations, and Other Legal Matters
+
+Dynamic Capital maintains a proactive compliance posture designed to meet the
+expectations of financial regulators, data protection authorities, and
+commercial partners. This overview summarizes the core registrations, filings,
+and governance processes that underpin the organization’s operations. It should
+be reviewed at least quarterly alongside updates from legal counsel to ensure
+the information remains accurate and complete.
+
+## Corporate Structure and Governance
+
+- **Parent entity:** Dynamic Capital, Inc., a Delaware corporation in good
+  standing. Corporate records, bylaws, and board resolutions are stored in the
+  internal governance repository and mirrored to the registered agent’s portal.
+- **Subsidiaries and affiliates:** Any new subsidiary must undergo a legal
+  entity creation review that covers jurisdictional requirements, tax
+  registrations, banking arrangements, and local representation obligations.
+- **Board oversight:** The board of directors maintains an annual compliance
+  calendar that tracks regulatory filings, audit engagements, and major risk
+  assessments. Minutes documenting board review of compliance matters are
+  retained for a minimum of seven years.
+
+## Financial Services and Fintech Licensing
+
+Dynamic Capital does not currently hold customer deposits or execute trades on
+behalf of customers. If the business model expands into regulated activities,
+the following licensing pathways must be evaluated before launch:
+
+- **Investment advisory services (United States):** Registration with the U.S.
+  Securities and Exchange Commission (SEC) or applicable state regulators may be
+  required under the Investment Advisers Act of 1940. Legal must prepare Form
+  ADV filings, supervisory procedures, and adviser representative registrations
+  where necessary.
+- **Broker-dealer activity:** Any order routing, matching, or execution services
+  involving securities trigger the need for Financial Industry Regulatory
+  Authority (FINRA) membership and compliance with SEC Rule 15c3-5. Written
+  supervisory procedures, net capital planning, and anti-money laundering (AML)
+  programs must be finalized before operations commence.
+- **Money transmission and virtual asset services:** Offering custodial wallets
+  or fiat on-ramps may require state-by-state money transmitter licenses in the
+  U.S. and virtual asset service provider (VASP) registrations in the European
+  Union, United Kingdom, Singapore, or other jurisdictions. Compliance must
+  coordinate licensing roadmaps and surety bond procurement with finance.
+- **Derivatives and commodities:** Providing futures, swaps, or leveraged token
+  products may bring the Commodity Futures Trading Commission (CFTC) and
+  National Futures Association (NFA) within scope. Commodity pool operator (CPO)
+  or commodity trading advisor (CTA) registration assessments are mandatory
+  before marketing any such products.
+
+## Data Protection and Privacy Filings
+
+- **GDPR and UK GDPR:** Dynamic Capital leverages an authorized EU and UK
+  representative network, supported by Article 30 records of processing
+  activities and data protection impact assessments (DPIAs). The Data Protection
+  Officer (DPO) maintains contact details for supervisory authorities and
+  coordinates breach notifications within statutory timelines.
+- **U.S. state privacy laws:** Compliance monitors developments in the
+  California Consumer Privacy Act (CCPA/CPRA), Virginia CDPA, Colorado Privacy
+  Act, and similar regimes. The privacy notice and opt-out controls are updated
+  whenever new state-level rights are enacted.
+- **International data transfers:** Standard Contractual Clauses (SCCs) or other
+  approved transfer mechanisms are executed with all processors handling
+  personal data outside of the originating jurisdiction. Transfer impact
+  assessments are logged in the trust and safety workspace.
+
+## Anti-Money Laundering and Financial Crime Controls
+
+- **KYC program:** Customer onboarding leverages risk-based verification,
+  screening against government watchlists, and ongoing monitoring using
+  third-party vendors. Enhanced due diligence is required for high-risk
+  customers, politically exposed persons (PEPs), and corporate accounts with
+  complex ownership structures.
+- **Suspicious activity reporting:** Procedures align with Bank Secrecy Act
+  (BSA) expectations. Suspicious Activity Reports (SARs) or analogous filings
+  must be submitted within required deadlines and retained per regulatory
+  guidance.
+- **Sanctions compliance:** Operations rely on the latest Office of Foreign
+  Assets Control (OFAC), United Nations, European Union, and UK sanctions lists.
+  Screening occurs at onboarding and continuously thereafter. Potential matches
+  are escalated to the sanctions officer for adjudication.
+
+## Insurance and Professional Certifications
+
+- **Errors and omissions (E&O) coverage:** Policies should be reviewed annually
+  to confirm limits align with contractual obligations and projected revenue.
+- **Cyber liability insurance:** Minimum coverage must support incident response
+  costs, notification expenses, and regulatory investigations arising from
+  security events.
+- **Third-party attestations:** SOC 2 Type II, ISO/IEC 27001, and penetration
+  testing reports are cataloged in the compliance portal to support due
+  diligence requests from enterprise customers.
+
+## Recordkeeping and Reporting
+
+- Maintain a centralized register of all active licenses, application statuses,
+  renewal dates, and responsible owners.
+- Track statutory reporting obligations (e.g., Form PF, Form CRS, MiFID II
+  transaction reporting) using the compliance calendar. Escalate any risk of
+  late filings to the Chief Compliance Officer (CCO) immediately.
+- Retain regulatory correspondence, inspection reports, and remediation plans in
+  a secure evidence repository with role-based access controls.
+
+## Contact Information
+
+For questions about licensing or regulatory matters, contact
+`legal@dynamic.capital` or the Chief Compliance Officer via the internal
+communications directory. Urgent regulatory inquiries should be escalated
+through the incident response hotline to ensure timely handling.


### PR DESCRIPTION
## Summary
- add a licensing and regulatory obligations overview for Dynamic Capital
- publish privacy notice, terms of use, and general risk warning for customer-facing properties
- document cookie and tracking practices to round out the legal policy set

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dc7876b49483228d7aaf3fe9fd1a60