### PR TITLE
Add Dhivehi language plumbing across AI orchestration

### DIFF
--- a/apps/web/components/tools/DynamicChat.tsx
+++ b/apps/web/components/tools/DynamicChat.tsx
@@ -147,6 +147,7 @@ export function DynamicChat() {
         })),
         temperature,
         maxTokens,
+        language: languageOption.lang,
       }),
       signal,
     });
@@ -161,7 +162,7 @@ export function DynamicChat() {
 
     const result = (await response.json()) as ChatResult;
     return result;
-  }, [maxTokens, selectedProvider, temperature]);
+  }, [languageOption.lang, maxTokens, selectedProvider, temperature]);
 
   const {
     conversation,

--- a/apps/web/config/locales.json
+++ b/apps/web/config/locales.json
@@ -1,4 +1,4 @@
 {
   "defaultLocale": "en",
-  "locales": ["en"]
+  "locales": ["en", "dv"]
 }

--- a/apps/web/hooks/useDynamicChat.ts
+++ b/apps/web/hooks/useDynamicChat.ts
@@ -31,6 +31,7 @@ interface SendMessageOptions {
   history: ChatMessage[];
   onToken?: (chunk: ChatStreamChunk) => void;
   signal?: AbortSignal;
+  language?: string;
 }
 
 interface SendMessageResult {
@@ -205,6 +206,7 @@ export function useDynamicChat({
       telegram: telegramData
         ? telegramAuthSchema.parse(telegramData)
         : undefined,
+      language: options.language,
     };
 
     let response: Response;

--- a/apps/web/services/dynamic-agi/client.ts
+++ b/apps/web/services/dynamic-agi/client.ts
@@ -10,6 +10,7 @@ interface DynamicAgiChatRequest {
   messages: ChatMessage[];
   temperature?: number;
   maxTokens?: number;
+  language?: string;
 }
 
 interface DynamicAgiChatResponse {
@@ -108,6 +109,7 @@ export async function callDynamicAgi(
         })),
         temperature: request.temperature,
         maxTokens: request.maxTokens,
+        language: request.language,
       }),
       signal: controller.signal,
     });

--- a/apps/web/services/dynamic-ai/client.ts
+++ b/apps/web/services/dynamic-ai/client.ts
@@ -29,6 +29,7 @@ export interface DynamicAiChatParams {
   sessionId: string;
   messages: ChatRequestMessage[];
   signal?: AbortSignal;
+  language?: string;
 }
 
 export type DynamicAiChatResult = DynamicAiResponse;
@@ -37,6 +38,7 @@ export async function callDynamicAi({
   sessionId,
   messages,
   signal,
+  language,
 }: DynamicAiChatParams): Promise<DynamicAiChatResult> {
   if (!DYNAMIC_AI_CHAT_URL || !DYNAMIC_AI_CHAT_KEY) {
     throw new Error("Dynamic AI chat is not configured");
@@ -68,7 +70,11 @@ export async function callDynamicAi({
         authorization: `Bearer ${DYNAMIC_AI_CHAT_KEY}`,
         "x-session-id": sessionId,
       },
-      body: JSON.stringify({ messages: parsedMessages, sessionId }),
+      body: JSON.stringify({
+        messages: parsedMessages,
+        sessionId,
+        language,
+      }),
       signal: signal ?? controller.signal,
     });
 

--- a/apps/web/services/dynamic-ai/schema.ts
+++ b/apps/web/services/dynamic-ai/schema.ts
@@ -12,6 +12,7 @@ export type TelegramAuthData = z.infer<typeof telegramAuthSchema>;
 export const chatMessageSchema = z.object({
   role: z.enum(["user", "assistant"]),
   content: z.string().min(1),
+  language: z.string().trim().min(2).max(32).optional(),
 });
 
 export type ChatMessage = z.infer<typeof chatMessageSchema>;
@@ -21,6 +22,7 @@ export const chatHistorySchema = z.array(chatMessageSchema);
 export const chatRequestMessageSchema = z.object({
   role: z.enum(["system", "user", "assistant"]),
   content: z.string().min(1),
+  language: z.string().trim().min(2).max(32).optional(),
 });
 
 export type ChatRequestMessage = z.infer<typeof chatRequestMessageSchema>;
@@ -37,6 +39,7 @@ export const chatRequestPayloadSchema = z.object({
   message: z.string().min(1),
   history: chatHistorySchema.max(50).default([]),
   telegram: telegramAuthSchema.optional(),
+  language: z.string().trim().min(2).max(32).optional(),
 });
 
 export type ChatRequestPayload = z.infer<typeof chatRequestPayloadSchema>;

--- a/apps/web/services/llm/providers.ts
+++ b/apps/web/services/llm/providers.ts
@@ -36,7 +36,7 @@ const providerDefinitions: ProviderDefinition[] = [
     maxOutputTokens: 4_096,
     envKeys: ["DYNAMIC_AGI_CHAT_URL", "DYNAMIC_AGI_CHAT_KEY"],
     async invoke(
-      { messages, temperature = 0.7, maxTokens },
+      { messages, temperature = 0.7, maxTokens, language },
     ): Promise<Omit<ChatResult, "provider">> {
       const { system, conversation } = normalizeMessages(messages);
       const result = await callDynamicAgi({
@@ -44,6 +44,7 @@ const providerDefinitions: ProviderDefinition[] = [
         messages: conversation,
         temperature,
         maxTokens,
+        language,
       });
       return result;
     },
@@ -57,7 +58,7 @@ const providerDefinitions: ProviderDefinition[] = [
     maxOutputTokens: 4_096,
     envKeys: ["OPENAI_API_KEY"],
     async invoke(
-      { messages, temperature = 0.7, maxTokens },
+      { messages, temperature = 0.7, maxTokens, language: _language },
     ): Promise<Omit<ChatResult, "provider">> {
       const client = new OpenAIClient();
       const { system, conversation } = normalizeMessages(messages);
@@ -91,7 +92,7 @@ const providerDefinitions: ProviderDefinition[] = [
     maxOutputTokens: 4_096,
     envKeys: ["ANTHROPIC_API_KEY"],
     async invoke(
-      { messages, temperature = 0.7, maxTokens },
+      { messages, temperature = 0.7, maxTokens, language: _language },
     ): Promise<Omit<ChatResult, "provider">> {
       const apiKey = requireEnvVar("ANTHROPIC_API_KEY");
       const { system, conversation } = normalizeMessages(messages);
@@ -147,7 +148,7 @@ const providerDefinitions: ProviderDefinition[] = [
     maxOutputTokens: 3_584,
     envKeys: ["GROQ_API_KEY"],
     async invoke(
-      { messages, temperature = 0.7, maxTokens },
+      { messages, temperature = 0.7, maxTokens, language: _language },
     ): Promise<Omit<ChatResult, "provider">> {
       const apiKey = requireEnvVar("GROQ_API_KEY");
       const { system, conversation } = normalizeMessages(messages);

--- a/apps/web/services/llm/schema.ts
+++ b/apps/web/services/llm/schema.ts
@@ -28,6 +28,7 @@ export const chatRequestSchema = z.object({
   ),
   temperature: z.number().min(0).max(2).default(0.7),
   maxTokens: z.number().min(32).max(8192).default(512),
+  language: z.string().trim().min(2).max(32).optional(),
 });
 
 export type ChatRequestInput = z.infer<typeof chatRequestSchema>;

--- a/apps/web/services/llm/types.ts
+++ b/apps/web/services/llm/types.ts
@@ -28,6 +28,7 @@ export interface ChatRequest {
   messages: ChatMessage[];
   temperature?: number;
   maxTokens?: number;
+  language?: string;
 }
 
 export interface ChatResult {

--- a/dynamic_playbook/__init__.py
+++ b/dynamic_playbook/__init__.py
@@ -1,0 +1,10 @@
+"""Dynamic playbook facade for governance utilities."""
+
+from __future__ import annotations
+
+from dynamic.governance.ags.dynamic_ags import (
+    DEFAULT_DYNAMIC_AGS_ENTRIES,
+    build_dynamic_ags_playbook,
+)
+
+__all__ = ["DEFAULT_DYNAMIC_AGS_ENTRIES", "build_dynamic_ags_playbook"]

--- a/tests/test_dynamic_ags_playbook.py
+++ b/tests/test_dynamic_ags_playbook.py
@@ -14,6 +14,10 @@ def test_build_dynamic_ags_playbook_payload() -> None:
     blueprint = payload["blueprint"]
     entries = payload["entries"]
 
+    assert payload["language"] == "en"
+    assert set(payload["supported_languages"]) == {"en", "dv"}
+    assert blueprint["language"] == "en"
+    assert set(blueprint["supported_languages"]) == {"en", "dv"}
     assert blueprint["mission_summary"].startswith(
         "Dynamic AGS Multi-Agent Governance Launch"
     )
@@ -35,6 +39,7 @@ def test_build_dynamic_ags_playbook_payload() -> None:
         "WITHDRAWAL",
     ]
     assert "dry_run_required" in policies_entry["metadata"]["approvals"]["T3"]
+    assert {entry["language"] for entry in entries} == {"en"}
 
 
 @pytest.mark.parametrize("cadence", ["Bi-weekly council sync", "Daily ops review"])
@@ -61,4 +66,13 @@ def test_additional_entries_extend_catalogue() -> None:
     assert payload["blueprint"]["total_entries"] == len(DEFAULT_DYNAMIC_AGS_ENTRIES) + 1
     titles = {entry["title"] for entry in payload["entries"]}
     assert "Stand Up Sandbox Environment" in titles
+
+
+def test_build_dynamic_ags_playbook_language_dhivehi() -> None:
+    payload = build_dynamic_ags_playbook(language="dv")
+
+    assert payload["language"] == "dv"
+    assert payload["blueprint"]["language"] == "dv"
+    assert set(payload["supported_languages"]) == {"en", "dv"}
+    assert {entry["language"] for entry in payload["entries"]} == {"dv"}
 


### PR DESCRIPTION
## Summary
- normalize and persist chat language metadata in the Dynamic AI API so Dhivehi prompts reach the service
- expose Dhivehi locale selection in the orchestration console and thread language through multi-LLM clients
- add Dhivehi-aware governance playbook payloads with a reusable `dynamic_playbook` entry point and regression tests

## Testing
- npm run lint
- npm run typecheck
- PYTHONPATH=. pytest tests/test_dynamic_ags_playbook.py


------
https://chatgpt.com/codex/tasks/task_e_68ddeb6132908322b05d3e464f19d989