### PR TITLE
docs: add dynamic training model architecture reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,9 @@ documenting which assets were consulted.
 | 1.10 | [INVENTORY.csv](./INVENTORY.csv)                                               | CSV export that tracks documentation counts, line totals, and repo metrics.                                                |
 | 1.11 | [CHANGELOG.md](./CHANGELOG.md)                                                 | Chronological release notes maintained by the release automation.                                                          |
 | 1.12 | [dynamic-capital-ecosystem-anatomy.md](./dynamic-capital-ecosystem-anatomy.md) | Biological metaphor guide detailing how every subsystem, feedback loop, and TradingView bridge maps to automation pillars. |
-| 1.13 | [dynamic-capital-code-of-conduct.md](./dynamic-capital-code-of-conduct.md)     | Community behavior expectations, reporting paths, and enforcement process.                                                 |
-| 1.14 | [dynamic-capital-milestones.md](./dynamic-capital-milestones.md)               | Stage-by-stage milestone ladder aligning infrastructure, treasury, governance, and community outcomes.                     |
+| 1.13 | [dynamic-training-model-architecture.md](./dynamic-training-model-architecture.md) | DAI, DAGI, and DAGS training mesh outline covering cores, capability domains, governance pillars, and phased rollout. |
+| 1.14 | [dynamic-capital-code-of-conduct.md](./dynamic-capital-code-of-conduct.md)     | Community behavior expectations, reporting paths, and enforcement process.                                                 |
+| 1.15 | [dynamic-capital-milestones.md](./dynamic-capital-milestones.md)               | Stage-by-stage milestone ladder aligning infrastructure, treasury, governance, and community outcomes.                     |
 
 ## 2. Development Workflow & Standards
 

--- a/docs/dynamic-training-model-architecture.md
+++ b/docs/dynamic-training-model-architecture.md
@@ -1,0 +1,145 @@
+# Dynamic Training Model Architecture
+
+## Overview
+
+The Dynamic Capital training stack combines three modular domains—Dynamic AI
+(DAI), Dynamic AGI (DAGI), and Dynamic AGS (DAGS)—to deliver progressive
+learning with tight governance controls. Each domain owns a distinct set of
+cores, capability areas, and oversight pillars that can be activated
+independently or orchestrated in concert.
+
+- **DAI** delivers the reasoning mesh, feature detection, and integration
+  surfaces that feed analytics into the broader system.
+- **DAGI** scales general intelligence capabilities, aligning strategic,
+  creative, and ethical reasoning across domains.
+- **DAGS** enforces governance, synchronization, and reliability so that DAI and
+  DAGI operate safely at scale.
+
+## DAI: 11-Core Training Mesh
+
+| Core   | Type                | Primary Focus                    |
+| ------ | ------------------- | -------------------------------- |
+| core1  | Data Processing     | Data ingestion and normalization |
+| core2  | Pattern Recognition | Feature detection and analysis   |
+| core3  | Predictive Modeling | Trend forecasting                |
+| core4  | Risk Assessment     | Probability and impact analysis  |
+| core5  | Optimization        | Parameter tuning and efficiency  |
+| core6  | Adaptive Learning   | Continuous improvement loops     |
+| core7  | Decision Logic      | Rule-based reasoning             |
+| core8  | Memory Management   | Knowledge retention              |
+| core9  | Context Analysis    | Situational awareness            |
+| core10 | Validation          | Output verification              |
+| core11 | Integration         | Cross-core synchronization       |
+
+### Implementation Notes
+
+- Start with `core1`–`core3` to bootstrap ingestion, pattern recognition, and
+  forecasting.
+- Add `core6` and `core7` when adaptive feedback loops and decision rules are
+  required.
+- Reserve `core10` and `core11` for integration testing and production handoff.
+
+## DAGI: 9 Domain Capability Lanes
+
+| Domain  | Capability                  | Training Emphasis                 |
+| ------- | --------------------------- | --------------------------------- |
+| domain1 | Natural Language Processing | Language models and comprehension |
+| domain2 | Strategic Planning          | Long-term goal optimization       |
+| domain3 | Problem Solving             | Multi-step reasoning              |
+| domain4 | Knowledge Synthesis         | Information integration           |
+| domain5 | Creative Generation         | Novel solution creation           |
+| domain6 | Ethical Reasoning           | Value-aligned decision making     |
+| domain7 | Social Intelligence         | Interaction and communication     |
+| domain8 | Self-Reflection             | Metacognition and improvement     |
+| domain9 | Cross-Domain Transfer       | Skill application across contexts |
+
+### Implementation Notes
+
+- Anchor early experiments in `domain1` and `domain2` to validate language and
+  planning.
+- Schedule `domain5`–`domain7` once the system requires creative ideation and
+  collaborative behaviors.
+- Keep `domain8` and `domain9` in continuous evaluation cycles to measure
+  cross-domain generalization.
+
+## DAGS: 5 Pillars of Governance
+
+| Pillar        | Training Focus Areas                                         | Core Methods                                        |
+| ------------- | ------------------------------------------------------------ | --------------------------------------------------- |
+| Governance    | Policy enforcement, compliance monitoring, decision auditing | Rule-based learning, constraint optimization        |
+| Sync          | Temporal coordination, data consistency, process alignment   | Distributed systems training, clock synchronization |
+| Memory        | Knowledge retention, experience logging, state management    | Vector databases, retrieval systems                 |
+| Observability | System monitoring, performance metrics, anomaly detection    | Log analysis, metric aggregation                    |
+| Reliability   | Fault tolerance, backup systems, recovery protocols          | Redundancy training, failover testing               |
+
+### Implementation Notes
+
+- Establish the Governance pillar first to codify policy and audit requirements.
+- Pair Sync and Observability for live operations so telemetry confirms data
+  alignment.
+- Stress test Reliability alongside Memory updates to validate disaster recovery
+  exercises.
+
+## Phased Training Orchestration
+
+The training program advances from foundation to integration using the following
+phases:
+
+1. **Foundation Training (4 weeks)**
+   - DAI cores: `core1`, `core2`, `core3`
+   - DAGI domains: `domain1`, `domain2`
+   - DAGS pillars: Governance, Reliability
+2. **Specialization Training (6 weeks)**
+   - Expand DAI coverage across advanced patterning, optimization, and adaptive
+     loops.
+   - Activate DAGI domains for problem solving, synthesis, creativity, and
+     ethics.
+   - Layer DAGS Sync, Memory, and Observability for operational oversight.
+3. **Integration Training (2 weeks)**
+   - Exercise DAI `core10` and `core11` for validation and cross-core
+     synchronization.
+   - Cross-train DAGI `domain8` and `domain9` on multi-domain workloads.
+   - Run full-stack drills through all DAGS pillars to ensure governance
+     readiness.
+
+## Training Data Requirements
+
+| Domain | Data Types                                       | Volume Target                | Quality Requirements                     |
+| ------ | ------------------------------------------------ | ---------------------------- | ---------------------------------------- |
+| DAI    | Time series, structured data, market signals     | High-frequency streaming     | Clean, timestamped, normalized           |
+| DAGI   | Text corpora, knowledge graphs, interaction logs | Diverse multi-modal datasets | Context-rich, diverse, ethically sourced |
+| DAGS   | System logs, performance metrics, audit trails   | Continuous monitoring        | Complete, consistent, tamper-proof       |
+
+## Evaluation Metrics
+
+| Domain | Metric              | Definition                              |
+| ------ | ------------------- | --------------------------------------- |
+| DAI    | Accuracy            | Prediction precision                    |
+| DAI    | Latency             | Response time                           |
+| DAI    | Adaptability        | Learning rate and responsiveness        |
+| DAGI   | Capability Coverage | Degree of domain mastery                |
+| DAGI   | Generalization      | Cross-task performance                  |
+| DAGI   | Reasoning Depth     | Complexity of solved problem structures |
+| DAGS   | System Stability    | Uptime and reliability benchmarks       |
+| DAGS   | Compliance Rate     | Policy adherence across workflows       |
+| DAGS   | Efficiency          | Resource utilization across components  |
+
+## Deployment Checklist
+
+1. Instantiate the training model scaffold and confirm core/domain/pillar
+   registration.
+2. Provision data pipelines that satisfy the domain-specific data requirements.
+3. Schedule the three-phase training program with stakeholder sign-off at each
+   gate.
+4. Configure metric dashboards aligned to the evaluation matrix above.
+5. Conduct integration reviews with DAGS governance leads before production
+   rollouts.
+
+## Next Steps
+
+- Extend the orchestration layer with automated runbooks for each phase
+  checkpoint.
+- Map DAI/DAGI artifacts to Supabase storage policies described in the
+  governance playbooks.
+- Add regression tests to verify that newly activated cores or domains report
+  metrics through the Observability pillar.


### PR DESCRIPTION
## Summary
- document the DAI, DAGI, and DAGS training architecture with core-by-core guidance
- index the new reference in the documentation table for quick discovery

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68dea044ab308322a5b586f472a9f49d