### PR TITLE
Point legacy domains to dynamiccapital.ton

### DIFF
--- a/dns/dynamic-capital.lovable.app.json
+++ b/dns/dynamic-capital.lovable.app.json
@@ -1,18 +1,22 @@
 {
   "domain": "dynamic-capital.lovable.app",
   "records": [
-    { "type": "A", "name": "@", "data": "162.159.140.98", "ttl": 3600 },
-    { "type": "A", "name": "@", "data": "172.66.0.96", "ttl": 3600 },
+    {
+      "type": "CNAME",
+      "name": "@",
+      "data": "dynamiccapital.ton",
+      "ttl": 3600
+    },
     {
       "type": "CNAME",
       "name": "www",
-      "data": "dynamic-capital.lovable.app",
+      "data": "dynamiccapital.ton",
       "ttl": 3600
     },
     {
       "type": "CNAME",
       "name": "api",
-      "data": "dynamic-capital.lovable.app",
+      "data": "dynamiccapital.ton",
       "ttl": 3600
     }
   ]

--- a/dns/dynamic-capital.ondigitalocean.app.zone
+++ b/dns/dynamic-capital.ondigitalocean.app.zone
@@ -5,5 +5,7 @@ dynamic-capital.ondigitalocean.app. IN SOA ns1.digitalocean.com. hostmaster.dyna
 dynamic-capital.ondigitalocean.app. 1800 IN NS ns1.digitalocean.com.
 dynamic-capital.ondigitalocean.app. 1800 IN NS ns2.digitalocean.com.
 dynamic-capital.ondigitalocean.app. 1800 IN NS ns3.digitalocean.com.
-dynamic-capital.ondigitalocean.app. 3600 IN A 162.159.140.98
-dynamic-capital.ondigitalocean.app. 3600 IN A 172.66.0.96
+; Route apex and common subdomains to the TON canonical surface
+dynamic-capital.ondigitalocean.app. 3600 IN CNAME dynamiccapital.ton.
+www                                    3600 IN CNAME dynamiccapital.ton.
+api                                    3600 IN CNAME dynamiccapital.ton.


### PR DESCRIPTION
## Summary
- point the lovable app DNS records to the canonical dynamiccapital.ton host
- update the DigitalOcean zone so the apex, www, and api records resolve via dynamiccapital.ton

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de7e8b40d0832297e8897251445388