### PR TITLE
Expand TON token and NFT workflow guide

### DIFF
--- a/docs/ton_token_nft_workflow.md
+++ b/docs/ton_token_nft_workflow.md
@@ -1,0 +1,137 @@
+# TON Token and NFT Creation Workflow
+
+This playbook breaks down the practical steps for launching fungible jettons
+(TIP-3 tokens) and NFT collections on The Open Network (TON). It covers both
+command-line tooling and marketplace-assisted paths, plus Tonkeeper verification
+requirements for removing the "Unverified" label.
+
+## Prerequisites
+
+- A funded TON wallet (Tonkeeper or equivalent) with access to the private/seed
+  phrase.
+- Familiarity with the
+  [TON CLI tooling](https://github.com/ton-community/toncli) or a trusted
+  marketplace such as [Getgems](https://getgems.io/).
+- Ability to sign transactions from the owner wallet. Keep the seed phrase and
+  any keystores offline.
+
+## 1. Launching a Jetton (TIP-3 Token)
+
+### Option A — Command-line workflow (toncli/tondev)
+
+1. **Create the project**
+   - Install toncli (`pip install toncli`) and initialise a project:
+     `toncli start my_jetton`.
+   - Add a jetton minter contract template or clone an audited implementation
+     (e.g. from
+     [ton-community/token-contracts](https://github.com/ton-community/token-contracts)).
+2. **Configure token metadata**
+   - Update the jetton parameters: `name`, `symbol`, `decimals`, initial supply
+     and owner address inside the config (`deploy.config.json` or equivalent).
+   - Prepare an off-chain metadata file (JSON) with icon URL and description for
+     wallets that support metadata fetch.
+3. **Compile and deploy**
+   - Run `toncli build` to compile the contract.
+   - Use `toncli deploy --network mainnet` (or `testnet`) supplying the owner
+     wallet keys. Confirm the deployment transaction hash and store it securely.
+4. **Mint or distribute supply**
+   - Call the `mint` function (via `toncli run` or an SDK script) to mint
+     additional supply to specified addresses.
+   - Alternatively, transfer balances from the owner wallet if the initial
+     supply was pre-minted.
+5. **Automate administration**
+   - Optional scripts can be written with the TON SDKs (TypeScript, Python) for
+     airdrops, treasury minting, or burning.
+
+### Option B — Web deployment assistants
+
+1. Choose a trusted jetton deployment service and connect your Tonkeeper wallet.
+2. Input the same metadata (name, symbol, decimals, icon URL, total supply) and
+   confirm the generated contract parameters.
+3. Approve the deployment transaction from Tonkeeper and note the minter
+   address.
+4. Use the interface or Tonkeeper to transfer minted tokens to recipients.
+
+### Tonkeeper jetton verification (ton-assets PR)
+
+1. Fork [`tonkeeper/ton-assets`](https://github.com/tonkeeper/ton-assets) and
+   clone your fork locally.
+2. Create a new file under `jettons/<token-symbol>.yaml` containing:
+   ```yaml
+   name: Example Token
+   symbol: EXMPL
+   address: <jetton-minter-address>
+   decimals: 9
+   description: >-
+     Short token blurb.
+   social:
+     - https://example.com
+   ```
+3. Commit the file, push, and open a Pull Request against the upstream
+   repository following their contribution checklist.
+4. Wait for Tonkeeper maintainers to review. Once merged, the wallet removes the
+   "Unverified Token" badge.
+
+## 2. Launching an NFT Collection
+
+### Option A — Getgems marketplace workflow
+
+1. **Connect and configure**
+   - Visit [Getgems Create](https://getgems.io/create) and connect your
+     Tonkeeper wallet.
+   - Choose "Collection" and fill in collection name, symbol, description,
+     royalties, and media hosting (IPFS/Arweave recommended).
+2. **Upload metadata**
+   - Provide item media (images, video, etc.), JSON attributes, and royalty
+     recipient address.
+   - Double-check hosted URLs are permanent before minting.
+3. **Mint collection**
+   - Approve the deployment transaction for the collection contract.
+   - Mint items individually or via batch upload (CSV/JSON) depending on the
+     Getgems UI options.
+4. **List and manage sales**
+   - Set listing price per item and sign sale listings from Tonkeeper.
+   - Monitor offers, accept bids, or transfer NFTs directly from the marketplace
+     dashboard.
+5. **Support**
+   - Refer to the Getgems FAQ/support links for platform-specific
+     troubleshooting.
+
+### Option B — Command-line workflow
+
+1. **Clone an NFT collection contract** (e.g. from
+   [ton-community/nft-contracts](https://github.com/ton-community/nft-contracts)).
+2. **Populate metadata**
+   - Prepare an off-chain metadata manifest with collection-level data and
+     per-item JSON files pointing to the media.
+   - Update contract configuration to reference the manifest URLs.
+3. **Compile and deploy**
+   - Use `toncli build` followed by `toncli deploy` (or equivalent SDK
+     deployment script) to publish the collection and NFT item contracts.
+4. **Mint items**
+   - Invoke the mint function with recipient addresses and metadata indices.
+     Track minted item IDs and transaction hashes.
+5. **Marketplace listings**
+   - Once items exist on-chain, they can be listed on Getgems or any TON
+     marketplace by connecting the owner wallet.
+
+### Tonkeeper NFT verification (ton-assets PR)
+
+1. In your `ton-assets` fork, add `collections/<collection-name>.yaml`
+   describing the collection address, metadata URL, and links.
+2. Follow the same PR workflow as jettons. Ensure the collection already exists
+   on-chain before submitting.
+
+## 3. Operational and Security Notes
+
+- Back up owner keys, mnemonic phrases, and deployment configs offline. Consider
+  multisig control for treasuries.
+- Use testnet to rehearse deployments before committing real funds.
+- Avoid duplicate entries or prohibited content in `ton-assets` PRs—maintainers
+  may reject submissions without detailed reasoning.
+- Monitor deployed contracts for suspicious activity and keep a runbook for
+  pausing minting or rotating admin keys if supported.
+- Communicate supply, vesting, and royalty policies transparently to holders.
+
+Provide your preferred tooling path (command-line vs. marketplace) if you need a
+more granular walkthrough or automation scripts.

--- a/docs/web-site-map.md
+++ b/docs/web-site-map.md
@@ -1,66 +1,101 @@
 # Dynamic Capital Unified Site Map
 
-Dynamic Capital guides first-time and seasoned investors through one coordinated journey that spans the responsive web app and the Telegram mini app. Each touchpoint uses minimalist layouts, confident tone, and concise CTAs so beginners always understand the next action.
+Dynamic Capital guides first-time and seasoned investors through one coordinated
+journey that spans the responsive web app and the Telegram mini app. Each
+touchpoint uses minimalist layouts, confident tone, and concise CTAs so
+beginners always understand the next action.
 
 ## Unified Experience Matrix
 
-| Journey stage | Experience | Web route & CTA | Telegram mini app route & CTA | Why it helps beginners |
-| --- | --- | --- | --- | --- |
-| Onboard & orient | Welcome launch pad | `/` → **Continue to Home** button reiterates the value promise beside social proof. | `/miniapp` → auto-redirect with matching hero copy and **Continue to Home** confirmation. | Sets expectations immediately and keeps the welcome story identical on every device. |
-| Onboard & orient | Personalized home hub | `/investor` → **Explore Home** cards highlight top tasks and a quick-start checklist. | `/miniapp/home` → **Explore Home** cards tailored via Telegram authentication. | Keeps guidance familiar whether investors begin on web or Telegram. |
-| Research & readiness | Fund transparency | `/token` → **Review Fund Metrics** button alongside plain-language charts on supply, utility, and allocation. | `/miniapp/fund` → **Review Fund Metrics** button above mirrored tokenomics visuals. | Explains token mechanics without jargon so investors can evaluate value quickly. |
-| Research & readiness | Signal feed | `/investor` → signals tab with **Follow Signals** button near mentor commentary. | `/miniapp/signals` → **Follow Signals** button with live tips for interpreting each alert. | Couples every alert with coaching so research and action stay aligned. |
-| Research & readiness | Watchlist builder | `/investor` → watchlist tab with **Update Watchlist** button synced to planning tools. | `/miniapp/watchlist` → **Update Watchlist** button for managing the same basket inside Telegram. | Maintains a single watchlist across channels, reducing duplicate work. |
-| Execute & monitor | Trading desk | `/investor` → trade workspace with **Place a Trade** button framed by guardrails and position sizing helpers. | `/miniapp/trade` → **Place a Trade** button inside a compact panel with identical safeguards. | Reinforces disciplined execution with consistent controls. |
-| Execute & monitor | Portfolio overview | `/investor` → overview tab with **View Portfolio** button next to performance trends. | `/miniapp/overview` → **View Portfolio** button for quick check-ins. | Provides a familiar health snapshot so investors stay confident. |
-| Support & upkeep | Mentorship access | `/support` → **Start Mentorship Chat** button connecting to mentors, FAQs, and playbooks. | `/miniapp/mentorship` → **Start Mentorship Chat** button for on-demand coaching. | Keeps human reassurance one tap away. |
-| Support & upkeep | Account center | `/investor` → account tools with **Manage Account** button covering billing, concierge access, and status updates. | `/miniapp/account` → **Manage Account** button with mirrored preferences. | Syncs billing and preferences automatically so upkeep stays simple. |
+| Journey stage        | Experience            | Web route & CTA                                                                                                    | Telegram mini app route & CTA                                                                    | Why it helps beginners                                                               |
+| -------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Onboard & orient     | Welcome launch pad    | `/` → **Continue to Home** button reiterates the value promise beside social proof.                                | `/miniapp` → auto-redirect with matching hero copy and **Continue to Home** confirmation.        | Sets expectations immediately and keeps the welcome story identical on every device. |
+| Onboard & orient     | Personalized home hub | `/investor` → **Explore Home** cards highlight top tasks and a quick-start checklist.                              | `/miniapp/home` → **Explore Home** cards tailored via Telegram authentication.                   | Keeps guidance familiar whether investors begin on web or Telegram.                  |
+| Research & readiness | Fund transparency     | `/token` → **Review Fund Metrics** button alongside plain-language charts on supply, utility, and allocation.      | `/miniapp/fund` → **Review Fund Metrics** button above mirrored tokenomics visuals.              | Explains token mechanics without jargon so investors can evaluate value quickly.     |
+| Research & readiness | Signal feed           | `/investor` → signals tab with **Follow Signals** button near mentor commentary.                                   | `/miniapp/signals` → **Follow Signals** button with live tips for interpreting each alert.       | Couples every alert with coaching so research and action stay aligned.               |
+| Research & readiness | Watchlist builder     | `/investor` → watchlist tab with **Update Watchlist** button synced to planning tools.                             | `/miniapp/watchlist` → **Update Watchlist** button for managing the same basket inside Telegram. | Maintains a single watchlist across channels, reducing duplicate work.               |
+| Execute & monitor    | Trading desk          | `/investor` → trade workspace with **Place a Trade** button framed by guardrails and position sizing helpers.      | `/miniapp/trade` → **Place a Trade** button inside a compact panel with identical safeguards.    | Reinforces disciplined execution with consistent controls.                           |
+| Execute & monitor    | Portfolio overview    | `/investor` → overview tab with **View Portfolio** button next to performance trends.                              | `/miniapp/overview` → **View Portfolio** button for quick check-ins.                             | Provides a familiar health snapshot so investors stay confident.                     |
+| Support & upkeep     | Mentorship access     | `/support` → **Start Mentorship Chat** button connecting to mentors, FAQs, and playbooks.                          | `/miniapp/mentorship` → **Start Mentorship Chat** button for on-demand coaching.                 | Keeps human reassurance one tap away.                                                |
+| Support & upkeep     | Account center        | `/investor` → account tools with **Manage Account** button covering billing, concierge access, and status updates. | `/miniapp/account` → **Manage Account** button with mirrored preferences.                        | Syncs billing and preferences automatically so upkeep stays simple.                  |
 
 ## Web App Route List
 
-- `/` — Welcome launch pad that introduces Dynamic Capital and drives the **Continue to Home** action.
-- `/investor` — Personalized hub containing **Explore Home**, trading, signals, watchlist, overview, and account tabs.
+- `/` — Welcome launch pad that introduces Dynamic Capital and drives the
+  **Continue to Home** action.
+- `/investor` — Personalized hub containing **Explore Home**, trading, signals,
+  watchlist, overview, and account tabs.
 - `/token` — Fund transparency dashboard with the **Review Fund Metrics** CTA.
-- `/support` — Mentorship and help center offering the **Start Mentorship Chat** CTA.
+- `/support` — Mentorship and help center offering the **Start Mentorship Chat**
+  CTA.
 
 ## Telegram Mini App Route List
 
-- `/miniapp` — Stable entry redirect that confirms the **Continue to Home** action.
+- `/miniapp` — Stable entry redirect that confirms the **Continue to Home**
+  action.
 - `/miniapp/home` — Personalized home hub surfaced via Telegram authentication.
-- `/miniapp/trade` — Trading workspace replicating web guardrails and the **Place a Trade** CTA.
-- `/miniapp/fund` — Tokenomics dashboard supporting the **Review Fund Metrics** CTA.
-- `/miniapp/signals` — Live signal feed with the **Follow Signals** CTA and beginner tips.
-- `/miniapp/overview` — Snapshot view for portfolio health and the **View Portfolio** CTA.
-- `/miniapp/mentorship` — Mentor chat access triggered by the **Start Mentorship Chat** CTA.
-- `/miniapp/account` — Account management center anchored by the **Manage Account** CTA.
-- `/miniapp/watchlist` — Synced watchlist management with the **Update Watchlist** CTA.
+- `/miniapp/trade` — Trading workspace replicating web guardrails and the
+  **Place a Trade** CTA.
+- `/miniapp/fund` — Tokenomics dashboard supporting the **Review Fund Metrics**
+  CTA.
+- `/miniapp/signals` — Live signal feed with the **Follow Signals** CTA and
+  beginner tips.
+- `/miniapp/overview` — Snapshot view for portfolio health and the **View
+  Portfolio** CTA.
+- `/miniapp/mentorship` — Mentor chat access triggered by the **Start Mentorship
+  Chat** CTA.
+- `/miniapp/account` — Account management center anchored by the **Manage
+  Account** CTA.
+- `/miniapp/watchlist` — Synced watchlist management with the **Update
+  Watchlist** CTA.
 
 ## Dynamic AGI Enhancements to Explore
 
-1. **Adaptive onboarding coach** — Use conversational AGI to gauge experience level and risk comfort, then surface tailored checklists across `/investor` and `/miniapp/home`.
-2. **Signal confidence labels** — Attach AGI-generated confidence scores and one-line rationales to `/investor` and `/miniapp/signals` alerts.
-3. **Smart fund digest** — Publish weekly AGI summaries explaining changes on `/token` and `/miniapp/fund` so beginners stay current.
-4. **Scenario rehearsal mode** — Offer AGI-simulated trade walk-throughs inside `/investor` and `/miniapp/trade` for safe practice.
-5. **Portfolio health nudges** — Monitor `/investor` overview and `/miniapp/overview` data to send proactive diversification or cash-buffer reminders.
-6. **Success roadmap generator** — Turn mentorship milestones into next-step learning plans surfaced in `/support` and `/miniapp/account`.
+1. **Adaptive onboarding coach** — Use conversational AGI to gauge experience
+   level and risk comfort, then surface tailored checklists across `/investor`
+   and `/miniapp/home`.
+2. **Signal confidence labels** — Attach AGI-generated confidence scores and
+   one-line rationales to `/investor` and `/miniapp/signals` alerts.
+3. **Smart fund digest** — Publish weekly AGI summaries explaining changes on
+   `/token` and `/miniapp/fund` so beginners stay current.
+4. **Scenario rehearsal mode** — Offer AGI-simulated trade walk-throughs inside
+   `/investor` and `/miniapp/trade` for safe practice.
+5. **Portfolio health nudges** — Monitor `/investor` overview and
+   `/miniapp/overview` data to send proactive diversification or cash-buffer
+   reminders.
+6. **Success roadmap generator** — Turn mentorship milestones into next-step
+   learning plans surfaced in `/support` and `/miniapp/account`.
 
 ## Implementation Checklist
 
 ### Stage 1 — Onboard & Orient
-- [ ] Align hero copy, visuals, and analytics events across `/` and `/miniapp` to keep the welcome promise identical.
-- [ ] Build personalized welcome states on `/investor` and `/miniapp/home`, tracking taps on the **Explore Home** CTA.
+
+- [ ] Align hero copy, visuals, and analytics events across `/` and `/miniapp`
+      to keep the welcome promise identical.
+- [ ] Build personalized welcome states on `/investor` and `/miniapp/home`,
+      tracking taps on the **Explore Home** CTA.
 
 ### Stage 2 — Research & Readiness
-- [ ] Serve the same data source to `/token` and `/miniapp/fund`, validating metric parity.
-- [ ] Standardize alert formatting and the **Follow Signals** CTA across `/investor` and `/miniapp/signals`.
-- [ ] Enable near-real-time syncing between `/investor` and `/miniapp/watchlist` edits.
+
+- [ ] Serve the same data source to `/token` and `/miniapp/fund`, validating
+      metric parity.
+- [ ] Standardize alert formatting and the **Follow Signals** CTA across
+      `/investor` and `/miniapp/signals`.
+- [ ] Enable near-real-time syncing between `/investor` and `/miniapp/watchlist`
+      edits.
 
 ### Stage 3 — Execute & Monitor
-- [ ] Match guardrails, order flows, and the **Place a Trade** CTA between `/investor` and `/miniapp/trade`.
-- [ ] Mirror portfolio calculations and labeling between `/investor` overview and `/miniapp/overview`.
+
+- [ ] Match guardrails, order flows, and the **Place a Trade** CTA between
+      `/investor` and `/miniapp/trade`.
+- [ ] Mirror portfolio calculations and labeling between `/investor` overview
+      and `/miniapp/overview`.
 
 ### Stage 4 — Support & Upkeep
-- [ ] Connect mentor routing, transcripts, and satisfaction tracking across `/support` and `/miniapp/mentorship`.
-- [ ] Centralize billing and status updates so changes on `/investor` account tools appear instantly in `/miniapp/account`.
-- [ ] Trigger beginner-friendly surveys after mentorship and account sessions to confirm clarity and confidence.
 
+- [ ] Connect mentor routing, transcripts, and satisfaction tracking across
+      `/support` and `/miniapp/mentorship`.
+- [ ] Centralize billing and status updates so changes on `/investor` account
+      tools appear instantly in `/miniapp/account`.
+- [ ] Trigger beginner-friendly surveys after mentorship and account sessions to
+      confirm clarity and confidence.


### PR DESCRIPTION
## Summary
- expand the TON token and NFT workflow guide with detailed command-line and marketplace paths plus ton-assets verification steps
- reflow the unified site map documentation to match current formatting conventions

## Testing
- npm run format
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dca7e305a48322b9da0eca35db4bbb