### PR TITLE
Add Nano Banana NFT image integration

### DIFF
--- a/dynamic_token/__init__.py
+++ b/dynamic_token/__init__.py
@@ -6,7 +6,8 @@ from .engine import (
     DynamicCapitalTokenEngine,
     committee_signals_from_optimisation,
 )
-from .nft import DynamicNFTMinter, MintedDynamicNFT
+from .image import GeneratedNFTImage, NanoBananaClient
+from .nft import DynamicNFTMinter, MintedDynamicNFT, NFTImageGenerator
 from .treasury import DynamicTreasuryAlgo
 
 __all__ = [
@@ -16,5 +17,8 @@ __all__ = [
     "DynamicTreasuryAlgo",
     "DynamicNFTMinter",
     "MintedDynamicNFT",
+    "GeneratedNFTImage",
+    "NFTImageGenerator",
+    "NanoBananaClient",
     "committee_signals_from_optimisation",
 ]

--- a/dynamic_token/image.py
+++ b/dynamic_token/image.py
@@ -1,0 +1,226 @@
+"""Image generation helpers for Dynamic Capital NFTs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Any, Mapping, MutableMapping, Sequence
+import importlib
+
+
+def _load_requests() -> ModuleType:
+    """Return the :mod:`requests` module if it is installed."""
+
+    return importlib.import_module("requests")
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return int(value)
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        value = value.strip()
+        if value:
+            return value
+    return None
+
+
+@dataclass(slots=True)
+class GeneratedNFTImage:
+    """Result from invoking an NFT image generator."""
+
+    url: str
+    prompt: str
+    mime_type: str | None = None
+    seed: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_metadata(self) -> MutableMapping[str, Any]:
+        """Return a serialisable payload for NFT metadata."""
+
+        payload: MutableMapping[str, Any] = {"url": self.url, "prompt": self.prompt}
+        if self.mime_type:
+            payload["mime_type"] = self.mime_type
+        if self.seed is not None:
+            payload["seed"] = self.seed
+        if self.metadata:
+            payload["extra"] = dict(self.metadata)
+        return payload
+
+
+class NanoBananaClient:
+    """Thin HTTP client for the Nano Banana AI text-to-image API."""
+
+    DEFAULT_ENDPOINT = "https://nanobananaai.org/api/generate"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 45.0,
+        session: Any | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/") if base_url else self.DEFAULT_ENDPOINT
+        self.timeout = float(timeout)
+        self._session = session
+        self._owns_session = False
+        self._request_exception: type[BaseException] = RuntimeError
+        if self._session is None:
+            try:
+                requests_mod = _load_requests()
+            except ModuleNotFoundError as exc:  # pragma: no cover - requires optional dependency
+                raise RuntimeError(
+                    "NanoBananaClient requires the optional 'requests' package."
+                ) from exc
+            self._session = requests_mod.Session()
+            self._owns_session = True
+            self._request_exception = getattr(requests_mod, "RequestException", RuntimeError)
+        else:
+            request_exception = getattr(self._session, "RequestException", None)
+            if isinstance(request_exception, type) and issubclass(request_exception, BaseException):
+                self._request_exception = request_exception
+
+    def close(self) -> None:
+        """Close any owned HTTP resources."""
+
+        if self._owns_session and hasattr(self._session, "close"):
+            self._session.close()
+
+    def __enter__(self) -> "NanoBananaClient":  # pragma: no cover - exercised indirectly
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - exercised indirectly
+        self.close()
+
+    def generate_image(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str | None = None,
+        aspect_ratio: str | None = None,
+        seed: int | None = None,
+        context: Mapping[str, Any] | None = None,
+    ) -> GeneratedNFTImage:
+        """Generate an image from a text ``prompt`` using Nano Banana AI."""
+
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+
+        payload: MutableMapping[str, Any] = {"prompt": prompt.strip()}
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+        if aspect_ratio:
+            payload["aspect_ratio"] = aspect_ratio
+        if seed is not None:
+            payload["seed"] = seed
+        if context:
+            payload["context"] = context
+
+        headers: MutableMapping[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            response = self._session.post(
+                self.base_url,
+                json=payload,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except self._request_exception as exc:  # pragma: no cover - requires real HTTP failures
+            raise RuntimeError("Failed to reach Nano Banana AI API") from exc
+
+        try:
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - requires HTTP failure response
+            raise RuntimeError("Nano Banana AI API returned an error response") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError("Nano Banana AI API returned invalid JSON") from exc
+
+        image_payload = self._find_image_payload(data)
+        if image_payload is None:
+            raise RuntimeError("Nano Banana AI API response did not contain an image URL")
+
+        image_url = self._extract_image_url(image_payload)
+        if image_url is None:
+            raise RuntimeError("Nano Banana AI API response did not include a valid image URL")
+
+        mime_type = _coerce_str(
+            image_payload.get("mime_type")
+            or image_payload.get("content_type")
+            or image_payload.get("type")
+        )
+        image_seed = _coerce_int(
+            image_payload.get("seed")
+            or (data.get("seed") if isinstance(data, Mapping) else None)
+            or seed
+        )
+
+        metadata: MutableMapping[str, Any] = {}
+        for key, value in image_payload.items():
+            if key in {"url", "image_url", "download_url", "mime_type", "content_type", "type", "seed"}:
+                continue
+            metadata[key] = value
+        if isinstance(data, Mapping):
+            for key in ("id", "request_id", "seed"):
+                if key in data and key not in metadata:
+                    metadata[key] = data[key]
+
+        return GeneratedNFTImage(
+            url=image_url,
+            prompt=payload["prompt"],
+            mime_type=mime_type,
+            seed=image_seed,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def _find_image_payload(cls, data: Any) -> Mapping[str, Any] | None:
+        if isinstance(data, Mapping):
+            if cls._extract_image_url(data):
+                return data
+            for key in ("data", "images", "results", "output"):
+                if key in data:
+                    nested = cls._find_image_payload(data[key])
+                    if nested is not None:
+                        return nested
+            for value in data.values():
+                nested = cls._find_image_payload(value)
+                if nested is not None:
+                    return nested
+        elif isinstance(data, Sequence) and not isinstance(data, (str, bytes, bytearray)):
+            for item in data:
+                nested = cls._find_image_payload(item)
+                if nested is not None:
+                    return nested
+        return None
+
+    @staticmethod
+    def _extract_image_url(payload: Mapping[str, Any]) -> str | None:
+        for key in ("image_url", "url", "download_url"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        images = payload.get("images")
+        if isinstance(images, Sequence) and not isinstance(images, (str, bytes, bytearray)):
+            for item in images:
+                if isinstance(item, str) and item.strip():
+                    return item.strip()
+                if isinstance(item, Mapping):
+                    nested = NanoBananaClient._extract_image_url(item)
+                    if nested:
+                        return nested
+        return None

--- a/tests_python/test_dynamic_token_nft_images.py
+++ b/tests_python/test_dynamic_token_nft_images.py
@@ -1,0 +1,167 @@
+"""Tests for dynamic NFT image generation integrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from dynamic_token import (
+    DynamicNFTMinter,
+    GeneratedNFTImage,
+    NanoBananaClient,
+)
+
+
+class StubImageGenerator:
+    def __init__(self, *, image: GeneratedNFTImage | None = None, should_fail: bool = False) -> None:
+        self.image = image or GeneratedNFTImage(
+            url="https://example.com/nft.png",
+            prompt="default",
+            mime_type="image/png",
+            seed=7,
+            metadata={"style": "futuristic"},
+        )
+        self.should_fail = should_fail
+        self.calls: list[tuple[str, Mapping[str, Any] | None]] = []
+
+    def generate(self, prompt: str, *, context: Mapping[str, Any] | None = None) -> GeneratedNFTImage:
+        self.calls.append((prompt, context))
+        if self.should_fail:
+            raise RuntimeError("generation failed")
+        return self.image
+
+
+class StubResponse:
+    def __init__(self, payload: Mapping[str, Any], *, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.headers: Mapping[str, Any] = {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError("error response")
+
+    def json(self) -> Mapping[str, Any]:
+        return self._payload
+
+
+class StubSession:
+    def __init__(self, response: StubResponse) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, *, json: Mapping[str, Any], headers: Mapping[str, str], timeout: float) -> StubResponse:
+        self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        return self._response
+
+
+def test_mint_includes_generated_image_metadata() -> None:
+    generator = StubImageGenerator()
+    minter = DynamicNFTMinter("dct", image_generator=generator)
+
+    nft = minter.mint(
+        "0xabc",
+        analysis={"action": "buy"},
+        tags=("alpha",),
+        image_prompt="Dynamic capital skyline",
+    )
+
+    assert nft.metadata["image"] == "https://example.com/nft.png"
+    properties = nft.metadata.get("properties")
+    assert isinstance(properties, dict)
+    image_properties = properties.get("image")
+    assert image_properties["url"] == "https://example.com/nft.png"
+    assert image_properties["prompt"] == "default"
+    assert image_properties["provider"] == "Nano Banana AI"
+    assert image_properties["seed"] == 7
+    assert image_properties["extra"]["style"] == "futuristic"
+
+    call_prompt, call_context = generator.calls[0]
+    assert call_prompt == "Dynamic capital skyline"
+    assert call_context["symbol"] == "DCT"
+    assert call_context["analysis"]["action"] == "buy"
+    assert call_context["tags"] == ["alpha"]
+
+
+def test_refresh_metadata_replaces_existing_image() -> None:
+    generator = StubImageGenerator(
+        image=GeneratedNFTImage(
+            url="https://example.com/updated.png",
+            prompt="updated",
+            metadata={},
+        )
+    )
+    minter = DynamicNFTMinter("dct", image_generator=generator)
+    nft = minter.mint("0xabc", image_prompt="initial")
+
+    refreshed = minter.refresh_metadata(
+        nft.token_id,
+        image_prompt="renewed",
+        image_context={"cycle": "morning"},
+    )
+
+    assert refreshed["image"] == "https://example.com/updated.png"
+    properties = refreshed.get("properties")
+    assert properties["image"]["prompt"] == "updated"
+    assert generator.calls[-1][0] == "renewed"
+    assert generator.calls[-1][1]["cycle"] == "morning"
+
+
+def test_image_generation_failure_is_non_fatal() -> None:
+    generator = StubImageGenerator(should_fail=True)
+    minter = DynamicNFTMinter("dct", image_generator=generator)
+
+    nft = minter.mint("0xabc", image_prompt="unstable")
+    assert "image" not in nft.metadata
+    assert "properties" not in nft.metadata
+
+
+def test_nanobanana_client_normalises_nested_payload() -> None:
+    payload = {
+        "id": "req-123",
+        "data": [
+            {
+                "image_url": "https://cdn.nanobanana.local/art.png",
+                "mime_type": "image/png",
+                "seed": "42",
+                "style": "digital",
+            }
+        ],
+    }
+    session = StubSession(StubResponse(payload))
+    client = NanoBananaClient(
+        api_key="secret",
+        base_url="https://nanobananaai.org/api/generate",
+        session=session,
+    )
+
+    result = client.generate_image(
+        "Dynamic capital token artwork",
+        aspect_ratio="16:9",
+        context={"symbol": "DCT"},
+    )
+
+    assert result.url == "https://cdn.nanobanana.local/art.png"
+    assert result.mime_type == "image/png"
+    assert result.seed == 42
+    assert result.metadata["style"] == "digital"
+    assert result.metadata["id"] == "req-123"
+
+    call = session.calls[0]
+    assert call["headers"]["Authorization"] == "Bearer secret"
+    assert call["json"]["aspect_ratio"] == "16:9"
+    assert call["json"]["context"]["symbol"] == "DCT"
+
+
+@pytest.mark.parametrize("prompt", [None, "   "])
+def test_invalid_prompt_is_rejected(prompt: str | None) -> None:
+    client = NanoBananaClient(session=StubSession(StubResponse({"image_url": "https://example"})))
+    with pytest.raises(ValueError):
+        client.generate_image(prompt)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add a Nano Banana API client and generated image container for dynamic token NFTs
- allow `DynamicNFTMinter` to optionally attach generated images using an injected generator
- cover the new functionality with unit tests for metadata and client response handling

## Testing
- pytest tests_python/test_dynamic_token_nft_images.py

------
https://chatgpt.com/codex/tasks/task_e_68dcbefa4c148322921b6332c3a72a92