### PR TITLE
chore: format repository docs and scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,18 +37,18 @@ documenting which assets were consulted.
 
 ## 2. Development Workflow & Standards
 
-| Ref | Document                                                           | Summary                                                                                              |
-| --- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| 2.1 | [BEST_PRACTICES.md](./BEST_PRACTICES.md)                           | Coding conventions, review expectations, and shared quality bars.                                    |
-| 2.2 | [DEVELOPMENT_WORKFLOW.md](./DEVELOPMENT_WORKFLOW.md)               | Local development flow, tooling setup, and day-to-day commands.                                      |
-| 2.3 | [HYBRID_DEVELOPMENT_WORKFLOW.md](./HYBRID_DEVELOPMENT_WORKFLOW.md) | Guidance for working across Dynamic, Supabase, and local Next.js surfaces concurrently.              |
-| 2.4 | [code-structure.md](./code-structure.md)                           | High-level overview of monorepo structure and module boundaries.                                     |
-| 2.5 | [codex_cli_workflow.md](./codex_cli_workflow.md)                   | Commands, flags, general knowledge, and GitHub handoff loop for the Codex CLI helper.                |
-| 2.6 | [CLEANUP_AND_CODEMODS.md](./CLEANUP_AND_CODEMODS.md)               | Strategy for running codemods and debt cleanups safely.                                              |
-| 2.7 | [NEXTJS_BUILD_CACHE_TASK.md](./NEXTJS_BUILD_CACHE_TASK.md)         | Instructions for the Next.js build cache maintenance task.                                           |
-| 2.8 | [ton-ide-plugins.md](./ton-ide-plugins.md)                         | Official TON IDE plugins for JetBrains, VS Code, and the Web IDE with install checklists.            |
-| 2.9 | [onedrive-sync-integration.md](./onedrive-sync-integration.md)     | GitHub and Supabase adapter guide for working with Microsoft OneDrive assets inside Codex workflows. |
-| 2.10 | [open-source-ai-crawlers.md](./open-source-ai-crawlers.md)        | Comparison of AI-driven crawling frameworks with implementation and selection guidance. |
+| Ref  | Document                                                           | Summary                                                                                              |
+| ---- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| 2.1  | [BEST_PRACTICES.md](./BEST_PRACTICES.md)                           | Coding conventions, review expectations, and shared quality bars.                                    |
+| 2.2  | [DEVELOPMENT_WORKFLOW.md](./DEVELOPMENT_WORKFLOW.md)               | Local development flow, tooling setup, and day-to-day commands.                                      |
+| 2.3  | [HYBRID_DEVELOPMENT_WORKFLOW.md](./HYBRID_DEVELOPMENT_WORKFLOW.md) | Guidance for working across Dynamic, Supabase, and local Next.js surfaces concurrently.              |
+| 2.4  | [code-structure.md](./code-structure.md)                           | High-level overview of monorepo structure and module boundaries.                                     |
+| 2.5  | [codex_cli_workflow.md](./codex_cli_workflow.md)                   | Commands, flags, general knowledge, and GitHub handoff loop for the Codex CLI helper.                |
+| 2.6  | [CLEANUP_AND_CODEMODS.md](./CLEANUP_AND_CODEMODS.md)               | Strategy for running codemods and debt cleanups safely.                                              |
+| 2.7  | [NEXTJS_BUILD_CACHE_TASK.md](./NEXTJS_BUILD_CACHE_TASK.md)         | Instructions for the Next.js build cache maintenance task.                                           |
+| 2.8  | [ton-ide-plugins.md](./ton-ide-plugins.md)                         | Official TON IDE plugins for JetBrains, VS Code, and the Web IDE with install checklists.            |
+| 2.9  | [onedrive-sync-integration.md](./onedrive-sync-integration.md)     | GitHub and Supabase adapter guide for working with Microsoft OneDrive assets inside Codex workflows. |
+| 2.10 | [open-source-ai-crawlers.md](./open-source-ai-crawlers.md)         | Comparison of AI-driven crawling frameworks with implementation and selection guidance.              |
 
 ## 3. Environment & Configuration
 

--- a/docs/TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md
+++ b/docs/TRADINGVIEW_TO_MT5_BRIDGE_CHECKLIST.md
@@ -37,8 +37,8 @@ Supabase-enabled, and productionized on the Windows host that runs MT5.
 - [ ] Remove or retire the upstream `src/scripts/init_db.py` workflow so
       migrations originate from the Dynamic Capital Supabase schema repo.
 - [ ] Map Supabase `signals` columns to the copier’s models
-      (`dynamic/models/dynamic_database`) and trim unused tables/fields that Supabase will
-      not expose.
+      (`dynamic/models/dynamic_database`) and trim unused tables/fields that
+      Supabase will not expose.
 - [ ] Use the new `trading_accounts`, `signals`, `signal_dispatches`, and
       `trades` tables from `20250920000000_trading_signals_pipeline.sql` as the
       source of truth (alert IDs remain unique).

--- a/docs/ci_cd_maturity_plan.md
+++ b/docs/ci_cd_maturity_plan.md
@@ -125,12 +125,13 @@ value.
 
 ## Dynamic Module, Model, and Engine Integration
 
-- **Dynamic AI (`dynamic.intelligence.ai_apps/`)**: Add targeted model validation suites and
-  reproducible dataset snapshots to CI so inference changes are profiled for
-  latency, accuracy, and safety regressions before merge.
-- **Dynamic AGI (`dynamic.intelligence.agi/`)**: Orchestrate multi-agent simulations within
-  nightly pipelines to validate orchestrator policies, prompt governance, and
-  self-healing behaviors across complex scenarios.
+- **Dynamic AI (`dynamic.intelligence.ai_apps/`)**: Add targeted model
+  validation suites and reproducible dataset snapshots to CI so inference
+  changes are profiled for latency, accuracy, and safety regressions before
+  merge.
+- **Dynamic AGI (`dynamic.intelligence.agi/`)**: Orchestrate multi-agent
+  simulations within nightly pipelines to validate orchestrator policies, prompt
+  governance, and self-healing behaviors across complex scenarios.
 - **Dynamic AGS (Autonomous Governance Systems)**: Incorporate policy drift
   detection workflows that reconcile governance artifacts with pipeline
   guardrails, ensuring AGS updates receive compliance, security, and ethics
@@ -141,9 +142,9 @@ value.
 - **Dynamic TA (Technical Analysis)**: Execute GPU-accelerated backtests and
   statistical validation within CI to certify that indicator updates, signal
   models, and trading heuristics stay within predefined risk envelopes.
-- **DCT – Dynamic Capital Token (`dynamic.platform.token/`)**: Extend release pipelines
-  with ledger simulation, smart contract linting, and supply integrity checks so
-  tokenomics updates align with treasury policy.
+- **DCT – Dynamic Capital Token (`dynamic.platform.token/`)**: Extend release
+  pipelines with ledger simulation, smart contract linting, and supply integrity
+  checks so tokenomics updates align with treasury policy.
 - **Engine Compatibility Matrix**: Maintain a matrix of inference engines,
   optimization kernels, and hardware targets (CPU/GPU/TPU) that is continuously
   exercised via pipeline matrix builds to surface incompatibilities early.

--- a/docs/currency_commodity_datasets.md
+++ b/docs/currency_commodity_datasets.md
@@ -2,7 +2,13 @@
 
 ## Introduction
 
-Access to reliable datasets for currencies and commodities underpins trading strategy development, macroeconomic research, and financial analytics. This guide catalogs reputable sources that offer downloadable files or API access for major foreign exchange pairs—particularly USD, EUR, JPY, and GBP—and for widely traded commodities such as gold, crude oil, wheat, and copper. It highlights data coverage, delivery formats, licensing terms, and developer tooling to simplify integration into quantitative workflows.
+Access to reliable datasets for currencies and commodities underpins trading
+strategy development, macroeconomic research, and financial analytics. This
+guide catalogs reputable sources that offer downloadable files or API access for
+major foreign exchange pairs—particularly USD, EUR, JPY, and GBP—and for widely
+traded commodities such as gold, crude oil, wheat, and copper. It highlights
+data coverage, delivery formats, licensing terms, and developer tooling to
+simplify integration into quantitative workflows.
 
 ## Currency Datasets
 
@@ -18,48 +24,58 @@ Effective currency datasets typically provide the following fields:
 
 ### Major Currency Data Providers
 
-| Provider | Coverage Highlights | Delivery Formats | Access Model | Notes |
-| --- | --- | --- | --- | --- |
-| ExchangeRate-API | Live and historical rates for 160+ currencies with nine years of history for core pairs | REST JSON | Freemium; attribution required on free tier | Straightforward documentation and predictable endpoints |
-| ForexRateAPI | Major FX pairs with historical volatility endpoints | REST JSON | Freemium with request limits | Includes volatility series useful for risk models |
-| UniRate-API | Major and minor FX pairs with 20+ years of data | REST JSON | Freemium up to 1,000 requests/month | Clean REST interface and developer onboarding |
-| Twelve Data | Spot FX and select derivatives with minute-level granularity | REST JSON/CSV, SDKs | Freemium with paid tiers for higher quotas | Offers Python/Node clients and technical indicators |
-| European Central Bank (ECB) SDW | Daily reference rates for EUR base pairs since 1999 | CSV, XML, SDMX API | Open access | Authoritative source for EUR cross rates |
-| Frankfurter API | ECB-sourced rates exposed without authentication | REST JSON | Open access | Ideal for prototypes; EUR base conversions required |
-| FCSAPI | FX, metals, indices, and crypto quotes | REST JSON | Freemium with commercial plans | Broad asset coverage in unified API |
-| Open Exchange Rates | Live and historical FX data for 200+ currencies | REST JSON | Freemium; commercial use requires paid tier | Includes time-series and currency metadata endpoints |
-| Alpha Vantage | Intraday and daily FX time series for popular pairs | REST JSON/CSV, SDKs | Freemium with throttling; premium tiers available | Official Python and JS SDKs simplify ingestion |
-| OANDA Exchange Rates API | Enterprise-grade rates and FX volume proxies | REST JSON/XML/CSV | Commercial subscription | Includes forward rates and exchange-traded volume proxies |
+| Provider                        | Coverage Highlights                                                                     | Delivery Formats    | Access Model                                      | Notes                                                     |
+| ------------------------------- | --------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------- | --------------------------------------------------------- |
+| ExchangeRate-API                | Live and historical rates for 160+ currencies with nine years of history for core pairs | REST JSON           | Freemium; attribution required on free tier       | Straightforward documentation and predictable endpoints   |
+| ForexRateAPI                    | Major FX pairs with historical volatility endpoints                                     | REST JSON           | Freemium with request limits                      | Includes volatility series useful for risk models         |
+| UniRate-API                     | Major and minor FX pairs with 20+ years of data                                         | REST JSON           | Freemium up to 1,000 requests/month               | Clean REST interface and developer onboarding             |
+| Twelve Data                     | Spot FX and select derivatives with minute-level granularity                            | REST JSON/CSV, SDKs | Freemium with paid tiers for higher quotas        | Offers Python/Node clients and technical indicators       |
+| European Central Bank (ECB) SDW | Daily reference rates for EUR base pairs since 1999                                     | CSV, XML, SDMX API  | Open access                                       | Authoritative source for EUR cross rates                  |
+| Frankfurter API                 | ECB-sourced rates exposed without authentication                                        | REST JSON           | Open access                                       | Ideal for prototypes; EUR base conversions required       |
+| FCSAPI                          | FX, metals, indices, and crypto quotes                                                  | REST JSON           | Freemium with commercial plans                    | Broad asset coverage in unified API                       |
+| Open Exchange Rates             | Live and historical FX data for 200+ currencies                                         | REST JSON           | Freemium; commercial use requires paid tier       | Includes time-series and currency metadata endpoints      |
+| Alpha Vantage                   | Intraday and daily FX time series for popular pairs                                     | REST JSON/CSV, SDKs | Freemium with throttling; premium tiers available | Official Python and JS SDKs simplify ingestion            |
+| OANDA Exchange Rates API        | Enterprise-grade rates and FX volume proxies                                            | REST JSON/XML/CSV   | Commercial subscription                           | Includes forward rates and exchange-traded volume proxies |
 
 ### Comparative Feature Matrix
 
-| Provider | USD | EUR | JPY | GBP | Historic Depth | Update Frequency | Volume Data | Volatility Data | Python Tooling |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| ExchangeRate-API | ✔︎ | ✔︎ | ✔︎ | ✔︎ | ~9 years | Hourly/Daily | ✖︎ | ✔︎ | Community wrappers |
-| ForexRateAPI | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 10+ years | Daily/Live | ✖︎ | ✔︎ | REST + examples |
-| UniRate-API | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 20+ years | Hourly/Daily | ✖︎ | ✔︎ | REST + SDK snippets |
-| Twelve Data | ✔︎ | ✔︎ | ✔︎ | ✔︎ | ~20 years | Minute/Daily | Limited | ✔︎ | Official SDKs |
-| ECB SDW | ✔︎* | – | – | – | 1999–present | Daily | ✖︎ | ✖︎ | SDMX tooling |
-| Frankfurter API | ✔︎* | ✔︎ | ✔︎ | ✔︎ | 1999–present | Daily | ✖︎ | ✖︎ | REST JSON |
-| FCSAPI | ✔︎ | ✔︎ | ✔︎ | ✔︎ | Varies | Real-time/Daily | ✖︎ | ✔︎ | REST + examples |
-| Open Exchange Rates | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 10+ years | Hourly/Daily | ✖︎ | ✔︎ | Official SDKs |
-| Alpha Vantage | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 20+ years | Minute/Daily | ✖︎ | ✔︎ | Python/Node SDK |
-| OANDA | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 25+ years | Tick/Minute/Daily | ✔︎ | ✔︎ | REST + historical downloads |
+| Provider            | USD | EUR | JPY | GBP | Historic Depth | Update Frequency  | Volume Data | Volatility Data | Python Tooling              |
+| ------------------- | --- | --- | --- | --- | -------------- | ----------------- | ----------- | --------------- | --------------------------- |
+| ExchangeRate-API    | ✔︎   | ✔︎   | ✔︎   | ✔︎   | ~9 years       | Hourly/Daily      | ✖︎           | ✔︎               | Community wrappers          |
+| ForexRateAPI        | ✔︎   | ✔︎   | ✔︎   | ✔︎   | 10+ years      | Daily/Live        | ✖︎           | ✔︎               | REST + examples             |
+| UniRate-API         | ✔︎   | ✔︎   | ✔︎   | ✔︎   | 20+ years      | Hourly/Daily      | ✖︎           | ✔︎               | REST + SDK snippets         |
+| Twelve Data         | ✔︎   | ✔︎   | ✔︎   | ✔︎   | ~20 years      | Minute/Daily      | Limited     | ✔︎               | Official SDKs               |
+| ECB SDW             | ✔︎*  | –   | –   | –   | 1999–present   | Daily             | ✖︎           | ✖︎               | SDMX tooling                |
+| Frankfurter API     | ✔︎*  | ✔︎   | ✔︎   | ✔︎   | 1999–present   | Daily             | ✖︎           | ✖︎               | REST JSON                   |
+| FCSAPI              | ✔︎   | ✔︎   | ✔︎   | ✔︎   | Varies         | Real-time/Daily   | ✖︎           | ✔︎               | REST + examples             |
+| Open Exchange Rates | ✔︎   | ✔︎   | ✔︎   | ✔︎   | 10+ years      | Hourly/Daily      | ✖︎           | ✔︎               | Official SDKs               |
+| Alpha Vantage       | ✔︎   | ✔︎   | ✔︎   | ✔︎   | 20+ years      | Minute/Daily      | ✖︎           | ✔︎               | Python/Node SDK             |
+| OANDA               | ✔︎   | ✔︎   | ✔︎   | ✔︎   | 25+ years      | Tick/Minute/Daily | ✔︎           | ✔︎               | REST + historical downloads |
 
-*ECB and Frankfurter provide EUR base reference rates; cross conversions are necessary for some USD pairs.
+*ECB and Frankfurter provide EUR base reference rates; cross conversions are
+necessary for some USD pairs.
 
 ### Licensing and Usage Considerations
 
-- **Freemium APIs** (ExchangeRate-API, ForexRateAPI, UniRate-API, Twelve Data, Alpha Vantage, Open Exchange Rates, FCSAPI) offer limited monthly requests for prototypes or academic work. Paid plans increase quotas and usually permit commercial deployment.
-- **Open data portals** (ECB SDW, Frankfurter) impose minimal restrictions, making them ideal for published research and reproducible analytics.
-- **Commercial feeds** (OANDA) provide service-level agreements, expanded history, and redistribution rights tailored for enterprise users.
-- Attribution is commonly required on free tiers; always review the provider’s terms of service before redistribution or monetization.
+- **Freemium APIs** (ExchangeRate-API, ForexRateAPI, UniRate-API, Twelve Data,
+  Alpha Vantage, Open Exchange Rates, FCSAPI) offer limited monthly requests for
+  prototypes or academic work. Paid plans increase quotas and usually permit
+  commercial deployment.
+- **Open data portals** (ECB SDW, Frankfurter) impose minimal restrictions,
+  making them ideal for published research and reproducible analytics.
+- **Commercial feeds** (OANDA) provide service-level agreements, expanded
+  history, and redistribution rights tailored for enterprise users.
+- Attribution is commonly required on free tiers; always review the provider’s
+  terms of service before redistribution or monetization.
 
 ### Python Integration Tips
 
-- Use `pandas-datareader`, `alpha_vantage`, `twelvedata`, or provider-specific SDKs to load time series directly into DataFrames.
-- Cache results locally to respect rate limits and to enable reproducible backtests.
-- Combine open reference rates with premium feeds when constructing hybrid datasets that balance legal certainty and depth.
+- Use `pandas-datareader`, `alpha_vantage`, `twelvedata`, or provider-specific
+  SDKs to load time series directly into DataFrames.
+- Cache results locally to respect rate limits and to enable reproducible
+  backtests.
+- Combine open reference rates with premium feeds when constructing hybrid
+  datasets that balance legal certainty and depth.
 
 ## Commodity Datasets
 
@@ -74,88 +90,120 @@ Commodity analytics typically rely on the following fields:
 
 ### Leading Commodity Data Providers
 
-| Provider | Assets Covered | Delivery Formats | Access Model | Notes |
-| --- | --- | --- | --- | --- |
-| Metal Price API | Gold spot and historical rates | REST JSON | Freemium | Multi-currency quotes with straightforward endpoints |
-| Metals-API | Precious and industrial metals | REST JSON | Freemium | Supports gold, silver, platinum, palladium, copper |
-| API Ninjas (Gold) | Gold spot and historical series | REST JSON | Freemium | Simple endpoints with lightweight authentication |
-| Commodities-API.com | Gold, oil, grains, softs, metals | REST JSON | Freemium/Paid | Unified commodity coverage with historical endpoints |
-| Investing.com | Broad commodity coverage with CSV downloads | CSV | Free for personal research | Requires manual download or scraping; includes volume where available |
-| Nasdaq Data Link (Quandl) | Exchange futures and spot benchmarks | REST JSON/CSV | Mixed free/premium | Deep historical coverage with contract-level metadata |
-| Polygon.io | CME/COMEX/ICE futures, spot FX, crypto | REST/WebSocket JSON | Commercial tiers | Intraday/tick data with order book depth |
-| Databento | CME Group and ICE futures | Binary/CSV via API | Commercial | Tick-level data licensed for institutional use |
-| OilPriceAPI | Brent, WTI, and refined products | REST JSON | Freemium/Paid | Focused coverage with clear attribution rules |
-| Opendatabay | Oil benchmarks with volume/volatility | CSV | Open access | Dataset-specific licensing; check download page |
-| Public GitHub Repositories | Curated gold, oil, copper, and grain datasets | CSV | Open access | Community-maintained; verify license per repo |
-| Alpha Vantage | Gold, oil, and select agricultural benchmarks | REST JSON/CSV | Freemium/Paid | Commodities endpoints with technical indicators |
+| Provider                   | Assets Covered                                | Delivery Formats    | Access Model               | Notes                                                                 |
+| -------------------------- | --------------------------------------------- | ------------------- | -------------------------- | --------------------------------------------------------------------- |
+| Metal Price API            | Gold spot and historical rates                | REST JSON           | Freemium                   | Multi-currency quotes with straightforward endpoints                  |
+| Metals-API                 | Precious and industrial metals                | REST JSON           | Freemium                   | Supports gold, silver, platinum, palladium, copper                    |
+| API Ninjas (Gold)          | Gold spot and historical series               | REST JSON           | Freemium                   | Simple endpoints with lightweight authentication                      |
+| Commodities-API.com        | Gold, oil, grains, softs, metals              | REST JSON           | Freemium/Paid              | Unified commodity coverage with historical endpoints                  |
+| Investing.com              | Broad commodity coverage with CSV downloads   | CSV                 | Free for personal research | Requires manual download or scraping; includes volume where available |
+| Nasdaq Data Link (Quandl)  | Exchange futures and spot benchmarks          | REST JSON/CSV       | Mixed free/premium         | Deep historical coverage with contract-level metadata                 |
+| Polygon.io                 | CME/COMEX/ICE futures, spot FX, crypto        | REST/WebSocket JSON | Commercial tiers           | Intraday/tick data with order book depth                              |
+| Databento                  | CME Group and ICE futures                     | Binary/CSV via API  | Commercial                 | Tick-level data licensed for institutional use                        |
+| OilPriceAPI                | Brent, WTI, and refined products              | REST JSON           | Freemium/Paid              | Focused coverage with clear attribution rules                         |
+| Opendatabay                | Oil benchmarks with volume/volatility         | CSV                 | Open access                | Dataset-specific licensing; check download page                       |
+| Public GitHub Repositories | Curated gold, oil, copper, and grain datasets | CSV                 | Open access                | Community-maintained; verify license per repo                         |
+| Alpha Vantage              | Gold, oil, and select agricultural benchmarks | REST JSON/CSV       | Freemium/Paid              | Commodities endpoints with technical indicators                       |
 
 ### Commodity Feature Comparison
 
-| Provider | Gold | Oil | Wheat | Copper | Historical Depth | Volume Data | Volatility Data | CSV Export | API Access | Free Tier |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Metal Price API | ✔︎ | ✖︎ | ✖︎ | ✖︎ | ~10 years | ✖︎ | ✖︎ | ✖︎ | ✔︎ | ✔︎ |
-| Metals-API | ✔︎ | ✖︎ | ✖︎ | ✔︎ | ~10 years | ✖︎ | ✖︎ | ✖︎ | ✔︎ | ✔︎ |
-| API Ninjas | ✔︎ | ✖︎ | ✖︎ | ✖︎ | ~5 years | ✖︎ | ✖︎ | ✖︎ | ✔︎ | ✔︎ |
-| Commodities-API.com | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 10+ years | ✔︎ | ✔︎ | ✖︎ | ✔︎ | ✔︎ |
-| Investing.com | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 20+ years | ✔︎ | ✔︎ | ✔︎ | ✖︎ | ✔︎ |
-| Nasdaq Data Link | ✔︎ | ✔︎ | ✔︎ | ✔︎ | 50+ years | ✔︎ | ✔︎ | ✔︎ | ✔︎ | Partial |
-| Polygon.io | ✔︎ | ✔︎ | ✔︎ | ✔︎ | Tick/minute | ✔︎ | ✔︎ | ✖︎ | ✔︎ | Trial |
-| Databento | ✔︎ | ✔︎ | ✔︎ | ✔︎ | Tick/minute | ✔︎ | ✔︎ | ✖︎ | ✔︎ | ✖︎ |
-| OilPriceAPI | ✖︎ | ✔︎ | ✖︎ | ✖︎ | 10+ years | ✖︎ | ✖︎ | ✖︎ | ✔︎ | ✔︎ |
-| Opendatabay | ✖︎ | ✔︎ | ✖︎ | ✖︎ | Up to 10 years | ✔︎ | ✔︎ | ✔︎ | ✖︎ | ✔︎ |
-| GitHub Datasets | ✔︎ | ✔︎ | ✖︎ | ✔︎ | Varies | Varies | Varies | ✔︎ | ✖︎ | ✔︎ |
-| Alpha Vantage | ✔︎ | ✔︎ | ✖︎ | ✔︎ | ~10 years | ✖︎ | ✔︎ | ✔︎ | ✔︎ | ✔︎ |
+| Provider            | Gold | Oil | Wheat | Copper | Historical Depth | Volume Data | Volatility Data | CSV Export | API Access | Free Tier |
+| ------------------- | ---- | --- | ----- | ------ | ---------------- | ----------- | --------------- | ---------- | ---------- | --------- |
+| Metal Price API     | ✔︎    | ✖︎   | ✖︎     | ✖︎      | ~10 years        | ✖︎           | ✖︎               | ✖︎          | ✔︎          | ✔︎         |
+| Metals-API          | ✔︎    | ✖︎   | ✖︎     | ✔︎      | ~10 years        | ✖︎           | ✖︎               | ✖︎          | ✔︎          | ✔︎         |
+| API Ninjas          | ✔︎    | ✖︎   | ✖︎     | ✖︎      | ~5 years         | ✖︎           | ✖︎               | ✖︎          | ✔︎          | ✔︎         |
+| Commodities-API.com | ✔︎    | ✔︎   | ✔︎     | ✔︎      | 10+ years        | ✔︎           | ✔︎               | ✖︎          | ✔︎          | ✔︎         |
+| Investing.com       | ✔︎    | ✔︎   | ✔︎     | ✔︎      | 20+ years        | ✔︎           | ✔︎               | ✔︎          | ✖︎          | ✔︎         |
+| Nasdaq Data Link    | ✔︎    | ✔︎   | ✔︎     | ✔︎      | 50+ years        | ✔︎           | ✔︎               | ✔︎          | ✔︎          | Partial   |
+| Polygon.io          | ✔︎    | ✔︎   | ✔︎     | ✔︎      | Tick/minute      | ✔︎           | ✔︎               | ✖︎          | ✔︎          | Trial     |
+| Databento           | ✔︎    | ✔︎   | ✔︎     | ✔︎      | Tick/minute      | ✔︎           | ✔︎               | ✖︎          | ✔︎          | ✖︎         |
+| OilPriceAPI         | ✖︎    | ✔︎   | ✖︎     | ✖︎      | 10+ years        | ✖︎           | ✖︎               | ✖︎          | ✔︎          | ✔︎         |
+| Opendatabay         | ✖︎    | ✔︎   | ✖︎     | ✖︎      | Up to 10 years   | ✔︎           | ✔︎               | ✔︎          | ✖︎          | ✔︎         |
+| GitHub Datasets     | ✔︎    | ✔︎   | ✖︎     | ✔︎      | Varies           | Varies      | Varies          | ✔︎          | ✖︎          | ✔︎         |
+| Alpha Vantage       | ✔︎    | ✔︎   | ✖︎     | ✔︎      | ~10 years        | ✖︎           | ✔︎               | ✔︎          | ✔︎          | ✔︎         |
 
 ### Licensing and Compliance Notes
 
-- **Open repositories and public portals** (GitHub datasets, Opendatabay) generally carry permissive licenses but always verify the repository’s `LICENSE` file before redistribution.
-- **Freemium APIs** often limit request volume and require attribution when used publicly; upgrading to paid plans typically unlocks commercial redistribution rights and higher rate limits.
-- **Commercial-grade feeds** (Polygon.io, Databento, Nasdaq Data Link premium) involve contractual agreements specifying data redistribution, retention periods, and acceptable use—critical for institutional deployments.
-- Many CSV downloads (Investing.com) are intended for personal research; scraping or republishing may violate terms without explicit permission.
+- **Open repositories and public portals** (GitHub datasets, Opendatabay)
+  generally carry permissive licenses but always verify the repository’s
+  `LICENSE` file before redistribution.
+- **Freemium APIs** often limit request volume and require attribution when used
+  publicly; upgrading to paid plans typically unlocks commercial redistribution
+  rights and higher rate limits.
+- **Commercial-grade feeds** (Polygon.io, Databento, Nasdaq Data Link premium)
+  involve contractual agreements specifying data redistribution, retention
+  periods, and acceptable use—critical for institutional deployments.
+- Many CSV downloads (Investing.com) are intended for personal research;
+  scraping or republishing may violate terms without explicit permission.
 
 ### Python Integration Tips
 
-- Load CSV datasets via `pandas.read_csv()` and annotate with contract metadata (exchange, contract code, delivery month) for futures research.
-- Use provider SDKs (`alpha_vantage`, `polygon`, `databento`) to access authenticated APIs with built-in pagination and rate-limit handling.
-- Normalize price units (currency per ounce/barrel/bushel) and calendar alignments when combining multiple commodity sources.
+- Load CSV datasets via `pandas.read_csv()` and annotate with contract metadata
+  (exchange, contract code, delivery month) for futures research.
+- Use provider SDKs (`alpha_vantage`, `polygon`, `databento`) to access
+  authenticated APIs with built-in pagination and rate-limit handling.
+- Normalize price units (currency per ounce/barrel/bushel) and calendar
+  alignments when combining multiple commodity sources.
 
 ## Optimizing Dynamic Data Pipelines
 
 ### End-to-End Workflow
 
-1. **Start with open or official data** to establish baseline reference series and reduce licensing risk.
-2. **Prototype with freemium APIs** to validate analytics, then migrate to paid plans when higher request volumes or commercial rights are required.
-3. **Document provenance** by recording API version, endpoint URLs, and access timestamps for every dataset ingested.
-4. **Continuously evaluate performance metrics** (latency, freshness, cost per call) and feed them back into capacity planning.
+1. **Start with open or official data** to establish baseline reference series
+   and reduce licensing risk.
+2. **Prototype with freemium APIs** to validate analytics, then migrate to paid
+   plans when higher request volumes or commercial rights are required.
+3. **Document provenance** by recording API version, endpoint URLs, and access
+   timestamps for every dataset ingested.
+4. **Continuously evaluate performance metrics** (latency, freshness, cost per
+   call) and feed them back into capacity planning.
 
 ### Optimization Playbooks
 
-| Use Case | Target Latency | Recommended Stack | Key Optimization Levers |
-| --- | --- | --- | --- |
-| Intraday FX trading | < 2 seconds | Streaming API (Polygon.io), Redis cache, columnar warehouse | WebSocket fan-out, tick deduplication, hot-cache invalidation |
-| Daily macro research | < 15 minutes | Scheduled Airflow DAG, Parquet lakehouse, dbt transforms | Incremental fetch windows, partition pruning, schema evolution tests |
-| Monthly regulatory reporting | < 6 hours | Managed ETL (Fivetran/Stitch), Delta Lake, BI tool | Change-data capture, automated reconciliation, immutable audit trails |
+| Use Case                     | Target Latency | Recommended Stack                                           | Key Optimization Levers                                               |
+| ---------------------------- | -------------- | ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| Intraday FX trading          | < 2 seconds    | Streaming API (Polygon.io), Redis cache, columnar warehouse | WebSocket fan-out, tick deduplication, hot-cache invalidation         |
+| Daily macro research         | < 15 minutes   | Scheduled Airflow DAG, Parquet lakehouse, dbt transforms    | Incremental fetch windows, partition pruning, schema evolution tests  |
+| Monthly regulatory reporting | < 6 hours      | Managed ETL (Fivetran/Stitch), Delta Lake, BI tool          | Change-data capture, automated reconciliation, immutable audit trails |
 
 ### Refresh and Latency Management
 
-- **Adopt incremental ingestion.** Pull only the newest observations (e.g., `lastUpdated` or pagination tokens) to minimize bandwidth and API credits.
-- **Layer change-data capture queues.** Webhooks, Kafka topics, or provider streaming sockets (Polygon.io, Databento) allow near-real-time synchronization for trading systems that require sub-minute updates.
-- **Stagger scheduling by provider limits.** Align cron or Airflow schedules with published rate limits, and centralize secrets management to rotate API keys without downtime.
-- **Throttle gracefully.** Implement exponential backoff and circuit breakers so pipelines degrade safely during provider incidents.
+- **Adopt incremental ingestion.** Pull only the newest observations (e.g.,
+  `lastUpdated` or pagination tokens) to minimize bandwidth and API credits.
+- **Layer change-data capture queues.** Webhooks, Kafka topics, or provider
+  streaming sockets (Polygon.io, Databento) allow near-real-time synchronization
+  for trading systems that require sub-minute updates.
+- **Stagger scheduling by provider limits.** Align cron or Airflow schedules
+  with published rate limits, and centralize secrets management to rotate API
+  keys without downtime.
+- **Throttle gracefully.** Implement exponential backoff and circuit breakers so
+  pipelines degrade safely during provider incidents.
 
 ### Storage and Access Optimization
 
-- **Normalize schemas across assets.** Use consistent field names (`timestamp`, `open`, `high`, `low`, `close`, `volume`, `volatility`) so downstream analytics can reuse transformations.
-- **Partition time-series storage.** Parquet/Delta Lake tables partitioned by `asset_class` and `date` accelerate queries and simplify retention policies.
-- **Build tiered caches.** Warm data warehouses (e.g., DuckDB, ClickHouse) with daily aggregates and retain raw ticks in object storage for replay when needed.
-- **Compress and index.** Apply ZSTD or Snappy compression and build Z-order or data skipping indexes to reduce scan time on large historical archives.
+- **Normalize schemas across assets.** Use consistent field names (`timestamp`,
+  `open`, `high`, `low`, `close`, `volume`, `volatility`) so downstream
+  analytics can reuse transformations.
+- **Partition time-series storage.** Parquet/Delta Lake tables partitioned by
+  `asset_class` and `date` accelerate queries and simplify retention policies.
+- **Build tiered caches.** Warm data warehouses (e.g., DuckDB, ClickHouse) with
+  daily aggregates and retain raw ticks in object storage for replay when
+  needed.
+- **Compress and index.** Apply ZSTD or Snappy compression and build Z-order or
+  data skipping indexes to reduce scan time on large historical archives.
 
 ### Quality Assurance and Governance
 
-- **Continuously validate inputs.** Implement schema validation (Great Expectations, Pandera) and cross-source parity checks (ECB vs. FX API) to detect anomalies.
-- **Track lineage and metadata.** Record ingestion job IDs, hash checksums, and derivation logic so analysts can audit transformations quickly.
-- **Audit licensing periodically.** Schedule reviews when upgrading service tiers or onboarding new partners to ensure usage terms remain compliant.
-- **Embed observability.** Emit data quality metrics, freshness SLAs, and contract utilization into monitoring dashboards (Grafana, DataDog) for proactive alerting.
+- **Continuously validate inputs.** Implement schema validation (Great
+  Expectations, Pandera) and cross-source parity checks (ECB vs. FX API) to
+  detect anomalies.
+- **Track lineage and metadata.** Record ingestion job IDs, hash checksums, and
+  derivation logic so analysts can audit transformations quickly.
+- **Audit licensing periodically.** Schedule reviews when upgrading service
+  tiers or onboarding new partners to ensure usage terms remain compliant.
+- **Embed observability.** Emit data quality metrics, freshness SLAs, and
+  contract utilization into monitoring dashboards (Grafana, DataDog) for
+  proactive alerting.
 
 ### Automation Patterns
 
@@ -191,9 +239,16 @@ if __name__ == "__main__":
     hydrate_cache("USD_EUR", cache=YourCacheLayer())
 ```
 
-- **Bundle automation into DAGs or serverless jobs.** Package functions like `hydrate_cache` into Airflow Operators or AWS Lambda handlers, and tag runs with dataset identifiers for lineage tracking.
-- **Pre- and post-load checks.** Compare row counts, min/max timestamps, and hash totals before promoting data to production schemas.
+- **Bundle automation into DAGs or serverless jobs.** Package functions like
+  `hydrate_cache` into Airflow Operators or AWS Lambda handlers, and tag runs
+  with dataset identifiers for lineage tracking.
+- **Pre- and post-load checks.** Compare row counts, min/max timestamps, and
+  hash totals before promoting data to production schemas.
 
 ## Conclusion
 
-A combination of open portals, freemium APIs, and commercial feeds can satisfy most analytical requirements for currency and commodity markets. By understanding coverage, licensing, and integration tooling, practitioners can assemble durable datasets for trading models, economic research, and financial reporting while maintaining compliance and data quality standards.
+A combination of open portals, freemium APIs, and commercial feeds can satisfy
+most analytical requirements for currency and commodity markets. By
+understanding coverage, licensing, and integration tooling, practitioners can
+assemble durable datasets for trading models, economic research, and financial
+reporting while maintaining compliance and data quality standards.

--- a/docs/dct-status-report.md
+++ b/docs/dct-status-report.md
@@ -2,12 +2,31 @@
 
 ## Snapshot
 
-- **Protocol scope:** DCT is the proof-of-contribution asset powering the intelligence, execution, and liquidity layers described in the whitepaper, coupling access to AI-assisted tooling with treasury-aligned incentives.【F:docs/dynamic-capital-ton-whitepaper.md†L7-L46】
-- **Supply & treasury controls:** Config manifests enforce the 100 M token cap, 60/30/10 treasury routing with guardrails, staking lock multipliers, and DAO-managed theme pass drops, keeping economics synchronized between on-chain and off-chain systems.【F:dynamic-capital-ton/config.yaml†L1-L49】【F:dynamic-capital-ton/supabase/schema.sql†L41-L74】
-- **Contract readiness:** The pool allocator already parses TIP-3 transfers according to spec, forwards the declared TON value, and emits structured deposit events; deployment docs cover the jetton master, wallets, timelocks, and NFT theme passes.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L66-L170】【F:dynamic-capital-ton/contracts/README.md†L1-L88】
-- **Application surface:** Telegram Mini App docs outline env setup and verification, while Supabase functions handle wallet linking and subscription intake with credential checks and unit tests guarding typical flows.【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L52】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.ts†L1-L113】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.ts†L1-L158】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】
-- **Quality focus:** Allocator and Supabase suites provide regression coverage, but the implementation checklist still needs to be updated and routine CI gates documented, as detailed in the technical audit.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】【F:docs/dct-ton-audit.md†L5-L92】
+- **Protocol scope:** DCT is the proof-of-contribution asset powering the
+  intelligence, execution, and liquidity layers described in the whitepaper,
+  coupling access to AI-assisted tooling with treasury-aligned
+  incentives.【F:docs/dynamic-capital-ton-whitepaper.md†L7-L46】
+- **Supply & treasury controls:** Config manifests enforce the 100 M token cap,
+  60/30/10 treasury routing with guardrails, staking lock multipliers, and
+  DAO-managed theme pass drops, keeping economics synchronized between on-chain
+  and off-chain
+  systems.【F:dynamic-capital-ton/config.yaml†L1-L49】【F:dynamic-capital-ton/supabase/schema.sql†L41-L74】
+- **Contract readiness:** The pool allocator already parses TIP-3 transfers
+  according to spec, forwards the declared TON value, and emits structured
+  deposit events; deployment docs cover the jetton master, wallets, timelocks,
+  and NFT theme
+  passes.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L66-L170】【F:dynamic-capital-ton/contracts/README.md†L1-L88】
+- **Application surface:** Telegram Mini App docs outline env setup and
+  verification, while Supabase functions handle wallet linking and subscription
+  intake with credential checks and unit tests guarding typical
+  flows.【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L52】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.ts†L1-L113】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.ts†L1-L158】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】
+- **Quality focus:** Allocator and Supabase suites provide regression coverage,
+  but the implementation checklist still needs to be updated and routine CI
+  gates documented, as detailed in the technical
+  audit.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】【F:docs/dct-ton-audit.md†L5-L92】
 
 ## Follow-Up
 
-Refer to [`dct-ton-audit.md`](./dct-ton-audit.md) for a full technical audit, risk assessment, and launch-readiness recommendations spanning governance, contracts, infrastructure, and operations.【F:docs/dct-ton-audit.md†L1-L124】
+Refer to [`dct-ton-audit.md`](./dct-ton-audit.md) for a full technical audit,
+risk assessment, and launch-readiness recommendations spanning governance,
+contracts, infrastructure, and operations.【F:docs/dct-ton-audit.md†L1-L124】

--- a/docs/dct-ton-audit.md
+++ b/docs/dct-ton-audit.md
@@ -2,44 +2,119 @@
 
 ## Executive Summary
 
-- **Deployment stack is implementation-ready:** Smart contracts, config manifests, and TON network parameters are present and aligned (token cap, treasury splits, timelocks, theme pass metadata), indicating the chain layer can be deployed with minimal modification.【F:dynamic-capital-ton/config.yaml†L1-L37】【F:dynamic-capital-ton/contracts/pool_allocator.tact†L1-L198】【F:dynamic-capital-ton/global.config.json†L1-L80】
-- **Off-chain services are wired for user onboarding:** Supabase schema, wallet-linking and subscription processing functions, and Telegram Mini App documentation provide a clear flow from user acquisition to treasury routing with automated guards.【F:dynamic-capital-ton/supabase/schema.sql†L1-L74】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.ts†L1-L113】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.ts†L1-L120】【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L52】
-- **Quality gates exist but need consistent execution:** Allocator parsing fixes and Supabase flows are covered by Deno-based unit tests, yet the implementation checklist remains unchecked and no CI evidence is captured; formalizing routine test runs and updating plan status should be prioritized.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts†L1-L120】【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】
+- **Deployment stack is implementation-ready:** Smart contracts, config
+  manifests, and TON network parameters are present and aligned (token cap,
+  treasury splits, timelocks, theme pass metadata), indicating the chain layer
+  can be deployed with minimal
+  modification.【F:dynamic-capital-ton/config.yaml†L1-L37】【F:dynamic-capital-ton/contracts/pool_allocator.tact†L1-L198】【F:dynamic-capital-ton/global.config.json†L1-L80】
+- **Off-chain services are wired for user onboarding:** Supabase schema,
+  wallet-linking and subscription processing functions, and Telegram Mini App
+  documentation provide a clear flow from user acquisition to treasury routing
+  with automated
+  guards.【F:dynamic-capital-ton/supabase/schema.sql†L1-L74】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.ts†L1-L113】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.ts†L1-L120】【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L52】
+- **Quality gates exist but need consistent execution:** Allocator parsing fixes
+  and Supabase flows are covered by Deno-based unit tests, yet the
+  implementation checklist remains unchecked and no CI evidence is captured;
+  formalizing routine test runs and updating plan status should be
+  prioritized.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts†L1-L120】【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】
 
 ## Governance, Tokenomics, and Treasury Controls
 
-- The on-chain configuration enforces a 100 M DCT hard cap, 9 decimals, and treasury split guardrails (60/30/10 default with explicit bounds) matching the whitepaper distribution schedule, supporting predictable emissions and treasury discipline.【F:dynamic-capital-ton/config.yaml†L1-L25】【F:docs/dynamic-capital-ton-whitepaper.md†L31-L66】
-- Staking locks and multipliers are codified (3/6/12 month tiers with 1.2×–2.0× boosts), aligning with the staking narrative in the whitepaper, while theme pass governance addresses and royalty sinks are preset for DAO-managed NFT drops.【F:dynamic-capital-ton/config.yaml†L16-L49】【F:docs/dynamic-capital-ton-whitepaper.md†L97-L133】
-- Supabase defaults replicate the treasury boundaries on the off-chain side, seeding operations, auto-invest, and buyback percentages along with authoritative wallet addresses, minimizing drift between database state and contract configuration.【F:dynamic-capital-ton/supabase/schema.sql†L41-L74】
+- The on-chain configuration enforces a 100 M DCT hard cap, 9 decimals, and
+  treasury split guardrails (60/30/10 default with explicit bounds) matching the
+  whitepaper distribution schedule, supporting predictable emissions and
+  treasury
+  discipline.【F:dynamic-capital-ton/config.yaml†L1-L25】【F:docs/dynamic-capital-ton-whitepaper.md†L31-L66】
+- Staking locks and multipliers are codified (3/6/12 month tiers with 1.2×–2.0×
+  boosts), aligning with the staking narrative in the whitepaper, while theme
+  pass governance addresses and royalty sinks are preset for DAO-managed NFT
+  drops.【F:dynamic-capital-ton/config.yaml†L16-L49】【F:docs/dynamic-capital-ton-whitepaper.md†L97-L133】
+- Supabase defaults replicate the treasury boundaries on the off-chain side,
+  seeding operations, auto-invest, and buyback percentages along with
+  authoritative wallet addresses, minimizing drift between database state and
+  contract configuration.【F:dynamic-capital-ton/supabase/schema.sql†L41-L74】
 
 ## Smart Contract Review
 
-- The allocator contract validates TIP-3 transfers end-to-end: it enforces jetton wallet provenance, reads all canonical fields, requires the declared forward TON amount, and emits structured `DepositEvent`s for analytics. Forward payload parsing confirms the `POOL` opcode and guards zero-value deposits.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L66-L170】
-- Governance functions include timelocked router/treasury updates and pause toggles, ensuring administrative actions require queued execution and base workchain validation to prevent cross-chain misconfigurations.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L1-L128】【F:dynamic-capital-ton/contracts/pool_allocator.tact†L170-L218】
-- Contract documentation covers deployment prerequisites for the jetton master/wallets, theme pass collection operations, and DNS integrations, providing concrete instructions for ops teams and indexers to track governance events.【F:dynamic-capital-ton/contracts/README.md†L1-L88】
+- The allocator contract validates TIP-3 transfers end-to-end: it enforces
+  jetton wallet provenance, reads all canonical fields, requires the declared
+  forward TON amount, and emits structured `DepositEvent`s for analytics.
+  Forward payload parsing confirms the `POOL` opcode and guards zero-value
+  deposits.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L66-L170】
+- Governance functions include timelocked router/treasury updates and pause
+  toggles, ensuring administrative actions require queued execution and base
+  workchain validation to prevent cross-chain
+  misconfigurations.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L1-L128】【F:dynamic-capital-ton/contracts/pool_allocator.tact†L170-L218】
+- Contract documentation covers deployment prerequisites for the jetton
+  master/wallets, theme pass collection operations, and DNS integrations,
+  providing concrete instructions for ops teams and indexers to track governance
+  events.【F:dynamic-capital-ton/contracts/README.md†L1-L88】
 
 ## Testing and Verification Coverage
 
-- Deno-based allocator tests simulate timelock behavior, swaps, withdrawals, and compliant TIP-3 transfers, asserting router forwarding, payload decoding, and rejection paths for malformed inputs.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】
-- Supabase edge functions are unit tested: wallet linking checks address ownership conflicts and update paths, while subscription processing stubs Supabase, pricing helpers, and TON indexer responses to validate config loading and payment verification logic.【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts†L1-L120】
-- Telegram Mini App documentation prescribes manual verification steps (proxy guards, env setup) complementing automated tests, ensuring developers can reproduce end-to-end flows during audits.【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L52】
+- Deno-based allocator tests simulate timelock behavior, swaps, withdrawals, and
+  compliant TIP-3 transfers, asserting router forwarding, payload decoding, and
+  rejection paths for malformed
+  inputs.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】
+- Supabase edge functions are unit tested: wallet linking checks address
+  ownership conflicts and update paths, while subscription processing stubs
+  Supabase, pricing helpers, and TON indexer responses to validate config
+  loading and payment verification
+  logic.【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts†L1-L120】
+- Telegram Mini App documentation prescribes manual verification steps (proxy
+  guards, env setup) complementing automated tests, ensuring developers can
+  reproduce end-to-end flows during
+  audits.【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L52】
 
 ## Infrastructure and Off-Chain Services
 
-- TON global configuration ships with a populated static node list, enabling validators and liteservers to bootstrap connectivity immediately after deployment.【F:dynamic-capital-ton/global.config.json†L1-L80】
-- Supabase schema models users, wallets, subscriptions, staking, emissions, config, and transaction logs with uniqueness constraints and seeded treasury endpoints, providing traceable accounting and emission reporting.【F:dynamic-capital-ton/supabase/schema.sql†L1-L74】
-- Subscription processing integrates shared pricing helpers for TON/USD calculations, expects Telegram bot credentials for confirmations, and verifies TON payments against a configurable indexer endpoint, aligning treasury reconciliation with market data inputs.【F:dynamic-capital-ton/supabase/functions/process-subscription/index.ts†L1-L158】
+- TON global configuration ships with a populated static node list, enabling
+  validators and liteservers to bootstrap connectivity immediately after
+  deployment.【F:dynamic-capital-ton/global.config.json†L1-L80】
+- Supabase schema models users, wallets, subscriptions, staking, emissions,
+  config, and transaction logs with uniqueness constraints and seeded treasury
+  endpoints, providing traceable accounting and emission
+  reporting.【F:dynamic-capital-ton/supabase/schema.sql†L1-L74】
+- Subscription processing integrates shared pricing helpers for TON/USD
+  calculations, expects Telegram bot credentials for confirmations, and verifies
+  TON payments against a configurable indexer endpoint, aligning treasury
+  reconciliation with market data
+  inputs.【F:dynamic-capital-ton/supabase/functions/process-subscription/index.ts†L1-L158】
 
 ## Outstanding Risks and Recommendations
 
-1. **Formalize implementation checklist tracking:** The allocator improvement checklist is still unchecked even though parsing and tests are present; update the plan or backlog residual tasks to avoid ambiguity for auditors.【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】
-2. **Document routine quality gates:** Capture the expected `deno`/`pnpm` commands (e.g., allocator tests, Supabase unit tests) in CI docs or scripts so future contributors run the same suites before deploys.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】
-3. **Extend monitoring playbooks:** While the whitepaper outlines analytics expectations, add operational runbooks tying on-chain events (DepositEvent, ThemeContentEvent) to observability dashboards to close the loop between contracts and reporting.【F:docs/dynamic-capital-ton-whitepaper.md†L108-L146】【F:dynamic-capital-ton/contracts/README.md†L54-L88】
-4. **Validate environment secrets management:** Supabase functions throw on missing credentials; ensure deployment tooling references secure secret storage (e.g., Doppler, Supabase config) and document rotation procedures alongside the Mini App setup guide.【F:dynamic-capital-ton/supabase/functions/link-wallet/index.ts†L1-L56】【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L35】
+1. **Formalize implementation checklist tracking:** The allocator improvement
+   checklist is still unchecked even though parsing and tests are present;
+   update the plan or backlog residual tasks to avoid ambiguity for
+   auditors.【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】
+2. **Document routine quality gates:** Capture the expected `deno`/`pnpm`
+   commands (e.g., allocator tests, Supabase unit tests) in CI docs or scripts
+   so future contributors run the same suites before
+   deploys.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/supabase/functions/link-wallet/index.test.ts†L1-L96】
+3. **Extend monitoring playbooks:** While the whitepaper outlines analytics
+   expectations, add operational runbooks tying on-chain events (DepositEvent,
+   ThemeContentEvent) to observability dashboards to close the loop between
+   contracts and
+   reporting.【F:docs/dynamic-capital-ton-whitepaper.md†L108-L146】【F:dynamic-capital-ton/contracts/README.md†L54-L88】
+4. **Validate environment secrets management:** Supabase functions throw on
+   missing credentials; ensure deployment tooling references secure secret
+   storage (e.g., Doppler, Supabase config) and document rotation procedures
+   alongside the Mini App setup
+   guide.【F:dynamic-capital-ton/supabase/functions/link-wallet/index.ts†L1-L56】【F:dynamic-capital-ton/apps/miniapp/README.md†L1-L35】
 
 ## Next Steps for Launch Readiness
 
-- Update the implementation plan to reflect completed allocator milestones and track any remaining governance or analytics tasks prior to mainnet launch.【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】
-- Run and record allocator and Supabase function tests as part of a release candidate checklist, ensuring reproducible evidence for stakeholders and external auditors.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts†L1-L120】
-- Align Supabase configuration with on-chain treasury addresses by verifying staged values match the final deployment accounts before flipping production traffic.【F:dynamic-capital-ton/supabase/schema.sql†L41-L74】
-- Expand documentation to include dashboard wiring for DepositEvent analytics, ensuring governance can monitor swap inflows, theme pass updates, and staking participation post-launch.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L114-L170】【F:dynamic-capital-ton/contracts/README.md†L54-L88】
+- Update the implementation plan to reflect completed allocator milestones and
+  track any remaining governance or analytics tasks prior to mainnet
+  launch.【F:dynamic-capital-ton/IMPLEMENTATION_PLAN.md†L47-L96】
+- Run and record allocator and Supabase function tests as part of a release
+  candidate checklist, ensuring reproducible evidence for stakeholders and
+  external
+  auditors.【F:dynamic-capital-ton/apps/tests/pool_allocator.test.ts†L1-L194】【F:dynamic-capital-ton/supabase/functions/process-subscription/index.test.ts†L1-L120】
+- Align Supabase configuration with on-chain treasury addresses by verifying
+  staged values match the final deployment accounts before flipping production
+  traffic.【F:dynamic-capital-ton/supabase/schema.sql†L41-L74】
+- Expand documentation to include dashboard wiring for DepositEvent analytics,
+  ensuring governance can monitor swap inflows, theme pass updates, and staking
+  participation
+  post-launch.【F:dynamic-capital-ton/contracts/pool_allocator.tact†L114-L170】【F:dynamic-capital-ton/contracts/README.md†L54-L88】

--- a/docs/dhivehi/snapshot.md
+++ b/docs/dhivehi/snapshot.md
@@ -55,4 +55,6 @@
 
 ## Simulation
 
-- Run `python -m dynamic_translation.dhivehi_simulation "ބާވަތް ބަލާލުން."` to generate a sample Dhivehi → English translation trace with glossary coverage, memory provenance, and post-edit prompts.
+- Run `python -m dynamic_translation.dhivehi_simulation "ބާވަތް ބަލާލުން."` to generate
+  a sample Dhivehi → English translation trace with glossary coverage, memory
+  provenance, and post-edit prompts.

--- a/docs/dhivehi_radheef_corpus.md
+++ b/docs/dhivehi_radheef_corpus.md
@@ -1,24 +1,30 @@
 # Dhivehi Radheef Corpus Snapshot
 
 ## Page Coverage
-- Unique Radheef pages represented across the JSONL shards: **1,563**, spanning page 26 through page 1,588.
-- Combined, the shards contribute **31,042** prompt-response pairs extracted from the dictionary.
+
+- Unique Radheef pages represented across the JSONL shards: **1,563**, spanning
+  page 26 through page 1,588.
+- Combined, the shards contribute **31,042** prompt-response pairs extracted
+  from the dictionary.
 
 ## Shard Breakdown
-| JSONL shard | Prompt-response rows | Distinct Radheef pages |
-| --- | ---: | ---: |
-| `dhivehi_radheef_pages_026_050.jsonl` | 495 | 25 |
-| `dhivehi_radheef_pages_051_100.jsonl` | 994 | 50 |
-| `dhivehi_radheef_pages_101_200.jsonl` | 1,983 | 100 |
-| `dhivehi_radheef_pages_201_499.jsonl` | 5,940 | 299 |
-| `dhivehi_radheef_pages_500_699.jsonl` | 3,976 | 200 |
-| `dhivehi_radheef_pages_699_800.jsonl` | 2,023 | 102 |
-| `dhivehi_radheef_pages_801_999.jsonl` | 3,946 | 199 |
-| `dhivehi_radheef_pages_999_1000.jsonl` | 39 | 2 |
-| `dhivehi_radheef_pages_1001_1199.jsonl` | 3,942 | 199 |
-| `dhivehi_radheef_pages_1200_1299.jsonl` | 1,977 | 100 |
-| `dhivehi_radheef_pages_1300_1399.jsonl` | 1,983 | 100 |
-| `dhivehi_radheef_pages_1400_1499.jsonl` | 1,984 | 100 |
-| `dhivehi_radheef_pages_1500_1588.jsonl` | 1,760 | 89 |
 
-> **Note:** Page counts reflect distinct page identifiers per shard. Pages 999–1,000 appear in overlapping exports, so the overall deduplicated corpus contains 1,563 distinct Radheef pages.
+| JSONL shard                             | Prompt-response rows | Distinct Radheef pages |
+| --------------------------------------- | -------------------: | ---------------------: |
+| `dhivehi_radheef_pages_026_050.jsonl`   |                  495 |                     25 |
+| `dhivehi_radheef_pages_051_100.jsonl`   |                  994 |                     50 |
+| `dhivehi_radheef_pages_101_200.jsonl`   |                1,983 |                    100 |
+| `dhivehi_radheef_pages_201_499.jsonl`   |                5,940 |                    299 |
+| `dhivehi_radheef_pages_500_699.jsonl`   |                3,976 |                    200 |
+| `dhivehi_radheef_pages_699_800.jsonl`   |                2,023 |                    102 |
+| `dhivehi_radheef_pages_801_999.jsonl`   |                3,946 |                    199 |
+| `dhivehi_radheef_pages_999_1000.jsonl`  |                   39 |                      2 |
+| `dhivehi_radheef_pages_1001_1199.jsonl` |                3,942 |                    199 |
+| `dhivehi_radheef_pages_1200_1299.jsonl` |                1,977 |                    100 |
+| `dhivehi_radheef_pages_1300_1399.jsonl` |                1,983 |                    100 |
+| `dhivehi_radheef_pages_1400_1499.jsonl` |                1,984 |                    100 |
+| `dhivehi_radheef_pages_1500_1588.jsonl` |                1,760 |                     89 |
+
+> **Note:** Page counts reflect distinct page identifiers per shard. Pages
+> 999–1,000 appear in overlapping exports, so the overall deduplicated corpus
+> contains 1,563 distinct Radheef pages.

--- a/docs/dynamic-agi-modular-framework.md
+++ b/docs/dynamic-agi-modular-framework.md
@@ -490,7 +490,7 @@ dialectical synthesis routines drive reflection and discourse.
 | `dynamic_reference`          | Citation and provenance management              | Knowledge graphs + LLM ranking                           | Reference parsing, PageRank heuristics              |
 | `dynamic_text`               | Reliable multi-format text generation           | Transformer-based language models + logic chains         | Coherence scoring, readability formulas             |
 | `dynamic_method`             | Method selection and composition                | Meta-learning + optimization                             | Utility maximization, dispatch logic                |
-| `dynamic.governance.ags`           | Adaptive workflow orchestration                 | Finite-state machines + rule engines                     | Flowchart heuristics, escalation matrices           |
+| `dynamic.governance.ags`     | Adaptive workflow orchestration                 | Finite-state machines + rule engines                     | Flowchart heuristics, escalation matrices           |
 | `dynamic_routine`            | Routine scheduling and adjustment               | Reinforcement learning schedulers + workflow mining      | Priority scoring, dynamic slotting                  |
 | `dynamic_energy`             | Distributed energy optimization                 | Multi-agent reinforcement learning + graph optimization  | Dispatch logic, load balancing, pricing             |
 | `dynamic_recycling`          | Waste processing optimization                   | Computer vision + reinforcement learning                 | Recycling rate maximization, sorting heuristics     |
@@ -501,9 +501,10 @@ dialectical synthesis routines drive reflection and discourse.
 
 ## Implementation Checklist
 
-The build scenario captured in `data/dynamic.intelligence.agi_modular_build.json` records
-telemetry pulses confirming the completion of the following integration
-milestones across each modular domain.
+The build scenario captured in
+`data/dynamic.intelligence.agi_modular_build.json` records telemetry pulses
+confirming the completion of the following integration milestones across each
+modular domain.
 
 ### Build Scenario Objective Tracker
 
@@ -599,8 +600,8 @@ evidence of delivery. Highlights include:
 
 - [x] Build meta-learning policy repositories to drive `dynamic_method`
       selections.
-- [x] Author adaptive incident response templates for `dynamic.governance.ags` with
-      branching logic tests.
+- [x] Author adaptive incident response templates for `dynamic.governance.ags`
+      with branching logic tests.
 - [x] Schedule reinforcement learning experiments for `dynamic_routine` to
       optimize recurring workflows.
 
@@ -625,12 +626,13 @@ evidence of delivery. Highlights include:
 ## Integrative Perspectives and Architectural Considerations
 
 To operationalize the modular landscape, we introduce a dedicated integrative
-blueprint captured in `data/dynamic.intelligence.agi_integrative_architecture.json`. This
-artifact codifies the cross-domain layers, interfaces, and governance contracts
-required to stitch telemetry, cognition, trust, and reflection into a unified
-capability fabric. The companion build scenario’s `objectives` ledger ensures
-that each integration is backed by observable telemetry pulses before it is
-promoted to production orchestration.
+blueprint captured in
+`data/dynamic.intelligence.agi_integrative_architecture.json`. This artifact
+codifies the cross-domain layers, interfaces, and governance contracts required
+to stitch telemetry, cognition, trust, and reflection into a unified capability
+fabric. The companion build scenario’s `objectives` ledger ensures that each
+integration is backed by observable telemetry pulses before it is promoted to
+production orchestration.
 
 ### Layered Architectural Stack
 

--- a/docs/dynamic-ai-core-architecture.md
+++ b/docs/dynamic-ai-core-architecture.md
@@ -35,7 +35,8 @@ and cleaner extensibility.
 Each micro-core hosts a minimal agent runtime tuned for peak throughput:
 
 - **Signal ingestion** normalises raw telemetry into the `PreparedMarketContext`
-  schema reused throughout Dynamic AI.【F:dynamic.intelligence.ai_apps/core.py†L68-L145】
+  schema reused throughout Dynamic
+  AI.【F:dynamic.intelligence.ai_apps/core.py†L68-L145】
 - **Heuristic evaluation** executes the relevant indicator blend and converts
   composite scores into discrete actions via `score_to_action`
   helpers.【F:dynamic.intelligence.ai_apps/core.py†L46-L103】
@@ -449,8 +450,8 @@ can triage anomalies rapidly.
 ## Implementation Roadmap
 
 1. **Prototype SM runtime** using existing async worker pools in
-   `dynamic.intelligence.ai_apps.training` to validate scheduling semantics before hardware
-   acceleration and to benchmark adapter-aware warp packing.
+   `dynamic.intelligence.ai_apps.training` to validate scheduling semantics
+   before hardware acceleration and to benchmark adapter-aware warp packing.
 2. **Introduce telemetry schema** mirroring the metrics outlined above and emit
    them via the existing monitoring stack, including adapter health feeds.
 3. **Layer in adaptive control plane** so persona changes, model routing rules,

--- a/docs/dynamic-ai-overview.md
+++ b/docs/dynamic-ai-overview.md
@@ -10,10 +10,10 @@ Brain remains aligned with execution, memory, and governance surfaces.
 
 | Capability             | What it does                                                                                                                              | Key implementation source                                                                           |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Multi-lobe fusion      | Normalises directional, momentum, sentiment, and treasury lobes into a bounded signal with rationale + confidence payloads.               | `dynamic.intelligence.ai_apps/fusion.py`【F:dynamic.intelligence.ai_apps/fusion.py†L13-L167】                                           |
-| Regime-aware weighting | Adjusts each lobe’s influence based on volatility, session, and risk-off signals before mapping to BUY/SELL/NEUTRAL actions.              | `dynamic.intelligence.ai_apps/fusion.py`【F:dynamic.intelligence.ai_apps/fusion.py†L169-L214】                                          |
-| Lorentzian calibration | Rebuilds Lorentzian lobes from serialized models, enforcing sane sensitivity thresholds for new market regimes.                           | `dynamic.intelligence.ai_apps/training.py`【F:dynamic.intelligence.ai_apps/training.py†L14-L48】                                        |
-| Persona agents         | Packages research, execution, and risk personas with consistent payloads so orchestration can route requests through a reusable chain.    | `dynamic.intelligence.ai_apps/agents.py`【F:dynamic.intelligence.ai_apps/agents.py†L1-L382】                                            |
+| Multi-lobe fusion      | Normalises directional, momentum, sentiment, and treasury lobes into a bounded signal with rationale + confidence payloads.               | `dynamic.intelligence.ai_apps/fusion.py`【F:dynamic.intelligence.ai_apps/fusion.py†L13-L167】       |
+| Regime-aware weighting | Adjusts each lobe’s influence based on volatility, session, and risk-off signals before mapping to BUY/SELL/NEUTRAL actions.              | `dynamic.intelligence.ai_apps/fusion.py`【F:dynamic.intelligence.ai_apps/fusion.py†L169-L214】      |
+| Lorentzian calibration | Rebuilds Lorentzian lobes from serialized models, enforcing sane sensitivity thresholds for new market regimes.                           | `dynamic.intelligence.ai_apps/training.py`【F:dynamic.intelligence.ai_apps/training.py†L14-L48】    |
+| Persona agents         | Packages research, execution, and risk personas with consistent payloads so orchestration can route requests through a reusable chain.    | `dynamic.intelligence.ai_apps/agents.py`【F:dynamic.intelligence.ai_apps/agents.py†L1-L382】        |
 | Automation feedback    | Routes telemetry, governance hooks, and integration payloads through the broader ecosystem so retraining and compliance stay in lockstep. | `docs/dynamic-capital-ecosystem-anatomy.md`【F:docs/dynamic-capital-ecosystem-anatomy.md†L16-L288】 |
 
 ## 2. Signal Lifecycle
@@ -38,8 +38,8 @@ Brain remains aligned with execution, memory, and governance surfaces.
 
 ## 3. Lobe Responsibilities
 
-| Lobe                    | Signal focus                                                               | Implementation notes                                                                                                                                    |
-| ----------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lobe                    | Signal focus                                                               | Implementation notes                                                                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Lorentzian Distance** | Detects outsized price deviations relative to a reference trajectory.      | Produces a contrarian score when deviation exceeds calibrated sensitivity, surfacing rationale text for auditability.【F:dynamic.intelligence.ai_apps/fusion.py†L54-L77】 |
 | **Trend Momentum**      | Blends directional bias with measured momentum intensity.                  | Maintains neutral stance until thresholds are hit, preventing premature flips during sideways regimes.【F:dynamic.intelligence.ai_apps/fusion.py†L83-L105】               |
 | **Sentiment**           | Aggregates qualitative feeds and keyword bias.                             | Enforces a floor on confidence and weights lexical tone to stabilise noisy social inputs.【F:dynamic.intelligence.ai_apps/fusion.py†L107-L142】                           |
@@ -88,7 +88,8 @@ Use the checklist below when deploying updates or reviewing production health:
   through Hands, Heart, Voice, and Memory
   layers.【F:docs/dynamic-capital-ecosystem-anatomy.md†L16-L288】
 - Start new lobes from the `SignalLobe` protocol, keeping score, confidence, and
-  rationale values bounded for consistency.【F:dynamic.intelligence.ai_apps/fusion.py†L24-L167】
+  rationale values bounded for
+  consistency.【F:dynamic.intelligence.ai_apps/fusion.py†L24-L167】
 - Capture evaluation metrics and experiment metadata so the training module can
   automatically recalibrate sensitivity thresholds over
   time.【F:dynamic.intelligence.ai_apps/training.py†L14-L48】
@@ -104,9 +105,9 @@ the automation stack scales across strategies and market conditions.
 Dynamic AI now exposes a persona chain that mirrors the roadmap’s research →
 execution → risk flow. The `ResearchAgent`, `ExecutionAgent`, and `RiskAgent`
 share a common result contract so orchestration can serialise outcomes without
-bespoke glue.【F:dynamic.intelligence.ai_apps/agents.py†L22-L365】 The sync helper
-`run_dynamic_agent_cycle` wires the personas together, expecting the following
-context keys when executed manually or via `AlgorithmSyncAdapter`:
+bespoke glue.【F:dynamic.intelligence.ai_apps/agents.py†L22-L365】 The sync
+helper `run_dynamic_agent_cycle` wires the personas together, expecting the
+following context keys when executed manually or via `AlgorithmSyncAdapter`:
 
 1. `research_payload` – optional research inputs
    (technical/fundamental/sentiment/macro) consumed by the analysis persona.
@@ -128,8 +129,8 @@ Cold starts are now optimised through cached persona instances. Call
 `get_dynamic_start_agents()` to materialise the shared research/execution/risk
 chain, override factories with `configure_dynamic_start_agents()`, and invoke
 `reset_dynamic_start_agents()` when you need to swap or reset
-personas.【F:dynamic.intelligence.ai_apps/agents.py†L694-L808】 The sync helper also honours an
-optional `dynamic_start_agents` (alias `start_agents`) mapping inside the
-context, so orchestration can pass pre-warmed persona objects without incurring
-new allocations on every
+personas.【F:dynamic.intelligence.ai_apps/agents.py†L694-L808】 The sync helper
+also honours an optional `dynamic_start_agents` (alias `start_agents`) mapping
+inside the context, so orchestration can pass pre-warmed persona objects without
+incurring new allocations on every
 cycle.【F:algorithms/python/dynamic.intelligence.ai_apps_sync.py†L202-L237】

--- a/docs/dynamic-capital-model-context-protocol.md
+++ b/docs/dynamic-capital-model-context-protocol.md
@@ -10,8 +10,9 @@ Optimizing MCP for Dynamic Capital means:
 - Giving the Telegram deposit assistant, Go orchestration service, and Supabase
   edge functions a shared definition of the context they consume.
 - Routing investor, market, and operational knowledge through the same
-  guardrails that already power `supabase/functions`, `dynamic.intelligence.ai_apps`,
-  `dynamic_bridge`, and the web surfaces in `apps`.
+  guardrails that already power `supabase/functions`,
+  `dynamic.intelligence.ai_apps`, `dynamic_bridge`, and the web surfaces in
+  `apps`.
 - Preserving compliance and latency guarantees while the platform scales
   multi-LLM experimentation and trading automation.
 
@@ -23,8 +24,9 @@ context, including:
 - **Runtime services** – Supabase edge functions (e.g.,
   `supabase/functions/miniapp`, `.../dynamic-hedge`), the Go service under
   `go-service`, and the WebSocket bridges in `dynamic_bridge`.
-- **AI orchestration** – Modules inside `dynamic.intelligence.ai_apps`, retrieval tooling in
-  `dynamic_memory`, and evaluation harnesses in `dynamic_library` and `grok-1`.
+- **AI orchestration** – Modules inside `dynamic.intelligence.ai_apps`,
+  retrieval tooling in `dynamic_memory`, and evaluation harnesses in
+  `dynamic_library` and `grok-1`.
 - **Client experiences** – Telegram bot flows, the Next.js Mini App (`apps`),
   analyst dashboards, and broadcast automations.
 - **Operational tooling** – Observability and compliance utilities inside
@@ -33,12 +35,12 @@ context, including:
 
 ## Context Value Streams
 
-| Value Stream                           | Primary Surfaces                                                                                   | Core Context Packages                                                        | Repository Touchpoints                                                                            |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Telegram deposit & KYC automation**  | Supabase functions `receipt-*`, `verify-*`, `payments-*`; Telegram bot sync jobs; Go webhook relay | Task manifest + investor snapshot + compliance policy + live payment signals | `apps` (Mini App UI), `supabase/functions/telegram-*`, `go-service`, `dynamic_memory` schemas     |
-| **Dynamic Hedge & liquidity controls** | Supabase function `dynamic-hedge`, `dynamic.intelligence.ai_apps/hedge.py`, MT5 bridge orchestrator                  | Risk envelope, market depth snapshot, treasury controls                      | `dynamic.intelligence.ai_apps`, `dynamic_bridge/mt5_bridge.py`, `supabase/functions/dynamic-hedge`, `dynamic_cache` |
-| **Multi-LLM strategy studio**          | `dynamic.intelligence.ai_apps` adapters, `supabase/functions/analysis-ingest`, notebooks in `ml`                     | Strategy brief, benchmark corpus, telemetry traces                           | `dynamic.intelligence.ai_apps/fusion.py`, `ml`, `dynamic_library`, `supabase/functions/analysis-ingest`             |
-| **Investor intelligence & broadcasts** | Broadcast Cron (`supabase/functions/broadcast-*`), analytics collectors, Next.js dashboards        | Audience cohort, messaging policy, market intel bundle                       | `broadcast`, `supabase/functions/analytics-*`, `apps`, `dynamic_reference`                        |
+| Value Stream                           | Primary Surfaces                                                                                    | Core Context Packages                                                        | Repository Touchpoints                                                                                              |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Telegram deposit & KYC automation**  | Supabase functions `receipt-*`, `verify-*`, `payments-*`; Telegram bot sync jobs; Go webhook relay  | Task manifest + investor snapshot + compliance policy + live payment signals | `apps` (Mini App UI), `supabase/functions/telegram-*`, `go-service`, `dynamic_memory` schemas                       |
+| **Dynamic Hedge & liquidity controls** | Supabase function `dynamic-hedge`, `dynamic.intelligence.ai_apps/hedge.py`, MT5 bridge orchestrator | Risk envelope, market depth snapshot, treasury controls                      | `dynamic.intelligence.ai_apps`, `dynamic_bridge/mt5_bridge.py`, `supabase/functions/dynamic-hedge`, `dynamic_cache` |
+| **Multi-LLM strategy studio**          | `dynamic.intelligence.ai_apps` adapters, `supabase/functions/analysis-ingest`, notebooks in `ml`    | Strategy brief, benchmark corpus, telemetry traces                           | `dynamic.intelligence.ai_apps/fusion.py`, `ml`, `dynamic_library`, `supabase/functions/analysis-ingest`             |
+| **Investor intelligence & broadcasts** | Broadcast Cron (`supabase/functions/broadcast-*`), analytics collectors, Next.js dashboards         | Audience cohort, messaging policy, market intel bundle                       | `broadcast`, `supabase/functions/analytics-*`, `apps`, `dynamic_reference`                                          |
 
 Use these streams to scope new integrations: each package inherits the base
 protocol while tailoring payload shape to the consuming surface.
@@ -63,13 +65,14 @@ protocol while tailoring payload shape to the consuming surface.
    `supabase/functions/*/config`) and Markdown conventions under `docs/` for
    narrative fragments. Every record carries provenance metadata: `source_id`,
    `hash`, `sensitivity`, and TTL.
-3. **Ranking** – Apply retrieval heuristics from `dynamic.intelligence.ai_apps/analysis.py`,
-   embeddings built in `dynamic_memory_reconsolidation`, or rule engines inside
+3. **Ranking** – Apply retrieval heuristics from
+   `dynamic.intelligence.ai_apps/analysis.py`, embeddings built in
+   `dynamic_memory_reconsolidation`, or rule engines inside
    `dynamic.intelligence.ai_apps/risk.py` depending on the stream.
 4. **Packaging** – Compose context packages via dedicated assemblers
    (recommended location: `supabase/functions/context-*` or reusable utilities
-   in `dynamic.intelligence.ai_apps/core.py`). Sign payloads with Supabase JWT scoped to access
-   tier.
+   in `dynamic.intelligence.ai_apps/core.py`). Sign payloads with Supabase JWT
+   scoped to access tier.
 5. **Delivery** – Surface packages through:
    - HTTPS responses to Telegram bot and Mini App.
    - WebSocket or gRPC pipes managed by `dynamic_bridge/orchestrator.py`.
@@ -81,8 +84,9 @@ protocol while tailoring payload shape to the consuming surface.
 - Publish OpenAPI specs per package in `docs/api/` (or co-located with the
   function) and JSON Schema definitions alongside each adapter or under a
   dedicated `docs/schemas/` directory.
-- Maintain Adapter SDKs in `dynamic_tool_kits` (TypeScript) and `dynamic.intelligence.ai_apps`
-  (Python) with automated guardrail checks before dispatch.
+- Maintain Adapter SDKs in `dynamic_tool_kits` (TypeScript) and
+  `dynamic.intelligence.ai_apps` (Python) with automated guardrail checks before
+  dispatch.
 - Emit audit events (`context.delivered`, `context.dropped`,
   `context.escalated`) through Supabase `analytics-data` function into analytics
   dashboards consumed by Ops and Compliance.
@@ -134,8 +138,8 @@ protocol while tailoring payload shape to the consuming surface.
   adapter (Telegram bot, Go service, MT5 bridge, analytics exports) to the
   minimal tier.
 - Perform **Redaction** using deterministic tokenization utilities in
-  `dynamic.intelligence.ai_apps/core.py` before embeddings or prompt assembly. Store reversible
-  secrets in Vault or Supabase secrets, never in code.
+  `dynamic.intelligence.ai_apps/core.py` before embeddings or prompt assembly.
+  Store reversible secrets in Vault or Supabase secrets, never in code.
 - Run **Drift Audits** weekly via a scheduled function
   (`supabase/functions/context-drift-audit`) comparing delivered packages vs.
   canonical records; escalate anomalies >2% divergence.
@@ -193,14 +197,14 @@ Key metrics:
 
 ## Repository Crosswalk
 
-| Capability           | Directory / Artifact                                                        | Notes                                   |
-| -------------------- | --------------------------------------------------------------------------- | --------------------------------------- |
+| Capability           | Directory / Artifact                                                                          | Notes                                   |
+| -------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------- |
 | Context assemblers   | `supabase/functions/context-*` (new) or shared libs in `dynamic.intelligence.ai_apps/core.py` | Centralize serialization + signing      |
-| Retrieval embeddings | `dynamic_memory`, `dynamic_memory_reconsolidation`                          | Manage vector stores, decay policies    |
+| Retrieval embeddings | `dynamic_memory`, `dynamic_memory_reconsolidation`                                            | Manage vector stores, decay policies    |
 | Hedge orchestration  | `dynamic.intelligence.ai_apps/hedge.py`, `dynamic_bridge/mt5_bridge.py`                       | Ensure MCP packages drive trading logic |
 | Multi-LLM tooling    | `dynamic.intelligence.ai_apps`, `dynamic_library`, `ml`                                       | Standardize experiment inputs           |
-| Client adapters      | `apps`, `go-service`, `broadcast`                                           | Respect tiered access + policy tagging  |
-| Compliance artifacts | `SECURITY.md`, `docs/compliance/*`, Supabase migrations                     | Keep protocol changes reviewable        |
+| Client adapters      | `apps`, `go-service`, `broadcast`                                                             | Respect tiered access + policy tagging  |
+| Compliance artifacts | `SECURITY.md`, `docs/compliance/*`, Supabase migrations                                       | Keep protocol changes reviewable        |
 
 Adhering to this protocol keeps model-facing systems consistent with the rest of
 the Dynamic Capital stack while giving teams a transparent, auditable framework

--- a/docs/dynamic-capital-token-review.md
+++ b/docs/dynamic-capital-token-review.md
@@ -74,7 +74,8 @@
 
 - **Profit-responsive treasury logic.** Burn, reward, and retention splits with
   rounding reconciliation guardrails ensure trading profits translate into
-  policy-compliant treasury actions.【F:dynamic.platform.token/treasury.py†L24-L130】
+  policy-compliant treasury
+  actions.【F:dynamic.platform.token/treasury.py†L24-L130】
 - **Liquidity guardrails.** Launch strategy, depth requirements, and buyback
   levers anchor token liquidity to treasury commitments and monitoring cadences
   spelled out in the
@@ -99,7 +100,8 @@
   allocations.【F:docs/dynamic-capital-ton-whitepaper.md†L36-L50】【F:docs/tonstarter/tokenomics-tables.md†L7-L17】
 - **Test-backed guardrails:** Loss coverage and custom distribution scenarios
   are unit-tested, validating both defensive notes and operator-tuned
-  burn/reward splits.【F:tests/dynamic.platform.token/test_dct_engine.py†L173-L205】
+  burn/reward
+  splits.【F:tests/dynamic.platform.token/test_dct_engine.py†L173-L205】
 
 ## Risks & Gaps
 
@@ -141,7 +143,8 @@
    mandate.【F:dynamic.platform.token/treasury.py†L92-L145】【F:docs/dct-intelligence-driven-tokenomics.md†L52-L107】
 3. **Neutral-trade telemetry:** Emit explicit zero-impact `TreasuryEvent`
    records so dashboards can monitor volume even when P&L is flat, preventing
-   blind spots in review meetings.【F:dynamic.platform.token/treasury.py†L59-L128】
+   blind spots in review
+   meetings.【F:dynamic.platform.token/treasury.py†L59-L128】
 4. **Residual auto-recycling:** Extend the allocation engine or treasury loop to
    recycle residual supply into reserves or future epochs automatically,
    reducing manual reconciliation work noted during

--- a/docs/dynamic-trading-telemetry-maldivian.md
+++ b/docs/dynamic-trading-telemetry-maldivian.md
@@ -15,7 +15,7 @@ execution.
 | Context        | `dynamic_regimes`                                                          | Market state tags                         | Monsoon watch stations         | Refresh cadence & drift detection      |
 | Signal         | `dynamic_candles`, `dynamic_indicators`, `dynamic_volume`, `dynamic_quote` | Price, derived signals, amplitude, spread | Reef beacons & lagoon currents | Signal cleanliness, latency budgets    |
 | Microstructure | `dynamic_orderflow`, `dynamic_liquidity`                                   | Execution flow, depth, slippage           | Atoll channels & reef passes   | Routing precision, slippage tolerances |
-| Control        | `dynamic.trading.logic`, `dynamic_sync`                                             | Capital guardrails, time alignment        | Helmsman & celestial navigator | Guardrail alerts, clock skew           |
+| Control        | `dynamic.trading.logic`, `dynamic_sync`                                    | Capital guardrails, time alignment        | Helmsman & celestial navigator | Guardrail alerts, clock skew           |
 | Oracle         | Intelligence scoring, mentorship, tokenomics                               | Composite scores, rituals                 | Council of Navigators          | Outcome attribution, narrative hooks   |
 
 ## Layered Architecture
@@ -96,8 +96,8 @@ execution.
 3. **Fleet Coordination**
    - Use `dynamic_sync` dashboards to ensure clock drift <±50ms across all
      feeds.
-   - Validate `dynamic.trading.logic` guardrails, recording ballast adjustments (position
-     caps) per strategy pod.
+   - Validate `dynamic.trading.logic` guardrails, recording ballast adjustments
+     (position caps) per strategy pod.
 4. **Oracle Council Session**
    - Run composite scoring, then narrate the verdict with Maldivian metaphors
      for governance, social, and training channels.

--- a/docs/dynamic_agi_inventory.md
+++ b/docs/dynamic_agi_inventory.md
@@ -1,8 +1,9 @@
 # Dynamic AGI Inventory
 
 This catalog summarises the modules, classes, and workflows that make up the
-`dynamic.intelligence.agi` package. Use it to understand how evaluation, self-improvement,
-and fine-tuning artifacts fit together and where inventory-sensitive hooks live.
+`dynamic.intelligence.agi` package. Use it to understand how evaluation,
+self-improvement, and fine-tuning artifacts fit together and where
+inventory-sensitive hooks live.
 
 ## Exported surface
 
@@ -28,7 +29,8 @@ for the full AGI toolchain.【F:dynamic.intelligence.agi/**init**.py†L1-L29】
 - **Evaluation pipeline** – `DynamicAGIModel.evaluate` prepares the market
   context, merges research, enforces risk, sizes exposure, and forwards treasury
   plus inventory state into the market-making layer before emitting diagnostics
-  and optional self-improvement feedback.【F:dynamic.intelligence.agi/model.py†L232-L326】
+  and optional self-improvement
+  feedback.【F:dynamic.intelligence.agi/model.py†L232-L326】
 - **Inventory-aware market making** – The orchestrator passes current inventory
   into `DynamicFusionAlgo.mm_parameters`, where elevated exposure increases the
   gamma setting to rein in quoting
@@ -71,14 +73,16 @@ for the full AGI toolchain.【F:dynamic.intelligence.agi/**init**.py†L1-L29】
 - **Telemetry-to-dataset bridge** – `DynamicAGIFineTuner` converts
   `LearningSnapshot` telemetry into prompt/completion examples, optionally
   batches them, and returns dataset summaries with default tag context for
-  downstream fine-tuning jobs.【F:dynamic.intelligence.agi/fine_tune.py†L233-L285】
+  downstream fine-tuning
+  jobs.【F:dynamic.intelligence.agi/fine_tune.py†L233-L285】
 
 ## Local machine integration (`local_machine.py`)
 
 - **Task configuration** – `AGILocalMachineTaskConfig` supplies default command
   templates plus category- or action-specific overrides, keeping working
   directory, environment, and resource estimates consistent when converting
-  plans into automation tasks.【F:dynamic.intelligence.agi/local_machine.py†L52-L117】
+  plans into automation
+  tasks.【F:dynamic.intelligence.agi/local_machine.py†L52-L117】
 - **Plan materialisers** – `build_local_machine_plan_from_improvement` and
   `build_local_machine_plan_from_output` translate improvement plans or AGI
   outputs into `LocalMachinePlan` instances so Dynamic AGI recommendations can

--- a/docs/dynamic_engines_usage.md
+++ b/docs/dynamic_engines_usage.md
@@ -28,8 +28,8 @@ Use this checklist when auditing an environment or planning improvements. Each
 subsection maps to the detailed guidance later in the document.
 
 - [ ] **Shim coverage** – inventory which orchestration engines are needed,
-      confirm they are exported via `dynamic.platform.engines`, and document any new
-      modules that must be registered in `_ENGINE_EXPORTS`.
+      confirm they are exported via `dynamic.platform.engines`, and document any
+      new modules that must be registered in `_ENGINE_EXPORTS`.
 - [ ] **Persona chain fit** – review the existing research → execution → risk
       flow, note where persona overrides are required, and schedule updates
       through `configure_dynamic_start_agents`.
@@ -48,10 +48,10 @@ into the team backlog.
 
 ## 1. Import engines through the `dynamic.platform.engines` shim
 
-The legacy-compatible `dynamic.platform.engines` module forwards attributes to the domain
-packages on demand, so you can keep call sites stable while implementations live
-beside their data models. Update `_ENGINE_EXPORTS` if you add a new engine so it
-becomes available via a single import path.
+The legacy-compatible `dynamic.platform.engines` module forwards attributes to
+the domain packages on demand, so you can keep call sites stable while
+implementations live beside their data models. Update `_ENGINE_EXPORTS` if you
+add a new engine so it becomes available via a single import path.
 
 ```python
 from dynamic.platform.engines import DynamicSpaceEngine, DynamicStateEngine
@@ -59,10 +59,11 @@ from dynamic.platform.engines import DynamicSpaceEngine, DynamicStateEngine
 
 _Optimisation tips:_
 
-- `dynamic.platform.engines.__getattr__` lazily imports the source module and caches the
-  symbol, covering engines such as `DynamicAssignEngine`, `DynamicSpaceEngine`,
-  and `DynamicStateEngine`. This keeps optional dependencies dormant until
-  needed and mirrors the historical surface area without duplicating
+- `dynamic.platform.engines.__getattr__` lazily imports the source module and
+  caches the symbol, covering engines such as `DynamicAssignEngine`,
+  `DynamicSpaceEngine`, and `DynamicStateEngine`. This keeps optional
+  dependencies dormant until needed and mirrors the historical surface area
+  without duplicating
   logic.【F:dynamic.platform.engines/**init**.py†L1-L123】【F:dynamic.platform.engines/**init**.py†L168-L212】
 - When adding a new engine, expose only the public entry points in
   `_ENGINE_EXPORTS` to avoid leaking experimental utilities.

--- a/docs/dynamic_inventory.md
+++ b/docs/dynamic_inventory.md
@@ -275,8 +275,8 @@ assets:
 
 ## Next steps to enrich the knowledge base
 
-1. Map relationships across domains (e.g., `dynamic.intelligence.ai_apps` → `dynamic_agents` →
-   `dynamic_task_manager`).
+1. Map relationships across domains (e.g., `dynamic.intelligence.ai_apps` →
+   `dynamic_agents` → `dynamic_task_manager`).
 2. Standardize a reusable playbook template covering overview, principles, use
    cases, examples, and links.
 3. Build navigational indices such as a table of contents or a search-friendly

--- a/docs/knowledge-base-books-ingestion.md
+++ b/docs/knowledge-base-books-ingestion.md
@@ -54,8 +54,8 @@ OneDrive/DynamicAI_DB/
    - Use `pdfplumber` or `PyPDF2` for PDFs, `python -m tika` for mixed formats,
      and `pandoc` for DOCX/EPUB conversions.
    - Run `python tools/books_corpus.py --pdf-dir data/knowledge_base/books/raw`
-     to batch extract mirrored books into `extracted/` and emit a
-     page-granular JSONL corpus under `processed/`.
+     to batch extract mirrored books into `extracted/` and emit a page-granular
+     JSONL corpus under `processed/`.
    - Normalise whitespace, remove boilerplate (copyright pages, tables of
      contents), and preserve headings with Markdown markers.
 3. **Chunking**

--- a/docs/maldivian_quantum_cheat_sheet.md
+++ b/docs/maldivian_quantum_cheat_sheet.md
@@ -6,23 +6,21 @@
 
 - **|0⟩ / ޒޮރު ތަކުން**: ބޭސިކް ސްޓޭޓު ("ތިޔަ" އެއް އަދި މިނަވަން)
 - **|1⟩ / އެއް އަދި އަށްނޫން**: ކުރި ސްޓޭޓު
-- **ސުޕަރޕޯޒިޝަން (Superposition)**:
-  \[
-  |\psi\rangle = \alpha |0\rangle + \beta |1\rangle
-  \]
-  އެހެން ދެ ސްޓޭޓުން އައު ރައްކާން ކުރަން އެކު ރާއްޖެ.
-- **މެޒަރމަންޓް (Measurement)**: ސްޓޭޓު |0⟩ އެއް |1⟩ އެއް އަށް އަންނަ އަދި ޕްރޮބޭބިލިޓީގެ ސަލާޒުތަކުން \(|\alpha|^2\) އެއް \(|\beta|^2\).
+- **ސުޕަރޕޯޒިޝަން (Superposition)**: \[ |\psi\rangle = \alpha |0\rangle + \beta
+  |1\rangle \] އެހެން ދެ ސްޓޭޓުން އައު ރައްކާން ކުރަން އެކު ރާއްޖެ.
+- **މެޒަރމަންޓް (Measurement)**: ސްޓޭޓު |0⟩ އެއް |1⟩ އެއް އަށް އަންނަ އަދި ޕްރޮބޭބިލިޓީގެ ސަލާޒުތަކުން
+  \(|\alpha|^2\) އެއް \(|\beta|^2\).
 
 ## 2. ކޮމަން Quantum ގޭޓުތައް
 
-| ގޭޓު | ސިމްބަލް | މެޓްރިކްސް | އެފެކްޓް |
-|------|-----------|--------------|-------------|
-| Pauli-X | ކޯލަ ފުރަ | \(\begin{bmatrix}0 & 1 \\ 1 & 0\end{bmatrix}\) | ބިޓް ފްލިޕް (ސިޓުއަށް ކުރަން) |
-| Pauli-Y | އަވަށް ފުރަ | \(\begin{bmatrix}0 & -i \\ i & 0\end{bmatrix}\) | ފޭޒް + ބިޓް ފްލިޕް |
-| Pauli-Z | ދިން ފުރަ | \(\begin{bmatrix}1 & 0 \\ 0 & -1\end{bmatrix}\) | ފޭޒް ފްލިޕް |
-| Hadamard | ހަޑަމާޑް | \(\tfrac{1}{\sqrt{2}}\begin{bmatrix}1 & 1 \\ 1 & -1\end{bmatrix}\) | ސުޕަރޕޯޒިޝަން އިތުރުކުރޭ |
-| CNOT | ސީނޯޓް | — | ކިއުބިޓް އެންޓޭންގޯލްކުރޭ |
-| Phase (S/T) | ފޭޒް ގޭޓު | — | ފޭޒް ސިޕްޓު |
+| ގޭޓު          | ސިމްބަލް   | މެޓްރިކްސް                                                              | އެފެކްޓް              |
+| ----------- | ------ | ------------------------------------------------------------------ | ----------------- |
+| Pauli-X     | ކޯލަ ފުރަ  | \(\begin{bmatrix}0 & 1 \\ 1 & 0\end{bmatrix}\)                     | ބިޓް ފްލިޕް (ސިޓުއަށް ކުރަން) |
+| Pauli-Y     | އަވަށް ފުރަ | \(\begin{bmatrix}0 & -i \\ i & 0\end{bmatrix}\)                    | ފޭޒް + ބިޓް ފްލިޕް       |
+| Pauli-Z     | ދިން ފުރަ  | \(\begin{bmatrix}1 & 0 \\ 0 & -1\end{bmatrix}\)                    | ފޭޒް ފްލިޕް            |
+| Hadamard    | ހަޑަމާޑް   | \(\tfrac{1}{\sqrt{2}}\begin{bmatrix}1 & 1 \\ 1 & -1\end{bmatrix}\) | ސުޕަރޕޯޒިޝަން އިތުރުކުރޭ     |
+| CNOT        | ސީނޯޓް    | —                                                                  | ކިއުބިޓް އެންޓޭންގޯލްކުރޭ     |
+| Phase (S/T) | ފޭޒް ގޭޓު  | —                                                                  | ފޭޒް ސިޕްޓު            |
 
 ### ASCII ސަޓްކޯލް ގޭޓު ޑައިގްރާމުތައް
 
@@ -87,52 +85,69 @@ MALDIVIAN_PERSONA = {
 
 ## 8. English Dynamic Quantum Engine
 
-> A rapid-reference layer that mirrors the Dhivehi notes while staying ready for global collaborators, interns, or visiting researchers. The focus below is on keeping the *dynamic* quantum engine tuned, observable, and deployable.
+> A rapid-reference layer that mirrors the Dhivehi notes while staying ready for
+> global collaborators, interns, or visiting researchers. The focus below is on
+> keeping the _dynamic_ quantum engine tuned, observable, and deployable.
 
 **Core Modules**
 
 - **Lookup** – Fast memory jolts for fundamentals (states, gates, diagnostics).
-- **Optimize** – A loop that cycles profile → stabilize → balance → validate → deploy.
-- **Coach** – Ready-made prompts and bilingual embeddings to feed mentorship bots.
-- **Operate** – Rollout checklist so the English cheat engine stays synchronized with the Dhivehi guide.
+- **Optimize** – A loop that cycles profile → stabilize → balance → validate →
+  deploy.
+- **Coach** – Ready-made prompts and bilingual embeddings to feed mentorship
+  bots.
+- **Operate** – Rollout checklist so the English cheat engine stays synchronized
+  with the Dhivehi guide.
 
 ### 8.1 Quick Lookup Grid
 
-| Topic | Core Idea | Mnemonic |
-|-------|-----------|----------|
-| Qubit States | `|0⟩` is the computational ground state, `|1⟩` is the excited state. | “Zero is calm sea, one is rising wave.” |
-| Superposition | Coefficients `α` and `β` define amplitudes; probabilities are `|α|²` and `|β|²`. | “Amplitudes square into outcomes.” |
-| Measurement | Observing collapses the state to `|0⟩` or `|1⟩` depending on amplitudes. | “Look and the wave picks a side.” |
-| Entanglement | CNOT entangles a control and target qubit, correlating outcomes. | “One switch tunes another.” |
-| Phase Gates | `S` and `T` rotate phase without changing measured probabilities. | “Phase shifts hide in angles.” |
+| Topic         | Core Idea                                                         | Mnemonic                               |
+| ------------- | ----------------------------------------------------------------- | -------------------------------------- |
+| Qubit States  | `                                                                 | 0⟩`is the computational ground state,` |
+| Superposition | Coefficients `α` and `β` define amplitudes; probabilities are `   | α                                      |
+| Measurement   | Observing collapses the state to `                                | 0⟩`or`                                 |
+| Entanglement  | CNOT entangles a control and target qubit, correlating outcomes.  | “One switch tunes another.”            |
+| Phase Gates   | `S` and `T` rotate phase without changing measured probabilities. | “Phase shifts hide in angles.”         |
 
 ### 8.2 Dynamic Engine Optimization Loop
 
-1. **Profile** – Capture execution depth, gate counts, and transpiler metrics (depth, 2-qubit error) for each circuit build.
-2. **Stabilize** – Apply noise-aware transpilation (level 2+) and insert dynamical decoupling where idle windows exceed coherence limits.
-3. **Balance** – Swap-qubit mapping to minimize CNOT distance; prefer hardware-native basis gates to reduce synthesis overhead.
-4. **Validate** – Run process tomography or randomized benchmarking on updated subroutines to ensure fidelity > 0.98 before release.
-5. **Deploy** – Promote optimized circuits into the Maldivian mentorship bot or AGI Oracle with paired Dhivehi/English annotations.
+1. **Profile** – Capture execution depth, gate counts, and transpiler metrics
+   (depth, 2-qubit error) for each circuit build.
+2. **Stabilize** – Apply noise-aware transpilation (level 2+) and insert
+   dynamical decoupling where idle windows exceed coherence limits.
+3. **Balance** – Swap-qubit mapping to minimize CNOT distance; prefer
+   hardware-native basis gates to reduce synthesis overhead.
+4. **Validate** – Run process tomography or randomized benchmarking on updated
+   subroutines to ensure fidelity > 0.98 before release.
+5. **Deploy** – Promote optimized circuits into the Maldivian mentorship bot or
+   AGI Oracle with paired Dhivehi/English annotations.
 
 ### 8.3 Rapid Diagnostic Checklist
 
-| Signal | Healthy Range | Investigate When |
-|--------|---------------|------------------|
-| Depth / Coherence Ratio | `< 0.6` | Ratio climbs above `0.8` → trim ancillae or parallelize gates. |
-| Two-Qubit Error Rate | `< 2.5%` | Error spikes → remap qubits, enable echo sequences. |
-| Shot Variance | `< 5%` across batches | Drift → recalibrate measurement or increase shots. |
-| Classical Latency | `< 120 ms` | Latency > 200 ms → cache compiled circuits, prefetch results. |
+| Signal                  | Healthy Range         | Investigate When                                               |
+| ----------------------- | --------------------- | -------------------------------------------------------------- |
+| Depth / Coherence Ratio | `< 0.6`               | Ratio climbs above `0.8` → trim ancillae or parallelize gates. |
+| Two-Qubit Error Rate    | `< 2.5%`              | Error spikes → remap qubits, enable echo sequences.            |
+| Shot Variance           | `< 5%` across batches | Drift → recalibrate measurement or increase shots.             |
+| Classical Latency       | `< 120 ms`            | Latency > 200 ms → cache compiled circuits, prefetch results.  |
 
 ### 8.4 Ready-Made Prompts
 
-- **Explain to a junior engineer**: “Summarize the Maldivian Quantum cheat sheet in three sentences, focusing on how qubit basics, gates, and measurement interrelate.”
-- **Debug assistance**: “Given a two-qubit circuit with H on qubit 0 and CX(0,1), describe the expected entanglement signature and probability distribution.”
-- **Optimization retro**: “List the top three gate-depth reductions achieved after remapping to the new topology and flag any trade-offs in fidelity.”
-- **Visualization request**: “Render ASCII circuit art for a Bell pair and note which gates introduce phase versus amplitude changes.”
+- **Explain to a junior engineer**: “Summarize the Maldivian Quantum cheat sheet
+  in three sentences, focusing on how qubit basics, gates, and measurement
+  interrelate.”
+- **Debug assistance**: “Given a two-qubit circuit with H on qubit 0 and
+  CX(0,1), describe the expected entanglement signature and probability
+  distribution.”
+- **Optimization retro**: “List the top three gate-depth reductions achieved
+  after remapping to the new topology and flag any trade-offs in fidelity.”
+- **Visualization request**: “Render ASCII circuit art for a Bell pair and note
+  which gates introduce phase versus amplitude changes.”
 
 ### 8.5 Dual-Language Embedding Tip
 
-When embedding into an AGI Oracle or mentorship bot, pair each Dhivehi block with its English summary:
+When embedding into an AGI Oracle or mentorship bot, pair each Dhivehi block
+with its English summary:
 
 ```json
 {
@@ -142,18 +157,21 @@ When embedding into an AGI Oracle or mentorship bot, pair each Dhivehi block wit
 }
 ```
 
-This “dynamic quantum engine” format keeps the Maldivian identity up front while delivering globally accessible context for rapid cross-team alignment and performance tuning.
+This “dynamic quantum engine” format keeps the Maldivian identity up front while
+delivering globally accessible context for rapid cross-team alignment and
+performance tuning.
 
 ### 8.6 Bilingual Deployment Sprint
 
-| Phase | English Engine Task | Dhivehi Mirror |
-|-------|---------------------|----------------|
-| Kickoff | Confirm shared glossary (`|0⟩`, `|1⟩`, superposition, entanglement). | ދިވެހި ބަޔަކުން ބަލާލައްވާ ޓަމިނޯލޮޖީ ސަލާޒު. |
-| Build | Draft circuits, record metrics, and log ASCII diagrams. | ސިރުއިޓުތައް ހަދާނީ އަދި ކުރިއަރާއި ނިޒާމަތް ލިޔުން. |
-| Review | Run optimization loop, capture fidelity deltas, prep release notes. | ފެންނަނީ އޮޕްޓިމައިޒޭޝަން ސަރކިޓު ނަގައިފި, ފިޑެލިޓީ އިތުރުކުރޭ. |
-| Deploy | Sync persona prompts, embeddings, and monitoring dashboards. | މެންޓޯރު ޕްރޮމްޕްޓްތައް އަދި އެމްބެޑިންގްތަކެއް ހަދައިފި. |
-| Retrospective | Compare usage analytics, collect next-sprint prompts, refresh glossaries. | އަތޮޅު ވަރަށް އެންޑަރްސްޓެއިންގް ރިޕޯޓްތަކުން ކުރެވޭ ސައްޙަލާތް.
+| Phase         | English Engine Task                                                       | Dhivehi Mirror                       |
+| ------------- | ------------------------------------------------------------------------- | ------------------------------------ |
+| Kickoff       | Confirm shared glossary (`                                                | 0⟩`,`                                |
+| Build         | Draft circuits, record metrics, and log ASCII diagrams.                   | ސިރުއިޓުތައް ހަދާނީ އަދި ކުރިއަރާއި ނިޒާމަތް ލިޔުން.        |
+| Review        | Run optimization loop, capture fidelity deltas, prep release notes.       | ފެންނަނީ އޮޕްޓިމައިޒޭޝަން ސަރކިޓު ނަގައިފި, ފިޑެލިޓީ އިތުރުކުރޭ. |
+| Deploy        | Sync persona prompts, embeddings, and monitoring dashboards.              | މެންޓޯރު ޕްރޮމްޕްޓްތައް އަދި އެމްބެޑިންގްތަކެއް ހަދައިފި.      |
+| Retrospective | Compare usage analytics, collect next-sprint prompts, refresh glossaries. | އަތޮޅު ވަރަށް އެންޑަރްސްޓެއިންގް ރިޕޯޓްތަކުން ކުރެވޭ ސައްޙަލާތް.  |
 
 ---
 
-**ސަބަބު**: މި cheat sheet އަށް ފަރާތު ކުރާ އެއްޗެއް މައްސަލަކަށް ތަރުތީބާއި އިތުރުކުރާ މަލްޑިވިއްޔާ ބްރެނޑްގެ ބަޔަކުން ބޭނުންކުރޭ.
+**ސަބަބު**: މި cheat sheet އަށް ފަރާތު ކުރާ އެއްޗެއް މައްސަލަކަށް ތަރުތީބާއި އިތުރުކުރާ މަލްޑިވިއްޔާ ބްރެނޑްގެ ބަޔަކުން
+ބޭނުންކުރޭ.

--- a/docs/model-intelligence-infrastructure-reference.md
+++ b/docs/model-intelligence-infrastructure-reference.md
@@ -146,12 +146,13 @@ preserving observability, governance, and cost efficiency.
 
 ## Reference Implementation
 
-The `dynamic.intelligence.ai_apps.infrastructure` module materialises this playbook in code. It
-defines the shared role palette, per-domain blueprints, and a
-`DynamicInfrastructure` registry that can register modules, assign role owners,
-and emit operational playbooks. Use `build_default_infrastructure()` when you
-need a ready-to-run baseline covering core modules such as `dynamic_supabase`,
-`dynamic_memory`, `dynamic_task_manager`, and `dynamic_validator`.
+The `dynamic.intelligence.ai_apps.infrastructure` module materialises this
+playbook in code. It defines the shared role palette, per-domain blueprints, and
+a `DynamicInfrastructure` registry that can register modules, assign role
+owners, and emit operational playbooks. Use `build_default_infrastructure()`
+when you need a ready-to-run baseline covering core modules such as
+`dynamic_supabase`, `dynamic_memory`, `dynamic_task_manager`, and
+`dynamic_validator`.
 
 For hands-on experiments, the repo now provides lightweight compatibility
 packages for the core operational personas:

--- a/docs/multi-llm-algo-enhancement-roadmap.md
+++ b/docs/multi-llm-algo-enhancement-roadmap.md
@@ -48,10 +48,10 @@ actions progressively reduce risk while layering in new capabilities.
 2. **Evolve the agent graph** – Introduce specialized Dynamic AI personas for
    research, risk, and execution review. Define explicit inputs/outputs and
    mediation protocols so the orchestrator can route complex requests through
-   multi-agent chains without losing context. The `dynamic.intelligence.ai_apps/agents.py` module
-   and `run_dynamic_agent_cycle` helper now supply the reference implementation
-   for this flow, so future roadmap work can extend or customise personas rather
-   than recreating the
+   multi-agent chains without losing context. The
+   `dynamic.intelligence.ai_apps/agents.py` module and `run_dynamic_agent_cycle`
+   helper now supply the reference implementation for this flow, so future
+   roadmap work can extend or customise personas rather than recreating the
    plumbing.【F:dynamic.intelligence.ai_apps/agents.py†L1-L365】【F:algorithms/python/dynamic.intelligence.ai_apps_sync.py†L64-L143】
 3. **Automate self-audits** – Schedule nightly replay jobs that compare provider
    rationales against historical market truth. Escalate regressions to analysts

--- a/docs/onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md
+++ b/docs/onedrive-shares/ekqbarlpv7hljyb9tgpdmqcbzpxonb18k7rhjp2iv6ofmq-folder.md
@@ -1,9 +1,9 @@
 # Ekqbarlpv7hLjyb9tgPdMqcBZpxonB18K7RHjp2IV6ofmQ Share
 
 This note records the metadata helpers for the newly provided OneDrive folder
-that contains the reference **books** mirrored under
-`knowledge_base\\books`. Mirror the information here into any runbooks or
-scripts that need to access the remote resources.
+that contains the reference **books** mirrored under `knowledge_base\\books`.
+Mirror the information here into any runbooks or scripts that need to access the
+remote resources.
 
 ## Share details
 

--- a/docs/onedrive-shares/epbjvzo1-p1llt5krgojiseb2gmb94px6ni1vpqhpktrfa-folder.403.html
+++ b/docs/onedrive-shares/epbjvzo1-p1llt5krgojiseb2gmb94px6ni1vpqhpktrfa-folder.403.html
@@ -1,1 +1,45 @@
-<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Transitional//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'><html xmlns='http://www.w3.org/1999/xhtml'><head><meta content='text/html; charset=utf-8' http-equiv='content-type'/><style type='text/css'>body { font-family:Arial; margin-left:40px; }img  { border:0 none; }#content { margin-left: auto; margin-right: auto }#message h2 { font-size: 20px; font-weight: normal; color: #000000; margin: 34px 0px 0px 0px }#message p  { font-size: 13px; color: #000000; margin: 7px 0px 0px 0px }#errorref { font-size: 11px; color: #737373; margin-top: 41px }</style><title>Microsoft</title></head><body><div id='content'><div id='message'><h2>The request is blocked.</h2></div><div id='errorref'><span>Ref A: 0CAECA75943B49FC95D2CC51C1D220EE Ref B: DM2EDGE0509 Ref C: 2025-10-02T04:35:43Z</span></div></div></body></html>
+<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Transitional//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+    <style type="text/css">
+      body {
+        font-family: Arial;
+        margin-left: 40px;
+      }
+      img {
+        border: 0 none;
+      }
+      #content {
+        margin-left: auto;
+        margin-right: auto;
+      }
+      #message h2 {
+        font-size: 20px;
+        font-weight: normal;
+        color: #000000;
+        margin: 34px 0px 0px 0px;
+      }
+      #message p {
+        font-size: 13px;
+        color: #000000;
+        margin: 7px 0px 0px 0px;
+      }
+      #errorref {
+        font-size: 11px;
+        color: #737373;
+        margin-top: 41px;
+      }
+    </style>
+    <title>Microsoft</title>
+  </head>
+  <body>
+    <div id="content">
+      <div id="message"><h2>The request is blocked.</h2></div>
+      <div id="errorref">
+        <span>Ref A: 0CAECA75943B49FC95D2CC51C1D220EE Ref B: DM2EDGE0509 Ref C:
+          2025-10-02T04:35:43Z</span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/docs/onedrive-shares/epbjvzo1-p1llt5krgojiseb2gmb94px6ni1vpqhpktrfa-folder.md
+++ b/docs/onedrive-shares/epbjvzo1-p1llt5krgojiseb2gmb94px6ni1vpqhpktrfa-folder.md
@@ -30,8 +30,8 @@ export ONEDRIVE_SHARE_LINK="https://1drv.ms/f/c/2ff0428a2f57c7a4/EpBJVZO1-P1Llt5
   curl -I "${ONEDRIVE_SHARE_LINK}"
   ```
 
-- Following the redirect anonymously still yields the HTML stub with the
-  message `The request is blocked.` from `onedrive.live.com`. Capture the output
+- Following the redirect anonymously still yields the HTML stub with the message
+  `The request is blocked.` from `onedrive.live.com`. Capture the output
   whenever you retry the command to watch for changes in the Edge `Ref`
   telemetry or HTTP status:
 
@@ -124,9 +124,11 @@ large drops.
 
 ## Unauthenticated API probes (2025-10-02)
 
-Anonymous access is still blocked, but the OneDrive web client now exposes a couple of useful endpoints worth capturing:
+Anonymous access is still blocked, but the OneDrive web client now exposes a
+couple of useful endpoints worth capturing:
 
-- The landing page loads when requesting the long URL directly with a modern browser user agent, e.g.:
+- The landing page loads when requesting the long URL directly with a modern
+  browser user agent, e.g.:
 
   ```bash
   curl \
@@ -135,7 +137,9 @@ Anonymous access is still blocked, but the OneDrive web client now exposes a cou
     --output /tmp/epbjvzo1-landing.html
   ```
 
-- The frontend subsequently posts to the legacy API with an `authKey`. The request fails with a `userContentMigrated` response, but the `Location` header documents the current personal-content domain:
+- The frontend subsequently posts to the legacy API with an `authKey`. The
+  request fails with a `userContentMigrated` response, but the `Location` header
+  documents the current personal-content domain:
 
   ```bash
   curl \
@@ -144,6 +148,10 @@ Anonymous access is still blocked, but the OneDrive web client now exposes a cou
     "https://api.onedrive.com/v1.0/drives/${CID}/items/${RESID}/children?authKey=${AUTHKEY}&$top=100"
   ```
 
-- Following the redirect to `https://my.microsoftpersonalcontent.com/` without valid Microsoft credentials yields `401 Unauthenticated`. Capture the exact headers whenever authentication access is available.
+- Following the redirect to `https://my.microsoftpersonalcontent.com/` without
+  valid Microsoft credentials yields `401 Unauthenticated`. Capture the exact
+  headers whenever authentication access is available.
 
-These probes confirm that the share has been migrated to the personal content service; once a valid token is available the same payload should enumerate the folder without switching code paths.
+These probes confirm that the share has been migrated to the personal content
+service; once a valid token is available the same payload should enumerate the
+folder without switching code paths.

--- a/docs/onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md
+++ b/docs/onedrive-shares/eu8_trb65jdbrll39t1gvwqbaiebw24rkuu17wcuk-c_qa-folder.md
@@ -1,9 +1,9 @@
 # Eu8_tRb65JdBrLL39T1GVwQBaieBW24rkUU17Wcuk-C_QA Share
 
 This folder hosts the external **datasets** mirrored from
-`OneDrive\\DynamicAI_D\\Bdatasets` that the trading agent reviews. The notes below
-capture the identifiers needed for Microsoft Graph workflows and repository
-scripts that sync the folder metadata.
+`OneDrive\\DynamicAI_D\\Bdatasets` that the trading agent reviews. The notes
+below capture the identifiers needed for Microsoft Graph workflows and
+repository scripts that sync the folder metadata.
 
 ## Share details
 
@@ -73,8 +73,8 @@ so the repository can track changes to the external share.
 
 The `dynamic_trading_knowledge` subfolder contains the PDF knowledge base that
 feeds the trading assistant. After mirroring the files into the repository, run
-the bundled helper to materialise plain text, table CSVs, and a page-level
-JSONL corpus ready for RAG ingestion.
+the bundled helper to materialise plain text, table CSVs, and a page-level JSONL
+corpus ready for RAG ingestion.
 
 ```bash
 python tools/dynamic_trading_corpus.py \
@@ -86,7 +86,7 @@ python tools/dynamic_trading_corpus.py \
 - `tools/dynamic_trading_corpus.py` wraps the shared PDF batch extractor, keeps
   `--structured` enabled for table capture, and writes
   `processed/dynamic_trading_summary.json` with run metadata.
-- Use `--no-skip-existing` when you need to refresh the artefacts after
-  updating OCR or extraction settings.
+- Use `--no-skip-existing` when you need to refresh the artefacts after updating
+  OCR or extraction settings.
 - Promote the resulting JSONL to Supabase (or your preferred object store) once
   QA is complete so downstream training jobs can consume a stable snapshot.

--- a/docs/open_source_dictionary_apis.md
+++ b/docs/open_source_dictionary_apis.md
@@ -178,9 +178,9 @@ curl -s "https://api.datamuse.com/words?ml=liquidity&max=5" | jq '.[].word'
 
 ## Connect with Dynamic AGI
 
-The `dynamic.intelligence.agi` package can ingest dictionary outputs as part of a broader
-knowledge or research pipeline. Use dictionary entries to enrich the `research`
-payload that accompanies a market or product evaluation.
+The `dynamic.intelligence.agi` package can ingest dictionary outputs as part of
+a broader knowledge or research pipeline. Use dictionary entries to enrich the
+`research` payload that accompanies a market or product evaluation.
 
 1. Normalise the API response into lightweight fields (definitions, synonyms,
    usage examples) so the AGI layer can digest it alongside other telemetry.

--- a/docs/project-catalog.md
+++ b/docs/project-catalog.md
@@ -58,8 +58,9 @@ strategic pillars.
   papers, inventories, and curated research libraries.
 - **Data Foundations (`data/`, `db/`, `dynamic/models/`, `ml/`, `trainer/`)** –
   Datasets, schema definitions, model checkpoints, and experiment harnesses.
-- **Research Initiatives (`dynamic.intelligence.ai_apps/`, `dynamic.intelligence.agi/`, `dynamic_quantum/`)** –
-  Exploratory programs that extend the platform's intelligence frontier.
+- **Research Initiatives (`dynamic.intelligence.ai_apps/`,
+  `dynamic.intelligence.agi/`, `dynamic_quantum/`)** – Exploratory programs that
+  extend the platform's intelligence frontier.
 
 ### Observability, Security & Governance
 

--- a/docs/project-scan.md
+++ b/docs/project-scan.md
@@ -11,8 +11,9 @@
    `landing` and `web` house the marketing site and the Next.js-powered Telegram
    Mini App/dashboard bundle respectively.
 3. **Review algorithmic engines** – Surveyed Python packages under
-   `algorithms/`, `core/`, `dynamic.intelligence.ai_apps/`, `dynamic.trading.algo/`, and `dynamic.platform.token/`
-   to map where trading, treasury, and AI orchestration logic live.
+   `algorithms/`, `core/`, `dynamic.intelligence.ai_apps/`,
+   `dynamic.trading.algo/`, and `dynamic.platform.token/` to map where trading,
+   treasury, and AI orchestration logic live.
 4. **Trace integrations and queues** – Checked `integrations/` and `queue/` to
    identify connectors for MT5, Telegram, TradingView, and the lightweight job
    runner dispatching asynchronous workloads.
@@ -31,12 +32,13 @@
   and webhook adapters for strategy experimentation and external integrations.
 - `core/`: Python trading core with fusion engines, market-making routines, and
   shared Supabase client utilities.
-- `dynamic.intelligence.ai_apps/`: AI orchestration layer coordinating agent behaviors, risk
-  modules, hedging, and training pipelines.
-- `dynamic.trading.algo/`: Modular automation suite describing roles (CEO/CFO/COO),
-  marketing, analytics, and middleware primitives for Dynamic Capital workflows.
-- `dynamic.platform.token/`: Treasury utilities managing Dynamic Capital Token accounting
-  logic.
+- `dynamic.intelligence.ai_apps/`: AI orchestration layer coordinating agent
+  behaviors, risk modules, hedging, and training pipelines.
+- `dynamic.trading.algo/`: Modular automation suite describing roles
+  (CEO/CFO/COO), marketing, analytics, and middleware primitives for Dynamic
+  Capital workflows.
+- `dynamic.platform.token/`: Treasury utilities managing Dynamic Capital Token
+  accounting logic.
 - `integrations/`: Connectors bridging MT5, Telegram bots, TradingView feeds,
   and Supabase logging helpers.
 - `queue/`: Custom TypeScript job queue with processors such as `dct-events` to
@@ -49,7 +51,7 @@
   whitepapers, and contributor guides.
 - `data/`: Datasets and machine learning artifact placeholders that support
   analytics and AI-driven features across the platform.
-- `dynamic/models/`: Model checkpoints and assets referenced by AI-assisted tooling and
-  analytics flows.
+- `dynamic/models/`: Model checkpoints and assets referenced by AI-assisted
+  tooling and analytics flows.
 - `tools/`: Developer utilities, including automation helpers and shared
   workflows for repository maintenance.

--- a/docs/project_inventory.md
+++ b/docs/project_inventory.md
@@ -43,8 +43,8 @@ related assets to simplify discovery and onboarding.
   assets supporting persistence layers.
 - **`dynamic_memory/` & `dynamic_memory_reconsolidation/`** – Modules dedicated
   to memory storage, retrieval, and reinforcement strategies.
-- **`ml/`, `dynamic/models/`, `trainer/`** – Machine learning experiments, trained
-  artifacts, and tooling for iterative model development.
+- **`ml/`, `dynamic/models/`, `trainer/`** – Machine learning experiments,
+  trained artifacts, and tooling for iterative model development.
 - **`docs/`, `_static/`, `content/`** – Documentation, static assets, and
   curated knowledge bases that aid onboarding and research.
 

--- a/docs/python-pdf-data-extraction.md
+++ b/docs/python-pdf-data-extraction.md
@@ -1,25 +1,48 @@
 # Python PDF Data Extraction Guide
 
-Extracting data from PDF documents can range from straightforward text pulls to parsing complex, multi-column layouts or tables. Python's ecosystem offers several specialized libraries that address these scenarios, giving developers the flexibility to choose tools that match their document structure, scale, and workflow preferences.
+Extracting data from PDF documents can range from straightforward text pulls to
+parsing complex, multi-column layouts or tables. Python's ecosystem offers
+several specialized libraries that address these scenarios, giving developers
+the flexibility to choose tools that match their document structure, scale, and
+workflow preferences.
 
 ## Libraries for Text and Mixed Content
 
-- **PyMuPDF (fitz):** Prioritizes speed and efficiency while extracting text, images, and layout metadata. Ideal for well-structured, text-centric PDFs where performance matters.
-- **pdfplumber:** Provides fine-grained control over page parsing, enabling extraction of text, tables, and embedded images even when layouts are irregular. Useful for invoices or forms with mixed content.
-- **Unstructured:** Tailored for AI and document intelligence workflows. It can partition PDFs into semantic elements and handle image-heavy or scanned pages with OCR-backed pipelines.
+- **PyMuPDF (fitz):** Prioritizes speed and efficiency while extracting text,
+  images, and layout metadata. Ideal for well-structured, text-centric PDFs
+  where performance matters.
+- **pdfplumber:** Provides fine-grained control over page parsing, enabling
+  extraction of text, tables, and embedded images even when layouts are
+  irregular. Useful for invoices or forms with mixed content.
+- **Unstructured:** Tailored for AI and document intelligence workflows. It can
+  partition PDFs into semantic elements and handle image-heavy or scanned pages
+  with OCR-backed pipelines.
 
 ## Libraries Focused on Tables
 
-- **Camelot:** Purpose-built for table extraction. Works best when tables have explicit ruling lines, and offers configuration options (e.g., `stream` mode) for more complex layouts.
-- **Tabula-py:** Python wrapper around the Tabula Java project. Converts detected tables directly into pandas DataFrames, making it convenient for downstream data analysis.
+- **Camelot:** Purpose-built for table extraction. Works best when tables have
+  explicit ruling lines, and offers configuration options (e.g., `stream` mode)
+  for more complex layouts.
+- **Tabula-py:** Python wrapper around the Tabula Java project. Converts
+  detected tables directly into pandas DataFrames, making it convenient for
+  downstream data analysis.
 
 ## Choosing the Right Approach
 
 When selecting a PDF extraction strategy, weigh the following factors:
 
-1. **PDF complexity:** Text-heavy documents pair well with PyMuPDF, whereas forms, invoices, or scans with tabular data may require Camelot or other AI-assisted tools.
-2. **Data volume:** Large, heterogeneous batches benefit from scalable, automated pipelines—AI-driven services can reduce manual tuning across document types.
-3. **Technical skillset:** Developers comfortable with Python gain maximum flexibility from open-source libraries. Teams seeking low-code solutions might prefer managed AI platforms.
-4. **Desired output:** Determine the target destination for extracted data. AI platforms often ship connectors for databases or spreadsheets, while Python scripts typically require custom export logic.
+1. **PDF complexity:** Text-heavy documents pair well with PyMuPDF, whereas
+   forms, invoices, or scans with tabular data may require Camelot or other
+   AI-assisted tools.
+2. **Data volume:** Large, heterogeneous batches benefit from scalable,
+   automated pipelines—AI-driven services can reduce manual tuning across
+   document types.
+3. **Technical skillset:** Developers comfortable with Python gain maximum
+   flexibility from open-source libraries. Teams seeking low-code solutions
+   might prefer managed AI platforms.
+4. **Desired output:** Determine the target destination for extracted data. AI
+   platforms often ship connectors for databases or spreadsheets, while Python
+   scripts typically require custom export logic.
 
-Selecting the right combination of tools keeps PDF extraction accurate, maintainable, and aligned with downstream analytics or automation goals.
+Selecting the right combination of tools keeps PDF extraction accurate,
+maintainable, and aligned with downstream analytics or automation goals.

--- a/docs/python_compileall_run.md
+++ b/docs/python_compileall_run.md
@@ -49,23 +49,25 @@ model still parses after changes to shared helpers or typing imports.
 The same safety net applies to the business-critical dynamic platforms that live
 at the repository root:
 
-- **`dynamic.intelligence.agi`** – synthesizes signals from the atmospheric layers and
-  ensures the orchestration logic in `agent.py` and `model.py` stay importable
-  after edits to shared prompt-building utilities.
-- **`dynamic.trading.algo`** – houses the trading strategy backtests, so compiling it
-  confirms that the algorithm entry points and the `portfolio/` helpers
-  reference only valid type hints.
-- **`dynamic.platform.token`** (plus the umbrella `dynamic.platform.token`-adjacent packages such
-  as `dynamic_capital_token/` and `dynamic_capital/`) – compileall traverses
-  these tokenomics modules to verify that smart-contract bindings and CLI
-  integration scripts remain syntax clean. This includes the `__init__.py` glue
-  that exposes the token clients to the broader stack.
+- **`dynamic.intelligence.agi`** – synthesizes signals from the atmospheric
+  layers and ensures the orchestration logic in `agent.py` and `model.py` stay
+  importable after edits to shared prompt-building utilities.
+- **`dynamic.trading.algo`** – houses the trading strategy backtests, so
+  compiling it confirms that the algorithm entry points and the `portfolio/`
+  helpers reference only valid type hints.
+- **`dynamic.platform.token`** (plus the umbrella
+  `dynamic.platform.token`-adjacent packages such as `dynamic_capital_token/`
+  and `dynamic_capital/`) – compileall traverses these tokenomics modules to
+  verify that smart-contract bindings and CLI integration scripts remain syntax
+  clean. This includes the `__init__.py` glue that exposes the token clients to
+  the broader stack.
 
 When `python -m compileall` runs from the repository root it traverses each
 `dynamic_*` package, ensuring that `model.py`, `agent.py`, and their siblings
 receive fresh bytecode. You can confirm this by spot-checking the transient
 `__pycache__/model.cpython-312.pyc` files that appear under directories such as
-`dynamic_stratosphere/`, `dynamic.intelligence.agi/`, and `dynamic.platform.token/` before cleanup.
+`dynamic_stratosphere/`, `dynamic.intelligence.agi/`, and
+`dynamic.platform.token/` before cleanup.
 
 ## Additional Python Surfaces to Audit
 

--- a/docs/quantum_stem_cell_modeling.md
+++ b/docs/quantum_stem_cell_modeling.md
@@ -1,46 +1,67 @@
 # Quantum-Level Stem Cell Modeling Frameworks
 
-This note distills several conceptual and mathematical frameworks that appear in quantum-informed models of stem cell dynamics. Each subsection outlines the governing equations, defines the relevant variables, and highlights how the framework informs experimental or computational workflows.
+This note distills several conceptual and mathematical frameworks that appear in
+quantum-informed models of stem cell dynamics. Each subsection outlines the
+governing equations, defines the relevant variables, and highlights how the
+framework informs experimental or computational workflows.
 
 ## Quantum Landscape and Flux Theory
 
-Stem cell differentiation can be cast as motion across a non-equilibrium energy landscape. The temporal evolution of the probability density \(P(x, t)\) across cell states \(x\) is governed by the continuity equation
+Stem cell differentiation can be cast as motion across a non-equilibrium energy
+landscape. The temporal evolution of the probability density \(P(x, t)\) across
+cell states \(x\) is governed by the continuity equation
 
 $$
 \frac{\partial P(x,t)}{\partial t} = -\nabla \cdot J(x,t),
 $$
 
-where the probability flux \(J(x,t)\) combines diffusive and drift contributions,
+where the probability flux \(J(x,t)\) combines diffusive and drift
+contributions,
 
 $$
 J(x,t) = -D \nabla P(x,t) + \frac{F(x)}{\gamma} P(x,t).
 $$
 
-- \(D\) denotes the effective diffusion coefficient that captures stochastic fluctuations in gene expression.
-- \(F(x) = -\nabla U(x)\) is the force derived from the differentiation landscape \(U(x)\).
+- \(D\) denotes the effective diffusion coefficient that captures stochastic
+  fluctuations in gene expression.
+- \(F(x) = -\nabla U(x)\) is the force derived from the differentiation
+  landscape \(U(x)\).
 - \(\gamma\) is an effective friction that encodes intracellular damping.
 
-The curl component of \(J(x,t)\) breaks detailed balance, representing irreversible fluxes that bias lineage commitment pathways.
+The curl component of \(J(x,t)\) breaks detailed balance, representing
+irreversible fluxes that bias lineage commitment pathways.
 
 ## Schrödinger-Type Evolution of Cell States
 
-In conceptual models that emphasize superposition across lineage potentials, stem cell states are written as wavefunctions \(\psi(x,t)\). Their evolution obeys a Schrödinger-like equation,
+In conceptual models that emphasize superposition across lineage potentials,
+stem cell states are written as wavefunctions \(\psi(x,t)\). Their evolution
+obeys a Schrödinger-like equation,
 
 $$
 i\hbar \frac{\partial \psi(x,t)}{\partial t} = \hat{H} \psi(x,t),
 $$
 
-with the Hamiltonian operator \(\hat{H}\) encoding effective gene-regulatory couplings. Diagonal terms describe self-renewal propensities, while off-diagonal components permit coherent transitions between fates. Although largely theoretical, this framing inspires algorithms that borrow from quantum state tomography to analyze single-cell measurements.
+with the Hamiltonian operator \(\hat{H}\) encoding effective gene-regulatory
+couplings. Diagonal terms describe self-renewal propensities, while off-diagonal
+components permit coherent transitions between fates. Although largely
+theoretical, this framing inspires algorithms that borrow from quantum state
+tomography to analyze single-cell measurements.
 
 ## Quantum Dot–Driven Differentiation Models
 
-When carbon or graphene quantum dots interface with stem cell cultures, electronic confinement modulates signaling cascades. A minimal description of confined energy levels is
+When carbon or graphene quantum dots interface with stem cell cultures,
+electronic confinement modulates signaling cascades. A minimal description of
+confined energy levels is
 
 $$
 E_n = \frac{n^2 h^2}{8 m L^2},
 $$
 
-where \(n\) is the principal quantum number, \(L\) is the characteristic size of the dot, \(m\) is the electron mass, and \(h\) is Planck's constant. By tuning \(L\) or the surface chemistry of the dots, researchers bias reactive oxygen species production, growth factor adsorption, and membrane depolarization, thereby steering differentiation outcomes.
+where \(n\) is the principal quantum number, \(L\) is the characteristic size of
+the dot, \(m\) is the electron mass, and \(h\) is Planck's constant. By tuning
+\(L\) or the surface chemistry of the dots, researchers bias reactive oxygen
+species production, growth factor adsorption, and membrane depolarization,
+thereby steering differentiation outcomes.
 
 ## Quantum Entropy for Fate Uncertainty
 
@@ -50,23 +71,38 @@ $$
 S = -\sum_i p_i \log p_i,
 $$
 
-with \(p_i\) denoting the probability of adopting lineage \(i\). High entropy indicates pluripotent populations with diffuse lineage preferences, whereas entropy decreases as cells commit to specific identities. Entropy trends extracted from single-cell RNA-seq distributions therefore serve as proxies for potency.
+with \(p_i\) denoting the probability of adopting lineage \(i\). High entropy
+indicates pluripotent populations with diffuse lineage preferences, whereas
+entropy decreases as cells commit to specific identities. Entropy trends
+extracted from single-cell RNA-seq distributions therefore serve as proxies for
+potency.
 
 ## Quantum-Inspired Stochastic Master Equation
 
-Discrete transitions among stem, progenitor, and differentiated states can be modeled by a master equation,
+Discrete transitions among stem, progenitor, and differentiated states can be
+modeled by a master equation,
 
 $$
 \frac{dP_i}{dt} = \sum_j \left(W_{ji} P_j - W_{ij} P_i\right),
 $$
 
-where \(P_i\) is the occupancy probability of state \(i\), and \(W_{ij}\) is the transition rate from \(i\) to \(j\). Non-diagonal elements integrate quantum-inspired tunneling or coherence effects, while diagonal terms enforce conservation of probability. Parameter inference typically leverages Bayesian or maximum-likelihood estimators fitted to lineage tracing data.
+where \(P_i\) is the occupancy probability of state \(i\), and \(W_{ij}\) is the
+transition rate from \(i\) to \(j\). Non-diagonal elements integrate
+quantum-inspired tunneling or coherence effects, while diagonal terms enforce
+conservation of probability. Parameter inference typically leverages Bayesian or
+maximum-likelihood estimators fitted to lineage tracing data.
 
 ## Experimental and Computational Implications
 
-- **Quantum dots** provide tunable probes for imaging, lineage tracking, and differentiation biasing without genetic modification.
-- **Landscape-flux analysis** identifies bottlenecks in reprogramming protocols and quantifies how non-equilibrium drives maintain pluripotency reservoirs.
-- **Entropy metrics** guide culture adjustments by signaling when populations drift toward undesired fates.
-- **Master equation solvers** enable stochastic simulations of differentiation strategies, supporting in silico experimentation before deploying costly lab interventions.
+- **Quantum dots** provide tunable probes for imaging, lineage tracking, and
+  differentiation biasing without genetic modification.
+- **Landscape-flux analysis** identifies bottlenecks in reprogramming protocols
+  and quantifies how non-equilibrium drives maintain pluripotency reservoirs.
+- **Entropy metrics** guide culture adjustments by signaling when populations
+  drift toward undesired fates.
+- **Master equation solvers** enable stochastic simulations of differentiation
+  strategies, supporting in silico experimentation before deploying costly lab
+  interventions.
 
-These frameworks remain exploratory yet offer a vocabulary for integrating quantum mechanical insights into regenerative medicine models.
+These frameworks remain exploratory yet offer a vocabulary for integrating
+quantum mechanical insights into regenerative medicine models.

--- a/docs/tonkeeper-messages.md
+++ b/docs/tonkeeper-messages.md
@@ -1,39 +1,51 @@
 # Tonkeeper Messages Integration Guide
 
-Tonkeeper Messages provides push notifications for decentralized applications that already onboarded users through TonConnect. Follow the steps below to register your application, verify ownership, and start sending campaigns.
+Tonkeeper Messages provides push notifications for decentralized applications
+that already onboarded users through TonConnect. Follow the steps below to
+register your application, verify ownership, and start sending campaigns.
 
 ## Register and Verify Your Dapp
 
 1. Open [Tonkeeper Messages](https://messages.tonkeeper.com/).
-2. Submit your TonConnect manifest URL or a public app URL, then choose **Register**.
+2. Submit your TonConnect manifest URL or a public app URL, then choose
+   **Register**.
 3. Create a `tc-verify.json` file in your hosting environment.
-4. Copy the `payload` value provided by Tonkeeper Messages into the `tc-verify.json` file.
-5. Host the file at the URL listed under the payload instructions (the link must be publicly accessible).
+4. Copy the `payload` value provided by Tonkeeper Messages into the
+   `tc-verify.json` file.
+5. Host the file at the URL listed under the payload instructions (the link must
+   be publicly accessible).
 6. Return to Tonkeeper Messages and click **Verify** to complete the validation.
 
-> **Note:** Each project can have only one connected decentralized application. Create a separate project if you need to register an additional app.
+> **Note:** Each project can have only one connected decentralized application.
+> Create a separate project if you need to register an additional app.
 
 ## Manage Message Quotas
 
-- Monitor the remaining message balance in the Tonkeeper Messages dashboard. The current quota appears on the right-hand side of the interface.
-- Click **Refill** to purchase more messages. If your TonConsole balance is low, refill it before completing the purchase.
+- Monitor the remaining message balance in the Tonkeeper Messages dashboard. The
+  current quota appears on the right-hand side of the interface.
+- Click **Refill** to purchase more messages. If your TonConsole balance is low,
+  refill it before completing the purchase.
 
 ## Authenticate API Requests
 
-Generate an authorization token in Tonkeeper Messages and include it in the `Authorization` header for every request:
+Generate an authorization token in Tonkeeper Messages and include it in the
+`Authorization` header for every request:
 
 ```http
 -H 'Authorization: Bearer <YOUR_TOKEN>'
 ```
 
-Treat the token as a secret. If you suspect that it has been compromised, revoke and regenerate it immediately.
+Treat the token as a secret. If you suspect that it has been compromised, revoke
+and regenerate it immediately.
 
 ## Send Notifications
 
-Tonkeeper Messages supports broadcasting to all connected wallets or targeting a specific address.
+Tonkeeper Messages supports broadcasting to all connected wallets or targeting a
+specific address.
 
 - **Broadcast to all users:** Omit the `address` field from the request body.
-- **Target a single wallet:** Include the TON wallet address in the `address` field.
+- **Target a single wallet:** Include the TON wallet address in the `address`
+  field.
 
 Example request body:
 
@@ -58,4 +70,5 @@ Example request body:
 - Event or deadline reminders.
 - Account notifications and transactional alerts.
 
-By adhering to these guidelines, you can deliver timely, trusted communications to the Tonkeeper users who have opted in through TonConnect.
+By adhering to these guidelines, you can deliver timely, trusted communications
+to the Tonkeeper users who have opted in through TonConnect.

--- a/scripts/run-checklists.js
+++ b/scripts/run-checklists.js
@@ -70,7 +70,8 @@ const TASK_LIBRARY = {
     id: "dynamic-ai-tests",
     label:
       "Run Dynamic AI persona and fusion tests (pytest tests/intelligence/ai_apps tests_python/test_dynamic_ai_phase3.py)",
-    command: "pytest tests/intelligence/ai_apps tests_python/test_dynamic_ai_phase3.py",
+    command:
+      "pytest tests/intelligence/ai_apps tests_python/test_dynamic_ai_phase3.py",
     optional: false,
     docs: [
       "docs/dai-dagi-dct-dtl-dta-checklist-review.md#dynamic-ai-dai",
@@ -82,8 +83,7 @@ const TASK_LIBRARY = {
   },
   "dynamic-agi-tests": {
     id: "dynamic-agi-tests",
-    label:
-      "Run Dynamic AGI oversight tests (pytest tests/intelligence/agi)",
+    label: "Run Dynamic AGI oversight tests (pytest tests/intelligence/agi)",
     command: "pytest tests/intelligence/agi",
     optional: false,
     docs: [


### PR DESCRIPTION
## Summary
- run the repository formatter to normalize documentation and checklist formatting
- align script formatting in `scripts/run-checklists.js` with deno fmt output

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68de52f93500832296d4015001b85f36