### PR TITLE
Install Firecrawl CLI dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "chokidar-cli": "^3.0.0",
         "deno": "^2.5.0",
         "dotenv": "^17.2.3",
+        "firecrawl": "^1.21.1",
         "ngrok": "^5.0.0-beta.2",
         "supabase": "^2.47.2",
         "tsx": "^4.20.6",
@@ -16653,6 +16654,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firecrawl": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/firecrawl/-/firecrawl-1.21.1.tgz",
+      "integrity": "sha512-ABjLdPz97/ffJuUZVGwZZ8CTk2poeavyUaLQd1tUPB0XwxaCSLv4twW6yXxgal8MNzwdQBtmtqCWQf73PXs6xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "isows": "^1.0.4",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -24707,6 +24722,13 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/typescript-event-target": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
+      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tzdata": {
       "version": "1.0.46",
       "resolved": "https://registry.npmjs.org/tzdata/-/tzdata-1.0.46.tgz",
@@ -26546,6 +26568,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "chokidar-cli": "^3.0.0",
     "deno": "^2.5.0",
     "dotenv": "^17.2.3",
+    "firecrawl": "^1.21.1",
     "ngrok": "^5.0.0-beta.2",
     "supabase": "^2.47.2",
     "tsx": "^4.20.6",


### PR DESCRIPTION
## Summary
- add the Firecrawl CLI to the root devDependencies so crawler plans referencing it can be executed

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ddbd1295e48322ae2207c9f7656886