### PR TITLE
Fix dataset parquet metadata handling and adjust trade sizing

### DIFF
--- a/algorithms/python/dataset_builder.py
+++ b/algorithms/python/dataset_builder.py
@@ -137,6 +137,19 @@ class DatasetWriter:
         payload = asdict(sample)
         payload["timestamp"] = sample.timestamp.isoformat()
         payload["features"] = list(sample.features)
+
+        metadata = sample.metadata
+        if metadata:
+            # ``pyarrow`` requires struct columns to define their child schema.
+            # By round-tripping through JSON we normalise any nested mapping
+            # into plain Python containers while preserving values. When the
+            # metadata is empty we explicitly store ``None`` so the column is
+            # treated as nullable instead of an empty struct, which Parquet
+            # cannot materialise.
+            payload["metadata"] = json.loads(json.dumps(metadata))
+        else:
+            payload["metadata"] = None
+
         return payload
 
     def _chunked_shuffle_records_for_tests(


### PR DESCRIPTION
## Summary
- normalise dataset sample metadata before parquet writes so pyarrow can stream empty payloads safely
- retune trade signal scaling factors and volatility penalty to align execution lot sizing with signal quality inputs

## Testing
- pytest algorithms/python/tests/test_dataset_builder.py
- pytest tests/test_dynamic_trading_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68dcb541fec483228a0ded8de8d2718c