### PR TITLE
Stabilize Telegram WebApp initialization

### DIFF
--- a/apps/web/app/(miniapp)/miniapp/(tabs)/account/page.tsx
+++ b/apps/web/app/(miniapp)/miniapp/(tabs)/account/page.tsx
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { BadgeCheck, CreditCard, Settings } from "lucide-react";
 import { Sheet } from "@/components/miniapp/Sheet";
-import { haptic, hideMainButton, setMainButton, tg } from "@/lib/telegram";
+import {
+  getTelegramWebApp,
+  haptic,
+  hideMainButton,
+  setMainButton,
+} from "@/lib/telegram";
 import { track } from "@/lib/metrics";
 
 export default function AccountTab() {
@@ -14,8 +19,9 @@ export default function AccountTab() {
     haptic("medium");
     void track("account_concierge_support");
     setShowSheet(false);
-    if (tg?.openTelegramLink) {
-      tg.openTelegramLink(conciergeUrl);
+    const telegram = getTelegramWebApp();
+    if (telegram?.openTelegramLink) {
+      telegram.openTelegramLink(conciergeUrl);
     } else {
       window.open(conciergeUrl, "_blank");
     }

--- a/apps/web/app/(miniapp)/miniapp/providers.tsx
+++ b/apps/web/app/(miniapp)/miniapp/providers.tsx
@@ -22,7 +22,7 @@ export default function MiniAppProviders(
   const router = useRouter();
 
   useEffect(() => {
-    initTelegram();
+    void initTelegram();
     applyThemeVars();
     const themeManager = getMiniAppThemeManager();
     const detachTonConnect = attachGlobalTonConnect(themeManager);


### PR DESCRIPTION
## Summary
- wait for the Telegram WebApp object before calling readiness APIs so the mini app consistently exits the loading state
- allow the mini app provider to invoke the async initializer without blocking React effects

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dceaeefef88322acda6c895c1fcd3e