### PR TITLE
Add February 2025 vulnerability audit report

### DIFF
--- a/docs/vulnerability-scan-2025-02-13.json
+++ b/docs/vulnerability-scan-2025-02-13.json
@@ -1,0 +1,306 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "@ethersproject/providers": {
+      "name": "@ethersproject/providers",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        "ws"
+      ],
+      "effects": [
+        "ethers"
+      ],
+      "range": "<=5.7.2",
+      "nodes": [
+        "node_modules/@ethersproject/providers"
+      ],
+      "fixAvailable": false
+    },
+    "@ethersproject/signing-key": {
+      "name": "@ethersproject/signing-key",
+      "severity": "low",
+      "isDirect": false,
+      "via": [
+        "elliptic"
+      ],
+      "effects": [],
+      "range": "<=5.7.0",
+      "nodes": [
+        "node_modules/@ethersproject/signing-key"
+      ],
+      "fixAvailable": true
+    },
+    "@web3-onboard/common": {
+      "name": "@web3-onboard/common",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        "viem"
+      ],
+      "effects": [],
+      "range": ">=2.4.0-alpha.2",
+      "nodes": [
+        "node_modules/@web3-onboard/common"
+      ],
+      "fixAvailable": true
+    },
+    "@web3-onboard/core": {
+      "name": "@web3-onboard/core",
+      "severity": "high",
+      "isDirect": true,
+      "via": [
+        "ethers",
+        "svelte"
+      ],
+      "effects": [],
+      "range": "*",
+      "nodes": [
+        "node_modules/@web3-onboard/core"
+      ],
+      "fixAvailable": false
+    },
+    "elliptic": {
+      "name": "elliptic",
+      "severity": "critical",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1098593,
+          "name": "elliptic",
+          "dependency": "elliptic",
+          "title": "Elliptic's EDDSA missing signature length check",
+          "url": "https://github.com/advisories/GHSA-f7q4-pwc6-w24p",
+          "severity": "low",
+          "cwe": [
+            "CWE-347"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+          },
+          "range": ">=4.0.0 <=6.5.6"
+        },
+        {
+          "source": 1098594,
+          "name": "elliptic",
+          "dependency": "elliptic",
+          "title": "Elliptic's ECDSA missing check for whether leading bit of r and s is zero",
+          "url": "https://github.com/advisories/GHSA-977x-g7h5-7qgw",
+          "severity": "low",
+          "cwe": [
+            "CWE-130"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+          },
+          "range": ">=2.0.0 <=6.5.6"
+        },
+        {
+          "source": 1098595,
+          "name": "elliptic",
+          "dependency": "elliptic",
+          "title": "Elliptic allows BER-encoded signatures",
+          "url": "https://github.com/advisories/GHSA-49q7-c7j4-3p7m",
+          "severity": "low",
+          "cwe": [
+            "CWE-347"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+          },
+          "range": ">=5.2.1 <=6.5.6"
+        },
+        {
+          "source": 1101424,
+          "name": "elliptic",
+          "dependency": "elliptic",
+          "title": "Elliptic's verify function omits uniqueness validation",
+          "url": "https://github.com/advisories/GHSA-434g-2637-qmqr",
+          "severity": "low",
+          "cwe": [
+            "CWE-347"
+          ],
+          "cvss": {
+            "score": 5.3,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+          },
+          "range": "<6.5.6"
+        },
+        {
+          "source": 1102901,
+          "name": "elliptic",
+          "dependency": "elliptic",
+          "title": "Elliptic's private key extraction in ECDSA upon signing a malformed input (e.g. a string)",
+          "url": "https://github.com/advisories/GHSA-vjh7-7g9h-fjfh",
+          "severity": "critical",
+          "cwe": [
+            "CWE-200"
+          ],
+          "cvss": {
+            "score": 0,
+            "vectorString": null
+          },
+          "range": "<=6.6.0"
+        },
+        {
+          "source": 1105750,
+          "name": "elliptic",
+          "dependency": "elliptic",
+          "title": "Valid ECDSA signatures erroneously rejected in Elliptic",
+          "url": "https://github.com/advisories/GHSA-fc9h-whq2-v747",
+          "severity": "low",
+          "cwe": [
+            "CWE-347"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:L"
+          },
+          "range": "<6.6.0"
+        }
+      ],
+      "effects": [
+        "@ethersproject/signing-key"
+      ],
+      "range": "<=6.6.0",
+      "nodes": [
+        "node_modules/elliptic"
+      ],
+      "fixAvailable": true
+    },
+    "ethers": {
+      "name": "ethers",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        "@ethersproject/providers",
+        "@ethersproject/signing-key"
+      ],
+      "effects": [
+        "@web3-onboard/core"
+      ],
+      "range": "5.0.15 - 5.7.2",
+      "nodes": [
+        "node_modules/ethers"
+      ],
+      "fixAvailable": false
+    },
+    "svelte": {
+      "name": "svelte",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1098725,
+          "name": "svelte",
+          "dependency": "svelte",
+          "title": "Svelte has a potential mXSS vulnerability due to improper HTML escaping",
+          "url": "https://github.com/advisories/GHSA-8266-84wp-wv5c",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-79"
+          ],
+          "cvss": {
+            "score": 5.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
+          },
+          "range": "<4.2.19"
+        }
+      ],
+      "effects": [
+        "@web3-onboard/core"
+      ],
+      "range": "<4.2.19",
+      "nodes": [
+        "node_modules/svelte"
+      ],
+      "fixAvailable": false
+    },
+    "viem": {
+      "name": "viem",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        "ws"
+      ],
+      "effects": [
+        "@web3-onboard/common"
+      ],
+      "range": "<=0.0.0-wagmiv2-20230628182101 || 0.2.2 - 2.15.0",
+      "nodes": [
+        "node_modules/viem"
+      ],
+      "fixAvailable": true
+    },
+    "ws": {
+      "name": "ws",
+      "severity": "high",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1098392,
+          "name": "ws",
+          "dependency": "ws",
+          "title": "ws affected by a DoS when handling a request with many HTTP headers",
+          "url": "https://github.com/advisories/GHSA-3h5v-q93c-6h6q",
+          "severity": "high",
+          "cwe": [
+            "CWE-476"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=8.0.0 <8.17.1"
+        },
+        {
+          "source": 1098393,
+          "name": "ws",
+          "dependency": "ws",
+          "title": "ws affected by a DoS when handling a request with many HTTP headers",
+          "url": "https://github.com/advisories/GHSA-3h5v-q93c-6h6q",
+          "severity": "high",
+          "cwe": [
+            "CWE-476"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=7.0.0 <7.5.10"
+        }
+      ],
+      "effects": [
+        "@ethersproject/providers",
+        "viem"
+      ],
+      "range": "7.0.0 - 7.5.9 || 8.0.0 - 8.17.0",
+      "nodes": [
+        "node_modules/@ethersproject/providers/node_modules/ws",
+        "node_modules/viem/node_modules/ws"
+      ],
+      "fixAvailable": false
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 1,
+      "moderate": 1,
+      "high": 6,
+      "critical": 1,
+      "total": 9
+    },
+    "dependencies": {
+      "prod": 1440,
+      "dev": 279,
+      "optional": 146,
+      "peer": 23,
+      "peerOptional": 0,
+      "total": 1856
+    }
+  }
+}

--- a/docs/vulnerability-scan-2025-02-13.md
+++ b/docs/vulnerability-scan-2025-02-13.md
@@ -1,0 +1,32 @@
+# Vulnerability Scan — 2025-02-13
+
+## Scan Context
+- **Command:** `npm audit --json`
+- **Node version:** v20.19.4
+- **Generated report:** [`docs/vulnerability-scan-2025-02-13.json`](./vulnerability-scan-2025-02-13.json)
+
+## Summary of Findings
+- **Total vulnerabilities:** 9
+- **Critical:** 1 (`elliptic` transitively via `@ethersproject/signing-key`)
+- **High:** 6 (primarily through the `ws` WebSocket dependency chain impacting Ethers and Web3 Onboard packages)
+- **Moderate:** 1 (`svelte` build tooling)
+- **Low:** 1 (`@ethersproject/signing-key`)
+- **Fix availability:** 4 issues report an available update, while 5 remain without an automated fix (`ws`-related advisories and packages pinned to affected ranges).
+
+## Detailed Results
+| Package | Severity | Introduced via | Fix availability | Notes |
+| --- | --- | --- | --- | --- |
+| `elliptic` | Critical | `@ethersproject/signing-key` | Yes | Multiple advisories including private key exposure (GHSA-vjh7-7g9h-fjfh). Update to a patched release once compatible.
+| `@ethersproject/providers` | High | `ws` | No | Affected by `ws` DoS vulnerability (GHSA-3h5v-q93c-6h6q); upstream fix pending in provider dependency chain.
+| `@web3-onboard/core` | High | `ethers`, `svelte` | No | Impacted by unresolved `ws` and `svelte` advisories inherited from dependency tree.
+| `@web3-onboard/common` | High | `viem` | Yes | Upgrade `@web3-onboard/common`/`viem` to versions pulling a patched WebSocket stack.
+| `ethers` | High | `@ethersproject/providers`, `@ethersproject/signing-key` | No | Blocked by `ws` and `elliptic` advisories; monitor for upstream releases.
+| `viem` | High | `ws` | Yes | Update to a release newer than `2.15.0` to pick up `ws@8.17.1` or newer.
+| `ws` | High | `@ethersproject/providers`, `viem` | No | DoS vulnerability under advisories GHSA-3h5v-q93c-6h6q; requires upstream patches.
+| `svelte` | Moderate | `svelte` | No | Patched in Svelte 4.2.19; upgrading from 3.x to 4.x requires migration work across Web3 Onboard dependencies.
+| `@ethersproject/signing-key` | Low | `elliptic` | Yes | Will be resolved once `elliptic` is upgraded to >=6.6.1.
+
+## Recommended Next Steps
+1. Track upstream releases for `ws` (>=8.17.1) and ensure dependent packages (`@ethersproject/providers`, `viem`, `@web3-onboard/*`) can adopt patched versions.
+2. Evaluate bumping `elliptic` and related Ethers packages once compatibility with the application's web3 integration is verified.
+3. Re-run `npm audit` after dependency updates to confirm remediation progress.


### PR DESCRIPTION
## Summary
- run `npm audit --json` to generate a current vulnerability snapshot for the monorepo dependencies
- check in the raw audit output alongside a human-readable markdown summary with remediation guidance

## Testing
- npm audit --json

------
https://chatgpt.com/codex/tasks/task_e_68dcd1697c3c83228a84c8ae33c16867