### PR TITLE
Add TON trading system improvement plan

### DIFF
--- a/docs/dynamic-ton-trading-system-plan.md
+++ b/docs/dynamic-ton-trading-system-plan.md
@@ -1,0 +1,128 @@
+# Dynamic TON Trading System Improvement Plan
+
+This plan categorizes the existing modules, identifies the minimum viable product (MVP) surface, and charts a path to a production-ready TON-native trading platform.
+
+## 1. Component Taxonomy and Priorities
+
+| Domain | Components | MVP Priority |
+| --- | --- | --- |
+| **Trading Engine & Strategy** | `dynamic_trading_language`, `dynamic_candles`, `dynamic_indicators`, `dynamic_orderflow`, `dynamic_agents`, `dynamic_bots`, `dynamic_forecast`, `dynamic_predictive`, `dynamic_quantitative`, `dynamic_evaluation`, `dynamic_sync`, `dynamic_loop`, `dynamic_arrow`, `dynamic_zone`, `dynamic_chain`, `dynamic_block`, `dynamic_matrix`, `dynamic_states`, `dynamic_method`, `dynamic_package`, `dynamic_framework` | Core: trading language, candles, indicators, bots. Enhanced: orderflow, agents, predictive, evaluation. Advanced: matrix/states abstractions. |
+| **Blockchain & TON Infrastructure** | `dynamic_ton`, `dynamic_blockchain`, `dynamic_contracts`, `dynamic_wallet`, `dynamic_validator`, `dynamic_domain`, `dynamic_domain_name_system`, `dynamic_proof_of_stake`, `dynamic_block`, `dynamic_chain`, `dynamic_link_model` | Core: TON SDK + wallets. Enhanced: contracts, staking, DNS hooks. Advanced: validator orchestration. |
+| **AI/ML & Cognitive Tooling** | `dynamic_deep_learning`, `dynamic_machine_learning`, `dynamic_reinforcement_learning`, `dynamic_predictive`, `dynamic_forecast`, `dynamic_cycle`, `dynamic_chaos_engine`, `dynamic_chaos_model`, `dynamic_learning`, `dynamic_memory`, `dynamic_metacognition`, `dynamic_thinking`, `dynamic_skills`, `dynamic_trainer` | Core: supervised models for signal generation. Enhanced: reinforcement learning, chaos/cycle analytics. Advanced: cognitive stacks for self-optimizing agents. |
+| **System Architecture & DevOps** | `dynamic_microservices`, `dynamic_client_server`, `dynamic_proxy`, `dynamic_firewall`, `dynamic_load_balancer`, `dynamic_cache`, `dynamic_database`, `dynamic_message_queue`, `dynamic_logging`, `dynamic_graphql`, `dynamic_dockerfile`, `dynamic_local_machine`, `dynamic_clusters`, `dynamic_superclusters` | Core: containerized services + database. Enhanced: queues, logging, API layer. Advanced: multi-cluster orchestration. |
+| **Business, Compliance & Ecosystem** | `dynamic_business_engine`, `dynamic_btmm`, `dynamic_social_engine`, `dynamic_kyc`, `dynamic_team`, `dynamic_builders`, `dynamic_watchers`, `dynamic_agents`, `dynamic_assign`, `dynamic_bridge`, `dynamic_dev_engine`, `dynamic_fine_tune_engine` | Core: business engine for account management. Enhanced: KYC + bridge. Advanced: fine-tuned partner integrations. |
+
+### MVP Scope
+
+1. **Market Data + Strategy Definition**: `dynamic_trading_language`, `dynamic_candles`, `dynamic_indicators`.
+2. **Execution & Blockchain Integration**: `dynamic_ton`, `dynamic_wallet`, basic contract wrappers from `dynamic_contracts`.
+3. **Operations Backbone**: `dynamic_database`, `dynamic_logging`, Supabase integration.
+4. **User Experience**: Next.js dashboard to monitor balances, configure strategies, and audit trades.
+
+### Expansion Priorities
+
+- **Phase 2**: Activate `dynamic_agents`, `dynamic_bots`, `dynamic_orderflow`, `dynamic_forecast`, real-time visualization (`dynamic_volume`).
+- **Phase 3**: Layer reinforcement learning, chaos/cycle analysis modules, and microservice scaling primitives.
+
+## 2. Reference Architecture & Interactions
+
+```
+Exchange / TON Market Feeds → Data Collectors (`dynamic_candles`, `dynamic_orderflow`) →
+Feature Store (`dynamic_indicators`, pandas, Feast) →
+Model Orchestrator (`dynamic_predictive`, `dynamic_machine_learning`, PyTorch/Scikit-Learn) →
+Signal Bus (Kafka / Redis Streams from `dynamic_message_queue`) →
+Strategy Runtime (`dynamic_trading_language`, `dynamic_agents`, Python DSL interpreter) →
+Execution Gateway (`dynamic_ton`, `dynamic_wallet`, smart-contract wrappers) →
+TON Blockchain → Trade Receipts → Persistence Layer (Supabase/PostgreSQL) →
+Frontend (Next.js, GraphQL) & Observability (`dynamic_logging`, Prometheus, Grafana).
+```
+
+- **Data Layer**: Python collectors pull OHLCV, order book, and on-chain metrics, normalize via `dynamic_candles`, then push to a time-series store.
+- **Feature & AI Layer**: `dynamic_indicators` produce deterministic features; AI pipelines use scikit-learn for MVP, later PyTorch and reinforcement agents.
+- **Strategy Runtime**: The DSL (`dynamic_trading_language`) parses strategy configs; `dynamic_agents` evaluate signals and invoke wallet actions.
+- **Blockchain Execution**: `dynamic_ton` abstracts RPC; `dynamic_wallet` handles key custody and signing; optional smart contracts enforce guardrails.
+- **Service Mesh**: FastAPI or GraphQL APIs expose signals to the Next.js frontend; Supabase manages auth and relational data; Docker/Kubernetes run microservices; message queues decouple ingestion, inference, and execution.
+- **Observability & Security**: Structured logs (OpenTelemetry), Prometheus metrics, alerting hooks; secrets stored in Vault/MPC; audit trails synced to Supabase.
+
+## 3. Technology Stack by Component
+
+| Component | Role | Preferred Technologies |
+| --- | --- | --- |
+| Market Data Pipeline | Collect and normalize exchange + on-chain feeds | Python, `ccxt`, `tonweb`, `pandas`, Apache Kafka/NATS |
+| Feature Engineering & Storage | Compute indicators, manage features | `dynamic_indicators`, pandas-ta, Feast/RedisTimeSeries |
+| Signal Modelling | Predict price/action probabilities | scikit-learn (MVP), PyTorch/Lightning (Phase 2+), MLflow |
+| Strategy DSL Runtime | Author and execute trading playbooks | Python interpreter, Pydantic for schema validation, YAML/JSON DSL |
+| Execution Gateway | Submit TON trades, manage wallets | `tonweb`/`pytonlib`, FastAPI service, HSM/MPC key store |
+| Backend Services | Orchestrate APIs and tasks | FastAPI + GraphQL (Ariadne), Supabase/PostgreSQL, Redis |
+| Frontend Dashboard | Operator console | Next.js + Tailwind CSS, React Query, WebSockets |
+| DevOps & Infrastructure | Packaging, deployment, monitoring | Docker, Kubernetes, Terraform, GitHub Actions, Prometheus/Grafana, Loki |
+
+## 4. Delivery Roadmap
+
+### Phase 1 – MVP (6–8 weeks)
+
+1. Wire TON wallet management and transaction submission (`dynamic_ton`, `dynamic_wallet`).
+2. Build Python market data collectors with candle + indicator computation.
+3. Implement strategy DSL parser and execution loop for simple indicators.
+4. Stand up Supabase schema for users, strategies, executions.
+5. Ship Next.js dashboard: login, wallet overview, strategy CRUD, trade history.
+6. Establish CI/CD with Docker images and GitHub Actions; add Prometheus/Grafana stack.
+
+### Phase 2 – Enhanced Features & Scale (8–12 weeks)
+
+1. Introduce advanced strategies (`dynamic_agents`, `dynamic_bots`, `dynamic_orderflow`).
+2. Add predictive models (gradient boosting, shallow neural nets) and model registry.
+3. Expand frontend with real-time charts (trading view widgets, WebSocket streaming).
+4. Deploy message queues and microservice separation (ingestion, inference, execution).
+5. Harden security: role-based access, KYC hooks, secrets management, contract audits.
+6. Roll out automated backtesting harness and risk analytics dashboards.
+
+### Phase 3 – Advanced AI & Autonomous Trading (12+ weeks)
+
+1. Integrate reinforcement learning agents and self-optimizing policy loops.
+2. Apply chaos/cycle analytics for regime detection (`dynamic_chaos_engine`, `dynamic_cycle`).
+3. Scale infrastructure: Kubernetes autoscaling, multi-region TON gateways, CDN for UI.
+4. Introduce governance/stewardship tooling (`dynamic_business_engine`, `dynamic_team`).
+5. Enable on-chain execution safeguards (conditional contracts, validator collaborations).
+6. Launch ecosystem APIs for partners via GraphQL/REST gateway.
+
+## 5. Implementation Playbooks
+
+### Trading Engine & DSL
+
+1. Define Pydantic schemas for strategy definitions (indicators, risk parameters, triggers).
+2. Build interpreter translating DSL to executable Python tasks using `dynamic_loop`.
+3. Implement backtest harness leveraging pandas and vectorbt to validate strategies.
+4. Wire runtime to message queue for asynchronous execution and failure recovery.
+
+### AI/ML Pipelines
+
+1. Stand up feature store with Feast; version datasets in DVC or LakeFS.
+2. Implement training notebooks/services using scikit-learn (MVP) and PyTorch (Phase 2).
+3. Automate model evaluation via MLflow and integrate drift detection (Evidently, WhyLogs).
+4. Deploy inference microservice with FastAPI + ONNX Runtime or TorchServe.
+
+### Blockchain Execution
+
+1. Implement wallet manager with mnemonic import/export, key rotation, and MPC/HSM storage.
+2. Create transaction builder utilities (TON transfer, DEX interaction) with tonweb SDK.
+3. Optional: deploy smart contracts for escrow/risk enforcement; integrate CI security scans.
+4. Monitor chain events via tonweb websockets and push updates to Supabase + UI.
+
+### Platform & DevOps
+
+1. Containerize services with Docker; define Kubernetes manifests/Helm charts.
+2. Provision Supabase or PostgreSQL, Redis, and object storage (S3/GCS) via Terraform.
+3. Configure GitHub Actions for linting, testing, docker builds, and deployment promotion.
+4. Establish observability stack (Prometheus, Loki, Grafana, OpenTelemetry tracing).
+
+### Business & Ecosystem Enablement
+
+1. Model partner onboarding flows (KYC, permissions) in `dynamic_business_engine`.
+2. Create community/alerting bots using `dynamic_social_engine` and Telegram APIs.
+3. Define governance cadence for builders/keepers/watchers, aligning with roadmap phases.
+4. Publish developer documentation and SDK examples for strategy authors.
+
+---
+
+This roadmap aligns modular development with TON-first execution, ensuring the MVP proves value quickly while paving a scalable path for advanced AI-driven trading capabilities.


### PR DESCRIPTION
## Summary
- add a documentation plan that categorizes trading, blockchain, AI, and operations components
- map component interactions, technology stack selections, and phased roadmap for the TON trading platform

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de9a0cb2508322bc7ba8602606cfec