### PR TITLE
fix: ignore external HOSTNAME when binding server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@ NEXT_PUBLIC_ENV=development
 NEXT_PUBLIC_COMMIT_SHA=
 
 # Supabase (shared across apps and functions)
-SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
+# Use placeholder values here; never commit real credentials.
+SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_PROJECT_REF=
 SUPABASE_PROJECT_ID=
 SUPABASE_DB_PASSWORD=
@@ -16,7 +17,8 @@ SUPABASE_DB_URL=
 SUPABASE_FN_URL=
 SUPABASE_ACCESS_TOKEN=
 DATABASE_URL=
-NEXT_PUBLIC_SUPABASE_URL=https://qeejuomcapbdlhnjqjcc.supabase.co
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+# Safe to expose in clients, but keep a placeholder to avoid copying live keys.
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
 # Deployment platform access
@@ -46,6 +48,7 @@ ALLOWED_ORIGINS=https://example.com,https://api.example.com
 HEALTH_URL=
 
 # Telegram bot + mini app
+# Populate these only in secure env vars; never commit live tokens.
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_APP_ID=
 TELEGRAM_APP_HASH=

--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ Keep secrets such as `SUPABASE_SERVICE_ROLE_KEY` or `TELEGRAM_BOT_TOKEN` only in
 the environment for the Next.js component. Do **not** prefix them with
 `NEXT_PUBLIC_` or expose them in the static site.
 
+If a credential is ever exposed publicly, follow the [Secret Rotation
+Playbook](docs/security/secret-rotation.md) to revoke and replace it across the
+stack before redeploying the affected services.
+
 For local work, create `.env`/`.env.local` at the repository root and run
 `npm run dev` to load the variables. In production, manage secrets through your
 platform's configuration for each component.

--- a/docs/security/secret-rotation.md
+++ b/docs/security/secret-rotation.md
@@ -1,0 +1,110 @@
+# Secret Rotation Playbook
+
+This guide outlines the immediate response when a credential leaks publicly.
+Follow the quick-reference table first, then work through the detailed
+procedures for each secret.
+
+## Quick reference
+
+| Secret                                                  | Where it lives                                                                           | Rotate via                                                                                        | Post-rotation verification                                                                      |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Telegram bot token (`TELEGRAM_BOT_TOKEN`)               | Telegram BotFather, deployment secrets, Supabase Edge Function env vars                  | BotFather `/revoke` + `/token`; update secret managers; redeploy webhook                          | `supabase functions logs telegram-webhook` shows successful auth; mini-app responds to `/start` |
+| Supabase service role key (`SUPABASE_SERVICE_ROLE_KEY`) | Supabase project API settings, Supabase CLI secret store, infrastructure secret managers | Supabase dashboard → **Reset service_role key**; rotate stored values; redeploy affected services | `supabase secrets list` shows new timestamp; server logs free of auth failures                  |
+
+---
+
+## Telegram bot token rotation
+
+### When to trigger
+
+- The token appears in logs, screenshots, commits, or third-party scanners.
+- BotFather reports that a token has been revoked unexpectedly.
+
+### Step-by-step
+
+1. **Invalidate the leaked token**
+   - DM [BotFather](https://t.me/BotFather) and run `/revoke` against the
+     impacted bot.
+   - Immediately request a replacement with `/token`; copy the new token into a
+     secure clipboard manager.
+2. **Propagate the new token**
+   - Update shared secret storage (e.g., 1Password vault entry or platform
+     secret store).
+   - Run `scripts/setup-telegram-webhook.sh` locally with the new token to
+     refresh the Supabase Edge Function configuration.
+   - Execute `supabase functions deploy telegram-webhook` to publish the updated
+     secret to production.
+3. **Validate**
+   - Call `supabase functions logs telegram-webhook --since 10m` and confirm
+     `401` responses stop.
+   - From a staging chat, run `/start` and verify that the bot responds without
+     error.
+
+### Clean-up
+
+- Purge the revoked token from chat transcripts and ticket descriptions.
+- Replace example values in documentation with neutral placeholders (see
+  `.env.example`).
+
+---
+
+## Supabase service role key rotation
+
+### When to trigger
+
+- Supabase dashboard flags suspicious activity or you observe unexpected
+  row-level access.
+- The key is exposed in telemetry, CI logs, or static configuration files.
+
+### Step-by-step
+
+1. **Reset the key**
+   - Navigate to **Project Settings → API** inside the Supabase dashboard.
+   - Click **Reset service_role key** and confirm the action; download the newly
+     generated key once.
+2. **Update dependent systems**
+   - Store the key in your central secret manager and update
+     `SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_SERVICE_ROLE` entries.
+   - Refresh local development environments by copying the new value into
+     `.env.local` (do **not** commit it).
+   - Push the secret to Supabase Edge Functions with
+     `supabase secrets set SUPABASE_SERVICE_ROLE_KEY=...`.
+   - Trigger redeployments for services that embed the key (e.g.,
+     `supabase functions deploy --all`).
+3. **Validate**
+   - Run `supabase secrets list` and confirm the `Updated` timestamp matches the
+     rotation time.
+   - Monitor application logs for failed Supabase requests; retry any jobs that
+     may have run during the rotation.
+
+### Clean-up
+
+- Use `git log -S "<leaked-key-fragment>"` to identify commits that referenced
+  the leaked key and scrub them.
+- If the key entered Git history, follow the
+  [GitHub credential scanning remediation](https://docs.github.com/en/code-security/secret-scanning/troubleshooting/removing-sensitive-data-from-a-repository)
+  guide to rewrite history.
+
+---
+
+## Incident communications
+
+- File an incident report summarizing the leak, the rotation timestamps, and
+  monitoring checkpoints.
+- Notify on-call engineers and relevant product owners so they can watch for
+  residual errors.
+- Schedule a post-incident review to capture lessons learned and preventive
+  controls.
+
+---
+
+## Post-rotation checklist
+
+- [ ] New secrets stored in password manager / secret store.
+- [ ] Supabase Edge Functions redeployed.
+- [ ] Webhook endpoints tested successfully.
+- [ ] Repository scrubbed of leaked values.
+- [ ] Stakeholders informed and follow-up actions tracked.
+
+Keeping this checklist handy shortens response times and helps avoid repeated
+credential exposure incidents.

--- a/server.js
+++ b/server.js
@@ -29,6 +29,22 @@ function coerceListenHost(raw) {
   return trimmed;
 }
 
+function isLikelyLoopbackHost(raw) {
+  if (!raw) return false;
+  const normalized = `${raw}`.trim().toLowerCase();
+  if (!normalized) return false;
+  if (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1"
+  ) {
+    return true;
+  }
+  return normalized.startsWith("127.") ||
+    normalized.startsWith("::ffff:127.");
+}
+
 const listenHostSources = [
   ["HOST", process.env.HOST],
   ["HOSTNAME", process.env.HOSTNAME],
@@ -49,6 +65,14 @@ for (const [source, value] of listenHostSources) {
 }
 
 if (!listenHost) {
+  listenHost = "0.0.0.0";
+  listenHostSource = "default";
+}
+
+if (listenHostSource === "HOSTNAME" && !isLikelyLoopbackHost(listenHost)) {
+  console.warn(
+    `Ignoring HOSTNAME ${listenHost} for listen host binding; defaulting to 0.0.0.0. Set HOST or LISTEN_HOST to override.`,
+  );
   listenHost = "0.0.0.0";
   listenHostSource = "default";
 }


### PR DESCRIPTION
## Summary
- ignore non-loopback HOSTNAME values so the local HTTP server falls back to 0.0.0.0 and stays reachable in tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7f0f1dc883229e34fed28f906616