### PR TITLE
Fix motion play button transition context memoization

### DIFF
--- a/apps/web/components/ui/motion-play-button.tsx
+++ b/apps/web/components/ui/motion-play-button.tsx
@@ -61,10 +61,16 @@ interface TransitionProps {
 const Transition = ({ value, children }: TransitionProps) => {
   const config = useContext(MotionConfigContext);
   const transition = value ?? config.transition;
+  const matchesParentTransition = Object.is(config.transition, transition);
+
   const contextValue = useMemo(
-    () => ({ ...config, transition }),
-    [config, transition],
+    () => (matchesParentTransition ? config : { ...config, transition }),
+    [config, matchesParentTransition, transition],
   );
+
+  if (matchesParentTransition) {
+    return <>{children}</>;
+  }
 
   return (
     <MotionConfigContext.Provider value={contextValue}>


### PR DESCRIPTION
## Summary
- add a Transition wrapper around the motion play button so its transition config mirrors MotionConfig updates
- memoize the provider value with both the upstream MotionConfig context and the requested transition

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68deed8ef20483229d3ec970b010d98a