### PR TITLE
Handle uppercase checklist markers

### DIFF
--- a/algorithms/python/checklist_parser.py
+++ b/algorithms/python/checklist_parser.py
@@ -10,7 +10,9 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
 
-_CHECKLIST_LINE = re.compile(r"^- \[( |x)\] (.+)$")
+_CHECKLIST_LINE = re.compile(
+    r"^\s*-\s*\[(?P<state>[ xX])\]\s+(?P<text>.+)$"
+)
 _DUE_DATE = re.compile(r"@(?P<date>\d{4}-\d{2}-\d{2})\b")
 
 
@@ -45,7 +47,8 @@ def _iter_checklist_lines(lines: Iterable[str]) -> Iterator[tuple[str, str]]:
         match = _CHECKLIST_LINE.match(line)
         if not match:
             continue
-        status_char, text = match.groups()
+        status_char = match.group("state").lower()
+        text = match.group("text").strip()
         status = "done" if status_char == "x" else "pending"
         yield status, text
 


### PR DESCRIPTION
## Summary
- allow the checklist parser to recognise uppercase completion markers
- normalise matched checklist text before extracting due dates

## Testing
- pytest algorithms/python/tests/test_checklist_parser.py
- pytest tests/test_dynamic_summary_planner.py

------
https://chatgpt.com/codex/tasks/task_e_68df450e97b48322bf9cbe39e7370fa0