### PR TITLE
Add Supabase passwordless auth flows and admin invite API

### DIFF
--- a/apps/web/app/api/admin/invite-user/route.ts
+++ b/apps/web/app/api/admin/invite-user/route.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+import { createClient } from "@/integrations/supabase/client";
+import { withApiMetrics } from "@/observability/server-metrics.ts";
+import {
+  bad,
+  corsHeaders,
+  json,
+  methodNotAllowed,
+  oops,
+} from "@/utils/http.ts";
+
+const ROUTE_NAME = "/api/admin/invite-user";
+
+const inviteSchema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().optional(),
+  role: z.string().optional(),
+  telegramId: z.string().optional(),
+  username: z.string().optional(),
+});
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  return withApiMetrics(req, ROUTE_NAME, async () => {
+    let payload: unknown;
+    try {
+      payload = await req.json();
+    } catch (error) {
+      return bad(
+        "Invalid JSON payload",
+        error instanceof Error ? error.message : undefined,
+        req,
+      );
+    }
+
+    const parsed = inviteSchema.safeParse(payload);
+    if (!parsed.success) {
+      const details = parsed.error.issues.map((issue) => issue.message).join(
+        ", ",
+      );
+      return bad("Invalid invite payload", details, req);
+    }
+
+    const { email, firstName, lastName, role, telegramId, username } =
+      parsed.data;
+
+    let supabaseAdmin;
+    try {
+      supabaseAdmin = createClient("service");
+    } catch (error) {
+      console.error("Failed to create Supabase admin client", error);
+      return oops(
+        "Supabase service role key is not configured",
+        undefined,
+        req,
+      );
+    }
+
+    const redirectTo = (() => {
+      if (typeof process === "undefined") {
+        return undefined;
+      }
+      const configuredBase = process.env.NEXT_PUBLIC_SITE_URL ||
+        process.env.SITE_URL;
+      if (!configuredBase) {
+        return undefined;
+      }
+      const normalizedBase = configuredBase.endsWith("/")
+        ? configuredBase.slice(0, -1)
+        : configuredBase;
+      return `${normalizedBase}/login`;
+    })();
+
+    const metadata: Record<string, unknown> = {
+      first_name: firstName,
+      last_name: lastName ?? null,
+      role: role ?? "user",
+      telegram_id: telegramId ?? null,
+      username: username ?? null,
+    };
+
+    try {
+      const { data, error } = await supabaseAdmin.auth.admin.inviteUserByEmail(
+        email,
+        {
+          data: metadata,
+          redirectTo,
+        },
+      );
+
+      if (error) {
+        console.error("Supabase invite error", error);
+        return bad("Failed to send invite", error.message, req);
+      }
+
+      return json({ ok: true, user: data.user }, 200, {}, req);
+    } catch (error) {
+      console.error("Unexpected invite error", error);
+      return oops("Unexpected error inviting user", undefined, req);
+    }
+  });
+}
+
+export const GET = methodNotAllowed;
+export const PUT = methodNotAllowed;
+export const PATCH = methodNotAllowed;
+export const DELETE = methodNotAllowed;
+
+export function OPTIONS(req: Request) {
+  const headers = corsHeaders(req, "POST");
+  return new Response(null, { status: 204, headers });
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from "next/navigation";
+
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
+import { ProfileSettingsForm } from "@/components/auth/ProfileSettingsForm";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+
+export const metadata = {
+  title: "Profile Settings – Dynamic Capital",
+  description:
+    "Update your Dynamic Capital profile details, including name and workspace identity metadata.",
+};
+
+export default async function ProfilePage() {
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/login?redirect=${encodeURIComponent("/profile")}`);
+  }
+
+  return (
+    <Column
+      gap="24"
+      paddingY="32"
+      align="center"
+      horizontal="center"
+      fillWidth
+    >
+      <Column maxWidth={28} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Profile settings
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          Maintain the identity that appears across investor dashboards and
+          administrative tooling.
+        </Text>
+      </Column>
+      <Column maxWidth={32} fillWidth>
+        <ProfileSettingsForm />
+      </Column>
+    </Column>
+  );
+}

--- a/apps/web/components/auth/AuthForm.tsx
+++ b/apps/web/components/auth/AuthForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import type { Provider } from "@supabase/supabase-js";
 
 import {
   Button,
@@ -37,12 +38,44 @@ const INITIAL_STATE: AuthFormState = {
 export function AuthForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { signIn, signUp, session, loading: authLoading } = useAuth();
+  const {
+    signIn,
+    signUp,
+    session,
+    loading: authLoading,
+    sendEmailOtp,
+    signInWithEmailOtp,
+    signUpWithPhone,
+    signInWithPhoneOtp,
+    verifyPhoneOtp,
+    resetPassword,
+    signInWithOAuth,
+  } = useAuth();
   const { toast } = useToast();
   const [mode, setMode] = useState<AuthMode>("signin");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState<AuthFormState>(INITIAL_STATE);
+  const [isResettingPassword, setIsResettingPassword] = useState(false);
+  const [magicLinkEmail, setMagicLinkEmail] = useState("");
+  const [magicLinkToken, setMagicLinkToken] = useState("");
+  const [magicLinkStatus, setMagicLinkStatus] = useState<string | null>(null);
+  const [magicLinkError, setMagicLinkError] = useState<string | null>(null);
+  const [isSendingMagicLink, setIsSendingMagicLink] = useState(false);
+  const [isVerifyingEmailOtp, setIsVerifyingEmailOtp] = useState(false);
+  const [phoneAuth, setPhoneAuth] = useState({
+    phone: "",
+    password: "",
+    otp: "",
+  });
+  const [phoneStatus, setPhoneStatus] = useState<string | null>(null);
+  const [phoneError, setPhoneError] = useState<string | null>(null);
+  const [phoneSubmitting, setPhoneSubmitting] = useState({
+    signup: false,
+    sendOtp: false,
+    verify: false,
+  });
+  const [oauthLoading, setOauthLoading] = useState<Provider | null>(null);
 
   const redirectParam = searchParams.get("redirect");
   const redirectPath = useMemo(() => {
@@ -223,6 +256,228 @@ export function AuthForm() {
 
   const onSubmit = mode === "signin" ? handleSignIn : handleSignUp;
 
+  const oauthProviders: Array<{ provider: Provider; label: string }> = [
+    { provider: "github", label: "Continue with GitHub" },
+    { provider: "google", label: "Continue with Google" },
+  ];
+
+  const resolveRedirectTo = () => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+    return `${window.location.origin}${resolvedRedirect}`;
+  };
+
+  const handleResetPassword = async () => {
+    const targetEmail = formData.email || magicLinkEmail;
+    if (!targetEmail) {
+      setMagicLinkError("Enter your email to receive a reset link.");
+      return;
+    }
+
+    setIsResettingPassword(true);
+    setMagicLinkError(null);
+    try {
+      const { error: resetError } = await resetPassword(targetEmail);
+      if (resetError) {
+        setMagicLinkError(resetError.message);
+      } else {
+        toast({
+          title: "Password reset email sent",
+          description:
+            "Check your inbox for a link to update your password securely.",
+        });
+      }
+    } catch (err) {
+      setMagicLinkError(
+        err instanceof Error ? err.message : "Unexpected error",
+      );
+    } finally {
+      setIsResettingPassword(false);
+    }
+  };
+
+  const handleSendMagicLink = async () => {
+    if (!magicLinkEmail) {
+      setMagicLinkError("Enter an email address to send a magic link.");
+      return;
+    }
+
+    setIsSendingMagicLink(true);
+    setMagicLinkError(null);
+    setMagicLinkStatus(null);
+    try {
+      const { error: otpError } = await sendEmailOtp(magicLinkEmail);
+      if (otpError) {
+        setMagicLinkError(otpError.message);
+      } else {
+        setMagicLinkStatus(
+          "Magic link sent. Check your inbox for a secure login link.",
+        );
+        toast({
+          title: "Magic link dispatched",
+          description: `We sent a sign-in link to ${magicLinkEmail}.`,
+        });
+      }
+    } catch (err) {
+      setMagicLinkError(
+        err instanceof Error ? err.message : "Unexpected error",
+      );
+    } finally {
+      setIsSendingMagicLink(false);
+    }
+  };
+
+  const handleVerifyEmailOtp = async () => {
+    if (!magicLinkEmail || !magicLinkToken) {
+      setMagicLinkError("Provide both your email and the code we sent you.");
+      return;
+    }
+
+    setIsVerifyingEmailOtp(true);
+    setMagicLinkError(null);
+    try {
+      const { error: verificationError } = await signInWithEmailOtp(
+        magicLinkEmail,
+        magicLinkToken,
+      );
+      if (verificationError) {
+        setMagicLinkError(verificationError.message);
+      } else {
+        setMagicLinkStatus("Email OTP verified. You are now signed in.");
+        toast({
+          title: "Signed in",
+          description: "OTP verified successfully.",
+        });
+        setMagicLinkToken("");
+      }
+    } catch (err) {
+      setMagicLinkError(
+        err instanceof Error ? err.message : "Unexpected error",
+      );
+    } finally {
+      setIsVerifyingEmailOtp(false);
+    }
+  };
+
+  const handlePhoneSignUp = async () => {
+    if (!phoneAuth.phone || !phoneAuth.password) {
+      setPhoneError("Enter a phone number and password to create an account.");
+      return;
+    }
+
+    setPhoneSubmitting((prev) => ({ ...prev, signup: true }));
+    setPhoneError(null);
+    setPhoneStatus(null);
+    try {
+      const { error: signUpError } = await signUpWithPhone(
+        phoneAuth.phone,
+        phoneAuth.password,
+      );
+      if (signUpError) {
+        setPhoneError(signUpError.message);
+      } else {
+        setPhoneStatus(
+          "Phone sign-up initiated. Verify the SMS code to finish.",
+        );
+        toast({
+          title: "Phone sign-up",
+          description: "We sent an SMS with your verification code.",
+        });
+      }
+    } catch (err) {
+      setPhoneError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setPhoneSubmitting((prev) => ({ ...prev, signup: false }));
+    }
+  };
+
+  const handleSendPhoneOtp = async () => {
+    if (!phoneAuth.phone) {
+      setPhoneError("Enter a phone number to request an SMS code.");
+      return;
+    }
+
+    setPhoneSubmitting((prev) => ({ ...prev, sendOtp: true }));
+    setPhoneError(null);
+    setPhoneStatus(null);
+    try {
+      const { error: otpError } = await signInWithPhoneOtp(phoneAuth.phone);
+      if (otpError) {
+        setPhoneError(otpError.message);
+      } else {
+        setPhoneStatus("SMS code sent. Enter the 6-digit code to verify.");
+        toast({
+          title: "SMS sent",
+          description: `We texted a verification code to ${phoneAuth.phone}.`,
+        });
+      }
+    } catch (err) {
+      setPhoneError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setPhoneSubmitting((prev) => ({ ...prev, sendOtp: false }));
+    }
+  };
+
+  const handleVerifyPhoneOtp = async () => {
+    if (!phoneAuth.phone || !phoneAuth.otp) {
+      setPhoneError("Enter both your phone number and the SMS code.");
+      return;
+    }
+
+    setPhoneSubmitting((prev) => ({ ...prev, verify: true }));
+    setPhoneError(null);
+    try {
+      const { error: verificationError } = await verifyPhoneOtp(
+        phoneAuth.phone,
+        phoneAuth.otp,
+      );
+      if (verificationError) {
+        setPhoneError(verificationError.message);
+      } else {
+        setPhoneStatus("Phone verified. You're now authenticated.");
+        toast({
+          title: "Phone verified",
+          description: "SMS code accepted successfully.",
+        });
+        setPhoneAuth((prev) => ({ ...prev, otp: "" }));
+      }
+    } catch (err) {
+      setPhoneError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setPhoneSubmitting((prev) => ({ ...prev, verify: false }));
+    }
+  };
+
+  const handleOAuthSignIn = async (provider: Provider) => {
+    setOauthLoading(provider);
+    try {
+      const redirectTo = resolveRedirectTo();
+      const { data, error: oauthError } = await signInWithOAuth(provider, {
+        redirectTo,
+      });
+      if (oauthError) {
+        toast({
+          title: "OAuth sign-in failed",
+          description: oauthError.message,
+          variant: "destructive",
+        });
+      } else if (data?.url) {
+        window.location.href = data.url;
+      }
+    } catch (err) {
+      toast({
+        title: "Unexpected OAuth error",
+        description: err instanceof Error
+          ? err.message
+          : "Unable to start provider sign-in.",
+        variant: "destructive",
+      });
+    } finally {
+      setOauthLoading(null);
+    }
+  };
+
   return (
     <Column
       fillWidth
@@ -382,8 +637,210 @@ export function AuthForm() {
                 ? "Sign in"
                 : "Create account"}
             </Button>
+            <Button
+              type="button"
+              size="s"
+              variant="tertiary"
+              data-border="rounded"
+              disabled={isResettingPassword}
+              onClick={handleResetPassword}
+            >
+              {isResettingPassword
+                ? "Sending reset link…"
+                : "Email me a password reset link"}
+            </Button>
           </Column>
         </form>
+        <Column gap="16">
+          <Column gap="8">
+            <Text variant="body-strong-m">Passwordless email access</Text>
+            <Text variant="body-default-s" onBackground="neutral-weak">
+              Send yourself a magic link or verify a one-time passcode when you
+              prefer passwordless sign-in.
+            </Text>
+          </Column>
+          <Column gap="8">
+            <Input
+              id="magicLinkEmail"
+              name="magicLinkEmail"
+              type="email"
+              value={magicLinkEmail}
+              onChange={(event) => {
+                setMagicLinkEmail(event.target.value);
+                setMagicLinkError(null);
+              }}
+              placeholder="analyst@dynamic.capital"
+              aria-label="Magic link email"
+            />
+            <Row gap="12" wrap>
+              <Button
+                type="button"
+                size="s"
+                variant="secondary"
+                data-border="rounded"
+                disabled={isSendingMagicLink}
+                onClick={handleSendMagicLink}
+              >
+                {isSendingMagicLink ? "Sending…" : "Send magic link"}
+              </Button>
+              <Button
+                type="button"
+                size="s"
+                variant="secondary"
+                data-border="rounded"
+                disabled={isVerifyingEmailOtp}
+                onClick={handleVerifyEmailOtp}
+              >
+                {isVerifyingEmailOtp ? "Verifying…" : "Verify email OTP"}
+              </Button>
+            </Row>
+            <Input
+              id="magicLinkToken"
+              name="magicLinkToken"
+              value={magicLinkToken}
+              onChange={(event) => {
+                setMagicLinkToken(event.target.value);
+                setMagicLinkError(null);
+              }}
+              placeholder="Enter 6-digit code"
+              aria-label="Email OTP token"
+            />
+            {magicLinkError
+              ? (
+                <Text variant="body-default-s" onBackground="brand-weak">
+                  {magicLinkError}
+                </Text>
+              )
+              : null}
+            {magicLinkStatus
+              ? (
+                <Text variant="body-default-s" onBackground="neutral-weak">
+                  {magicLinkStatus}
+                </Text>
+              )
+              : null}
+          </Column>
+        </Column>
+        <Column gap="16">
+          <Column gap="8">
+            <Text variant="body-strong-m">SMS authentication</Text>
+            <Text variant="body-default-s" onBackground="neutral-weak">
+              Use phone-based codes when you cannot access email. Twilio
+              credentials must be configured for SMS delivery.
+            </Text>
+          </Column>
+          <Column gap="8">
+            <Input
+              id="phone"
+              name="phone"
+              value={phoneAuth.phone}
+              onChange={(event) => {
+                setPhoneAuth((previous) => ({
+                  ...previous,
+                  phone: event.target.value,
+                }));
+                setPhoneError(null);
+              }}
+              placeholder="+13334445555"
+              aria-label="Phone number"
+            />
+            <PasswordInput
+              id="phonePassword"
+              name="phonePassword"
+              label="Phone account password"
+              value={phoneAuth.password}
+              onChange={(event) => {
+                setPhoneAuth((previous) => ({
+                  ...previous,
+                  password: event.target.value,
+                }));
+                setPhoneError(null);
+              }}
+              required={false}
+            />
+            <Row gap="12" wrap>
+              <Button
+                type="button"
+                size="s"
+                variant="secondary"
+                data-border="rounded"
+                disabled={phoneSubmitting.signup}
+                onClick={handlePhoneSignUp}
+              >
+                {phoneSubmitting.signup
+                  ? "Submitting…"
+                  : "Create phone account"}
+              </Button>
+              <Button
+                type="button"
+                size="s"
+                variant="secondary"
+                data-border="rounded"
+                disabled={phoneSubmitting.sendOtp}
+                onClick={handleSendPhoneOtp}
+              >
+                {phoneSubmitting.sendOtp ? "Sending…" : "Send SMS code"}
+              </Button>
+            </Row>
+            <Input
+              id="phoneOtp"
+              name="phoneOtp"
+              value={phoneAuth.otp}
+              onChange={(event) => {
+                setPhoneAuth((previous) => ({
+                  ...previous,
+                  otp: event.target.value,
+                }));
+                setPhoneError(null);
+              }}
+              placeholder="123456"
+              aria-label="SMS verification code"
+            />
+            <Button
+              type="button"
+              size="s"
+              variant="secondary"
+              data-border="rounded"
+              disabled={phoneSubmitting.verify}
+              onClick={handleVerifyPhoneOtp}
+            >
+              {phoneSubmitting.verify ? "Verifying…" : "Verify SMS OTP"}
+            </Button>
+            {phoneError
+              ? (
+                <Text variant="body-default-s" onBackground="brand-weak">
+                  {phoneError}
+                </Text>
+              )
+              : null}
+            {phoneStatus
+              ? (
+                <Text variant="body-default-s" onBackground="neutral-weak">
+                  {phoneStatus}
+                </Text>
+              )
+              : null}
+          </Column>
+        </Column>
+        <Column gap="12">
+          <Text variant="body-strong-m">Sign in with a provider</Text>
+          <Column gap="8">
+            {oauthProviders.map(({ provider, label }) => (
+              <Button
+                key={provider}
+                type="button"
+                size="m"
+                variant="secondary"
+                data-border="rounded"
+                disabled={oauthLoading === provider}
+                loading={oauthLoading === provider}
+                onClick={() => handleOAuthSignIn(provider)}
+              >
+                {label}
+              </Button>
+            ))}
+          </Column>
+        </Column>
         <Column gap="8" align="center">
           <Text
             variant="body-default-s"

--- a/apps/web/components/auth/ProfileSettingsForm.tsx
+++ b/apps/web/components/auth/ProfileSettingsForm.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { type ChangeEvent, useEffect, useState } from "react";
+
+import {
+  Button,
+  Column,
+  Heading,
+  Input,
+  Row,
+  Text,
+} from "@/components/dynamic-ui-system";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/useToast";
+
+interface ProfileFormState {
+  firstName: string;
+  lastName: string;
+  displayName: string;
+}
+
+const INITIAL_STATE: ProfileFormState = {
+  firstName: "",
+  lastName: "",
+  displayName: "",
+};
+
+export function ProfileSettingsForm() {
+  const { user, updateUser } = useAuth();
+  const { toast } = useToast();
+  const [formState, setFormState] = useState<ProfileFormState>(INITIAL_STATE);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      setFormState(INITIAL_STATE);
+      return;
+    }
+
+    const metadata = user.user_metadata as Record<string, unknown> | undefined;
+    setFormState({
+      firstName: typeof metadata?.first_name === "string"
+        ? metadata.first_name
+        : "",
+      lastName: typeof metadata?.last_name === "string"
+        ? metadata.last_name
+        : "",
+      displayName: typeof metadata?.display_name === "string"
+        ? metadata.display_name
+        : "",
+    });
+  }, [user]);
+
+  const handleChange =
+    (key: keyof ProfileFormState) => (event: ChangeEvent<HTMLInputElement>) => {
+      setFormState((previous) => ({
+        ...previous,
+        [key]: event.target.value,
+      }));
+      setError(null);
+    };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const { error: updateError } = await updateUser({
+        data: {
+          first_name: formState.firstName || null,
+          last_name: formState.lastName || null,
+          display_name: formState.displayName || null,
+        },
+      });
+
+      if (updateError) {
+        setError(updateError.message);
+      } else {
+        toast({
+          title: "Profile updated",
+          description: "Your profile details were saved successfully.",
+        });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Column
+      fillWidth
+      gap="16"
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      shadow="xl"
+    >
+      <Column gap="8">
+        <Heading variant="heading-strong-s">Profile details</Heading>
+        <Text variant="body-default-s" onBackground="neutral-weak">
+          Update the name information shared with your Dynamic Capital
+          workspaces.
+        </Text>
+      </Column>
+      <form onSubmit={handleSubmit}>
+        <Column gap="16">
+          <Row gap="12" wrap>
+            <Column flex={1} minWidth={12} gap="4">
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                First name
+              </Text>
+              <Input
+                id="profile-first-name"
+                name="profile-first-name"
+                value={formState.firstName}
+                onChange={handleChange("firstName")}
+                placeholder="Jordan"
+              />
+            </Column>
+            <Column flex={1} minWidth={12} gap="4">
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                Last name
+              </Text>
+              <Input
+                id="profile-last-name"
+                name="profile-last-name"
+                value={formState.lastName}
+                onChange={handleChange("lastName")}
+                placeholder="Rivera"
+              />
+            </Column>
+          </Row>
+          <Column gap="4">
+            <Text variant="body-default-s" onBackground="neutral-weak">
+              Display name
+            </Text>
+            <Input
+              id="profile-display-name"
+              name="profile-display-name"
+              value={formState.displayName}
+              onChange={handleChange("displayName")}
+              placeholder="Jordan R."
+            />
+          </Column>
+          {error
+            ? (
+              <Text variant="body-default-s" onBackground="brand-weak">
+                {error}
+              </Text>
+            )
+            : null}
+          <Button
+            type="submit"
+            size="m"
+            variant="secondary"
+            data-border="rounded"
+            disabled={isSubmitting}
+            loading={isSubmitting}
+          >
+            {isSubmitting ? "Saving…" : "Save changes"}
+          </Button>
+        </Column>
+      </form>
+    </Column>
+  );
+}
+
+export default ProfileSettingsForm;

--- a/apps/web/components/navigation/SiteHeader.tsx
+++ b/apps/web/components/navigation/SiteHeader.tsx
@@ -96,14 +96,24 @@ export function SiteHeader() {
           </Button>
           {user
             ? (
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => signOut()}
-                className="hidden lg:inline-flex"
-              >
-                Sign out
-              </Button>
+              <>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className="hidden text-xs font-semibold uppercase tracking-wider text-muted-foreground hover:text-primary lg:inline-flex"
+                >
+                  <Link href="/profile">Profile</Link>
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => signOut()}
+                  className="hidden lg:inline-flex"
+                >
+                  Sign out
+                </Button>
+              </>
             )
             : (
               <Button


### PR DESCRIPTION
## Summary
- expand the auth context with passwordless helpers, OAuth support, and user maintenance methods
- surface magic link, SMS OTP, and provider sign-in options alongside profile settings UI
- add a Supabase-backed admin invite route and link the form plus navigation entry points

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dcd9e1f0ac8322abbdba64968e9254