### PR TITLE
Add dynamic quantum programming cheat sheets

### DIFF
--- a/docs/dynamic_quantum_cheat_sheets.md
+++ b/docs/dynamic_quantum_cheat_sheets.md
@@ -9,28 +9,55 @@ blogs, or repositories so you can jump straight into the most relevant tools.
 
 - **Primary use cases**: Portfolio optimisation, risk modelling, option pricing,
   and algorithmic trading workflows.
-- **Use the tooling for**:
-  - [`qiskit-finance`](https://qiskit.org/documentation/finance/): The
-    documentation describes the package as “an open-source framework that
-    contains uncertainty components for stock/securities problems, applications
-    for finance problems, such as portfolio optimization, and data providers to
-    source real or random data.”
+- **Corpus extraction**:
+  - [`qiskit-finance`](https://qiskit.org/documentation/finance/): “Qiskit
+    Finance is an open-source framework that contains uncertainty components for
+    stock/securities problems, applications for finance problems, such as
+    portfolio optimization, and data providers to source real or random data to
+    finance experiments.” The tutorial index lists “Quantum Amplitude
+    Estimation,” “Portfolio Optimization,” “Pricing European Call Options,”
+    “Credit Risk Analysis,” and “Loading and Processing Stock-Market Time-Series
+    Data.”
   - [`PennyLane`](https://github.com/PennyLaneAI/pennylane/blob/master/README.md):
-    The README positions PennyLane as “the definitive open-source framework for
-    quantum programming” with features that let you “build quantum circuits …
-    run on high-performance simulators or various hardware devices … integrate
-    with PyTorch, TensorFlow, JAX, Keras, or NumPy to define and train hybrid
-    models.”
+    The README introduces PennyLane as “a cross-platform Python library for
+    quantum computing, quantum machine learning, and quantum chemistry” and
+    calls it “the definitive open-source framework for quantum programming.” Its
+    key features note that you can “build quantum circuits with a wide range of
+    state preparations, gates, and measurements” and “run on high-performance
+    simulators or various hardware devices, with advanced features like
+    mid-circuit measurements and error mitigation.” PennyLane lets you
+    “integrate with PyTorch, TensorFlow, JAX, Keras, or NumPy to define and
+    train hybrid models using quantum-aware optimizers and hardware-compatible
+    gradients for advanced research tasks,” “access high-quality, pre-simulated
+    datasets to decrease time-to-research and accelerate algorithm development,”
+    and benefit from “experimental support for just-in-time compilation” that
+    can “compile your entire hybrid workflow, with support for advanced features
+    such as adaptive circuits, real-time measurement feedback, and unbounded
+    loops.”
   - [Quantum Finance & Numerical Methods](https://github.com/MonitSharma/Quantum-Finance-and-Numerical-Methods):
-    The repository README emphasises curated materials for “financial modeling,
-    data visualization, and economic forecasting” with course folders that cover
-    “Introduction to Finance with Python,” “Machine Learning for Finance,” and
-    “Classical Use Cases.”
+    The repository “contains a variety of materials related to the intersection
+    of finance, economics, and quantum computing,” with an emphasis on
+    “financial modeling, data visualization, and economic forecasting.” It
+    stresses that “the materials in this repository are well-documented and
+    tested.” “Introduction to Finance with Python” is “designed for students and
+    professionals with little or no background in finance, but who have a strong
+    foundation in programming and data analysis” so that “this course will
+    introduce you to the basics of financial concepts and provide you with the
+    skills needed to apply these concepts using Python.” “Machine Learning for
+    Finance” is “designed for students and professionals with a background in
+    finance and an interest in using cutting-edge machine learning techniques to
+    analyze and make predictions about financial data,” while “Classical Use
+    Cases” is “a collection of case studies demonstrating the application of
+    Python programming and numerical methods to solve real-world problems of
+    finance and supply chain.” The quantum-focused folder features “lecture
+    notes, exercises, and projects that cover topics such as quantum algorithms
+    for portfolio optimization, supply chain and option call price prediction,
+    and the applications of quantum computing to financial risk analysis.”
 - **Execution notes**:
   - Encode historical or simulated price paths into amplitude registers, then
     call Qiskit Finance data providers for scenario generation.
-  - Build differentiable pipelines with PennyLane to optimise hedging
-    strategies against simulated payoffs.
+  - Build differentiable pipelines with PennyLane to optimise hedging strategies
+    against simulated payoffs.
   - Prototype Monte-Carlo and phase-estimation pricing examples by adapting the
     repository’s notebooks.
 
@@ -41,9 +68,9 @@ blogs, or repositories so you can jump straight into the most relevant tools.
 - **Use the tooling for**:
   - [`D-Wave Ocean`](https://docs.ocean.dwavesys.com/en/stable/ocean/index.html):
     The SDK overview highlights the “Python-based open-source software
-    development kit … [that] makes application development for quantum
-    computers rapid and efficient” plus the Leap service for running demos on
-    D-Wave hardware.
+    development kit … [that] makes application development for quantum computers
+    rapid and efficient” plus the Leap service for running demos on D-Wave
+    hardware.
   - [`Qiskit Optimization`](https://qiskit.org/ecosystem/optimization/index.html):
     Its overview explains that the framework spans “high-level modeling of
     optimization problems … automatic conversion between different problem
@@ -120,19 +147,20 @@ blogs, or repositories so you can jump straight into the most relevant tools.
 
 ## Dynamic Quantum Physics
 
-- **Primary use cases**: Many-body simulation, quantum field approximations,
-  and decoherence modelling.
+- **Primary use cases**: Many-body simulation, quantum field approximations, and
+  decoherence modelling.
 - **Resource extraction**:
   - [IQM Circuit Magicians](https://meetiqm.com/blog/quantum-computing-cheat-sheet-for-circuit-magicians/)
     explains that the downloadable cheat sheet “contains not only basics about
     qubits but also various gates and some building blocks that might be helpful
     in your algorithm,” acting as a gate-level aide-mémoire for physical
     modelling.
-  - The [IQM Academy cheat sheet hub](https://github.com/iqm-finland/iqm-academy-cheat-sheets/blob/master/README.md)
+  - The
+    [IQM Academy cheat sheet hub](https://github.com/iqm-finland/iqm-academy-cheat-sheets/blob/master/README.md)
     documents translations and licensing for sharing circuit resources, useful
     for collaborative lab environments.
 - **Execution notes**:
   - Reference the gate catalogue when constructing trotterised Hamiltonian
     evolutions or noise-insertion experiments.
-  - Align lab documentation with the CC-BY-SA licence guidance when adapting
-    IQM materials for internal physics curricula.
+  - Align lab documentation with the CC-BY-SA licence guidance when adapting IQM
+    materials for internal physics curricula.


### PR DESCRIPTION
## Summary
- add a documentation page that consolidates cheat-sheet resources across the dynamic quantum domains
- highlight use cases, tooling, and focus areas for finance, business, space science, biology, math, and physics tracks

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68ddb236002c83229c8dc3da9c8e70c2