### PR TITLE
docs: catalog llm-first crawling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
     - [Docker](#docker)
 - [Automation & Data Pipelines](#automation--data-pipelines)
   - [Analyst Insights Collector](#analyst-insights-collector)
+  - [LLM-native crawling stack](#llm-native-crawling-stack)
   - [Dynamic Hedge Model](#dynamic-hedge-model)
 - [GitHub Integration](#github-integration)
 - [Hybrid Development Workflow](#hybrid-development-workflow)


### PR DESCRIPTION
## Summary
- add an "LLM-native crawling stack" section to the Automation & Data Pipelines chapter in the README
- highlight Crawl4AI, ScrapeGraphAI, Firecrawl, Crawlee, and LLM Scraper with direct GitHub links and capability summaries for quick discovery

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68ddb5eadfbc83229a2557fff17abca1