### PR TITLE
Add worksnap tracking fields to server header comment

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,12 @@
-// Always sign the code pages, © 2025 Dynamic Capital. All Rights Reserved.
-// author (Deathcoder), 2016
-// Worksnap Short: Refreshed header metadata to include tracking details per request.
-// Hours Spent: 0.1
-// Date Time Month Year: 02 October 2025 12:31 UTC
-// Milestones: Header comment updated with Worksnap summary fields.
+/**
+ * Always sign the code pages.
+ * © 2025 Dynamic Capital. All Rights Reserved.
+ * Author: Deathcoder (2016)
+ * Worksnap Short: Refreshed header metadata to include tracking details per request.
+ * Hours Spent: 0.10
+ * Timestamp: 2025-10-02T12:31:00Z
+ * Milestones: Header comment updated with Worksnap summary fields.
+ */
 import http from "node:http";
 import https from "node:https";
 import { createReadStream, existsSync, readFileSync } from "node:fs";


### PR DESCRIPTION
## Summary
- add worksnap short, hours spent, date/time, and milestone metadata to the `server.js` header comment

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68de6ffc875483229b54d74b69cfdc65