### PR TITLE
Align Dynamic CLI bridge with AGI build module

### DIFF
--- a/apps/web/app/api/dynamic-cli/route.test.ts
+++ b/apps/web/app/api/dynamic-cli/route.test.ts
@@ -178,8 +178,14 @@ Deno.test("POST /api/dynamic-cli returns CLI output", async () => {
     throw new Error("Expected Dynamic CLI process to be spawned");
   }
 
-  if (!spawnCall.args.includes("--fine-tune-dataset")) {
-    throw new Error("Expected --fine-tune-dataset flag to be forwarded");
+  if (!spawnCall.args.includes("--dataset")) {
+    throw new Error("Expected --dataset flag to be forwarded");
+  }
+
+  if (!spawnCall.args.includes("dynamic.intelligence.agi.build")) {
+    throw new Error(
+      "Expected dynamic.intelligence.agi.build module to be used",
+    );
   }
 
   const stdinData = lastProcess?.stdin.chunks.join("");

--- a/apps/web/app/api/dynamic-cli/route.ts
+++ b/apps/web/app/api/dynamic-cli/route.ts
@@ -22,6 +22,7 @@ import {
 } from "@/utils/admin-auth.ts";
 
 const ROUTE_NAME = "/api/dynamic-cli";
+const CLI_MODULE = "dynamic.intelligence.agi.build";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -97,12 +98,14 @@ interface CliResult {
 async function executeCli(
   payload: z.infer<typeof requestSchema>,
 ): Promise<CliResult> {
-  const pythonBinary = process.env.DYNAMIC_CLI_PYTHON ?? process.env.PYTHON ??
+  const pythonBinary = process.env.DYNAMIC_AGI_PYTHON ??
+    process.env.DYNAMIC_CLI_PYTHON ??
+    process.env.PYTHON ??
     "python3";
 
   const args: string[] = [
     "-m",
-    "dynamic_framework",
+    CLI_MODULE,
     "--format",
     payload.format,
   ];
@@ -112,7 +115,7 @@ async function executeCli(
   }
 
   if (payload.exportDataset || payload.format === "fine-tune") {
-    args.push("--fine-tune-dataset", "-");
+    args.push("--dataset", "-");
   }
 
   for (const tag of payload.fineTuneTags) {

--- a/docs/DYNAMIC_CLI_MANUAL.md
+++ b/docs/DYNAMIC_CLI_MANUAL.md
@@ -27,8 +27,9 @@
 
 ## Page 1 — Preface & Audience
 
-The Dynamic CLI (command-line interface) orchestrates the `dynamic_framework`
-evaluation engine, enabling engineering leaders, delivery managers, and platform
+The Dynamic CLI (command-line interface) orchestrates the
+`dynamic.intelligence.agi.build` command—backed by the `dynamic_framework`
+evaluation engine—enabling engineering leaders, delivery managers, and platform
 strategists to transform scenario definitions into actionable maturity reports.
 This manual targets:
 
@@ -45,7 +46,7 @@ such as CI/CD, cron jobs, and ChatOps command handlers.
 ## Page 2 — Quick Start Synopsis
 
 1. Prepare a scenario definition in JSON (JavaScript Object Notation).
-2. Run `python -m dynamic_framework --scenario scenario.json`.
+2. Run `python -m dynamic.intelligence.agi.build --scenario scenario.json`.
 3. Review the text report summary in the terminal or request structured JSON
    using `--format json`.
 
@@ -67,10 +68,10 @@ such as CI/CD, cron jobs, and ChatOps command handlers.
 
 ### Invocation Patterns
 
-| Usage Form                    | Description                                                      | Synonyms              |
-| ----------------------------- | ---------------------------------------------------------------- | --------------------- |
-| `python -m dynamic_framework` | Execute the CLI using the module loader.                         | run, launch, initiate |
-| `dynamic-framework`           | If installed via an entry point script, invokes the same runner. | command, executable   |
+| Usage Form                                | Description                                                      | Synonyms              |
+| ----------------------------------------- | ---------------------------------------------------------------- | --------------------- |
+| `python -m dynamic.intelligence.agi.build` | Execute the enhanced Dynamic CLI module via the Python loader.   | run, launch, initiate |
+| `dynamic-framework`                       | If installed via an entry point script, invokes the same runner. | command, executable   |
 
 ### Core Flags
 
@@ -79,7 +80,7 @@ such as CI/CD, cron jobs, and ChatOps command handlers.
 | `--scenario PATH`                | _(optional)_   | Load scenario JSON from a file path or '-' for STDIN.                                                                | context file, input manifest, blueprint source |
 | `--format {text,json,fine-tune}` | `text`         | Choose plain text, JSON, or fine-tune dataset output.                                                                | output mode, rendering style, representation   |
 | `--indent N`                     | `2`            | Number of spaces applied to JSON pretty-printing.                                                                    | spacing, padding, indentation depth            |
-| `--fine-tune-dataset PATH`       | _(optional)_   | Write the Dynamic AGI training payload to `PATH` (use `-` for stdout). Parent directories are created automatically. | dataset export, training payload, AGI corpus   |
+| `--dataset PATH`                 | _(optional)_   | Write the Dynamic AGI training payload to `PATH` (use `-` for stdout). Parent directories are created automatically. | dataset export, training payload, AGI corpus   |
 | `--fine-tune-tag TAG`            | _(repeatable)_ | Apply default tags to generated fine-tune examples.                                                                  | label, classification marker, taxonomy token   |
 
 ---
@@ -91,7 +92,7 @@ such as CI/CD, cron jobs, and ChatOps command handlers.
 - **Filesystem path**: Absolute or relative path to a UTF-8 encoded JSON
   document.
 - **Standard input (`-`)**: Pipe a JSON payload directly, e.g.
-  `cat scenario.json | python -m dynamic_framework --scenario -`.
+  `cat scenario.json | python -m dynamic.intelligence.agi.build --scenario -`.
 - **Implicit default**: Omit `--scenario` to evaluate the baked-in exemplar
   scenario described in Appendix A.
 
@@ -168,7 +169,7 @@ such as CI/CD, cron jobs, and ChatOps command handlers.
 - Streams the Dynamic AGI training dataset derived from the current report.
 - Mirrors the structure returned by `build_fine_tune_dataset`, embedding the
   report payload alongside fine-tune examples and a dataset summary.
-- Combine with `--fine-tune-dataset PATH` to persist the JSON for ingestion by
+- Combine with `--dataset PATH` to persist the JSON for ingestion by
   the `DynamicAGIFineTuner` utility or orchestration pipelines.
 - Examples are ordered by node key so successive runs remain deterministic when
   the scenario input is unchanged.
@@ -236,11 +237,12 @@ can iterate on scenarios without a terminal.
   `-1` to minimise whitespace when exporting JSON.
 - **Fine-tune tags** — parallels the repeatable `--fine-tune-tag` flag. Enter up
   to 16 tags; they are forwarded to the CLI whenever datasets are generated.
-- **Dataset toggle** — invokes `--fine-tune-dataset -` when enabled so the API
-  response contains both the narrative report and the training dataset JSON.
+- **Dataset toggle** — invokes `--dataset -` when enabled so the API response
+  contains both the narrative report and the training dataset JSON.
 
 The underlying API route (`POST /api/dynamic-cli`) executes
-`python -m dynamic_framework`, streams scenario JSON over STDIN, and returns the
+`python -m dynamic.intelligence.agi.build`, streams scenario JSON over STDIN,
+and returns the
 serialised output—or CLI error—as a JSON response.
 
 > **Access control:** The web workbench is reserved for admin operators. The
@@ -255,7 +257,7 @@ serialised output—or CLI error—as a JSON response.
 ### Example 1: Evaluate Default Scenario
 
 ```bash
-python -m dynamic_framework
+python -m dynamic.intelligence.agi.build
 ```
 
 Produces the text summary for the built-in benchmark scenario.
@@ -264,7 +266,7 @@ Produces the text summary for the built-in benchmark scenario.
 
 ```bash
 jq '.pulses[0].momentum = 0.35' scenario.json \
-  | python -m dynamic_framework --scenario - --format json --indent 4
+  | python -m dynamic.intelligence.agi.build --scenario - --format json --indent 4
 ```
 
 Returns prettified JSON for integration into dashboards or alerting systems.
@@ -272,7 +274,7 @@ Returns prettified JSON for integration into dashboards or alerting systems.
 ### Example 3: Compact Machine Output
 
 ```bash
-python -m dynamic_framework --scenario scenario.json --format json --indent 0
+python -m dynamic.intelligence.agi.build --scenario scenario.json --format json --indent 0
 ```
 
 Useful for minimizing payload size in message queues.

--- a/docs/dynamic_cli_gui.md
+++ b/docs/dynamic_cli_gui.md
@@ -1,6 +1,7 @@
 # Dynamic CLI/CD Web Workbench
 
-The Dynamic CLI/CD workbench exposes the Python `dynamic_framework` engine
+The Dynamic CLI/CD workbench exposes the Python `dynamic.intelligence.agi.build`
+CLI (backed by the `dynamic_framework` engine)
 through the Next.js application so product, platform, and operations teams can
 experiment with maturity scenarios without leaving the browser. This document
 summarises how the GUI maps to the existing CLI workflow and the environment
@@ -17,7 +18,7 @@ variables required for local development.
 - **Fine-tune tags**: Adds up to 16 default tags, forwarding them via the
   repeatable `--fine-tune-tag` CLI flag.
 - **Dataset toggle**: Streams the dataset inline by invoking
-  `--fine-tune-dataset -`, allowing the API to return both report text/JSON and
+  `--dataset -`, allowing the API to return both report text/JSON and
   the training payload.
 
 ## Admin access
@@ -31,8 +32,8 @@ session required" prompt—refresh the admin control room to generate a new toke
 
 ## Next.js API bridge
 
-`POST /api/dynamic-cli` executes `python -m dynamic_framework`, passes scenario
-JSON via STDIN, and normalises the output into a JSON response:
+`POST /api/dynamic-cli` executes `python -m dynamic.intelligence.agi.build`,
+passes scenario JSON via STDIN, and normalises the output into a JSON response:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- update the Dynamic CLI API route to invoke the new `dynamic.intelligence.agi.build` module, prefer the `DYNAMIC_AGI_PYTHON` interpreter override, and use the updated `--dataset` flag
- refresh the CLI workbench documentation to reflect the new command path and dataset flag nomenclature
- adjust the Dynamic CLI API route test to assert the new module and flag usage

## Testing
- npm run lint
- npm run typecheck
- npm run test -- --filter dynamic-cli

------
https://chatgpt.com/codex/tasks/task_e_68dee09c23dc8322a4ef1b483ecc5280