### PR TITLE
Expose structured go-live error for Web3 engine

### DIFF
--- a/dynamic_web3/__init__.py
+++ b/dynamic_web3/__init__.py
@@ -2,6 +2,7 @@
 
 from .engine import (
     DynamicWeb3Engine,
+    GoLiveBlockedError,
     NetworkTelemetry,
     NetworkHealthSummary,
     Web3UnifiedBuild,
@@ -22,4 +23,5 @@ __all__ = [
     "Web3Action",
     "Web3Network",
     "TransactionProfile",
+    "GoLiveBlockedError",
 ]


### PR DESCRIPTION
## Summary
- introduce a `GoLiveBlockedError` that carries the computed readiness details when `DynamicWeb3Engine.go_live` blocks launch
- export the new error type and update the go-live tests to assert the structured failure context

## Testing
- pytest tests/dynamic_web3/test_engine.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dccbc5c350832297df3fc29e4cb395