### PR TITLE
feat: add TON site optimisation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# Dynamic Capital — Telegram Bot & Mini App
+# Dynamic Capital Ecosystem Platform
+
+<div align="center">
+
+  <strong>Institutional-grade intelligence, trading, and automation for digital asset growth.</strong>
+
+  <sub>Dynamic Capital unifies Web3 infrastructure, machine intelligence, and precise execution tooling into an adaptive platform that scales with market velocity.</sub>
+
+</div>
+
+---
 
 <!-- BADGES:START -->
 <!-- BADGES:END -->
@@ -9,7 +19,20 @@
 
 <!-- TOC:START -->
 
-- [Overview](#overview)
+- [Executive Overview](#executive-overview)
+  - [Vision](#vision)
+  - [Strategic Focus](#strategic-focus)
+- [Investor Snapshot](#investor-snapshot)
+  - [Value Drivers](#value-drivers)
+  - [Traction Signals](#traction-signals)
+- [Beginner's Guide](#beginners-guide)
+  - [First Steps](#first-steps)
+  - [Learning Resources](#learning-resources)
+- [Ecosystem Pillars](#ecosystem-pillars)
+  - [Dynamic Capital Modules](#dynamic-capital-modules)
+- [Interface Layout](#interface-layout)
+  - [Header](#header)
+  - [Footer](#footer)
 - [What's New](#whats-new)
 - [Quick Links](#quick-links)
   - [Saved GitHub queries](#saved-github-queries)
@@ -80,25 +103,128 @@
   - [Dynamic Hedge Model](#dynamic-hedge-model)
 - [GitHub Integration](#github-integration)
 - [Hybrid Development Workflow](#hybrid-development-workflow)
+- [References](#references)
 - [License / contributions](#license--contributions)
 - [Notes](#notes)
 
 <!-- TOC:END -->
 
-## Overview
+## Executive Overview
 
-Telegram-first bot with optional Mini App (Web App) for deposit workflows (bank
-OCR + crypto TXID). Built with **Dynamic Codex** for enhanced development
-experience.
+### Vision
 
-A single Next.js application powers both the marketing landing page and the
-authenticated dashboard. The build pipeline captures the homepage into the
-repository-level `_static/` directory so it can be served via CDN without
-touching runtime secrets, while the live `/app` routes continue to handle
-Supabase access, authentication, and other server-side features.
+Dynamic Capital brings institutional discipline to the digital asset market by
+combining compliant onboarding, intelligent automation, and transparent risk
+controls. The platform empowers investors to deploy capital confidently while
+engineering teams continue to evolve the product with the full Dynamic Codex
+toolchain.
 
-The Telegram Mini App is built with Next.js/React, hosted on DigitalOcean, and
-backed by Supabase.
+### Strategic Focus
+
+- Deliver regulated-friendly deposit and withdrawal workflows that work across
+  traditional banking and on-chain rails.
+- Augment trading desks with explainable AI copilot experiences that keep
+  humans in the loop.
+- Provide a modular foundation—spanning infrastructure, analytics, and
+  operations—that scales from pilot programs to multi-entity portfolios.
+
+## Investor Snapshot
+
+### Value Drivers
+
+- **Unified surface area:** A single Next.js codebase powers the Telegram bot,
+  web dashboard, and landing experience for consistent messaging and faster
+  iteration.
+- **Governance-ready architecture:** Supabase-backed data services, auditable
+  automations, and configurable guardrails support treasury oversight and
+  compliance reviews.
+- **AI-enhanced execution:** Integrated research, signal generation, and
+  hedging logic compress decision cycles for discretionary and systematic
+  strategies alike.
+
+### Traction Signals
+
+- Production-ready Telegram Mini App deployed on DigitalOcean with Supabase for
+  authentication, storage, and secure edge functions.
+- Automated build pipeline that snapshots the marketing site into `_static/`
+  for CDN delivery without exposing secrets.
+- Continuous discovery via Dynamic Codex workflows that shorten prototyping
+  loops for new trading logic, models, and user journeys.
+
+## Beginner's Guide
+
+### First Steps
+
+1. **Explore the platform story:** Start with the [Executive Overview](#executive-overview)
+   to understand the strategy and scope.
+2. **Review capabilities:** Dive into [Platform Capabilities](#platform-capabilities)
+   for a breakdown of product surfaces, integrations, and AI features.
+3. **Follow the workflows:** Use the [Development Workflow](#development-workflow)
+   and [Build & Deployment](#build--deployment) sections to see how teams ship
+   updates safely.
+
+### Learning Resources
+
+- **Quick reference:** The [Quick Links](#quick-links) section collects saved
+  GitHub searches and CLI snippets for deeper due diligence.
+- **Technical deep dives:** Explore [Architecture & Docs](#architecture--docs)
+  and [Security Features](#security-features) for implementation specifics.
+- **Operational readiness:** Consult [Testing & Validation](#testing--validation)
+  and [Operational Routines](#operational-routines) to understand monitoring
+  and maintenance practices.
+
+## Ecosystem Pillars
+
+### Dynamic Capital Modules
+
+| No. | Module | Focus |
+| --- | --- | --- |
+| 1 | **DYNAMIC CAPITAL WEB3** | Bridges custody, settlement, and network access across leading blockchains. |
+| 2 | **DYNAMIC CAPITAL TOKEN** | Structures treasury incentives, access tiers, and on-chain governance hooks. |
+| 3 | **DYNAMIC AGS** | Coordinates governance services to align stakeholders and automate policy enforcement. |
+| 4 | **DYNAMIC AGI** | Drives the self-improving intelligence loop that continuously retrains and redeploys AI agents. |
+| 5 | **DYNAMIC AI** | Bundles research assistants, copilots, and analytics dashboards for decision support. |
+| 6 | **DYNAMIC TRADING LOGIC** | Captures risk rules, execution parameters, and guardrails for discretionary traders. |
+| 7 | **DYNAMIC TRADING ALGO** | Automates systematic strategies with parameterized bots and adaptive hedging. |
+| 8 | **DYNAMIC ENGINES** | Powers low-latency execution services, routing, and connectivity with market venues. |
+| 9 | **DYNAMIC TOOLS** | Provides developer and operator utilities, from observability to workflow orchestration. |
+| 10 | **DYNAMIC MODELS** | Houses predictive, quantitative, and sentiment models that feed trading decisions. |
+| 11 | **DYNAMIC** | Represents the shared brand system and experience layer that unites every module. |
+
+These modules operate together to deliver a cohesive ecosystem—from the
+on-chain Web3 foundation and token mechanics to intelligence systems, trading
+automation, and supporting tooling.
+
+## Interface Layout
+
+The Dynamic Capital experience prioritizes clarity, trust, and real-time signal
+delivery for traders and operators. The following guidelines ensure the UI
+reinforces brand identity while surfacing critical actions.
+
+### Header
+
+- **Identity first:** Persist the Dynamic Capital logotype and gradient motif to
+  anchor the ecosystem branding across the Telegram Mini App and web surfaces.
+- **Status-aware controls:** Surface live portfolio health, treasury runway, or
+  trading session state with concise iconography and color semantics that follow
+  accessibility contrast ratios.
+- **Action shortcuts:** Pin universal actions—"Deposit", "Launch AI Copilot",
+  and "Review Signals"—so power users can switch contexts without losing
+  situational awareness.
+- **Telemetry hooks:** Emit lightweight analytics events (`header:view` and
+  `header:cta_click`) to keep observability consistent across clients.
+
+### Footer
+
+- **Contextual navigation:** Group navigation targets by workflow pillars (AI,
+  Trading, Treasury, Operations) and keep tap targets within 48px minimum height
+  for touch ergonomics.
+- **Regulatory confidence:** Reserve a footer band for compliance badges,
+  jurisdiction disclosures, and updated audit timestamps to reinforce trust.
+- **Realtime alerts:** Integrate a non-intrusive toast rail or ticker that can
+  surface hedging directives, market volatility flags, or AI audit summaries.
+- **Support loop:** Provide a persistent "Need Help?" affordance that routes to
+  the Dynamic Support desk or kicks off an in-bot troubleshooting flow.
 
 ## What's New
 
@@ -211,6 +337,19 @@ import { FiActivity, FiHome, FiUser } from "react-icons/fi";
 - **Live DEX references**: monitor liquidity and pricing on
   [STON.fi](https://app.ston.fi) and [DeDust](https://dedust.io) pairs, with
   hedging hooks synced to the Supabase ledger service.
+
+### TON Sites Optimisation
+
+- **dynamic_ton.sites** introduces telemetry-aware optimisation plans for TON
+  Sites. Feed latency, availability, TLS, and storage ratios into
+  `TonSiteOptimizer` to receive prioritised actions, risk focus areas, and
+  remediation metadata for each domain.
+- **Portfolio rollups** via `evaluate_portfolio` aggregate scores and
+  high-priority blockers across domains so investor updates can reference a
+  single health snapshot before capital deployment.
+- **Regression coverage** lives in
+  `tests/test_dynamic_ton_sites.py`, ensuring remediation guidance stays
+  deterministic as we tune hosting guardrails.
 
 ### Architecture & Docs
 
@@ -1099,6 +1238,19 @@ with Dynamic and local tooling, see
 [docs/HYBRID_DEVELOPMENT_WORKFLOW.md](docs/HYBRID_DEVELOPMENT_WORKFLOW.md). It
 covers prototyping in Dynamic, exporting via the Codex CLI, local testing, and
 syncing changes through GitHub to maintain a seamless deployment pipeline.
+
+## References
+
+| Focus Area                | Resource                                                                 | Description |
+| ------------------------- | ------------------------------------------------------------------------- | ----------- |
+| Ecosystem architecture    | [dynamic_ecosystem/](dynamic_ecosystem/)                                  | High-level specs and models for the interconnected Dynamic platform pillars. |
+| Trading intelligence      | [dynamic_algo/](dynamic_algo/)                                            | Core automation routines orchestrating trading signals and hedging logic. |
+| AI research               | [dynamic_ai/](dynamic_ai/)                                                | Machine intelligence experiments, copilots, and model governance assets. |
+| Token & treasury          | [dynamic_token/](dynamic_token/)                                          | Tokenomics artifacts plus treasury operations playbooks. |
+| Operational guardrails    | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)                                  | Deployment, environment, and rollback procedures for production stability. |
+| Security & compliance     | [SECURITY.md](SECURITY.md)                                                | Security postures, reporting channels, and ongoing compliance commitments. |
+| Developer productivity    | [docs/codex_cli_workflow.md](docs/codex_cli_workflow.md)                  | Codex workflows, templates, and tooling for rapid iteration. |
+| Data & analytics pipelines| [data/](data/)                                                            | Datasets, ingestion scripts, and analytics-ready exports. |
 
 ## License / contributions
 

--- a/dynamic_ton/__init__.py
+++ b/dynamic_ton/__init__.py
@@ -22,6 +22,13 @@ from .engine import (
     TonNetworkTelemetry,
     TonTreasuryPosture,
 )
+from .sites import (
+    TonSiteOptimizationAction,
+    TonSiteOptimizationPlan,
+    TonSiteOptimizer,
+    TonSitePortfolioReport,
+    TonSiteProfile,
+)
 
 __all__ = [
     "AUCTION_START_TIME",
@@ -37,6 +44,11 @@ __all__ = [
     "TonLiquidityPool",
     "TonNetworkTelemetry",
     "TonTreasuryPosture",
+    "TonSiteOptimizationAction",
+    "TonSiteOptimizationPlan",
+    "TonSiteOptimizer",
+    "TonSitePortfolioReport",
+    "TonSiteProfile",
     "check_domain_string",
     "get_min_price",
     "get_min_price_config",

--- a/dynamic_ton/sites.py
+++ b/dynamic_ton/sites.py
@@ -1,0 +1,407 @@
+"""Optimisation utilities for Dynamic Capital's TON Sites footprint.
+
+The TON ecosystem encourages decentralised hosting through TON Sites, TON DNS,
+and TON Storage.  This module provides lightweight analytics primitives that
+convert telemetry about individual sites into actionable optimisation plans.
+It focuses on conditions we regularly monitor for investor-grade uptime:
+
+* latency and availability relative to published SLAs
+* the share of content pinned on TON Storage/IPFS versus legacy hosting
+* transport security posture (TLS scores, certificate runway)
+* delivery health, including asset weight and cache efficiency
+
+The resulting plans can be surfaced in operator dashboards or fed into the
+automation layer to escalate remediation work.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Sequence
+
+__all__ = [
+    "TonSiteProfile",
+    "TonSiteOptimizationAction",
+    "TonSiteOptimizationPlan",
+    "TonSitePortfolioReport",
+    "TonSiteOptimizer",
+]
+
+
+_ALLOWED_PRIORITIES = {"low", "normal", "high"}
+
+
+def _normalise_text(value: str) -> str:
+    if not isinstance(value, str):  # pragma: no cover - defensive guard
+        raise TypeError("value must be a string")
+    text = value.strip()
+    if not text:
+        raise ValueError("value must not be empty")
+    return text
+
+
+def _normalise_domain(value: str) -> str:
+    domain = _normalise_text(value).lower()
+    if "." not in domain:
+        raise ValueError("domain must include at least one dot")
+    return domain
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _ensure_non_negative(value: float) -> float:
+    return max(0.0, float(value))
+
+
+def _ensure_mapping(mapping: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    if mapping is None:
+        return None
+    if not isinstance(mapping, Mapping):  # pragma: no cover - defensive guard
+        raise TypeError("metadata must be a mapping")
+    return dict(mapping)
+
+
+@dataclass(slots=True)
+class TonSiteProfile:
+    """Snapshot of TON Site delivery and hosting telemetry."""
+
+    domain: str
+    average_latency_ms: float
+    availability_30d: float
+    ton_storage_ratio: float
+    https_score: float
+    dns_ttl_hours: float
+    certificate_days_remaining: int
+    asset_weight_kb: float
+    edge_cache_hit_rate: float
+    ipfs_pin_health: float
+    ton_dns_verified: bool = True
+
+    def __post_init__(self) -> None:
+        self.domain = _normalise_domain(self.domain)
+        self.average_latency_ms = _ensure_non_negative(self.average_latency_ms)
+        self.availability_30d = _clamp01(self.availability_30d)
+        self.ton_storage_ratio = _clamp01(self.ton_storage_ratio)
+        self.https_score = _clamp01(self.https_score)
+        self.dns_ttl_hours = _ensure_non_negative(self.dns_ttl_hours)
+        self.certificate_days_remaining = int(max(0, self.certificate_days_remaining))
+        self.asset_weight_kb = _ensure_non_negative(self.asset_weight_kb)
+        self.edge_cache_hit_rate = _clamp01(self.edge_cache_hit_rate)
+        self.ipfs_pin_health = _clamp01(self.ipfs_pin_health)
+        self.ton_dns_verified = bool(self.ton_dns_verified)
+
+
+@dataclass(slots=True)
+class TonSiteOptimizationAction:
+    """Actionable remediation step for a TON Site."""
+
+    category: str
+    description: str
+    priority: str = "normal"
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.category = _normalise_text(self.category).lower()
+        self.description = _normalise_text(self.description)
+        priority = _normalise_text(self.priority).lower()
+        if priority not in _ALLOWED_PRIORITIES:
+            raise ValueError(f"priority must be one of {_ALLOWED_PRIORITIES!r}")
+        self.priority = priority
+        self.metadata = _ensure_mapping(self.metadata)
+
+
+@dataclass(slots=True)
+class TonSiteOptimizationPlan:
+    """Aggregated optimisation plan for a single site."""
+
+    domain: str
+    score: float
+    actions: tuple[TonSiteOptimizationAction, ...]
+    focus_areas: tuple[str, ...]
+    summary: str
+
+    @property
+    def high_priority_actions(self) -> int:
+        return sum(1 for action in self.actions if action.priority == "high")
+
+    @property
+    def has_blockers(self) -> bool:
+        return any(action.priority == "high" for action in self.actions)
+
+
+@dataclass(slots=True)
+class TonSitePortfolioReport:
+    """Portfolio-level aggregation of TON Site optimisation plans."""
+
+    plans: tuple[TonSiteOptimizationPlan, ...]
+    average_score: float
+    focus_area_counts: Mapping[str, int]
+    high_priority_actions: int
+
+    @property
+    def needs_attention(self) -> bool:
+        return self.high_priority_actions > 0
+
+
+class TonSiteOptimizer:
+    """Generate optimisation plans for TON Sites based on telemetry."""
+
+    def __init__(
+        self,
+        *,
+        latency_sla_ms: float = 450.0,
+        availability_sla: float = 0.995,
+        min_ton_storage_ratio: float = 0.6,
+        min_https_score: float = 0.85,
+        min_edge_cache_hit_rate: float = 0.7,
+        max_asset_weight_kb: float = 1400.0,
+        min_dns_ttl_hours: float = 1.0,
+        min_certificate_days: int = 21,
+        min_ipfs_pin_health: float = 0.9,
+    ) -> None:
+        if latency_sla_ms <= 0:
+            raise ValueError("latency_sla_ms must be positive")
+        if not 0 < availability_sla <= 1:
+            raise ValueError("availability_sla must be in (0, 1]")
+        if not 0 <= min_ton_storage_ratio <= 1:
+            raise ValueError("min_ton_storage_ratio must be in [0, 1]")
+        if not 0 <= min_https_score <= 1:
+            raise ValueError("min_https_score must be in [0, 1]")
+        if not 0 <= min_edge_cache_hit_rate <= 1:
+            raise ValueError("min_edge_cache_hit_rate must be in [0, 1]")
+        if max_asset_weight_kb <= 0:
+            raise ValueError("max_asset_weight_kb must be positive")
+        if min_dns_ttl_hours < 0:
+            raise ValueError("min_dns_ttl_hours must be non-negative")
+        if min_certificate_days < 0:
+            raise ValueError("min_certificate_days must be non-negative")
+        if not 0 <= min_ipfs_pin_health <= 1:
+            raise ValueError("min_ipfs_pin_health must be in [0, 1]")
+
+        self._latency_sla_ms = float(latency_sla_ms)
+        self._availability_sla = float(availability_sla)
+        self._min_ton_storage_ratio = float(min_ton_storage_ratio)
+        self._min_https_score = float(min_https_score)
+        self._min_edge_cache_hit_rate = float(min_edge_cache_hit_rate)
+        self._max_asset_weight_kb = float(max_asset_weight_kb)
+        self._min_dns_ttl_hours = float(min_dns_ttl_hours)
+        self._min_certificate_days = int(min_certificate_days)
+        self._min_ipfs_pin_health = float(min_ipfs_pin_health)
+
+    def evaluate_site(self, profile: TonSiteProfile) -> TonSiteOptimizationPlan:
+        actions: list[TonSiteOptimizationAction] = []
+        focus_tags: set[str] = set()
+        score = 100.0
+
+        def register_action(action: TonSiteOptimizationAction, *, focus: str, penalty: float) -> None:
+            nonlocal score
+            actions.append(action)
+            focus_tags.add(focus)
+            score = max(0.0, score - penalty)
+
+        # Performance: latency
+        if profile.average_latency_ms > self._latency_sla_ms:
+            delta = profile.average_latency_ms - self._latency_sla_ms
+            penalty = min(delta / self._latency_sla_ms * 20.0, 20.0)
+            priority = "high" if profile.average_latency_ms > self._latency_sla_ms * 1.5 else "normal"
+            register_action(
+                TonSiteOptimizationAction(
+                    category="performance",
+                    description=(
+                        f"Reduce latency by ~{delta:.0f} ms to meet the {self._latency_sla_ms:.0f} ms SLA; "
+                        "review CDN edges and bridge routing."
+                    ),
+                    priority=priority,
+                    metadata={
+                        "latencyMs": round(profile.average_latency_ms, 2),
+                        "targetMs": round(self._latency_sla_ms, 2),
+                    },
+                ),
+                focus="performance",
+                penalty=penalty,
+            )
+
+        # Resilience: availability
+        if profile.availability_30d < self._availability_sla:
+            gap = self._availability_sla - profile.availability_30d
+            penalty = min(gap / self._availability_sla * 25.0, 25.0)
+            register_action(
+                TonSiteOptimizationAction(
+                    category="resilience",
+                    description=(
+                        f"Availability at {profile.availability_30d:.3f}; investigate incidents to restore "
+                        f"the {self._availability_sla:.3f} SLA."
+                    ),
+                    priority="high" if gap > 0.01 else "normal",
+                    metadata={"availability": round(profile.availability_30d, 4)},
+                ),
+                focus="resilience",
+                penalty=penalty,
+            )
+
+        # Decentralisation: TON Storage usage
+        if profile.ton_storage_ratio < self._min_ton_storage_ratio:
+            gap = self._min_ton_storage_ratio - profile.ton_storage_ratio
+            penalty = min(gap / max(self._min_ton_storage_ratio, 0.01) * 12.0, 12.0)
+            register_action(
+                TonSiteOptimizationAction(
+                    category="decentralisation",
+                    description=(
+                        "Increase TON Storage coverage to keep content decentralised; ramp pinning "
+                        f"from {profile.ton_storage_ratio:.0%} toward {self._min_ton_storage_ratio:.0%}."
+                    ),
+                    metadata={"currentRatio": round(profile.ton_storage_ratio, 3)},
+                ),
+                focus="decentralisation",
+                penalty=penalty,
+            )
+
+        # Security: HTTPS score and certificate runway
+        if profile.https_score < self._min_https_score:
+            gap = self._min_https_score - profile.https_score
+            penalty = min(gap / max(self._min_https_score, 0.01) * 15.0, 15.0)
+            register_action(
+                TonSiteOptimizationAction(
+                    category="security",
+                    description=(
+                        "Improve TLS hardening; upgrade cipher suites and headers to raise the HTTPS score "
+                        f"to {self._min_https_score:.0%}."
+                    ),
+                    priority="high" if profile.https_score < 0.6 else "normal",
+                    metadata={"httpsScore": round(profile.https_score, 3)},
+                ),
+                focus="security",
+                penalty=penalty,
+            )
+
+        if profile.certificate_days_remaining <= self._min_certificate_days:
+            penalty = 10.0 if profile.certificate_days_remaining == 0 else 6.0
+            register_action(
+                TonSiteOptimizationAction(
+                    category="security",
+                    description=(
+                        f"Renew TLS certificate; only {profile.certificate_days_remaining} days of coverage remaining."
+                    ),
+                    priority="high" if profile.certificate_days_remaining <= 7 else "normal",
+                    metadata={"daysRemaining": profile.certificate_days_remaining},
+                ),
+                focus="security",
+                penalty=penalty,
+            )
+
+        # Delivery: payload weight and cache efficiency
+        if profile.asset_weight_kb > self._max_asset_weight_kb:
+            excess = profile.asset_weight_kb - self._max_asset_weight_kb
+            penalty = min(excess / self._max_asset_weight_kb * 10.0, 10.0)
+            register_action(
+                TonSiteOptimizationAction(
+                    category="delivery",
+                    description=(
+                        "Reduce bundle size by trimming media or deferring non-critical assets; "
+                        f"currently {profile.asset_weight_kb:.0f} kB."
+                    ),
+                    metadata={"assetWeightKb": round(profile.asset_weight_kb, 1)},
+                ),
+                focus="delivery",
+                penalty=penalty,
+            )
+
+        if profile.edge_cache_hit_rate < self._min_edge_cache_hit_rate:
+            gap = self._min_edge_cache_hit_rate - profile.edge_cache_hit_rate
+            penalty = min(gap / max(self._min_edge_cache_hit_rate, 0.01) * 8.0, 8.0)
+            register_action(
+                TonSiteOptimizationAction(
+                    category="delivery",
+                    description=(
+                        "Tune caching rules to lift edge hit rate; target at least "
+                        f"{self._min_edge_cache_hit_rate:.0%}."
+                    ),
+                    metadata={"edgeHitRate": round(profile.edge_cache_hit_rate, 3)},
+                ),
+                focus="delivery",
+                penalty=penalty,
+            )
+
+        # Integrity: IPFS pin health
+        if profile.ipfs_pin_health < self._min_ipfs_pin_health:
+            gap = self._min_ipfs_pin_health - profile.ipfs_pin_health
+            penalty = min(gap / max(self._min_ipfs_pin_health, 0.01) * 12.0, 12.0)
+            register_action(
+                TonSiteOptimizationAction(
+                    category="integrity",
+                    description=(
+                        "Restore redundant IPFS/TON Storage pins; ensure health exceeds "
+                        f"{self._min_ipfs_pin_health:.0%}."
+                    ),
+                    priority="high" if profile.ipfs_pin_health < 0.5 else "normal",
+                    metadata={"pinHealth": round(profile.ipfs_pin_health, 3)},
+                ),
+                focus="integrity",
+                penalty=penalty,
+            )
+
+        # Operations: DNS hygiene
+        if profile.dns_ttl_hours < self._min_dns_ttl_hours:
+            penalty = 5.0
+            register_action(
+                TonSiteOptimizationAction(
+                    category="operations",
+                    description=(
+                        "Increase DNS TTL to reduce resolver churn and improve caching stability."
+                    ),
+                    metadata={"ttlHours": round(profile.dns_ttl_hours, 2)},
+                ),
+                focus="operations",
+                penalty=penalty,
+            )
+
+        if not profile.ton_dns_verified:
+            penalty = 10.0
+            register_action(
+                TonSiteOptimizationAction(
+                    category="compliance",
+                    description="Verify TON DNS ownership to restore trusted resolution.",
+                    priority="high",
+                ),
+                focus="compliance",
+                penalty=penalty,
+            )
+
+        focus_areas = tuple(sorted(focus_tags))
+        summary = (
+            f"{profile.domain} scores {score:.1f}; focus on {', '.join(focus_areas) if focus_areas else 'ongoing monitoring'}."
+        )
+        return TonSiteOptimizationPlan(
+            domain=profile.domain,
+            score=round(score, 2),
+            actions=tuple(actions),
+            focus_areas=focus_areas,
+            summary=summary,
+        )
+
+    def evaluate_portfolio(self, sites: Sequence[TonSiteProfile]) -> TonSitePortfolioReport:
+        plans = tuple(self.evaluate_site(site) for site in sites)
+        if not plans:
+            return TonSitePortfolioReport(
+                plans=(),
+                average_score=100.0,
+                focus_area_counts={},
+                high_priority_actions=0,
+            )
+
+        focus_counter: Counter[str] = Counter()
+        high_priority = 0
+        for plan in plans:
+            focus_counter.update(plan.focus_areas)
+            high_priority += plan.high_priority_actions
+
+        average_score = sum(plan.score for plan in plans) / len(plans)
+        return TonSitePortfolioReport(
+            plans=plans,
+            average_score=round(average_score, 2),
+            focus_area_counts=dict(focus_counter),
+            high_priority_actions=high_priority,
+        )

--- a/tests/test_dynamic_ton_sites.py
+++ b/tests/test_dynamic_ton_sites.py
@@ -1,0 +1,105 @@
+"""Tests for the TON Site optimisation tooling."""
+
+from __future__ import annotations
+
+import pytest
+
+from dynamic_ton import (
+    TonSiteOptimizationAction,
+    TonSiteOptimizationPlan,
+    TonSiteOptimizer,
+    TonSitePortfolioReport,
+    TonSiteProfile,
+)
+
+
+def test_site_optimizer_identifies_blockers() -> None:
+    profile = TonSiteProfile(
+        domain="alpha.dynamic.ton",
+        average_latency_ms=720.0,
+        availability_30d=0.982,
+        ton_storage_ratio=0.42,
+        https_score=0.58,
+        dns_ttl_hours=0.5,
+        certificate_days_remaining=5,
+        asset_weight_kb=2200.0,
+        edge_cache_hit_rate=0.55,
+        ipfs_pin_health=0.47,
+        ton_dns_verified=False,
+    )
+
+    optimizer = TonSiteOptimizer()
+    plan = optimizer.evaluate_site(profile)
+
+    assert isinstance(plan, TonSiteOptimizationPlan)
+    assert plan.domain == "alpha.dynamic.ton"
+    assert plan.score < 60.0
+    assert plan.has_blockers
+    assert plan.high_priority_actions >= 3
+
+    categories = {action.category for action in plan.actions}
+    assert {"performance", "security", "compliance"}.issubset(categories)
+
+
+def test_site_optimizer_handles_healthy_site() -> None:
+    profile = TonSiteProfile(
+        domain="stable.dynamic.ton",
+        average_latency_ms=180.0,
+        availability_30d=0.999,
+        ton_storage_ratio=0.85,
+        https_score=0.92,
+        dns_ttl_hours=12.0,
+        certificate_days_remaining=90,
+        asset_weight_kb=680.0,
+        edge_cache_hit_rate=0.84,
+        ipfs_pin_health=0.97,
+    )
+
+    optimizer = TonSiteOptimizer()
+    plan = optimizer.evaluate_site(profile)
+
+    assert isinstance(plan, TonSiteOptimizationPlan)
+    assert plan.actions == ()
+    assert pytest.approx(plan.score, rel=1e-3) == 100.0
+    assert plan.focus_areas == ()
+    assert not plan.has_blockers
+
+
+def test_portfolio_report_aggregates_plans() -> None:
+    optimizer = TonSiteOptimizer()
+    degraded = TonSiteProfile(
+        domain="beta.dynamic.ton",
+        average_latency_ms=560.0,
+        availability_30d=0.988,
+        ton_storage_ratio=0.55,
+        https_score=0.78,
+        dns_ttl_hours=0.25,
+        certificate_days_remaining=2,
+        asset_weight_kb=1650.0,
+        edge_cache_hit_rate=0.62,
+        ipfs_pin_health=0.82,
+    )
+    healthy = TonSiteProfile(
+        domain="gamma.dynamic.ton",
+        average_latency_ms=220.0,
+        availability_30d=0.998,
+        ton_storage_ratio=0.7,
+        https_score=0.94,
+        dns_ttl_hours=6.0,
+        certificate_days_remaining=60,
+        asset_weight_kb=900.0,
+        edge_cache_hit_rate=0.78,
+        ipfs_pin_health=0.95,
+    )
+
+    report = optimizer.evaluate_portfolio([degraded, healthy])
+
+    assert isinstance(report, TonSitePortfolioReport)
+    assert len(report.plans) == 2
+    assert report.average_score < 100.0
+    assert report.high_priority_actions >= 1
+    assert "delivery" in report.focus_area_counts
+
+    # Ensure plans themselves are returned for downstream processing.
+    assert all(isinstance(plan, TonSiteOptimizationPlan) for plan in report.plans)
+    assert any(isinstance(action, TonSiteOptimizationAction) for plan in report.plans for action in plan.actions)


### PR DESCRIPTION
## Summary
- add a telemetry-driven TON Sites optimiser module that generates per-domain action plans and aggregated portfolio reports
- expose the new optimisation interfaces via the dynamic_ton package and document the capability in the README
- backfill targeted pytest coverage to keep optimisation guidance deterministic

## Testing
- pytest tests/test_dynamic_ton_sites.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dcde8434388322b4394148d0a09578