### PR TITLE
fix: update root tsconfig path aliases

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "extends": "./apps/web/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["apps/web/*"],
-      "~/*": ["src/*"],
-      "next/font/google": ["src/stubs/next-font-google.ts"]
+      "@/*": ["./apps/web/*"],
+      "~/*": ["./src/*"],
+      "next/font/google": ["./src/stubs/next-font-google.ts"]
     },
     "types": ["vite/client"]
   },


### PR DESCRIPTION
## Summary
- update the repository root tsconfig path mappings to use explicit relative segments
- remove the redundant baseUrl entry now that all paths resolve explicitly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deb81fa2b08322898ddd21161f96e1