### PR TITLE
Improve TON Site gateway validation

### DIFF
--- a/scripts/verify/ton_site.mjs
+++ b/scripts/verify/ton_site.mjs
@@ -1,0 +1,382 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const [configPath = "dns/dynamiccapital.ton.json", domainOverride = ""] =
+  process.argv.slice(2);
+
+const lines = [];
+const record = (key, value) => {
+  lines.push(`${key}=${String(value)}`);
+};
+
+const sanitize = (value) => String(value ?? "").replace(/\s+/g, " ").trim();
+
+record("config_path", configPath);
+
+let config;
+try {
+  const raw = await readFile(configPath, "utf8");
+  config = JSON.parse(raw);
+  record("config_present", "PASS");
+} catch (error) {
+  record("config_present", "FAIL");
+  record("error", sanitize(error.message));
+  console.log(lines.join("\n"));
+  process.exit(0);
+}
+
+const domain = sanitize(domainOverride) || sanitize(config.domain) ||
+  sanitize(config.dns);
+if (domain) {
+  record("domain", domain);
+} else {
+  record("domain", "UNKNOWN");
+}
+
+const tonSite = config.ton_site && typeof config.ton_site === "object"
+  ? config.ton_site
+  : null;
+if (tonSite) {
+  record("ton_site_present", "PASS");
+} else {
+  record("ton_site_present", "FAIL");
+}
+
+const adnl = tonSite?.adnl_address;
+if (typeof adnl === "string") {
+  const normalized = adnl.trim();
+  const adnlRegex = /^0:[0-9a-fA-F]{64}$/;
+  record("adnl_address", normalized);
+  record("adnl_format", adnlRegex.test(normalized) ? "PASS" : "FAIL");
+} else {
+  record("adnl_address", "MISSING");
+  record("adnl_format", "FAIL");
+}
+
+const publicKey = tonSite?.public_key_base64;
+if (typeof publicKey === "string" && publicKey.trim()) {
+  let decodedBytes = 0;
+  let validBase64 = false;
+  try {
+    const normalized = publicKey.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized + "=".repeat((4 - normalized.length % 4) % 4);
+    const buf = Buffer.from(padded, "base64");
+    decodedBytes = buf.length;
+    validBase64 = decodedBytes === 32;
+  } catch (error) {
+    record("public_key_error", sanitize(error.message));
+  }
+  record("public_key_base64", publicKey.trim());
+  record("public_key_bytes", decodedBytes);
+  record("public_key_valid", validBase64 ? "PASS" : "FAIL");
+} else {
+  record("public_key_base64", "MISSING");
+  record("public_key_bytes", 0);
+  record("public_key_valid", "FAIL");
+}
+
+const generated = tonSite && typeof tonSite.generated === "object"
+  ? tonSite.generated
+  : null;
+if (generated) {
+  const command = sanitize(generated.command);
+  if (command) {
+    record("generated_command", command);
+    record(
+      "generated_command_status",
+      command === "npm run ton:generate-adnl" ? "PASS" : "WARN",
+    );
+  } else {
+    record("generated_command", "MISSING");
+    record("generated_command_status", "FAIL");
+  }
+
+  const timestamp = sanitize(generated.timestamp);
+  if (timestamp) {
+    record("generated_timestamp", timestamp);
+    const parsed = new Date(timestamp);
+    record(
+      "generated_timestamp_status",
+      Number.isNaN(parsed.getTime()) ? "FAIL" : "PASS",
+    );
+  } else {
+    record("generated_timestamp", "MISSING");
+    record("generated_timestamp_status", "FAIL");
+  }
+
+  if (generated.note) {
+    record("generated_note", sanitize(generated.note));
+  }
+} else {
+  record("generated_command", "MISSING");
+  record("generated_command_status", "FAIL");
+  record("generated_timestamp", "MISSING");
+  record("generated_timestamp_status", "FAIL");
+}
+
+const resolver = typeof config.resolver_contract === "string"
+  ? config.resolver_contract.trim()
+  : "";
+record("resolver_contract", resolver || "MISSING");
+
+let resolverDetails = null;
+if (resolver) {
+  try {
+    const normalized = resolver.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized + "=".repeat((4 - normalized.length % 4) % 4);
+    const buf = Buffer.from(padded, "base64");
+    if (buf.length !== 36) {
+      throw new Error(`Unexpected friendly address length ${buf.length}`);
+    }
+    const tag = buf[0];
+    const workchainByte = buf[1];
+    const isBounceable = (tag & 0x11) === 0x11;
+    const isTestOnly = (tag & 0x80) === 0x80;
+    const workchain = workchainByte > 127 ? workchainByte - 256 : workchainByte;
+    const hashPart = buf.subarray(2, 34).toString("hex");
+    resolverDetails = { isBounceable, isTestOnly, workchain, hash: hashPart };
+    record("resolver_address_workchain", workchain);
+    record("resolver_address_hash", hashPart);
+    record("resolver_address_bounceable", isBounceable ? "yes" : "no");
+    record("resolver_address_testnet", isTestOnly ? "yes" : "no");
+    record("resolver_format", "PASS");
+  } catch (error) {
+    record("resolver_format", "FAIL");
+    record("resolver_error", sanitize(error.message));
+  }
+} else {
+  record("resolver_format", "FAIL");
+}
+
+if (Array.isArray(config.notes) && adnl) {
+  const mention = config.notes.some((note) =>
+    typeof note === "string" && note.includes(adnl)
+  );
+  record("notes_reference_adnl", mention ? "PASS" : "FAIL");
+}
+
+const fetchWithCurlFallback = async (
+  url,
+  { label = "", timeoutMs = 8000 } = {},
+) => {
+  const errorPrefix = label ? `${label}_` : "";
+  if (typeof fetch === "function") {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      const body = await response.text();
+      return {
+        status: response.status,
+        body,
+        ok: response.ok,
+        transport: "fetch",
+      };
+    } catch (error) {
+      if (errorPrefix) {
+        record(`${errorPrefix}fetch_error`, sanitize(error.message));
+      }
+    }
+  }
+
+  try {
+    const { stdout } = await execFileAsync("curl", [
+      "-sS",
+      "-m",
+      String(Math.ceil(timeoutMs / 1000)),
+      "-w",
+      "\n%{http_code}",
+      url,
+    ]);
+    const trimmed = stdout.trimEnd();
+    const lines = trimmed.split("\n");
+    const statusLine = lines.pop() ?? "";
+    const status = Number.parseInt(statusLine, 10);
+    const body = lines.join("\n");
+    if (!Number.isNaN(status)) {
+      return {
+        status,
+        body,
+        ok: status >= 200 && status < 300,
+        transport: "curl",
+      };
+    }
+    return { status: 0, body, ok: false };
+  } catch (error) {
+    if (errorPrefix) {
+      record(`${errorPrefix}curl_error`, sanitize(error.message));
+    }
+    return { status: 0, body: "", ok: false };
+  }
+};
+
+let tonapiStatus = "SKIPPED";
+if (domain) {
+  const url = `https://tonapi.io/v2/dns/${encodeURIComponent(domain)}`;
+  const result = await fetchWithCurlFallback(url, { label: "tonapi" });
+  if (result.status) {
+    record("tonapi_http_status", result.status);
+  }
+  if (result.transport) {
+    record("tonapi_transport", result.transport);
+  }
+  if (result.ok) {
+    tonapiStatus = "PASS";
+    try {
+      const payload = JSON.parse(result.body);
+      const tonapiAddress = payload?.item?.address;
+      if (tonapiAddress) {
+        record("tonapi_resolver_address", tonapiAddress);
+        const [wcStr, hashPart] = tonapiAddress.split(":");
+        const wc = Number.parseInt(wcStr, 10);
+        if (resolverDetails && !Number.isNaN(wc) && hashPart) {
+          const match = wc === resolverDetails.workchain &&
+            hashPart.toLowerCase() === resolverDetails.hash;
+          record("resolver_matches_dns", match ? "PASS" : "FAIL");
+        }
+      }
+    } catch (error) {
+      tonapiStatus = "FAIL";
+      record("tonapi_error", sanitize(error.message));
+    }
+  } else if (result.status) {
+    tonapiStatus = "FAIL";
+    const preview = sanitize(result.body).slice(0, 240);
+    if (preview) {
+      record("tonapi_error", preview);
+    }
+  } else if (!result.status) {
+    tonapiStatus = "ERROR";
+  }
+}
+record("tonapi_lookup", tonapiStatus);
+
+const gatewayFailureIndicators = [
+  "dns resolution failure",
+  "not found",
+  "upstream connect error",
+  "connection timeout",
+  "domain for sale",
+  "forsale",
+  "error",
+];
+
+const rawGatewayList = process.env.TON_SITE_GATEWAYS ?? "";
+const gatewayBases = rawGatewayList
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const defaultGatewayBases = [
+  "https://tonsite.io",
+  "https://resolve.tonapi.io",
+  "https://toncdn.io",
+  "https://tonsite.link",
+  "https://ton.site",
+];
+
+const candidateGateways = gatewayBases.length > 0
+  ? gatewayBases
+  : defaultGatewayBases;
+
+if (candidateGateways.length > 0) {
+  record("tonsite_gateway_candidates", candidateGateways.join(","));
+}
+
+let gatewayStatus = domain ? "FAIL" : "SKIPPED";
+let firstPreview = "";
+let firstStatus = 0;
+let firstTransport = "";
+let firstUrl = "";
+let successfulGateway = null;
+
+if (domain) {
+  const encodedDomain = encodeURIComponent(domain);
+  for (let i = 0; i < candidateGateways.length; i += 1) {
+    const base = candidateGateways[i]?.replace(/\/+$/, "");
+    if (!base) {
+      continue;
+    }
+    const url = `${base}/${encodedDomain}`;
+    const label = `tonsite_gateway${i}`;
+    const result = await fetchWithCurlFallback(url, {
+      label,
+      timeoutMs: 8000,
+    });
+    const preview = sanitize(result.body).slice(0, 240);
+    if (!firstUrl) {
+      firstUrl = url;
+      firstStatus = result.status ?? 0;
+      firstTransport = result.transport ?? "";
+      firstPreview = preview;
+    }
+    record(`${label}_url`, url);
+    if (result.status) {
+      record(`${label}_http_status`, result.status);
+    }
+    if (result.transport) {
+      record(`${label}_transport`, result.transport);
+    }
+    if (preview) {
+      record(`${label}_preview`, preview);
+    }
+
+    const lowerPreview = preview.toLowerCase();
+    const flaggedFailure = gatewayFailureIndicators.some((indicator) =>
+      lowerPreview.includes(indicator)
+    );
+
+    if (result.ok && !flaggedFailure) {
+      const byteLength = Buffer.byteLength(result.body, "utf8");
+      successfulGateway = {
+        url,
+        status: result.status,
+        transport: result.transport,
+        preview,
+        bytes: byteLength,
+        label,
+      };
+      break;
+    }
+  }
+}
+
+if (successfulGateway) {
+  gatewayStatus = "PASS";
+  record("tonsite_gateway_lookup", gatewayStatus);
+  record("tonsite_gateway_source", successfulGateway.url);
+  if (successfulGateway.status) {
+    record("tonsite_gateway_http_status", successfulGateway.status);
+  }
+  if (successfulGateway.transport) {
+    record("tonsite_gateway_transport", successfulGateway.transport);
+  }
+  if (successfulGateway.preview) {
+    record("tonsite_gateway_preview", successfulGateway.preview);
+  }
+  record("tonsite_gateway_bytes", successfulGateway.bytes);
+} else if (domain) {
+  if (firstStatus) {
+    gatewayStatus = "FAIL";
+    record("tonsite_gateway_http_status", firstStatus);
+  } else {
+    gatewayStatus = "ERROR";
+  }
+  if (firstTransport) {
+    record("tonsite_gateway_transport", firstTransport);
+  }
+  if (firstPreview) {
+    record("tonsite_gateway_error", firstPreview);
+  }
+  if (firstUrl) {
+    record("tonsite_gateway_source", firstUrl);
+  }
+  record("tonsite_gateway_lookup", gatewayStatus);
+} else {
+  record("tonsite_gateway_lookup", gatewayStatus);
+}
+
+console.log(lines.join("\n"));

--- a/scripts/verify/ton_site.sh
+++ b/scripts/verify/ton_site.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+
+ensure_out
+OUT=".out/ton_site.txt"
+: > "$OUT"
+
+say "H) TON Site Verification"
+
+if ! command -v node >/dev/null 2>&1; then
+  warn "node is not available; skipping TON Site verification."
+  {
+    echo "node=missing"
+    echo "verified=SKIPPED"
+  } >> "$OUT"
+  exit 0
+fi
+
+CONFIG_PATH="${TON_SITE_CONFIG_PATH:-dns/dynamiccapital.ton.json}"
+DOMAIN_OVERRIDE="${TON_SITE_DOMAIN:-}"
+
+if [ ! -f "$CONFIG_PATH" ]; then
+  warn "TON Site config file '$CONFIG_PATH' not found."
+  {
+    echo "config_path=$CONFIG_PATH"
+    echo "config_present=FAIL"
+  } >> "$OUT"
+  exit 0
+fi
+
+if ! output=$(node scripts/verify/ton_site.mjs "$CONFIG_PATH" "$DOMAIN_OVERRIDE" 2>&1); then
+  warn "ton_site.mjs execution encountered an error"
+  echo "$output" >> "$OUT"
+  echo "verified=FAIL" >> "$OUT"
+  exit 0
+fi
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  echo "$line" >> "$OUT"
+  key="${line%%=*}"
+  value="${line#*=}"
+  case "$key" in
+    config_present)
+      if [ "$value" = "PASS" ]; then
+        pass "Loaded TON Site configuration"
+      else
+        warn "Failed to load TON Site configuration"
+      fi
+      ;;
+    domain)
+      if [ "$value" != "UNKNOWN" ]; then
+        say "Domain under verification: $value"
+      else
+        warn "Domain missing from TON Site configuration"
+      fi
+      ;;
+    ton_site_present)
+      if [ "$value" = "PASS" ]; then
+        pass "TON Site metadata present"
+      else
+        warn "TON Site metadata missing"
+      fi
+      ;;
+    adnl_format)
+      if [ "$value" = "PASS" ]; then
+        pass "ADNL address format valid"
+      else
+        warn "ADNL address failed validation"
+      fi
+      ;;
+    public_key_valid)
+      if [ "$value" = "PASS" ]; then
+        pass "TON Site public key decoded successfully"
+      else
+        warn "TON Site public key failed validation"
+      fi
+      ;;
+    resolver_format)
+      if [ "$value" = "PASS" ]; then
+        pass "Resolver contract decoded successfully"
+      else
+        warn "Resolver contract address invalid"
+      fi
+      ;;
+    resolver_matches_dns)
+      if [ "$value" = "PASS" ]; then
+        pass "Resolver matches TON DNS lookup"
+      else
+        warn "Resolver mismatch between config and TON DNS"
+      fi
+      ;;
+    tonapi_lookup)
+      case "$value" in
+        PASS)
+          pass "TON API lookup succeeded"
+          ;;
+        SKIPPED)
+          warn "TON API lookup skipped"
+          ;;
+        ERROR)
+          warn "TON API lookup encountered an exception"
+          ;;
+        *)
+          warn "TON API lookup returned status: $value"
+          ;;
+      esac
+      ;;
+    tonapi_error)
+      warn "TON API response preview: $value"
+      ;;
+    tonapi_transport)
+      say "TON API transport used: $value"
+      ;;
+    tonapi_fetch_error)
+      warn "TON API fetch error: $value"
+      ;;
+    tonapi_curl_error)
+      warn "TON API curl fallback error: $value"
+      ;;
+    generated_command_status)
+      if [ "$value" = "PASS" ]; then
+        pass "Generated command metadata matches expected value"
+      elif [ "$value" = "WARN" ]; then
+        warn "Generated command metadata differs from expected"
+      else
+        warn "Generated command metadata missing"
+      fi
+      ;;
+    generated_timestamp_status)
+      if [ "$value" = "PASS" ]; then
+        pass "Generated timestamp parsed successfully"
+      else
+        warn "Generated timestamp missing or invalid"
+      fi
+      ;;
+    notes_reference_adnl)
+      if [ "$value" = "PASS" ]; then
+        pass "DNS notes reference the ADNL address"
+      else
+        warn "DNS notes do not reference the ADNL address"
+      fi
+      ;;
+    tonsite_gateway_lookup)
+      case "$value" in
+        PASS)
+          pass "TON Site gateway served content"
+          ;;
+        SKIPPED)
+          warn "TON Site gateway check skipped"
+          ;;
+        ERROR)
+          warn "TON Site gateway lookup encountered an exception"
+          ;;
+        *)
+          warn "TON Site gateway reported status: $value"
+          ;;
+      esac
+      ;;
+    tonsite_gateway_source)
+      say "TON Site gateway attempted: $value"
+      ;;
+    tonsite_gateway_error)
+      warn "TON Site gateway response preview: $value"
+      ;;
+    tonsite_gateway_transport)
+      say "TON Site gateway transport used: $value"
+      ;;
+    tonsite_gateway_preview)
+      say "TON Site gateway content preview: $value"
+      ;;
+    tonsite_gateway_fetch_error)
+      warn "TON Site gateway fetch error: $value"
+      ;;
+    tonsite_gateway_curl_error)
+      warn "TON Site gateway curl error: $value"
+      ;;
+    tonsite_gateway_candidates)
+      say "TON Site gateway candidates: $value"
+      ;;
+  esac
+  if [ "$key" = "adnl_address" ] && [ "$value" != "MISSING" ]; then
+    say "ADNL address: $value"
+  fi
+  if [ "$key" = "resolver_contract" ] && [ "$value" != "MISSING" ]; then
+    say "Resolver contract: $value"
+  fi
+  if [ "$key" = "tonapi_resolver_address" ]; then
+    say "TON API resolver address: $value"
+  fi
+  if [ "$key" = "resolver_address_hash" ]; then
+    say "Resolver hash: $value"
+  fi
+  if [ "$key" = "public_key_bytes" ]; then
+    say "Public key bytes: $value"
+  fi
+  if [ "$key" = "generated_command" ] && [ "$value" != "MISSING" ]; then
+    say "Generated command: $value"
+  fi
+  if [ "$key" = "generated_timestamp" ] && [ "$value" != "MISSING" ]; then
+    say "Generated timestamp: $value"
+  fi
+  if [ "$key" = "generated_note" ]; then
+    say "Generated note: $value"
+  fi
+  if [ "$key" = "tonapi_http_status" ]; then
+    say "TON API HTTP status: $value"
+  fi
+  case "$key" in
+    tonsite_gateway_http_status)
+      say "TON Site gateway HTTP status: $value"
+      ;;
+    tonsite_gateway_bytes)
+      say "TON Site gateway bytes: $value"
+      ;;
+    tonsite_gateway_source)
+      ;; # already handled above
+    tonsite_gateway_*_http_status)
+      say "${key/_http_status/} HTTP status: $value"
+      ;;
+    tonsite_gateway_*_transport)
+      say "${key/_transport/} transport: $value"
+      ;;
+    tonsite_gateway_*_preview)
+      say "${key/_preview/} preview: $value"
+      ;;
+    tonsite_gateway_*_url)
+      say "${key/_url/} url: $value"
+      ;;
+    tonsite_gateway_*_fetch_error)
+      warn "${key/_fetch_error/} fetch error: $value"
+      ;;
+    tonsite_gateway_*_curl_error)
+      warn "${key/_curl_error/} curl error: $value"
+      ;;
+  esac
+  if [ "$key" = "resolver_address_testnet" ]; then
+    say "Resolver testnet flag: $value"
+  fi
+  if [ "$key" = "resolver_address_bounceable" ]; then
+    say "Resolver bounceable flag: $value"
+  fi
+  if [ "$key" = "tonapi_lookup" ] && [ "$value" != "PASS" ]; then
+    echo "verified=FAIL" >> "$OUT"
+  fi
+  if [ "$key" = "tonsite_gateway_lookup" ] && [ "$value" != "PASS" ]; then
+    echo "verified=FAIL" >> "$OUT"
+  fi
+done <<< "$output"
+
+if ! grep -q '^verified=' "$OUT"; then
+  echo "verified=PASS" >> "$OUT"
+fi
+
+say "TON Site verification complete."

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -15,6 +15,7 @@ bash scripts/verify/miniapp_safety.sh
 bash scripts/verify/tradingview_webhook.sh
 bash scripts/verify/tunnel_checks.sh
 bash scripts/verify/dynamic_modules.sh
+bash scripts/verify/ton_site.sh
 
 # Build markdown report
 OUT=".out/verify_report.md"
@@ -43,6 +44,7 @@ emit_section "D) Mini App Safety" ".out/miniapp_safety.txt"
 emit_section "E) TradingView Webhook" ".out/tradingview_webhook.txt"
 emit_section "F) Tunnel CLI Checks" ".out/tunnel_checks.txt"
 emit_section "G) Dynamic Modules" ".out/dynamic_modules.txt"
+emit_section "H) TON Site" ".out/ton_site.txt"
 
 echo "Report written to $OUT"
 say "Done."


### PR DESCRIPTION
## Summary
- extend the TON Site verifier to probe multiple public gateways with configurable overrides and treat known error templates as failures
- capture gateway diagnostics for every attempt, expose the successful source, and surface previews in the shell wrapper output

## Testing
- npm run format
- npm run lint
- npm run typecheck
- bash scripts/verify/ton_site.sh

------
https://chatgpt.com/codex/tasks/task_e_68dd0994b064832284d62dafcaacb9db