### PR TITLE
Refine Al-Wadud letter layout guidance

### DIFF
--- a/docs/wafq-al-wadud.md
+++ b/docs/wafq-al-wadud.md
@@ -1,0 +1,77 @@
+# Wafq Construction for Al-Wadud
+
+## Phase 1 — Foundation: Abjad Calculation
+
+To anchor the talisman to the Divine Name **Al-Wadud** (The Most Loving), start by converting each letter into its Abjad value.
+
+| Letter | Arabic | Abjad Value |
+| ------ | ------ | ----------- |
+| A      | ا      | 1           |
+| L      | ل      | 30          |
+| W      | و      | 6           |
+| D      | د      | 4           |
+| W      | و      | 6           |
+| D      | د      | 4           |
+
+Sum the values to obtain the base number: `1 + 30 + 6 + 4 + 6 + 4 = 51`.
+
+Reduce 51 to a single digit by adding its digits: `5 + 1 = 6`. This **root number** (6) will become the center of the square and drives the target sum for every row, column, and diagonal.
+
+## Phase 2 — Construction: 3x3 Wafq Layout
+
+A 3×3 magic square has a magic constant of `3 × root`. With a root of 6, each line must total **18**.
+
+1. Begin with the Lo Shu base pattern that covers the integers 1–9.
+
+   ```text
+   8  1  6
+   3  5  7
+   4  9  2
+   ```
+
+2. Shift the pattern so that the center aligns with the new root. The Lo Shu center is 5, so add `6 − 5 = 1` to every cell.
+3. The transformed square becomes:
+
+   ```text
+   9  2  7
+   4  6  8
+   5 10  3
+   ```
+
+   Mapping each value back to its Abjad letter (using the chart above) gives the following layout for the nine cells. Cross-check each entry against the Phase 1 table to ensure the numerical and alphabetic correspondences remain consistent:
+
+   | Position        | Number | Letter |
+   | --------------- | ------ | ------ |
+   | Top-left        | 9      | ط      |
+   | Top-center      | 2      | ب      |
+   | Top-right       | 7      | ز      |
+   | Mid-left        | 4      | د      |
+   | Center          | 6      | و      |
+   | Mid-right       | 8      | ح      |
+   | Bottom-left     | 5      | ه      |
+   | Bottom-center   | 10     | ي      |
+   | Bottom-right    | 3      | ج      |
+
+   For quick transcription, the letters can also be visualized in the same 3×3 arrangement:
+
+   ```text
+   ط  ب  ز
+   د  و  ح
+   ه  ي  ج
+   ```
+
+4. Verify that each line equals 18: rows `(9+2+7)`, `(4+6+8)`, `(5+10+3)`; columns `(9+4+5)`, `(2+6+10)`, `(7+8+3)`; diagonals `(9+6+3)`, `(7+6+5)`.
+
+The center now holds **6**, matching the root of Al-Wadud.
+
+## Phase 3 — Application: Talisman Assembly
+
+When translating the numeric template into a working talisman, practitioners in the Shams al-Ma'arif tradition typically layer several correspondences:
+
+- **Material preparation.** Inscribe the grid on a clean substrate such as pure silver, virgin parchment, or consecrated paper.
+- **Nominal anchoring.** Surround the square with the invocation *Ya Wadud* (يا ودود) so that the written form of the Name mirrors the numeric core. The central value 6 corresponds to the letter **و** (Waw), reinforcing the theme of love and connection.
+- **Letter inscription.** Populate the wafq with the nine letters from the table above (or the letter grid for easy copying) so the finished square mirrors both the numeric and alphabetic harmonies of the Name.
+- **Scriptural framing.** Add verses or mystical letters associated with affection and mercy—for example, the Qur’anic passage, “And among His signs is that He created for you mates … and placed between you affection and mercy.”
+- **Timing.** Perform the inscription during an auspicious window—traditionally Friday in the hour of Venus (Zuhra) and under the lunar mansion linked to union and commerce (al-Sharatain).
+
+Following these steps produces a complete Wafq of Al-Wadud that balances mathematical harmony with its spiritual intent.


### PR DESCRIPTION
## Summary
- clarify that each numeric entry in the Al-Wadud wafq should be cross-checked against the base Abjad chart when mapping to letters
- add a 3×3 letter grid for quick transcription and reference it in the talisman instructions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deafe66314832282295919cb7c39ee