### PR TITLE
Optimize TON-to-Supabase bridge for Web3 provenance

### DIFF
--- a/dns/dynamiccapital.ton.json
+++ b/dns/dynamiccapital.ton.json
@@ -53,9 +53,16 @@
     {
       "type": "CNAME",
       "name": "api",
-      "data": "dynamiccapital.ton",
-      "ttl": 3600,
-      "note": "API subdomain for backend services"
+      "data": "your-project-ref.supabase.co",
+      "ttl": 300,
+      "note": "Points the Supabase API surface at the project-ref host. Replace `your-project-ref` with the live Supabase project ref before activation."
+    },
+    {
+      "type": "TXT",
+      "name": "_acme-challenge.api",
+      "data": "pending-supabase-verification-token",
+      "ttl": 300,
+      "note": "Placeholder for Supabase-issued ACME challenge. Replace with the live token, then pin the raw TXT payload to TON Storage/IPFS for Web3 attestation."
     }
   ],
   "notes": [
@@ -64,6 +71,9 @@
     "Register domain at TON DNS marketplace (e.g., dns.ton.org)",
     "Update resolver_contract address after deployment",
     "TON Site ADNL 0:192631d3bc9dd251d3b6d5cd4e807c68e53e1b6126499d8c5db3e7bb4ccc9243 (see ton_site.public_key_base64)",
-    "Verify resolution through TON DNS tools before going live"
+    "Verify resolution through TON DNS tools before going live",
+    "Supabase custom domains require `_acme-challenge.api.dynamiccapital.ton` TXT records during verification. Capture the issued tokens in this repo before activation and pin them to TON Storage/IPFS with the hash recorded in the operations multisig memo.",
+    "Use a low TTL (e.g., 60–300 seconds) on the API CNAME until the Supabase certificate is issued, then raise it for stability.",
+    "After activation, emit a `custom_domain_activated` event into Supabase `tx_logs` referencing the DNS bundle hash so auditors can verify the Web3 linkage."
   ]
 }

--- a/docs/ton-web3-guidelines.md
+++ b/docs/ton-web3-guidelines.md
@@ -66,6 +66,17 @@ keep the TON surfaces aligned with the broader platform roadmap.
    front-end links or Mini App deep links.
 5. **Renew before expiry**; add an Ops reminder alongside the `PHASE_06_OPS.md`
    workstream when TTL thresholds approach.
+6. **Bridge Supabase services** by pointing `api.dynamiccapital.ton` to the
+   Supabase project host (`<project-ref>.supabase.co`) and capturing the
+   `_acme-challenge.api.dynamiccapital.ton` TXT tokens provided during
+   verification. Mirror the TXT bundle into TON Storage/IPFS, reference the
+   content hash in the multisig memo, and store the structured snapshot in
+   [`dns/`](../dns) so auditors can replay and cryptographically verify the Web2
+   ↔ Web3 linkup.
+7. **Emit resolver telemetry** after activation by logging a
+   `custom_domain_activated` event in Supabase `tx_logs` and broadcasting the
+   DNS bundle hash through the operations multisig. This creates an immutable
+   attestation that the resolver, Supabase, and on-chain state match.
 
 ### Resolver reference table
 


### PR DESCRIPTION
## Summary
- reframe the networking playbook around a TON ↔ Supabase bridge with Web3 audit trails, telemetry, and resolver verification steps
- capture the Supabase ACME TXT placeholder in the TON DNS snapshot and expand the operational notes for on-chain attestation
- extend the TON Web3 guidelines with storage pinning and multisig hash broadcasting so auditors can verify the custom-domain linkage

## Testing
- npm run format
- ./node_modules/.bin/deno fmt docs/NETWORKING.md docs/ton-web3-guidelines.md dns/dynamiccapital.ton.json


------
https://chatgpt.com/codex/tasks/task_e_68ddd045c7588322af9316de0fdec12b