### PR TITLE
Add markdown rendering to dynamic trading language narratives

### DIFF
--- a/dynamic_trading_language/model.py
+++ b/dynamic_trading_language/model.py
@@ -220,6 +220,43 @@ class MarketNarrative:
         self.insights = _normalise_tuple(self.insights)
         self.tags = _normalise_tuple(self.tags)
 
+    def to_markdown(self) -> str:
+        """Render the narrative as a markdown deck for distribution."""
+
+        lines: list[str] = [f"# {self.headline}", "", "## Thesis", self.thesis]
+
+        lines.extend(["", "## Key Levels"])
+        if self.key_levels:
+            lines.extend(f"- {level}" for level in self.key_levels)
+        else:  # pragma: no cover - defensive branch
+            lines.append("- None specified")
+
+        lines.extend(["", "## Risk Mitigation"])
+        if self.risk_mitigation:
+            lines.extend(f"- {item}" for item in self.risk_mitigation)
+        else:  # pragma: no cover - defensive branch
+            lines.append("- Maintain disciplined execution")
+
+        lines.extend(["", "## Call To Action", self.call_to_action])
+
+        lines.extend(
+            [
+                "",
+                "## Meta",
+                f"- Style: {self.style}",
+                f"- Confidence: {self.confidence:.0%}",
+            ]
+        )
+
+        if self.insights:
+            lines.extend(["", "## Desk Insights"])
+            lines.extend(f"- {insight}" for insight in self.insights)
+
+        if self.tags:
+            lines.extend(["", "## Tags", ", ".join(self.tags)])
+
+        return "\n".join(lines) + "\n"
+
 
 class DynamicTradingLanguageModel:
     """Crafts institutional-grade narratives for Dynamic Capital trade ideas."""

--- a/tests/test_dynamic_trading_language_model.py
+++ b/tests/test_dynamic_trading_language_model.py
@@ -144,3 +144,27 @@ def test_strong_flow_tagging() -> None:
 
     assert "FLOW_STRONG" in narrative.tags
     assert narrative.confidence > 0.4
+
+
+def test_market_narrative_markdown_rendering() -> None:
+    narrative = MarketNarrative(
+        headline="Long ETHUSD setup — intraday focus",
+        thesis="Dynamic desk sees opportunity in ETHUSD.",
+        key_levels=("Entry: 1850.0000", "Target: 1900.0000"),
+        risk_mitigation=("Respect risk limits", "Monitor volatility"),
+        call_to_action="Structure the long expression.",
+        confidence=0.72,
+        style="institutional",
+        insights=("Funding normalising",),
+        tags=("ETHUSD", "INTRADAY"),
+    )
+
+    markdown = narrative.to_markdown()
+
+    assert markdown.startswith("# Long ETHUSD setup — intraday focus")
+    assert "## Key Levels" in markdown
+    assert "- Entry: 1850.0000" in markdown
+    assert "## Risk Mitigation" in markdown
+    assert "- Confidence: 72%" in markdown
+    assert "## Desk Insights" in markdown
+    assert "ETHUSD, INTRADAY" in markdown


### PR DESCRIPTION
## Summary
- add a `to_markdown` renderer to `MarketNarrative` for sharing structured trade decks
- add regression coverage ensuring the markdown output captures key sections and metadata

## Testing
- pytest tests/test_dynamic_trading_language_model.py

------
https://chatgpt.com/codex/tasks/task_e_68de8541bfb883228c63fb518d79e18f