### PR TITLE
Fix web3-onboard compatibility and NextAuth route exports

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -2,7 +2,7 @@ import NextAuth from "next-auth";
 import { SupabaseAdapter } from "@auth/supabase-adapter";
 import GitHub from "next-auth/providers/github";
 
-const { handlers } = NextAuth({
+const handler = NextAuth({
   adapter: SupabaseAdapter({
     url: process.env.SUPABASE_URL || "https://stub.supabase.co",
     secret: process.env.SUPABASE_SERVICE_ROLE_KEY || "stub-service-role-key",
@@ -15,4 +15,4 @@ const { handlers } = NextAuth({
   ],
 });
 
-export const { GET, POST } = handlers;
+export { handler as GET, handler as POST };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,6 +65,7 @@
     "@tanstack/react-query": "^5.90.2",
     "@vercel/otel": "^1.13.0",
     "@web3-onboard/bitget": "^2.0.1",
+    "@web3-onboard/common": "2.2.2",
     "@web3-onboard/core": "^2.2.12",
     "@web3-onboard/injected-wallets": "^2.10.17",
     "axios": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tanstack/react-query": "^5.90.2",
         "@upstash/redis": "^1.35.4",
         "@vercel/otel": "^1.13.0",
+        "@web3-onboard/common": "2.2.2",
         "@web3-onboard/core": "2.2.12",
         "compressorjs": "^1.2.1",
         "framer-motion": "^12.23.22",
@@ -104,6 +105,7 @@
         "@tanstack/react-query": "^5.90.2",
         "@vercel/otel": "^1.13.0",
         "@web3-onboard/bitget": "^2.0.1",
+        "@web3-onboard/common": "2.2.2",
         "@web3-onboard/core": "^2.2.12",
         "@web3-onboard/injected-wallets": "^2.10.17",
         "axios": "^1.11.0",
@@ -222,6 +224,16 @@
         "@web3-onboard/common": "^2.3.3"
       }
     },
+    "apps/web/node_modules/@web3-onboard/bitget/node_modules/@web3-onboard/common": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@web3-onboard/common/-/common-2.4.2.tgz",
+      "integrity": "sha512-3+zkBru5W2jBYFBPPQsnqZ7tuN1GUyM5PzD9/MmhvjCLNhmjFtMQ0MkLzG4Yshodb4UW/DmZpjUVrpjdhEhj/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "joi": "17.9.1",
+        "viem": "2.12.0"
+      }
+    },
     "apps/web/node_modules/@web3-onboard/injected-wallets": {
       "version": "2.10.17",
       "resolved": "https://registry.npmjs.org/@web3-onboard/injected-wallets/-/injected-wallets-2.10.17.tgz",
@@ -231,6 +243,16 @@
         "@web3-onboard/common": "^2.3.3",
         "joi": "17.9.1",
         "lodash.uniqby": "^4.7.0"
+      }
+    },
+    "apps/web/node_modules/@web3-onboard/injected-wallets/node_modules/@web3-onboard/common": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@web3-onboard/common/-/common-2.4.2.tgz",
+      "integrity": "sha512-3+zkBru5W2jBYFBPPQsnqZ7tuN1GUyM5PzD9/MmhvjCLNhmjFtMQ0MkLzG4Yshodb4UW/DmZpjUVrpjdhEhj/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "joi": "17.9.1",
+        "viem": "2.12.0"
       }
     },
     "apps/web/node_modules/fdir": {
@@ -13126,13 +13148,120 @@
       }
     },
     "node_modules/@web3-onboard/common": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@web3-onboard/common/-/common-2.4.2.tgz",
-      "integrity": "sha512-3+zkBru5W2jBYFBPPQsnqZ7tuN1GUyM5PzD9/MmhvjCLNhmjFtMQ0MkLzG4Yshodb4UW/DmZpjUVrpjdhEhj/Q==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@web3-onboard/common/-/common-2.2.2.tgz",
+      "integrity": "sha512-04Y2Fryiu48nW27dgAtYmPugdhYbeIZq4HM1wsqRftQjgyEWnsam3YyeKRWBABa5iTsE2a/Fo4LofuBG5RMVYw==",
       "license": "MIT",
       "dependencies": {
-        "joi": "17.9.1",
-        "viem": "2.12.0"
+        "bignumber.js": "^9.1.0",
+        "ethers": "5.5.4",
+        "joi": "^17.4.2"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/@ethersproject/providers": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.3.tgz",
+      "integrity": "sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "@ethersproject/address": "^5.5.0",
+        "@ethersproject/basex": "^5.5.0",
+        "@ethersproject/bignumber": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/constants": "^5.5.0",
+        "@ethersproject/hash": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/networks": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/random": "^5.5.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "@ethersproject/sha2": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0",
+        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/web": "^5.5.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/ethers": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.4.tgz",
+      "integrity": "sha512-N9IAXsF8iKhgHIC6pquzRgPBJEzc9auw3JoRkaKe+y4Wl/LFBtDDunNe7YmdomontECAcC5APaAgWZBiu1kirw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "5.5.0",
+        "@ethersproject/abstract-provider": "5.5.1",
+        "@ethersproject/abstract-signer": "5.5.0",
+        "@ethersproject/address": "5.5.0",
+        "@ethersproject/base64": "5.5.0",
+        "@ethersproject/basex": "5.5.0",
+        "@ethersproject/bignumber": "5.5.0",
+        "@ethersproject/bytes": "5.5.0",
+        "@ethersproject/constants": "5.5.0",
+        "@ethersproject/contracts": "5.5.0",
+        "@ethersproject/hash": "5.5.0",
+        "@ethersproject/hdnode": "5.5.0",
+        "@ethersproject/json-wallets": "5.5.0",
+        "@ethersproject/keccak256": "5.5.0",
+        "@ethersproject/logger": "5.5.0",
+        "@ethersproject/networks": "5.5.2",
+        "@ethersproject/pbkdf2": "5.5.0",
+        "@ethersproject/properties": "5.5.0",
+        "@ethersproject/providers": "5.5.3",
+        "@ethersproject/random": "5.5.1",
+        "@ethersproject/rlp": "5.5.0",
+        "@ethersproject/sha2": "5.5.0",
+        "@ethersproject/signing-key": "5.5.0",
+        "@ethersproject/solidity": "5.5.0",
+        "@ethersproject/strings": "5.5.0",
+        "@ethersproject/transactions": "5.5.0",
+        "@ethersproject/units": "5.5.0",
+        "@ethersproject/wallet": "5.5.0",
+        "@ethersproject/web": "5.5.1",
+        "@ethersproject/wordlists": "5.5.0"
+      }
+    },
+    "node_modules/@web3-onboard/common/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@web3-onboard/core": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@tanstack/react-query": "^5.90.2",
     "@upstash/redis": "^1.35.4",
     "@vercel/otel": "^1.13.0",
+    "@web3-onboard/common": "2.2.2",
     "@web3-onboard/core": "2.2.12",
     "compressorjs": "^1.2.1",
     "framer-motion": "^12.23.22",


### PR DESCRIPTION
## Summary
- pin `@web3-onboard/common` to version 2.2.2 so the core package builds with the expected SofiaProRegular export
- update the NextAuth app route to export the handler for GET and POST requests in the format NextAuth v4 expects

## Testing
- npm run build:web
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dcd3bb502c8322b39bd4e39a23a012