### PR TITLE
Cache Supabase equity quotes

### DIFF
--- a/apps/web/components/dynamic-portfolio/home/__tests__/MarketWatchlist.test.ts
+++ b/apps/web/components/dynamic-portfolio/home/__tests__/MarketWatchlist.test.ts
@@ -1,4 +1,5 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { SUPABASE_CONFIG } from "@/config/supabase";
 
 vi.mock("@/components/dynamic-ui-system", () => ({
   Column: () => null,
@@ -18,12 +19,18 @@ vi.mock("../RefreshAnimation", () => ({
   RefreshAnimation: () => null,
 }));
 
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+
 type MarketWatchlistModule = typeof import("../MarketWatchlist");
 
 let marketWatchlistModule: MarketWatchlistModule;
 
 beforeAll(async () => {
   marketWatchlistModule = await import("../MarketWatchlist");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("MarketWatchlist taxonomy", () => {
@@ -55,5 +62,145 @@ describe("MarketWatchlist taxonomy", () => {
         expect(item.category).toBe(group.category);
       }
     }
+  });
+});
+
+describe("loadMarketQuotes", () => {
+  it("merges stock overrides from the equity quote provider", async () => {
+    const awesomePayload = {
+      EURUSD: {
+        bid: "1.1000",
+        pctChange: "0.50",
+        high: "1.2000",
+        low: "1.0000",
+        create_date: "2024-04-30 15:30:00",
+      },
+    } satisfies Record<string, unknown>;
+
+    const equityPayload = {
+      data: {
+        AAPL: {
+          last: 175.12,
+          changePercent: 1.2,
+          high: 180.5,
+          low: 170.3,
+        },
+        MSFT: {
+          last: 320.55,
+          changePercent: -0.4,
+          high: 325.0,
+          low: 315.0,
+        },
+      },
+      meta: { lastUpdated: "2024-05-01T12:00:00.000Z" },
+    } satisfies Record<string, unknown>;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+      if (url.includes("economia.awesomeapi.com.br")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(awesomePayload), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      if (url.includes("market-equity-quotes")) {
+        const headers = new Headers(init?.headers ?? {});
+        expect(headers.get("apikey")).toBe(SUPABASE_CONFIG.ANON_KEY);
+
+        return Promise.resolve(
+          new Response(JSON.stringify(equityPayload), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      throw new Error(`Unexpected fetch request for ${url}`);
+    });
+
+    const { quotes, lastUpdated } = await marketWatchlistModule
+      .loadMarketQuotes();
+
+    expect(quotes.AAPL).toEqual({
+      last: 175.12,
+      changePercent: 1.2,
+      high: 180.5,
+      low: 170.3,
+    });
+
+    expect(quotes.MSFT).toEqual({
+      last: 320.55,
+      changePercent: -0.4,
+      high: 325.0,
+      low: 315.0,
+    });
+
+    expect(quotes.EURUSD).toEqual({
+      last: 1.1,
+      changePercent: 0.5,
+      high: 1.2,
+      low: 1.0,
+    });
+
+    expect(lastUpdated?.toISOString()).toBe("2024-05-01T12:00:00.000Z");
+  });
+
+  it("continues when the equity feed request fails", async () => {
+    const awesomePayload = {
+      EURUSD: {
+        bid: "1.1000",
+        pctChange: "0.50",
+        high: "1.2000",
+        low: "1.0000",
+        create_date: "2024-04-30 15:30:00",
+      },
+    } satisfies Record<string, unknown>;
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+      if (url.includes("economia.awesomeapi.com.br")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(awesomePayload), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      if (url.includes("market-equity-quotes")) {
+        return Promise.resolve(new Response("", { status: 500 }));
+      }
+
+      throw new Error(`Unexpected fetch request for ${url}`);
+    });
+
+    const { quotes, lastUpdated } = await marketWatchlistModule
+      .loadMarketQuotes();
+
+    expect(quotes.EURUSD).toEqual({
+      last: 1.1,
+      changePercent: 0.5,
+      high: 1.2,
+      low: 1.0,
+    });
+
+    expect(quotes.AAPL).toBeUndefined();
+    expect(lastUpdated?.toISOString()).toBe("2024-04-30T15:30:00.000Z");
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/supabase/functions/market-equity-quotes/index.ts
+++ b/supabase/functions/market-equity-quotes/index.ts
@@ -1,0 +1,273 @@
+import {
+  corsHeaders,
+  jsonResponse,
+  methodNotAllowed,
+} from "../_shared/http.ts";
+import { createLogger } from "../_shared/logger.ts";
+import { registerHandler } from "../_shared/serve.ts";
+
+const FUNCTION_NAME = "market-equity-quotes";
+const PROVIDER_ENDPOINT = "https://www.alphavantage.co/query";
+const PROVIDER_FUNCTION = "GLOBAL_QUOTE";
+const API_KEY_ENV_VARS = [
+  "ALPHA_VANTAGE_API_KEY",
+  "DCT_ALPHA_VANTAGE_API_KEY",
+  "STOCK_FEED_API_KEY",
+] as const;
+
+const CACHE_TTL_MS = 30_000;
+const MAX_CACHE_SIZE = 256;
+
+interface AlphaVantageQuote {
+  "01. symbol"?: string;
+  "03. high"?: string;
+  "04. low"?: string;
+  "05. price"?: string;
+  "07. latest trading day"?: string;
+  "10. change percent"?: string;
+}
+
+interface AlphaVantageResponse {
+  "Global Quote"?: AlphaVantageQuote;
+  Note?: string;
+  Information?: string;
+}
+
+export type EquityQuote = {
+  last: number;
+  changePercent: number;
+  high: number;
+  low: number;
+};
+
+type EquityQuoteResult = {
+  quote: EquityQuote;
+  updatedAt?: string;
+};
+
+type CacheEntry = {
+  value: EquityQuoteResult | null;
+  expiresAt: number;
+};
+
+const quoteCache = new Map<string, CacheEntry>();
+
+const pruneExpiredCacheEntries = (now: number) => {
+  for (const [symbol, entry] of quoteCache.entries()) {
+    if (entry.expiresAt <= now) {
+      quoteCache.delete(symbol);
+    }
+  }
+};
+
+const enforceCacheSizeLimit = () => {
+  if (quoteCache.size <= MAX_CACHE_SIZE) {
+    return;
+  }
+
+  const entries = Array.from(quoteCache.entries()).sort(
+    (a, b) => a[1].expiresAt - b[1].expiresAt,
+  );
+
+  while (quoteCache.size > MAX_CACHE_SIZE && entries.length > 0) {
+    const [symbol] = entries.shift()!;
+    quoteCache.delete(symbol);
+  }
+};
+
+const getCachedQuote = (
+  symbol: string,
+): EquityQuoteResult | null | undefined => {
+  const cached = quoteCache.get(symbol);
+  if (!cached) {
+    return undefined;
+  }
+  if (cached.expiresAt <= Date.now()) {
+    quoteCache.delete(symbol);
+    return undefined;
+  }
+  return cached.value;
+};
+
+const setCachedQuote = (symbol: string, value: EquityQuoteResult | null) => {
+  pruneExpiredCacheEntries(Date.now());
+  const expiresAt = Date.now() + CACHE_TTL_MS;
+  quoteCache.set(symbol, { value, expiresAt });
+  enforceCacheSizeLimit();
+};
+
+const parseSymbols = (value: string | null): string[] => {
+  if (!value) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((token) => token.trim().toUpperCase())
+        .filter((token) => token.length > 0),
+    ),
+  );
+};
+
+const resolveApiKey = (): string | null => {
+  for (const key of API_KEY_ENV_VARS) {
+    const value = Deno.env.get(key)?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+};
+
+const parseNumber = (value: string | undefined): number | null => {
+  if (!value) return null;
+  const parsed = Number.parseFloat(value.replace(/,/g, ""));
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parsePercent = (value: string | undefined): number | null => {
+  if (!value) return null;
+  const sanitized = value.replace(/%/g, "").trim();
+  return parseNumber(sanitized);
+};
+
+const toQuote = (payload: AlphaVantageQuote): EquityQuoteResult | null => {
+  const last = parseNumber(payload["05. price"]);
+  const high = parseNumber(payload["03. high"]);
+  const low = parseNumber(payload["04. low"]);
+  const changePercent = parsePercent(payload["10. change percent"]);
+
+  if (
+    last === null ||
+    high === null ||
+    low === null ||
+    changePercent === null
+  ) {
+    return null;
+  }
+
+  return {
+    quote: { last, high, low, changePercent },
+    updatedAt: payload["07. latest trading day"],
+  };
+};
+
+const fetchQuote = async (
+  symbol: string,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<EquityQuoteResult | null> => {
+  const url = new URL(PROVIDER_ENDPOINT);
+  url.searchParams.set("function", PROVIDER_FUNCTION);
+  url.searchParams.set("symbol", symbol);
+  url.searchParams.set("apikey", apiKey);
+
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`Provider request failed (${response.status})`);
+  }
+
+  const payload = (await response.json()) as AlphaVantageResponse;
+
+  if (!payload["Global Quote"]) {
+    if (payload.Note || payload.Information) {
+      throw new Error(payload.Note || payload.Information || "Unknown error");
+    }
+    return null;
+  }
+
+  const parsed = toQuote(payload["Global Quote"] ?? {});
+  return parsed;
+};
+
+export const handler = registerHandler(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        ...corsHeaders(req, "GET,OPTIONS"),
+        "access-control-max-age": "86400",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return methodNotAllowed(req);
+  }
+
+  const logger = createLogger({
+    function: FUNCTION_NAME,
+    requestId: req.headers.get("sb-request-id") ||
+      req.headers.get("x-request-id") ||
+      crypto.randomUUID(),
+  });
+
+  const symbols = parseSymbols(new URL(req.url).searchParams.get("symbols"));
+
+  if (symbols.length === 0) {
+    return jsonResponse(
+      { error: "missing_symbols" },
+      { status: 400, headers: corsHeaders(req, "GET,OPTIONS") },
+    );
+  }
+
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    logger.error("Equity quotes API key is not configured");
+    return jsonResponse(
+      { error: "provider_not_configured" },
+      { status: 500, headers: corsHeaders(req, "GET,OPTIONS") },
+    );
+  }
+
+  try {
+    const quotes: Record<string, EquityQuote> = {};
+    let latestTimestamp: string | null = null;
+
+    const results = await Promise.all(
+      symbols.map(async (symbol) => {
+        const cached = getCachedQuote(symbol);
+        if (cached !== undefined) {
+          return { symbol, result: cached };
+        }
+
+        try {
+          const fetched = await fetchQuote(symbol, apiKey, req.signal);
+          setCachedQuote(symbol, fetched ?? null);
+          return { symbol, result: fetched };
+        } catch (error) {
+          logger.warn(`Failed to fetch quote for ${symbol}`, error);
+          return { symbol, result: null };
+        }
+      }),
+    );
+
+    for (const { symbol, result } of results) {
+      if (!result) {
+        continue;
+      }
+
+      quotes[symbol] = result.quote;
+
+      if (result.updatedAt) {
+        const existing = latestTimestamp ? Date.parse(latestTimestamp) : 0;
+        const candidate = Date.parse(result.updatedAt);
+        if (!Number.isNaN(candidate) && candidate > existing) {
+          latestTimestamp = new Date(candidate).toISOString();
+        }
+      }
+    }
+
+    return jsonResponse(
+      { data: quotes, meta: { lastUpdated: latestTimestamp } },
+      { status: 200, headers: corsHeaders(req, "GET,OPTIONS") },
+    );
+  } catch (error) {
+    logger.error("Unhandled error while fetching equity quotes", error);
+    return jsonResponse(
+      { error: "unexpected_error" },
+      { status: 500, headers: corsHeaders(req, "GET,OPTIONS") },
+    );
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,52 +1,63 @@
-import { defineConfig } from "vite";
+import { defineConfig, type PluginOption } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 // Proxy configuration to forward to Next.js app
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    proxy: {
-      // Forward all requests to Next.js app running on port 3000
-      "/": {
-        target: "http://localhost:3000",
-        changeOrigin: true,
-        ws: true,
-        secure: false,
-        timeout: 30000,
-        configure: (proxy, _options) => {
-          proxy.on("error", (err, _req, _res) => {
-            console.log("🔴 Proxy error:", err.message);
-          });
-          proxy.on("proxyReq", (_proxyReq, req, _res) => {
-            console.log("➡️  Proxying:", req.method, req.url);
-          });
-          proxy.on("proxyRes", (proxyRes, req, _res) => {
-            console.log("✅ Response:", proxyRes.statusCode, req.url);
-          });
+export default defineConfig(async ({ mode }) => {
+  let componentTaggerPlugin: PluginOption | undefined;
+
+  if (mode === "development") {
+    componentTaggerPlugin = await import("lovable-tagger")
+      .then((mod) => mod.componentTagger?.(), () => undefined);
+  }
+
+  const plugins: PluginOption[] = [react()];
+
+  if (componentTaggerPlugin) {
+    plugins.push(componentTaggerPlugin);
+  }
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      proxy: {
+        // Forward all requests to Next.js app running on port 3000
+        "/": {
+          target: "http://localhost:3000",
+          changeOrigin: true,
+          ws: true,
+          secure: false,
+          timeout: 30000,
+          configure: (proxy, _options) => {
+            proxy.on("error", (err, _req, _res) => {
+              console.log("🔴 Proxy error:", err.message);
+            });
+            proxy.on("proxyReq", (_proxyReq, req, _res) => {
+              console.log("➡️  Proxying:", req.method, req.url);
+            });
+            proxy.on("proxyRes", (proxyRes, req, _res) => {
+              console.log("✅ Response:", proxyRes.statusCode, req.url);
+            });
+          },
         },
       },
+      // Enable Hot Module Replacement for better dev experience
+      hmr: {
+        port: 8081,
+      },
     },
-    // Enable Hot Module Replacement for better dev experience
-    hmr: {
-      port: 8081,
+    plugins,
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "apps/web"),
+        "~": path.resolve(__dirname, "src"),
+        "next/font/google": path.resolve(
+          __dirname,
+          "src/stubs/next-font-google.ts",
+        ),
+      },
     },
-  },
-  plugins: [
-    react(),
-    mode === "development" && componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "apps/web"),
-      "~": path.resolve(__dirname, "src"),
-      "next/font/google": path.resolve(
-        __dirname,
-        "src/stubs/next-font-google.ts",
-      ),
-    },
-  },
-  envPrefix: ["VITE_", "NEXT_PUBLIC_"],
-}));
+    envPrefix: ["VITE_", "NEXT_PUBLIC_"],
+  };
+});


### PR DESCRIPTION
## Summary
- normalize the Supabase functions URL before requesting equity quotes and attach the anon key header so stock overrides work across environments
- skip the equity fetch when the endpoint cannot be derived and log a warning instead of breaking the base feed refresh
- extend the MarketWatchlist tests to assert the Supabase header usage and resilience when the equity endpoint fails
- add an in-memory cache to the market-equity-quotes edge function, limiting cache size and reusing provider responses across requests while parallelizing symbol fetches

## Testing
- npm run lint
- npm run typecheck
- npx vitest run apps/web/components/dynamic-portfolio/home/__tests__/MarketWatchlist.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68def3cdbf948322851ff6eefc53b59b