### PR TITLE
Add Python PDF data extraction documentation

### DIFF
--- a/docs/python-pdf-data-extraction.md
+++ b/docs/python-pdf-data-extraction.md
@@ -1,0 +1,25 @@
+# Python PDF Data Extraction Guide
+
+Extracting data from PDF documents can range from straightforward text pulls to parsing complex, multi-column layouts or tables. Python's ecosystem offers several specialized libraries that address these scenarios, giving developers the flexibility to choose tools that match their document structure, scale, and workflow preferences.
+
+## Libraries for Text and Mixed Content
+
+- **PyMuPDF (fitz):** Prioritizes speed and efficiency while extracting text, images, and layout metadata. Ideal for well-structured, text-centric PDFs where performance matters.
+- **pdfplumber:** Provides fine-grained control over page parsing, enabling extraction of text, tables, and embedded images even when layouts are irregular. Useful for invoices or forms with mixed content.
+- **Unstructured:** Tailored for AI and document intelligence workflows. It can partition PDFs into semantic elements and handle image-heavy or scanned pages with OCR-backed pipelines.
+
+## Libraries Focused on Tables
+
+- **Camelot:** Purpose-built for table extraction. Works best when tables have explicit ruling lines, and offers configuration options (e.g., `stream` mode) for more complex layouts.
+- **Tabula-py:** Python wrapper around the Tabula Java project. Converts detected tables directly into pandas DataFrames, making it convenient for downstream data analysis.
+
+## Choosing the Right Approach
+
+When selecting a PDF extraction strategy, weigh the following factors:
+
+1. **PDF complexity:** Text-heavy documents pair well with PyMuPDF, whereas forms, invoices, or scans with tabular data may require Camelot or other AI-assisted tools.
+2. **Data volume:** Large, heterogeneous batches benefit from scalable, automated pipelines—AI-driven services can reduce manual tuning across document types.
+3. **Technical skillset:** Developers comfortable with Python gain maximum flexibility from open-source libraries. Teams seeking low-code solutions might prefer managed AI platforms.
+4. **Desired output:** Determine the target destination for extracted data. AI platforms often ship connectors for databases or spreadsheets, while Python scripts typically require custom export logic.
+
+Selecting the right combination of tools keeps PDF extraction accurate, maintainable, and aligned with downstream analytics or automation goals.


### PR DESCRIPTION
## Summary
- add a documentation page covering Python libraries for extracting text and tables from PDFs
- outline key factors for choosing between libraries and AI-driven platforms

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde0daaf648322b7bc291837e5ff67