### PR TITLE
Enforce base workchain checks for TON contracts

### DIFF
--- a/dynamic-capital-ton/contracts/jetton/master.tact
+++ b/dynamic-capital-ton/contracts/jetton/master.tact
@@ -45,6 +45,9 @@ contract DynamicCapitalMaster with JettonMaster {
   pendingRouter?: TimelockPayload;
 
   init(admin: Address, content: Cell, walletCode: Cell, treasury: Address, dexRouter: Address, timelockHours: Int) {
+    self.requireBaseWorkchain(admin, "master: admin workchain");
+    self.requireBaseWorkchain(treasury, "master: treasury workchain");
+    self.requireBaseWorkchain(dexRouter, "master: router workchain");
     self.admin = admin;
     self.jettonContent = content;
     self.jettonWalletCode = walletCode;
@@ -116,6 +119,7 @@ contract DynamicCapitalMaster with JettonMaster {
     if (op == OP_SCHEDULE_TREASURY) {
       self.requireAdmin(msg.info.src);
       Address newTreasury = sc.loadMsgAddress();
+      self.requireBaseWorkchain(newTreasury, "master: treasury workchain");
       self.pendingTreasury = TimelockPayload{ executeAfter: now() + self.timelockSeconds, boolValue: false, intValue: 0, addressValue: newTreasury };
       return;
     }
@@ -129,6 +133,7 @@ contract DynamicCapitalMaster with JettonMaster {
     if (op == OP_SCHEDULE_ROUTER) {
       self.requireAdmin(msg.info.src);
       Address newRouter = sc.loadMsgAddress();
+      self.requireBaseWorkchain(newRouter, "master: router workchain");
       self.pendingRouter = TimelockPayload{ executeAfter: now() + self.timelockSeconds, boolValue: false, intValue: 0, addressValue: newRouter };
       return;
     }
@@ -186,12 +191,14 @@ contract DynamicCapitalMaster with JettonMaster {
     }
 
     if (kind == TimelockKind::Treasury) {
+      self.requireBaseWorkchain(payload.addressValue, "master: treasury workchain");
       self.treasury = payload.addressValue;
       self.pendingTreasury = null;
       return;
     }
 
     if (kind == TimelockKind::Router) {
+      self.requireBaseWorkchain(payload.addressValue, "master: router workchain");
       self.dexRouter = payload.addressValue;
       self.pendingRouter = null;
       return;
@@ -200,5 +207,10 @@ contract DynamicCapitalMaster with JettonMaster {
 
   fun requireAdmin(addr: Address) {
     require(addr == self.admin, "not admin");
+  }
+
+  fun requireBaseWorkchain(addr: Address, err: String) {
+    StdAddress components = parseStdAddress(addr.asSlice());
+    require(components.workchain == 0, err);
   }
 }

--- a/dynamic-capital-ton/contracts/pool_allocator.tact
+++ b/dynamic-capital-ton/contracts/pool_allocator.tact
@@ -48,6 +48,11 @@ contract TonPoolAllocator {
     dctMaster: Address,
     timelockHours: Int,
   ) {
+    self.requireBaseWorkchain(admin, "allocator: admin workchain");
+    self.requireBaseWorkchain(treasury, "allocator: treasury workchain");
+    self.requireBaseWorkchain(dexRouter, "allocator: router workchain");
+    self.requireBaseWorkchain(usdtJetton, "allocator: usdt workchain");
+    self.requireBaseWorkchain(dctMaster, "allocator: dct master workchain");
     self.admin = admin;
     self.treasury = treasury;
     self.dexRouter = dexRouter;
@@ -88,6 +93,7 @@ contract TonPoolAllocator {
 
     if (op == OP_SCHEDULE_ROUTER) {
       Address next = body.loadMsgAddress();
+      self.requireBaseWorkchain(next, "allocator: router workchain");
       self.pendingRouter = TimelockAction{
         executeAfter: now() + self.timelockSeconds,
         addressValue: next,
@@ -103,6 +109,7 @@ contract TonPoolAllocator {
 
     if (op == OP_SCHEDULE_TREASURY) {
       Address nextTreasury = body.loadMsgAddress();
+      self.requireBaseWorkchain(nextTreasury, "allocator: treasury workchain");
       self.pendingTreasury = TimelockAction{
         executeAfter: now() + self.timelockSeconds,
         addressValue: nextTreasury,
@@ -182,7 +189,9 @@ contract TonPoolAllocator {
     require(pending != null(), "allocator: nothing scheduled");
     require(now() >= pending?.executeAfter, "allocator: timelock");
     require(pending?.addressValue != null(), "allocator: invalid address");
-    return pending?.addressValue as Address;
+    Address value = pending?.addressValue as Address;
+    self.requireBaseWorkchain(value, "allocator: workchain mismatch");
+    return value;
   }
 
   fun requirePause(pending?: PauseAction): Bool {
@@ -203,5 +212,10 @@ contract TonPoolAllocator {
         body: beginCell().storeUint(op::transfer_notification, 32).storeString(err).endCell(),
       },
     );
+  }
+
+  fun requireBaseWorkchain(addr: Address, err: String) {
+    StdAddress components = parseStdAddress(addr.asSlice());
+    require(components.workchain == 0, err);
   }
 }

--- a/dynamic-capital-ton/contracts/theme/theme_collection.tact
+++ b/dynamic-capital-ton/contracts/theme/theme_collection.tact
@@ -37,6 +37,8 @@ contract ThemeCollection with NftCollection {
     itemCode: Cell,
     royalty: RoyaltyParams,
   ) {
+    self.requireBaseWorkchain(owner, "theme: owner workchain");
+    self.requireBaseWorkchain(dao, "theme: dao workchain");
     self.owner = owner;
     self.dao = dao;
     self.collectionContent = collectionContent;
@@ -107,6 +109,11 @@ contract ThemeCollection with NftCollection {
 
   fun requireDao(sender: Address) {
     require(sender == self.dao, "theme: unauthorized");
+  }
+
+  fun requireBaseWorkchain(addr: Address, err: String) {
+    StdAddress components = parseStdAddress(addr.asSlice());
+    require(components.workchain == 0, err);
   }
 
   get fun get_collection_data(): (Int, Cell, Address, Cell) {

--- a/dynamic-capital-ton/contracts/theme/theme_item.tact
+++ b/dynamic-capital-ton/contracts/theme/theme_item.tact
@@ -20,6 +20,8 @@ contract ThemeItem with NftItem {
     priority: Int,
     frozen: Bool,
   ) {
+    self.requireBaseWorkchain(collection, "theme-item: collection workchain");
+    self.requireBaseWorkchain(owner, "theme-item: owner workchain");
     self.collection = collection;
     self.owner = owner;
     self.index = index;
@@ -62,6 +64,11 @@ contract ThemeItem with NftItem {
 
   fun requireCollection(sender: Address) {
     require(sender == self.collection, "theme-item: unauthorized");
+  }
+
+  fun requireBaseWorkchain(addr: Address, err: String) {
+    StdAddress components = parseStdAddress(addr.asSlice());
+    require(components.workchain == 0, err);
   }
 
   get fun get_nft_data(): (Int, Address, Address, Slice, Int, Bool) {


### PR DESCRIPTION
## Summary
- enforce base workchain validation for jetton master administrator, treasury, and router updates
- require base workchain addresses during pool allocator initialization and timelock execution
- guard theme collection and item contracts against non-base workchain owners and DAO addresses

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dcbb30eae8832286a1419b7f5e9552