### PR TITLE
Handle Telegram mini app redirect client-side

### DIFF
--- a/apps/web/app/(miniapp)/miniapp/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/page.tsx
@@ -1,19 +1,27 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 
 export default function MiniAppIndex() {
   const router = useRouter();
-  const searchParams = useSearchParams();
+  const hasRedirectedRef = useRef(false);
 
   useEffect(() => {
-    const search = searchParams.toString();
-    const hash = typeof window !== "undefined" ? window.location.hash : "";
-    const nextPath = `/miniapp/home${search ? `?${search}` : ""}${hash}`;
+    if (hasRedirectedRef.current) {
+      return;
+    }
 
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const { search, hash } = window.location;
+    const nextPath = `/miniapp/home${search ?? ""}${hash ?? ""}`;
+
+    hasRedirectedRef.current = true;
     router.replace(nextPath);
-  }, [router, searchParams]);
+  }, [router]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- replace the server-side redirect on `/miniapp` with a client-side redirect that keeps query strings and hashes
- ensure the mini app hand-off to `/miniapp/home` preserves Telegram start parameters

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dcd9b491c48322b971c112faf804f3