### PR TITLE
Streamline IQM cheat sheet integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 !.yarn/plugins
 !.yarn/sdks
 !.yarn/versions
+.deno/
 
 # Next.js & build outputs
 .next/
@@ -90,3 +91,6 @@ bun.lockb
 .project-cache/
 # Python bytecode cache directories
 __pycache__/
+
+# External resources (downloaded on demand)
+third_party/iqm-academy-cheat-sheets/

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Explore the broader platform anatomy and contributor guides:
 - [Dynamic Trading ALGO vs LOGIC](docs/dynamic-trading-algo-vs-logic.md)
 - [Model intelligence & infrastructure reference](docs/model-intelligence-infrastructure-reference.md)
 - [Protocol layering framework](docs/dynamic_protocol_layers.md)
+- [IQM cheat sheets sync instructions](docs/iqm-cheatsheets.md) — fetch the
+  external documentation without bloating Git history.
 
 #### Dynamic AGI self-improvement loop
 

--- a/docs/iqm-cheatsheets.md
+++ b/docs/iqm-cheatsheets.md
@@ -1,0 +1,29 @@
+# IQM Academy Cheat Sheets Integration
+
+## Overview
+
+The original IQM Academy cheat sheets repository contained large SVG assets that
+inflated this project's Git history. Instead of keeping those artifacts under
+version control, we provide a small helper script that fetches or updates the
+upstream repository on demand.
+
+## Usage
+
+Run the synchronization script whenever you need the cheat sheets locally:
+
+```bash
+deno run -A scripts/sync-iqm-cheatsheets.ts
+```
+
+The script stores the repository in `third_party/iqm-academy-cheat-sheets/`,
+which is ignored by Git. Subsequent executions update the checkout in place,
+ensuring you always have the latest files without bloating this repository.
+
+## Rationale
+
+- **Lean history** – avoids tracking multi-megabyte SVG assets inside the main
+  repository.
+- **Deterministic updates** – the script always resets the checkout to the
+  latest `main` branch.
+- **Simple workflow** – mirrors the previous "clone" behavior with a single
+  command.

--- a/scripts/sync-iqm-cheatsheets.ts
+++ b/scripts/sync-iqm-cheatsheets.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env -S deno run -A
+
+import {
+  dirname,
+  fromFileUrl,
+} from "https://deno.land/std@0.224.0/path/mod.ts";
+
+const REPO_URL = "https://github.com/iqm-finland/iqm-academy-cheat-sheets.git";
+const TARGET = fromFileUrl(
+  new URL("../third_party/iqm-academy-cheat-sheets", import.meta.url),
+);
+
+const decoder = new TextDecoder();
+
+async function directoryExists(path: string): Promise<boolean> {
+  try {
+    const stat = await Deno.stat(path);
+    return stat.isDirectory;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function runGit(args: string[]) {
+  const command = new Deno.Command("git", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await command.output();
+  if (code !== 0) {
+    const message = decoder.decode(stderr) || decoder.decode(stdout);
+    throw new Error(`git ${args.join(" ")} failed: ${message}`.trim());
+  }
+  const output = decoder.decode(stdout).trim();
+  if (output) {
+    console.log(output);
+  }
+}
+
+async function ensureParent(path: string) {
+  await Deno.mkdir(dirname(path), { recursive: true });
+}
+
+async function cloneRepository() {
+  console.log(`Cloning IQM cheat sheets into ${TARGET}...`);
+  await ensureParent(TARGET);
+  await runGit(["clone", "--depth=1", REPO_URL, TARGET]);
+}
+
+async function updateRepository() {
+  console.log(`Updating IQM cheat sheets in ${TARGET}...`);
+  await runGit(["-C", TARGET, "fetch", "--depth=1", "origin", "main"]);
+  await runGit(["-C", TARGET, "reset", "--hard", "origin/main"]);
+  await runGit(["-C", TARGET, "clean", "-fdx"]);
+}
+
+if (import.meta.main) {
+  try {
+    if (await directoryExists(TARGET)) {
+      await updateRepository();
+    } else {
+      await cloneRepository();
+    }
+    console.log(
+      "IQM cheat sheets are ready under third_party/iqm-academy-cheat-sheets.",
+    );
+  } catch (error) {
+    console.error(error);
+    Deno.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- remove the vendored `iqm-academy-cheat-sheets` assets to shrink the repository footprint
- add a documented Deno script that clones or updates the upstream cheat sheets into `third_party/`
- ignore the generated checkout and reference the new instructions from the main README

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dddf6d95d083228d428685b4494b59