### PR TITLE
Refresh Telegram bot fallback messaging

### DIFF
--- a/docs/BOT_CONTENT.md
+++ b/docs/BOT_CONTENT.md
@@ -1,17 +1,195 @@
 # Bot Content Keys
 
-The Telegram bot looks up the following keys in the `bot_content` table. If a
-key is absent, the bot falls back to the default message shown below.
+The Telegram bot reads rich text snippets from the `bot_content` table. When a
+key is missing or the database is offline, the bot falls back to the default
+messages below. Update these values in Supabase to customize the experience
+without redeploying code.
 
-| Key                      | Default message                                           |
-| ------------------------ | --------------------------------------------------------- |
-| `ask_usage`              | Please provide a question. Example: /ask What is trading? |
-| `service_unavailable`    | Service unavailable.                                      |
-| `ask_no_answer`          | Unable to get answer.                                     |
-| `ask_failed`             | Failed to get answer.                                     |
-| `shouldibuy_usage`       | Please provide an instrument. Example: /shouldibuy XAUUSD |
-| `shouldibuy_no_analysis` | Unable to get analysis.                                   |
-| `shouldibuy_failed`      | Failed to get analysis.                                   |
+## Default fallback messages
 
-Admins can override any of these messages by inserting or updating records in
-the `bot_content` table with the corresponding `content_key`.
+### `welcome_message`
+
+```
+🏁 Welcome to Dynamic Capital!
+
+📊 Institutional-grade trade intelligence on demand
+⚡ Live signals with human + automation oversight
+🎓 Progression tracks to scale from first trade to managed capital
+
+Use the menu or try commands like /packages, /education, /promo, /dashboard, or /support to get started.
+```
+
+### `welcome_back_message`
+
+```
+👋 Welcome back to Dynamic Capital!
+
+Here's what's live right now:
+• 📈 Alpha Signals – intraday & swing setups with risk levels
+• 🧠 Mentorship Tracks – tighten discipline and execution
+• 🤖 Automation Access – connect bots once your review clears
+
+Quick commands:
+• /dashboard — view your status & receipts
+• /packages — compare VIP routes
+• /education — unlock training tracks
+• /support — reach the concierge desk
+
+Let us know if you need anything.
+```
+
+### `about_us`
+
+```
+🏢 About Dynamic Capital
+
+Dynamic Capital pairs senior analysts with automation so every member receives:
+• Institutional-grade trade ideas with transparent performance
+• Structured mentorship paths that level up risk governance
+• Concierge support that keeps you accountable to the playbook
+
+We operate across timezones to keep members synced with the desk.
+```
+
+### `support_message`
+
+```
+🛟 *Need Help?*
+
+Our support team is here for you!
+
+📧 Support: support@dynamiccapital.ton
+💬 Telegram: @DynamicCapital_Support
+📣 Marketing: marketing@dynamiccapital.ton
+🕐 Support Hours: 24/7
+
+We typically respond within 2-4 hours.
+```
+
+### `terms_conditions`
+
+```
+📋 Terms & Policies
+
+By using Dynamic Capital you acknowledge:
+• Trading involves risk; results are never guaranteed
+• Signals and automation are educational guidance only
+• Access is personal and monitored for compliance
+• Refunds follow the onboarding guarantee outlined in your plan
+
+Full terms: https://dynamic.capital/terms
+```
+
+### `help_message`
+
+```
+❓ Bot Commands & Shortcuts
+
+/start — reopen the main menu
+/dashboard — view status, receipts, and automation
+/packages — compare VIP routes
+/promo — check active incentives
+/vip — review membership benefits
+/education — browse training tracks
+/support — contact the concierge desk
+/ask QUESTION — get AI coaching
+/shouldibuy SYMBOL — request an educational breakdown
+/about — learn more about Dynamic Capital
+
+Need a human? Message @DynamicCapital_Support.
+```
+
+### `faq_general`
+
+```
+❓ Frequently Asked Questions
+
+🔹 How do I join VIP?
+Select a package, follow the payment instructions, and upload your receipt. The desk verifies within 24 hours.
+
+🔹 What payments are supported?
+USDT (TRC20) and vetted bank transfers. Concierge will route you to the correct channel.
+
+🔹 How fast are signals delivered?
+The desk streams intraday calls in real time with clear entry, stop, and target guidance.
+
+🔹 What else is included?
+Mentorship pathways, automation access once approved, and daily debriefs so you stay aligned.
+
+🔹 Can I cancel?
+Yes. You retain access until the end of your current billing window.
+
+Still stuck? Reach out via /support.
+```
+
+### `vip_benefits`
+
+```
+💎 VIP Membership Benefits
+
+🚀 Real-time signal desk with analyst commentary
+📊 Performance dashboards and accountability reviews
+🧠 Mentorship sprints tailored to your trading tier
+🤖 Automation hooks once your risk review clears
+🛎️ Concierge support around the clock
+🎁 Members-only promotions and capital unlocks
+```
+
+### `payment_instructions`
+
+```
+💳 Payment Instructions
+
+We currently accept:
+🏦 Bank transfer through our vetted partners
+🪙 USDT (TRC20) sent to the treasury address
+
+After payment:
+1. Capture the receipt or transaction hash.
+2. Upload it here so the desk can verify ownership.
+3. Our team confirms and activates your access within 24 hours (often sooner).
+
+Need help with payment routing? Use /support.
+```
+
+### `ask_usage`
+
+```
+Please send a question, e.g. /ask How do I size positions?
+```
+
+### `ask_no_answer`
+
+```
+I couldn't find anything helpful. Try rephrasing or ask /support.
+```
+
+### `ask_failed`
+
+```
+The coaching assistant is unavailable right now. Please try again shortly.
+```
+
+### `service_unavailable`
+
+```
+Service temporarily unavailable. Please try again soon.
+```
+
+### `shouldibuy_usage`
+
+```
+Please send a symbol, e.g. /shouldibuy XAUUSD.
+```
+
+### `shouldibuy_no_analysis`
+
+```
+No analysis is available yet. Try again soon or contact /support.
+```
+
+### `shouldibuy_failed`
+
+```
+The analysis desk is offline right now. Please try again shortly.
+```

--- a/supabase/functions/telegram-bot/database-utils.ts
+++ b/supabase/functions/telegram-bot/database-utils.ts
@@ -160,41 +160,35 @@ async function createDefaultContent(
   contentKey: string,
 ): Promise<string | null> {
   const defaultContents: Record<string, string> = {
-    "welcome_message": `🎯 Welcome to Dynamic Capital Bot!
+    "welcome_message": `🏁 Welcome to Dynamic Capital!
 
-📈 Get premium trading signals & education
-💎 Join our VIP community
+📊 Institutional-grade trade intelligence on demand
+⚡ Live signals with human + automation oversight
+🎓 Progression tracks to scale from first trade to managed capital
 
-Use the buttons below or try commands like /packages, /promo, /account, /support, /help, /faq, /education, /ask or /shouldibuy to get started.`,
-    "welcome_back_message": `👋 Welcome back to Dynamic Capital Bot!
+Use the menu or try commands like /packages, /education, /promo, /dashboard, or /support to get started.`,
+    "welcome_back_message": `👋 Welcome back to Dynamic Capital!
 
-🔥 VIP Packages:
-• 1 Month – access to premium signals
-• 3 Months – best value plan
-• Lifetime – one-time payment for lifetime access
+Here's what's live right now:
+• 📈 Alpha Signals – intraday & swing setups with risk levels
+• 🧠 Mentorship Tracks – tighten discipline and execution
+• 🤖 Automation Access – connect bots once your review clears
 
-Available commands:
-/start - Main menu
-/dashboard or /account - View account dashboard
-/packages - View VIP packages
-/promo - View active promotions
-/vip - VIP benefits
-/support - Contact support
-/help - Show help
-/faq - Frequently asked questions
-/education - View education packages
-/ask - Ask our AI assistant
-/shouldibuy - Get educational trade analysis
-/about - About us`,
+Quick commands:
+• /dashboard — view your status & receipts
+• /packages — compare VIP routes
+• /education — unlock training tracks
+• /support — reach the concierge desk
+
+Let us know if you need anything.`,
     "about_us": `🏢 About Dynamic Capital
 
-We are a leading trading education and signals provider with years of experience in financial markets.
+Dynamic Capital pairs senior analysts with automation so every member receives:
+• Institutional-grade trade ideas with transparent performance
+• Structured mentorship paths that level up risk governance
+• Concierge support that keeps you accountable to the playbook
 
-Our mission is to help traders succeed through:
-• Premium trading signals
-• Educational resources
-• Community support
-• Expert guidance`,
+We operate across timezones to keep members synced with the desk.`,
     "support_message": `🛟 *Need Help?*
 
 Our support team is here for you!
@@ -205,72 +199,67 @@ Our support team is here for you!
 🕐 Support Hours: 24/7
 
 We typically respond within 2-4 hours.`,
-    "terms_conditions": `📋 Terms & Conditions
+    "terms_conditions": `📋 Terms & Policies
 
-By using our services, you agree to:
+By using Dynamic Capital you acknowledge:
+• Trading involves risk; results are never guaranteed
+• Signals and automation are educational guidance only
+• Access is personal and monitored for compliance
+• Refunds follow the onboarding guarantee outlined in your plan
 
-• 🔒 Privacy Policy
-• 📊 Trading Risk Disclosures
-• 💼 Service Usage Guidelines
-• 🚫 No Financial Advice Disclaimer
+Full terms: https://dynamic.capital/terms`,
+    "help_message": `❓ Bot Commands & Shortcuts
 
-Read the full terms at: dynamiccapital.com/terms`,
-    "help_message": `❓ Bot Commands & Help
+/start — reopen the main menu
+/dashboard — view status, receipts, and automation
+/packages — compare VIP routes
+/promo — check active incentives
+/vip — review membership benefits
+/education — browse training tracks
+/support — contact the concierge desk
+/ask QUESTION — get AI coaching
+/shouldibuy SYMBOL — request an educational breakdown
+/about — learn more about Dynamic Capital
 
-Available commands:
-/start - Main menu
-/dashboard or /account - View account dashboard
-/packages - View VIP packages
-/promo - View active promotions
-/vip - VIP benefits
-/help - Show this help
-/support - Contact support
-/faq - Frequently asked questions
-/education - View education packages
-/ask QUESTION - Ask our AI assistant
-/shouldibuy SYMBOL - Get educational trade analysis
-/about - About us
+Need a human? Message @DynamicCapital_Support.`,
+    "faq_general": `❓ Frequently Asked Questions
 
-Need assistance? Contact @DynamicCapital_Support`,
-    "faq_general": `❓ **Frequently Asked Questions**
+🔹 How do I join VIP?
+Select a package, follow the payment instructions, and upload your receipt. The desk verifies within 24 hours.
 
-🔷 **Q: How do I join VIP?**
-A: Select a VIP package, complete payment, and you'll be added automatically after verification.
+🔹 What payments are supported?
+USDT (TRC20) and vetted bank transfers. Concierge will route you to the correct channel.
 
-🔷 **Q: What payment methods do you accept?**
-A: We accept USDT (TRC20) and bank transfers.
+🔹 How fast are signals delivered?
+The desk streams intraday calls in real time with clear entry, stop, and target guidance.
 
-🔷 **Q: How quickly are signals sent?**
-A: VIP signals are sent in real-time as market opportunities arise, typically 5-10 per day.
+🔹 What else is included?
+Mentorship pathways, automation access once approved, and daily debriefs so you stay aligned.
 
-🔷 **Q: Do you offer refunds?**
-A: We offer a 7-day satisfaction guarantee for new VIP members.
+🔹 Can I cancel?
+Yes. You retain access until the end of your current billing window.
 
-🔷 **Q: What's included in VIP membership?**
-A: Real-time signals, market analysis, educational content, priority support, and access to VIP community.
-
-🔷 **Q: Can I cancel my subscription?**
-A: Yes, you can cancel anytime. Access continues until your current period ends.
-
-🔷 **Q: Do you provide trading education?**
-A: Yes! We offer comprehensive courses for beginners to advanced traders.
-
-💡 **Still have questions?** Contact our support team!`,
+Still stuck? Reach out via /support.`,
     "vip_benefits": `💎 VIP Membership Benefits
 
-🚀 Premium Trading Signals
-📊 Daily Market Analysis
-💬 VIP Community Access
-🎓 Educational Resources
-📞 Priority Support
-💰 Exclusive Promotions`,
+🚀 Real-time signal desk with analyst commentary
+📊 Performance dashboards and accountability reviews
+🧠 Mentorship sprints tailored to your trading tier
+🤖 Automation hooks once your risk review clears
+🛎️ Concierge support around the clock
+🎁 Members-only promotions and capital unlocks`,
     "payment_instructions": `💳 Payment Instructions
 
-We accept:
-🏦 Bank Transfer
-🪙 USDT (TRC20)
+We currently accept:
+🏦 Bank transfer through our vetted partners
+🪙 USDT (TRC20) sent to the treasury address
 
-After payment, upload your receipt and our admin will verify it manually within 24 hours.`,
+After payment:
+1. Capture the receipt or transaction hash.
+2. Upload it here so the desk can verify ownership.
+3. Our team confirms and activates your access within 24 hours (often sooner).
+
+Need help with payment routing? Use /support.`,
   };
 
   const defaultValue = defaultContents[contentKey];

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -540,17 +540,18 @@ async function handleAskCommand(ctx: CommandContext): Promise<void> {
   const question = ctx.args.join(" ");
   if (!question) {
     const usage = await getContent("ask_usage") ??
-      "Please provide a question. Example: /ask What is trading?";
+      "Please send a question, e.g. /ask How do I size positions?";
     await notifyUser(ctx.chatId, usage);
     return;
   }
   try {
     const answer = await askChatGPT(question) ??
       (await getContent("ask_no_answer")) ??
-      "Unable to get answer.";
+      "I couldn't find anything helpful. Try rephrasing or ask /support.";
     await notifyUser(ctx.chatId, answer);
   } catch {
-    const msg = await getContent("ask_failed") ?? "Failed to get answer.";
+    const msg = await getContent("ask_failed") ??
+      "The coaching assistant is unavailable right now. Please try again shortly.";
     await notifyUser(ctx.chatId, msg);
   }
 }
@@ -559,13 +560,13 @@ async function handleShouldIBuyCommand(ctx: CommandContext): Promise<void> {
   const instrument = ctx.args[0];
   if (!instrument) {
     const usage = await getContent("shouldibuy_usage") ??
-      "Please provide an instrument. Example: /shouldibuy XAUUSD";
+      "Please send a symbol, e.g. /shouldibuy XAUUSD.";
     await notifyUser(ctx.chatId, usage);
     return;
   }
   if (!SUPABASE_URL) {
     const msg = await getContent("service_unavailable") ??
-      "Service unavailable.";
+      "Service temporarily unavailable. Please try again soon.";
     await notifyUser(ctx.chatId, msg);
     return;
   }
@@ -578,11 +579,11 @@ async function handleShouldIBuyCommand(ctx: CommandContext): Promise<void> {
     const data = await res.json().catch(() => ({}));
     const analysis = data.analysis ??
       (await getContent("shouldibuy_no_analysis")) ??
-      "Unable to get analysis.";
+      "No analysis is available yet. Try again soon or contact /support.";
     await notifyUser(ctx.chatId, analysis, { parse_mode: "Markdown" });
   } catch {
     const msg = await getContent("shouldibuy_failed") ??
-      "Failed to get analysis.";
+      "The analysis desk is offline right now. Please try again shortly.";
     await notifyUser(ctx.chatId, msg);
   }
 }
@@ -876,7 +877,8 @@ Route inquiries or marketing requests to the channels listed above.`;
   }
   const msg = await getContent("welcome_message");
   return {
-    text: msg ?? "Welcome! Choose an option:",
+    text: msg ??
+      "Welcome to Dynamic Capital! Choose how you'd like to continue:",
     extra: { reply_markup: markup, parse_mode: "Markdown" },
   };
 }
@@ -1564,7 +1566,7 @@ async function handleCallback(update: TelegramUpdate): Promise<void> {
       }
       if (!SUPABASE_URL) {
         const msg = await getContent("service_unavailable") ??
-          "Service unavailable.";
+          "Service temporarily unavailable. Please try again soon.";
         await notifyUser(chatId, msg);
         return;
       }


### PR DESCRIPTION
## Summary
- refresh the default Telegram bot content that is auto-seeded when entries are missing so new members see up-to-date messaging
- update the /ask and /shouldibuy fallbacks plus the welcome menu text to match the refreshed voice when dynamic content is unavailable
- expand the bot content reference doc with the new defaults for easier operator overrides

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68de85cd1844832290638f59e52aff31