### PR TITLE
Fix vitest globals typing and add TonConnect module declaration

### DIFF
--- a/apps/web/types/tonconnect-ui-react.d.ts
+++ b/apps/web/types/tonconnect-ui-react.d.ts
@@ -1,0 +1,24 @@
+declare module "@tonconnect/ui-react" {
+  import type { ComponentType, ReactNode } from "react";
+
+  export interface TonConnectAccount {
+    address: string;
+    chain?: string;
+  }
+
+  export interface TonWallet {
+    account?: TonConnectAccount | null;
+  }
+
+  export interface TonConnectUIProviderProps {
+    manifestUrl: string;
+    children?: ReactNode;
+  }
+
+  export const TonConnectUIProvider: ComponentType<TonConnectUIProviderProps>;
+
+  export const TonConnectButton: ComponentType<Record<string, unknown>>;
+
+  export function useTonAddress(): string | null;
+  export function useTonWallet(): TonWallet | null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "~/*": ["./src/*"],
       "next/font/google": ["./src/stubs/next-font-google.ts"]
     },
-    "types": ["vite/client"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
   },
   "include": ["src", "apps/web", "shared"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- include Vitest and Testing Library globals in the root TypeScript config so `vi` mock helpers are available during type checks
- add a lightweight module declaration for `@tonconnect/ui-react` to satisfy the web app type checker without the upstream package

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68debb5a2dec83228acf0b27b863a9fe