### PR TITLE
Add installation guidance to TON toolkit documentation

### DIFF
--- a/docs/ton-trading-open-source-toolkit.md
+++ b/docs/ton-trading-open-source-toolkit.md
@@ -1,0 +1,305 @@
+# TON Trading Open-Source AI Toolkit
+
+This playbook consolidates the open-source tooling required to build a
+TON-native trading intelligence stack. It covers data collection, model
+development, orchestration, deployment, and monitoring layers so engineers can
+assemble end-to-end pipelines without relying on closed SaaS dependencies.
+
+## Installation Quickstart
+
+Set up a reproducible environment before integrating individual tools. The
+snippets below cover the primary ecosystems used throughout this catalogue.
+
+### Python
+
+Create an isolated environment (via `venv`, Conda, or Poetry) and install the
+core analytics and trading dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install "tonpy" "tonapi-sdk" "ccxt" "pandas" "numpy" "pandas-ta" \
+    "ta-lib" "tsfresh" "scikit-learn" "xgboost" "lightgbm" "catboost" \
+    "torch" "pytorch-lightning" "prophet" "statsmodels" "mlflow" \
+    "backtrader" "vectorbt" "pyportfolioopt"
+```
+
+Add optional packages as needed:
+
+- **Data validation** – `pip install great-expectations pandera`
+- **Reinforcement learning** – `pip install stable-baselines3 finrl`
+- **Experiment tracking** – `pip install wandb tensorboard`
+
+### JavaScript / TypeScript
+
+Use Node.js (v18+) and install TON and automation SDKs with your preferred
+package manager:
+
+```bash
+pnpm add tonweb ton tonapi-sdk ccxt playwright @playwright/test
+npm install --save tonweb ton tonapi-sdk ccxt playwright
+```
+
+Install browser binaries for Playwright-based scrapers or tests:
+
+```bash
+npx playwright install
+```
+
+### System Services
+
+Leverage containers or managed offerings for stateful components:
+
+```bash
+# Kafka + Zookeeper
+docker compose up -d kafka zookeeper
+
+# PostgreSQL with TimescaleDB extension
+docker run --name ton-timescale -p 5432:5432 \
+  -e POSTGRES_PASSWORD=postgres timescale/timescaledb:latest-pg15
+
+# Redis cache
+docker run --name ton-redis -p 6379:6379 -d redis:7
+```
+
+When deploying in production, codify infrastructure with Terraform or similar
+IaC tooling so data pipelines and services can be recreated consistently.
+
+## Data Extraction & Collection
+
+### Blockchain & TON-Specific Libraries
+
+- **TonWeb** – JavaScript SDK for interacting with TON smart contracts, wallets,
+  and storage primitives.
+- **PyTON / ton-python** – Python clients for sending TON transactions, calling
+  get methods, and integrating with Python-based analytics.
+- **TON API SDKs** – Official API clients for explorers and indexers that
+  surface transactions, jetton metadata, and account state.
+- **Web3.py** – Ethereum-compatible client helpful for bridging TON flows with
+  other chains.
+- **ccxt** – Unified exchange API supporting 100+ centralized and decentralized
+  venues.
+
+### Web Scraping & Data Gathering
+
+- **Scrapy** – Full-featured crawling framework for structured data extraction
+  pipelines.
+- **BeautifulSoup4** – HTML and XML parser ideal for rapid prototyping scrapers
+  and data normalization.
+- **Selenium** – Browser automation for interacting with dynamic sites or
+  portals requiring user flows.
+- **Playwright** – Modern browser automation with cross-browser support and
+  resilient selectors.
+- **Pandas** – Tabular data manipulation, CSV/Excel handling, and lightweight
+  ETL routines.
+- **requests** – HTTP client for REST, GraphQL, and RPC endpoints.
+
+### Real-Time Data Streams
+
+- **Apache Kafka** – Distributed log for market data, alerts, and event-driven
+  microservices.
+- **Redis** – In-memory cache and message broker for low-latency fan-out.
+- **InfluxDB** – Time-series database optimized for metrics and high-cardinality
+  signals.
+- **WebSocket libraries** – `websockets`, `socket.io`, or similar stacks for
+  streaming exchange data and bot events.
+
+## Data Processing & Feature Engineering
+
+### Data Processing Runtimes
+
+- **Pandas** – Core DataFrame API for reshaping signals, joins, and rolling
+  computations.
+- **NumPy** – Numerical array operations, linear algebra, and vectorized math.
+- **Polars** – Arrow-powered alternative to Pandas delivering faster query plans
+  on large datasets.
+- **Dask** – Parallel computing primitives for scaling DataFrame and array
+  workloads.
+- **Apache Spark (PySpark)** – Distributed compute engine for petabyte-scale
+  ETL.
+
+### Feature Engineering Libraries
+
+- **TA-Lib** – Battle-tested technical indicators including RSI, MACD, and
+  Bollinger Bands.
+- **pandas-ta** – Pure Python indicator suite that integrates tightly with
+  Pandas.
+- **Feature-engine** – Transformers for outlier handling, encoding, and feature
+  selection.
+- **tsfresh** – Automated time-series feature extraction with statistical
+  significance tests.
+
+### Data Quality Tooling
+
+- **Great Expectations** – Declarative data validation and documentation.
+- **Pandera** – DataFrame typing and runtime validation for Pandas and Polars.
+- **cleanlab** – Detects label issues and data quality defects in ML datasets.
+
+## Machine Learning Frameworks
+
+### Core Machine Learning
+
+- **scikit-learn** – Classical models such as Random Forest, SVM, and linear
+  methods.
+- **XGBoost** – Gradient boosting with tree ensembles and GPU acceleration.
+- **LightGBM** – High-performance gradient boosting optimized for large
+  datasets.
+- **CatBoost** – Gradient boosting with native categorical feature handling.
+
+### Deep Learning Stacks
+
+- **TensorFlow** – Production-ready deep learning framework with rich tooling.
+- **PyTorch** – Research-friendly deep learning framework with dynamic
+  computation graphs.
+- **Keras** – High-level neural network API running atop TensorFlow.
+- **JAX** – High-performance numerical computing with auto-differentiation and
+  TPU support.
+
+### Time-Series Forecasting
+
+- **Prophet** – Additive time-series forecasting tuned for business signals.
+- **statsmodels** – Statistical modeling suite covering ARIMA, SARIMAX, and
+  regression.
+- **Darts** – Unified API for classical, machine learning, and deep learning
+  forecasters.
+- **GluonTS** – Probabilistic forecasting library built on MXNet.
+- **LSTM/GRU implementations** – Sequence models in PyTorch or TensorFlow for
+  recurrent forecasting.
+
+### Reinforcement Learning
+
+- **Stable-Baselines3** – Implementations of PPO, A2C, SAC, and other RL
+  algorithms.
+- **Ray RLlib** – Distributed reinforcement learning at cluster scale.
+- **OpenAI Gym** – Standardized RL environment interfaces and benchmarks.
+- **FinRL** – Finance-focused RL library with market simulators and baseline
+  strategies.
+
+## Natural Language Processing & Sentiment
+
+### NLP Foundations
+
+- **Hugging Face Transformers** – Pre-trained language models (BERT, GPT, T5)
+  and fine-tuning utilities.
+- **spaCy** – Industrial-strength NLP pipelines with NER, dependency parsing,
+  and tokenization.
+- **NLTK** – Classic NLP toolkit for linguistic preprocessing and education.
+- **Gensim** – Topic modeling, word embeddings, and document similarity APIs.
+- **TextBlob** – Lightweight sentiment and text processing helpers.
+
+### Sentiment Analysis Models
+
+- **VADER** – Rule-based sentiment analyzer tuned for social media tone.
+- **FinBERT** – Financial sentiment model adapted to news and filings.
+- **Twitter-roBERTa** – RoBERTa variant trained on social media data for
+  context-aware sentiment scoring.
+
+## Model Training, Optimization & Deployment
+
+### Hyperparameter Tuning
+
+- **Optuna** – Bayesian optimization with pruning strategies and visualization
+  dashboards.
+- **Ray Tune** – Distributed tuning framework with support for schedulers and
+  search algorithms.
+- **Hyperopt** – Sequential model-based optimization for search spaces defined
+  by Python dictionaries.
+- **scikit-optimize** – Lightweight optimization built on top of `scikit-learn`
+  primitives.
+
+### Experiment Tracking
+
+- **MLflow** – Experiment logging, model registry, and artifact management.
+- **Weights & Biases** – SaaS-backed experiment tracker with collaboration
+  features (free tier available).
+- **TensorBoard** – Visualization suite for metrics, scalars, and graphs.
+- **DVC** – Data version control for datasets, models, and pipelines.
+
+### Model Serving & Deployment
+
+- **ONNX** – Interoperable model format spanning PyTorch, TensorFlow, and more.
+- **TorchServe** – PyTorch-native model server for REST and gRPC inference.
+- **TensorFlow Serving** – TensorFlow model deployment with A/B testing support.
+- **BentoML** – Framework-agnostic model packaging and API serving.
+
+## Backtesting, Strategy Design & Portfolio Management
+
+### Trading Strategy Frameworks
+
+- **Backtrader** – Python backtesting engine with broker integrations.
+- **Zipline** – Quantopian’s algorithmic trading library with pipeline API.
+- **VectorBT** – Vectorized backtesting toolkit using NumPy and Pandas.
+- **Backtesting.py** – Lightweight framework for strategy research.
+- **QuantConnect LEAN** – Open-source multi-asset algorithmic trading engine.
+
+### Portfolio Optimization & Risk
+
+- **PyPortfolioOpt** – Portfolio construction, efficient frontier, and risk
+  parity.
+- **Riskfolio-Lib** – Advanced portfolio optimization, risk attribution, and
+  allocation models.
+- **empyrical** – Financial risk metrics including Sharpe, drawdown, and
+  volatility.
+
+## Visualization & Monitoring
+
+### Data Visualization
+
+- **Matplotlib** – Foundational plotting library for static charts.
+- **Plotly** – Interactive web-ready plotting toolkit.
+- **Seaborn** – Statistical visualization built on Matplotlib.
+- **Bokeh** – Interactive web visualization and dashboarding.
+- **Dash** – Web application framework for Plotly dashboards.
+
+### Trading Visualizations
+
+- **mplfinance** – Financial charting for candlesticks, OHLC, and overlays.
+- **Lightweight Charts** – TradingView-style interactive charts.
+
+## Storage & Infrastructure
+
+### Databases & Storage Engines
+
+- **PostgreSQL** – Relational database with rich SQL support; pair with
+  TimescaleDB for time-series.
+- **MongoDB** – Document store suited for unstructured market intelligence.
+- **ClickHouse** – Columnar OLAP database for analytical queries.
+- **QuestDB** – High-ingest time-series database with SQL interface.
+- **SQLite** – Embedded database for local prototyping and edge deployments.
+
+## Orchestration & Automation
+
+### Workflow Orchestration
+
+- **Apache Airflow** – DAG-based workflow scheduler for ETL and model pipelines.
+- **Prefect** – Pythonic orchestration with reactive flows and cloud/local
+  agents.
+- **Luigi** – Dependency-driven pipeline manager from Spotify.
+- **Dagster** – Data-aware orchestrator with asset-based abstractions.
+
+### Task Scheduling & Queues
+
+- **Celery** – Distributed task queue with broker-agnostic support.
+- **APScheduler** – Lightweight job scheduler for cron, interval, and date
+  triggers.
+
+## Recommended TON Trading Stack
+
+- **Data Pipeline:** Pandas + ccxt + TON SDK + Kafka for resilient ingestion and
+  normalization.
+- **Feature Engineering:** pandas-ta + NumPy + tsfresh to generate technical and
+  statistical factors.
+- **Machine Learning:** PyTorch + Stable-Baselines3 to combine supervised
+  signals with reinforcement learning policies.
+- **Backtesting:** Backtrader or VectorBT for fast iteration on trading logic
+  prior to production deployment.
+- **Experiment Tracking:** MLflow + TensorBoard to log experiments, artifacts,
+  and training curves.
+- **Deployment:** FastAPI + Docker to expose inference services and automate
+  containerized releases.
+- **Database:** PostgreSQL with TimescaleDB extensions for durable, queryable
+  market history.
+
+Keep this catalogue updated as new TON ecosystem tooling and open-source AI
+libraries mature so engineering teams can ship end-to-end trading capabilities
+faster.


### PR DESCRIPTION
## Summary
- add a TON trading open-source AI toolkit playbook that consolidates data collection, machine learning, orchestration, and deployment libraries
- document installation quickstart for Python, JavaScript, and infrastructure tooling referenced in the TON trading toolkit

## Testing
- npx deno fmt docs/ton-trading-open-source-toolkit.md

------
https://chatgpt.com/codex/tasks/task_e_68de9170fd048322951a33dc38b97307