### PR TITLE
feat: add optimized naming engine

### DIFF
--- a/naming-engine/README.md
+++ b/naming-engine/README.md
@@ -1,0 +1,37 @@
+# Naming Engine
+
+Optimised utilities for maintaining a shared dictionary of short codes and
+semantic names across Dynamic Capital projects.
+
+## Features
+
+- ⚡️ Zero-allocation lookups via pre-computed maps.
+- 🧠 Semantic short-code generation with deterministic variants.
+- 🛠️ CLI that supports dry-runs, directory traversal, and timestamped backups.
+
+## Quick start
+
+```bash
+npm install
+npm run replace -- --dry-run examples
+```
+
+Use the `--dry-run` flag to preview replacements. Omit it to write the changes
+in place. Pass directories or individual files as targets.
+
+### Options
+
+| Flag         | Description                                    |
+| ------------ | ---------------------------------------------- |
+| `--dry-run`  | Preview replacements without editing files.    |
+| `--backup`   | Create timestamped backups before writing.     |
+| `--silent`   | Suppress informational logs.                   |
+
+## Extending the schema
+
+1. Add new entries to [`naming.schema.json`](./naming.schema.json).
+2. Import helpers from [`engine/index.ts`](./engine/index.ts) for quick lookups.
+3. Use [`generateShortName`](./engine/utils.ts) when deriving new codes.
+
+Remember to run `npm run replace` within this package directory so that the
+local `tsconfig.json` is used.

--- a/naming-engine/engine/cli.ts
+++ b/naming-engine/engine/cli.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { ensureDir, pathExists, readFile, readdir, stat, writeFile } from 'fs-extra';
+import { getAllMappings } from './index.js';
+
+interface CliOptions {
+  readonly dryRun: boolean;
+  readonly backup: boolean;
+  readonly silent: boolean;
+}
+
+interface ReplacementResult {
+  readonly filePath: string;
+  readonly replacements: number;
+}
+
+const DEFAULT_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.md',
+]);
+
+async function collectFiles(targetPath: string): Promise<string[]> {
+  const stats = await stat(targetPath);
+  if (stats.isDirectory()) {
+    const directoryName = path.basename(targetPath);
+    if (directoryName === 'node_modules' || directoryName === '.git') {
+      return [];
+    }
+
+    const entries = await readdir(targetPath);
+    const nested = await Promise.all(
+      entries.map((entry) => collectFiles(path.join(targetPath, entry))),
+    );
+    return nested.flat();
+  }
+
+  if (!DEFAULT_EXTENSIONS.has(path.extname(targetPath))) {
+    return [];
+  }
+
+  return [targetPath];
+}
+
+function parseArgs(rawArgs: readonly string[]): { targets: string[]; options: CliOptions } {
+  const targets: string[] = [];
+  const options: CliOptions = { dryRun: false, backup: false, silent: false };
+
+  for (const arg of rawArgs) {
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--backup') {
+      options.backup = true;
+    } else if (arg === '--silent') {
+      options.silent = true;
+    } else {
+      targets.push(arg);
+    }
+  }
+
+  return { targets, options };
+}
+
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function backupFile(filePath: string): Promise<void> {
+  const directory = path.dirname(filePath);
+  const filename = path.basename(filePath);
+  const backupDir = path.join(directory, '.naming-engine');
+  await ensureDir(backupDir);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = path.join(backupDir, `${filename}.${timestamp}.bak`);
+  const content = await readFile(filePath, 'utf8');
+  await writeFile(backupPath, content, 'utf8');
+}
+
+async function replaceInFile(filePath: string, options: CliOptions): Promise<ReplacementResult | null> {
+  const originalContent = await readFile(filePath, 'utf8');
+  let mutatedContent = originalContent;
+  let replacements = 0;
+
+  for (const { short, full } of getAllMappings()) {
+    const regex = new RegExp(`\\b${escapeRegex(full)}\\b`, 'g');
+    mutatedContent = mutatedContent.replace(regex, () => {
+      replacements += 1;
+      return short;
+    });
+  }
+
+  if (replacements === 0) {
+    return null;
+  }
+
+  if (!options.dryRun) {
+    if (options.backup) {
+      await backupFile(filePath);
+    }
+
+    await writeFile(filePath, mutatedContent, 'utf8');
+  }
+
+  return { filePath, replacements };
+}
+
+async function run(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const { targets, options } = parseArgs(argv);
+
+  if (targets.length === 0) {
+    console.error('Please provide at least one file or directory to process.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const resolvedTargets = await Promise.all(targets.map(async (target) => {
+    const resolved = path.resolve(target);
+    if (!(await pathExists(resolved))) {
+      throw new Error(`Target does not exist: ${target}`);
+    }
+    return resolved;
+  }));
+
+  const files = (
+    await Promise.all(resolvedTargets.map((target) => collectFiles(target)))
+  ).flat();
+
+  if (files.length === 0) {
+    if (!options.silent) {
+      console.log('No files matched the provided targets.');
+    }
+    return;
+  }
+
+  const results = await Promise.all(
+    files.map(async (file) => replaceInFile(file, options)),
+  );
+
+  const successful = results.filter((result): result is ReplacementResult => result !== null);
+
+  if (successful.length === 0) {
+    if (!options.silent) {
+      console.log('No replacements were necessary.');
+    }
+    return;
+  }
+
+  const total = successful.reduce((sum, { replacements }) => sum + replacements, 0);
+  if (!options.silent) {
+    for (const { filePath, replacements } of successful) {
+      console.log(`✅ ${options.dryRun ? 'Would replace' : 'Replaced'} ${replacements} entr${replacements === 1 ? 'y' : 'ies'} in ${pathToFileURL(filePath).href}`);
+    }
+    console.log(`ℹ️  ${options.dryRun ? 'Identified' : 'Completed'} ${total} total replacement${total === 1 ? '' : 's'} across ${successful.length} file${successful.length === 1 ? '' : 's'}.`);
+  }
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/naming-engine/engine/index.ts
+++ b/naming-engine/engine/index.ts
@@ -1,0 +1,56 @@
+import namingMapJson from '../naming.schema.json' assert { type: 'json' };
+
+export type NamingMap = Record<string, string>;
+
+type NormalisedLookup = {
+  readonly shortToFull: NamingMap;
+  readonly fullToShort: Map<string, string>;
+};
+
+const { shortToFull, fullToShort } = initialiseLookups(namingMapJson as NamingMap);
+
+function initialiseLookups(map: NamingMap): NormalisedLookup {
+  const shortEntries = Object.entries(map);
+  const shortToFull: NamingMap = {};
+  const fullToShort = new Map<string, string>();
+
+  for (const [short, full] of shortEntries) {
+    const trimmedShort = short.trim();
+    const trimmedFull = full.trim();
+
+    if (!trimmedShort || !trimmedFull) {
+      continue;
+    }
+
+    shortToFull[trimmedShort] = trimmedFull;
+    fullToShort.set(normaliseFullName(trimmedFull), trimmedShort);
+  }
+
+  return { shortToFull, fullToShort };
+}
+
+function normaliseFullName(fullName: string): string {
+  return fullName.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function getShortName(fullName: string): string | null {
+  if (!fullName) return null;
+  return fullToShort.get(normaliseFullName(fullName)) ?? null;
+}
+
+export function getFullName(shortName: string): string | null {
+  if (!shortName) return null;
+  return shortToFull[shortName.trim()] ?? null;
+}
+
+export function hasShortName(shortName: string): boolean {
+  return getFullName(shortName) !== null;
+}
+
+export function hasFullName(fullName: string): boolean {
+  return getShortName(fullName) !== null;
+}
+
+export function getAllMappings(): ReadonlyArray<{ short: string; full: string }> {
+  return Object.entries(shortToFull).map(([short, full]) => ({ short, full }));
+}

--- a/naming-engine/engine/utils.ts
+++ b/naming-engine/engine/utils.ts
@@ -1,0 +1,41 @@
+const LAYER_PREFIX: Record<'core' | 'gui' | 'oracle', string> = {
+  core: 'C',
+  gui: 'G',
+  oracle: 'O',
+};
+
+const TYPE_SUFFIX: Record<'module' | 'token' | 'bot', string> = {
+  module: 'M',
+  token: 'T',
+  bot: 'B',
+};
+
+export interface GenerateShortNameOptions {
+  readonly domain: 'DC' | 'AGI' | 'TON';
+  readonly layer: 'core' | 'gui' | 'oracle';
+  readonly type: 'module' | 'token' | 'bot';
+  readonly variant?: number | string;
+}
+
+export function generateShortName(options: GenerateShortNameOptions): string {
+  const domain = options.domain.toUpperCase();
+  const layer = LAYER_PREFIX[options.layer];
+  const type = TYPE_SUFFIX[options.type];
+  const variant = normaliseVariant(options.variant);
+
+  return variant ? `${domain}-${layer}${type}${variant}` : `${domain}-${layer}${type}`;
+}
+
+function normaliseVariant(variant: GenerateShortNameOptions['variant']): string {
+  if (variant === undefined || variant === null || variant === '') {
+    return '';
+  }
+
+  if (typeof variant === 'number') {
+    const normalised = Math.max(0, Math.floor(variant));
+    return Number.isNaN(normalised) ? '' : `-${normalised}`;
+  }
+
+  const cleaned = variant.toString().toUpperCase().replace(/[^A-Z0-9]/g, '');
+  return cleaned ? `-${cleaned}` : '';
+}

--- a/naming-engine/examples/sample.config.yaml
+++ b/naming-engine/examples/sample.config.yaml
@@ -1,0 +1,7 @@
+modules:
+  - name: Dynamic Capital Token
+    short: DCT
+  - name: AGI Intelligence Oracle
+    short: AGI-O
+  - name: Dynamic GUI Sync
+    short: DC-GUI

--- a/naming-engine/examples/sample.module.ts
+++ b/naming-engine/examples/sample.module.ts
@@ -1,0 +1,4 @@
+// Before replacement
+const moduleName = "Dynamic Capital Token";
+const oracle = "AGI Intelligence Oracle";
+const onboardingBot = "TON Onboarding Bot";

--- a/naming-engine/naming.schema.json
+++ b/naming-engine/naming.schema.json
@@ -1,0 +1,7 @@
+{
+  "DCT": "Dynamic Capital Token",
+  "DCM": "Dynamic Core Module",
+  "AGI-O": "AGI Intelligence Oracle",
+  "TON-OB": "TON Onboarding Bot",
+  "DC-GUI": "Dynamic GUI Sync"
+}

--- a/naming-engine/package.json
+++ b/naming-engine/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "naming-engine",
+  "version": "1.1.0",
+  "description": "Optimized dynamic naming engine for short code injection across modular ecosystems",
+  "type": "module",
+  "main": "engine/index.ts",
+  "scripts": {
+    "replace": "ts-node --esm engine/cli.ts examples/sample.module.ts"
+  },
+  "dependencies": {
+    "fs-extra": "^11.2.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/naming-engine/tsconfig.json
+++ b/naming-engine/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["engine/**/*.ts", "examples/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a standalone `naming-engine` package with precomputed lookups for short code resolution and CLI automation
- introduce utilities for semantic short code generation plus examples and schema entries for Dynamic Capital naming
- document usage patterns, configuration, and CLI options for the optimized naming workflow

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ddc733c4408322ac17a67d5b4ddc5c