### PR TITLE
Add Dhivehi transliteration benchmark dataset

### DIFF
--- a/docs/dhivehi-language-processing-playbook.md
+++ b/docs/dhivehi-language-processing-playbook.md
@@ -68,6 +68,12 @@ from the very first ticket.
 - Seed the shared utilities workspace with transliteration helpers
   (`tools/dhivehi/transliteration.ts`) so Storybook examples can rely on a
   vetted mapping and reverse conversions.
+- Add a QA harness that replays the open-source `div-transliteration` evaluation
+  pairs via `evaluateTransliterationBenchmark` to surface accuracy and
+  Levenshtein scores inside tooling dashboards.
+- Ship a reusable keyboard binding manifest
+  (`tools/dhivehi/thaana-input-toolkit.ts`) so client apps can render virtual
+  Thaana layouts, intercept key events, and replay sequences for QA scenarios.
 
 #### Checklist
 

--- a/tests/asserts.ts
+++ b/tests/asserts.ts
@@ -1,0 +1,61 @@
+export function assert(
+  condition: unknown,
+  message = "Assertion failed",
+): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function formatValue(value: unknown): string {
+  return typeof value === "string" ? `"${value}"` : String(value);
+}
+
+export function assertEquals<T>(
+  actual: T,
+  expected: T,
+  message?: string,
+): void {
+  if (!Object.is(actual, expected)) {
+    const details = `Expected ${formatValue(actual)} to strictly equal ${
+      formatValue(expected)
+    }`;
+    throw new Error(message ? `${message}: ${details}` : details);
+  }
+}
+
+export function assertExists<T>(
+  value: T,
+  message = "Expected value to be defined",
+): asserts value is NonNullable<T> {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+}
+
+export function assertGreater(
+  actual: number,
+  expected: number,
+  message?: string,
+): void {
+  if (!(actual > expected)) {
+    const details = `Expected ${actual} to be greater than ${expected}`;
+    throw new Error(message ? `${message}: ${details}` : details);
+  }
+}
+
+export function assertAlmostEquals(
+  actual: number,
+  expected: number,
+  epsilon = 1e-6,
+  message?: string,
+): void {
+  if (!Number.isFinite(actual) || !Number.isFinite(expected)) {
+    throw new TypeError("assertAlmostEquals requires finite numbers");
+  }
+  if (Math.abs(actual - expected) > epsilon) {
+    const details =
+      `Expected ${actual} to be within ±${epsilon} of ${expected}`;
+    throw new Error(message ? `${message}: ${details}` : details);
+  }
+}

--- a/tests/dhivehi/glossary.test.ts
+++ b/tests/dhivehi/glossary.test.ts
@@ -1,7 +1,4 @@
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assert, assertEquals } from "../asserts.ts";
 import { defaultGlossary, Glossary } from "../../tools/dhivehi/glossary.ts";
 
 Deno.test("loads baseline glossary entries", () => {

--- a/tests/dhivehi/thaana-input-toolkit.test.ts
+++ b/tests/dhivehi/thaana-input-toolkit.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals, assertExists } from "../asserts.ts";
+import {
+  createThaanaKeyboardLayout,
+  DEFAULT_THAANA_KEYBOARD_LAYOUT,
+  mapKeyboardInputToThaana,
+  projectLatinToThaanaKeyboardSequence,
+  resolveThaanaKeyBinding,
+  THAANA_KEYBOARD_BINDINGS,
+} from "../../tools/dhivehi/thaana-input-toolkit.ts";
+
+Deno.test("exposes baseline key bindings for Thaana keyboard", () => {
+  const binding = resolveThaanaKeyBinding("q");
+  assertExists(binding);
+  assertEquals(binding.output, "ް");
+  assertEquals(binding.modifier, "default");
+});
+
+Deno.test("maps keyboard input sequences into Thaana glyphs", () => {
+  const output = mapKeyboardInputToThaana("tAna");
+  assertEquals(output, "ތާނަ");
+});
+
+Deno.test("supports punctuation swaps defined by aharen/thaana-keyboard", () => {
+  const output = mapKeyboardInputToThaana("Hello?");
+  assertEquals(output, "ޙެލލޮ؟");
+});
+
+Deno.test("default layout includes shift and punctuation rows", () => {
+  const layout = DEFAULT_THAANA_KEYBOARD_LAYOUT;
+  assertEquals(layout.length, 7);
+  assertEquals(layout[0].keys.length, 10);
+  assertEquals(layout.at(-1)?.id, "punctuation-row");
+});
+
+Deno.test("layout builder can omit shift rows when requested", () => {
+  const layout = createThaanaKeyboardLayout({
+    includeShiftRows: false,
+  });
+  assertEquals(layout.length, 4);
+});
+
+Deno.test("can project latin words into keyboard sequence for replay", () => {
+  const sequence = projectLatinToThaanaKeyboardSequence("thaana");
+  const rendered = mapKeyboardInputToThaana(sequence);
+  assertEquals(rendered, "ތާނަ");
+});
+
+Deno.test("key bindings remain immutable", () => {
+  const binding = THAANA_KEYBOARD_BINDINGS[0];
+  try {
+    (binding as { input: string }).input = "";
+  } catch {
+    // Ignore if runtime prevents mutation directly.
+  }
+  assertEquals(THAANA_KEYBOARD_BINDINGS[0].input, "q");
+});

--- a/tests/dhivehi/translation-memory.test.ts
+++ b/tests/dhivehi/translation-memory.test.ts
@@ -1,8 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertGreater,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assert, assertEquals, assertGreater } from "../asserts.ts";
 import { TranslationMemory } from "../../tools/dhivehi/translation-memory.ts";
 
 Deno.test("stores and retrieves translation segments", () => {

--- a/tests/dhivehi/transliteration.test.ts
+++ b/tests/dhivehi/transliteration.test.ts
@@ -1,7 +1,4 @@
-import {
-  assertAlmostEquals,
-  assertEquals,
-} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertAlmostEquals, assertEquals } from "../asserts.ts";
 import {
   scoreTransliterationPair,
   transliterateLatinToThaana,

--- a/tools/dhivehi/data/transliteration-pairs.json
+++ b/tools/dhivehi/data/transliteration-pairs.json
@@ -1,0 +1,322 @@
+[
+  {
+    "latin": "aai",
+    "thaana": "އާއި"
+  },
+  {
+    "latin": "adhi",
+    "thaana": "އަދި"
+  },
+  {
+    "latin": "ah",
+    "thaana": "އަށް"
+  },
+  {
+    "latin": "aharah",
+    "thaana": "އަހަރަށް"
+  },
+  {
+    "latin": "akah",
+    "thaana": "އަކަށް"
+  },
+  {
+    "latin": "beynunkurun",
+    "thaana": "ބޭނުންކުރުން"
+  },
+  {
+    "latin": "boegen",
+    "thaana": "ބޯއެން"
+  },
+  {
+    "latin": "career",
+    "thaana": "ކަރީރާ"
+  },
+  {
+    "latin": "chandler",
+    "thaana": "ޗެނޑދެ"
+  },
+  {
+    "latin": "clooney",
+    "thaana": "ކްލޫނީ"
+  },
+  {
+    "latin": "deepika",
+    "thaana": "ޑީޕިކާ"
+  },
+  {
+    "latin": "dhamahattan",
+    "thaana": "ދަމަހައްޓަން"
+  },
+  {
+    "latin": "dhigu",
+    "thaana": "ދިގު"
+  },
+  {
+    "latin": "dhuvasvee",
+    "thaana": "ދުވަސްވީ"
+  },
+  {
+    "latin": "eh",
+    "thaana": "އެއް"
+  },
+  {
+    "latin": "eri",
+    "thaana": "އެރި"
+  },
+  {
+    "latin": "fahu",
+    "thaana": "ފަހު"
+  },
+  {
+    "latin": "faisaa",
+    "thaana": "ފައިސާ"
+  },
+  {
+    "latin": "faraathah",
+    "thaana": "ފަރާތަށް"
+  },
+  {
+    "latin": "faraathugai",
+    "thaana": "ފަރާތުގައި"
+  },
+  {
+    "latin": "fen",
+    "thaana": "ފެން"
+  },
+  {
+    "latin": "feshunee",
+    "thaana": "ފެށުނީ"
+  },
+  {
+    "latin": "film",
+    "thaana": "ފިލްމު"
+  },
+  {
+    "latin": "firihenunnakah",
+    "thaana": "ފިރިހެނުންނަކަށް"
+  },
+  {
+    "latin": "fonuvaali",
+    "thaana": "ފޮނުވާލި"
+  },
+  {
+    "latin": "gai",
+    "thaana": "ގައި"
+  },
+  {
+    "latin": "gai",
+    "thaana": "ގައި"
+  },
+  {
+    "latin": "gamuga",
+    "thaana": "ގަމުގ"
+  },
+  {
+    "latin": "george",
+    "thaana": "ގިއާެ"
+  },
+  {
+    "latin": "gina",
+    "thaana": "ގިނަ"
+  },
+  {
+    "latin": "hikeytha",
+    "thaana": "ހިކޭތަ"
+  },
+  {
+    "latin": "himaayaiy",
+    "thaana": "ހިމާޔަތް"
+  },
+  {
+    "latin": "hoonu",
+    "thaana": "ހޫނު"
+  },
+  {
+    "latin": "huddha",
+    "thaana": "ހުއްދަ"
+  },
+  {
+    "latin": "hushahelhi",
+    "thaana": "ހުށަހެޅި"
+  },
+  {
+    "latin": "irumathee",
+    "thaana": "އިރަމަތީ"
+  },
+  {
+    "latin": "ithuru",
+    "thaana": "އިތުރު"
+  },
+  {
+    "latin": "kaiveni",
+    "thaana": "ކައިވެނި"
+  },
+  {
+    "latin": "king",
+    "thaana": "ކިންގް"
+  },
+  {
+    "latin": "kulhen",
+    "thaana": "ކުޅެން"
+  },
+  {
+    "latin": "kurimatheegai",
+    "thaana": "ކުރިމަތީގައި"
+  },
+  {
+    "latin": "kurumah",
+    "thaana": "ކުރުމަށް"
+  },
+  {
+    "latin": "kyle",
+    "thaana": "ކަލްލީ"
+  },
+  {
+    "latin": "laamu",
+    "thaana": "ލާމު"
+  },
+  {
+    "latin": "lanee",
+    "thaana": "ލަނީ"
+  },
+  {
+    "latin": "league",
+    "thaana": "ލީގު"
+  },
+  {
+    "latin": "loaiybakun",
+    "thaana": "ލޯތްބަކުން"
+  },
+  {
+    "latin": "male'",
+    "thaana": "މާލެ"
+  },
+  {
+    "latin": "manaakoffi",
+    "thaana": "މަނާކޮށްފި"
+  },
+  {
+    "latin": "maruvejje",
+    "thaana": "މަރުވެއްޖެ"
+  },
+  {
+    "latin": "meehaku",
+    "thaana": "މީހަކު"
+  },
+  {
+    "latin": "mi",
+    "thaana": "މި"
+  },
+  {
+    "latin": "miskiy",
+    "thaana": "މިސްކިތ"
+  },
+  {
+    "latin": "missile",
+    "thaana": "މިސިއިލް"
+  },
+  {
+    "latin": "miuzikee",
+    "thaana": "މިއުޒީކްކާ"
+  },
+  {
+    "latin": "moodhah",
+    "thaana": "މޫދަށް"
+  },
+  {
+    "latin": "nudhin",
+    "thaana": "ނުދިން"
+  },
+  {
+    "latin": "nufennaane",
+    "thaana": "ނުފެންނާނެ"
+  },
+  {
+    "latin": "nufudhey",
+    "thaana": "ނުފުދޭ"
+  },
+  {
+    "latin": "oiy",
+    "thaana": "އޮތް"
+  },
+  {
+    "latin": "othas",
+    "thaana": "އޮތަސަ"
+  },
+  {
+    "latin": "party",
+    "thaana": "ޕާޓީ"
+  },
+  {
+    "latin": "premier",
+    "thaana": "ޕްރިމިއާ"
+  },
+  {
+    "latin": "raihan",
+    "thaana": "ރައިހަން"
+  },
+  {
+    "latin": "ranveer",
+    "thaana": "ރަންވީރު"
+  },
+  {
+    "latin": "role",
+    "thaana": "ރޯލް"
+  },
+  {
+    "latin": "russia",
+    "thaana": "ރަޝިޔާ"
+  },
+  {
+    "latin": "salman",
+    "thaana": "ސަލްމާން"
+  },
+  {
+    "latin": "soikoffi",
+    "thaana": "ސޮއިކޮށްފި"
+  },
+  {
+    "latin": "syria",
+    "thaana": "ސީރިއާ"
+  },
+  {
+    "latin": "telegram",
+    "thaana": "ޓެލަގްރާމް"
+  },
+  {
+    "latin": "thee",
+    "thaana": "ތީ"
+  },
+  {
+    "latin": "thotteh",
+    "thaana": "ތޮޓްޓެއް"
+  },
+  {
+    "latin": "ufaddhan",
+    "thaana": "އުފައްދަން"
+  },
+  {
+    "latin": "ulhunu",
+    "thaana": "އުޅުނު"
+  },
+  {
+    "latin": "umurun",
+    "thaana": "އުމުރުން"
+  },
+  {
+    "latin": "ves",
+    "thaana": "ވެސް"
+  },
+  {
+    "latin": "vure",
+    "thaana": "ވުރެ"
+  },
+  {
+    "latin": "wolves",
+    "thaana": "ވޮލްވްް"
+  },
+  {
+    "latin": "yaarakee",
+    "thaana": "ޔާރަކީ"
+  }
+]

--- a/tools/dhivehi/index.ts
+++ b/tools/dhivehi/index.ts
@@ -1,4 +1,6 @@
 export * from "./transliteration.ts";
+export * from "./transliteration-benchmark.ts";
+export * from "./thaana-input-toolkit.ts";
 export * from "./translation-memory.ts";
 export * from "./glossary.ts";
 export * from "./utils.ts";

--- a/tools/dhivehi/thaana-input-toolkit.ts
+++ b/tools/dhivehi/thaana-input-toolkit.ts
@@ -1,0 +1,261 @@
+import { transliterateLatinToThaana } from "./transliteration.ts";
+
+export type ThaanaKeyModifier = "default" | "shift" | "punctuation";
+
+export interface ThaanaKeyBinding {
+  /** Latin keyboard character captured by the Thaana keyboard hook. */
+  input: string;
+  /** Thaana glyph inserted into the target element. */
+  output: string;
+  /** Which keyboard modifier is required to produce the glyph. */
+  modifier: ThaanaKeyModifier;
+  /** Optional short description used by UI tooltips or docs. */
+  description?: string;
+  /** Optional semantic label used for analytics or UI grouping. */
+  label?: string;
+}
+
+export interface ThaanaKeyboardLayoutRow {
+  /** Stable identifier so downstream UIs can track layout rows. */
+  id: string;
+  /** Human readable label (e.g. displayed in configuration menus). */
+  label: string;
+  /** The bindings that should be rendered for the row. */
+  keys: readonly ThaanaKeyBinding[];
+}
+
+export interface CreateThaanaKeyboardLayoutOptions {
+  /**
+   * Include upper-case / Shift bindings alongside base keys. Enabled by default
+   * so virtual keyboards mirror physical layouts.
+   */
+  includeShiftRows?: boolean;
+  /** Include punctuation bindings commonly swapped in Thaana layouts. */
+  includePunctuationRow?: boolean;
+}
+
+type BindingDefinition = readonly [
+  input: string,
+  output: string,
+  modifier: ThaanaKeyModifier,
+  description?: string,
+  label?: string,
+];
+
+const KEYBOARD_BINDINGS_DEFINITION: readonly BindingDefinition[] = [
+  ["q", "ް", "default", "Sukun / virama"],
+  ["w", "އ", "default", "Alifu"],
+  ["e", "ެ", "default", "Short vowel 'e'"],
+  ["r", "ރ", "default", "Raa"],
+  ["t", "ތ", "default", "Thaa"],
+  ["y", "ޔ", "default", "Yaamu"],
+  ["u", "ު", "default", "Short vowel 'u'"],
+  ["i", "ި", "default", "Short vowel 'i'"],
+  ["o", "ޮ", "default", "Short vowel 'o'"],
+  ["p", "ޕ", "default", "Pey"],
+  ["a", "ަ", "default", "Short vowel 'a'"],
+  ["s", "ސ", "default", "Seenu"],
+  ["d", "ދ", "default", "Dhaa"],
+  ["f", "ފ", "default", "Faafu"],
+  ["g", "ގ", "default", "Gaafu"],
+  ["h", "ހ", "default", "Haa"],
+  ["j", "ޖ", "default", "Jeem"],
+  ["k", "ކ", "default", "Kaafu"],
+  ["l", "ލ", "default", "Laamu"],
+  ["z", "ޒ", "default", "Zey"],
+  ["x", "×", "default", "Multiplication sign"],
+  ["c", "ޗ", "default", "Chaa"],
+  ["v", "ވ", "default", "Vaavu"],
+  ["b", "ބ", "default", "Bey"],
+  ["n", "ނ", "default", "Noonu"],
+  ["m", "މ", "default", "Meem"],
+  ["Q", "ޤ", "shift", "Ghain / Qaafu"],
+  ["W", "ޢ", "shift", "Ayn"],
+  ["E", "ޭ", "shift", "Long vowel 'ey'"],
+  ["R", "ޜ", "shift", "Zaa"],
+  ["T", "ޓ", "shift", "Ttaa"],
+  ["Y", "ޠ", "shift", "Tah"],
+  ["U", "ޫ", "shift", "Long vowel 'oo'"],
+  ["I", "ީ", "shift", "Long vowel 'ee'"],
+  ["O", "ޯ", "shift", "Long vowel 'oa'"],
+  ["P", "÷", "shift", "Division sign"],
+  ["A", "ާ", "shift", "Long vowel 'aa'"],
+  ["S", "ށ", "shift", "Sheen"],
+  ["D", "ޑ", "shift", "Retroflex dha"],
+  ["F", "ﷲ", "shift", "Ligature Allah"],
+  ["G", "ޣ", "shift", "Ghain"],
+  ["H", "ޙ", "shift", "Hhaa"],
+  ["J", "ޛ", "shift", "Zain"],
+  ["K", "ޚ", "shift", "Khaa"],
+  ["L", "ޅ", "shift", "Lhaviyani"],
+  ["Z", "ޡ", "shift", "Dad"],
+  ["X", "ޘ", "shift", "Tah"],
+  ["C", "ޝ", "shift", "Sha"],
+  ["V", "ޥ", "shift", "Vaviyani"],
+  ["B", "ޞ", "shift", "Saa"],
+  ["N", "ޏ", "shift", "Nya"],
+  ["M", "ޟ", "shift", "Dhaa retroflex"],
+  [",", "،", "punctuation", "Arabic comma"],
+  [";", "؛", "punctuation", "Arabic semicolon"],
+  ["?", "؟", "punctuation", "Arabic question mark"],
+  ["[", "]", "punctuation", "Swap bracket"],
+  ["]", "[", "punctuation", "Swap bracket"],
+  ["(", ")", "punctuation", "Swap parenthesis"],
+  [")", "(", "punctuation", "Swap parenthesis"],
+  ["{", "}", "punctuation", "Swap brace"],
+  ["}", "{", "punctuation", "Swap brace"],
+  ["<", ">", "punctuation", "Swap chevron"],
+  [">", "<", "punctuation", "Swap chevron"],
+] as const;
+
+export const THAANA_KEYBOARD_BINDINGS: readonly ThaanaKeyBinding[] = Object
+  .freeze(KEYBOARD_BINDINGS_DEFINITION.map((definition) => {
+    const [input, output, modifier, description, label] = definition;
+    return Object.freeze({
+      input,
+      output,
+      modifier,
+      description,
+      label,
+    }) as ThaanaKeyBinding;
+  }));
+
+const BINDING_LOOKUP = new Map<string, ThaanaKeyBinding>(
+  THAANA_KEYBOARD_BINDINGS.map((binding) => [binding.input, binding]),
+);
+
+const DEFAULT_LAYOUT_DEFINITION: readonly (readonly string[])[] = [
+  ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+  ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+  ["z", "x", "c", "v", "b", "n", "m"],
+];
+
+const SHIFT_LAYOUT_DEFINITION: readonly (readonly string[])[] = [
+  ["Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"],
+  ["A", "S", "D", "F", "G", "H", "J", "K", "L"],
+  ["Z", "X", "C", "V", "B", "N", "M"],
+];
+
+const PUNCTUATION_LAYOUT_DEFINITION: readonly string[] = [
+  ",",
+  ";",
+  "?",
+  "[",
+  "]",
+  "(",
+  ")",
+  "{",
+  "}",
+  "<",
+  ">",
+];
+
+function resolveBindingOrThrow(key: string): ThaanaKeyBinding {
+  const binding = BINDING_LOOKUP.get(key);
+  if (!binding) {
+    throw new Error(`No Thaana keyboard binding registered for \"${key}\"`);
+  }
+  return binding;
+}
+
+function createLayoutRow(
+  id: string,
+  label: string,
+  keys: readonly string[],
+): ThaanaKeyboardLayoutRow {
+  const bindings = keys.map((key) => resolveBindingOrThrow(key));
+  return Object.freeze({ id, label, keys: Object.freeze(bindings) });
+}
+
+export function createThaanaKeyboardLayout(
+  options: CreateThaanaKeyboardLayoutOptions = {},
+): readonly ThaanaKeyboardLayoutRow[] {
+  const {
+    includeShiftRows = true,
+    includePunctuationRow = true,
+  } = options;
+
+  const rows: ThaanaKeyboardLayoutRow[] = [];
+
+  DEFAULT_LAYOUT_DEFINITION.forEach((row, index) => {
+    rows.push(createLayoutRow(
+      `default-row-${index + 1}`,
+      `Default row ${index + 1}`,
+      row,
+    ));
+  });
+
+  if (includeShiftRows) {
+    SHIFT_LAYOUT_DEFINITION.forEach((row, index) => {
+      rows.push(createLayoutRow(
+        `shift-row-${index + 1}`,
+        `Shift row ${index + 1}`,
+        row,
+      ));
+    });
+  }
+
+  if (includePunctuationRow) {
+    rows.push(createLayoutRow(
+      "punctuation-row",
+      "Punctuation",
+      PUNCTUATION_LAYOUT_DEFINITION,
+    ));
+  }
+
+  return Object.freeze(rows.slice());
+}
+
+export const DEFAULT_THAANA_KEYBOARD_LAYOUT = createThaanaKeyboardLayout();
+
+export function resolveThaanaKeyBinding(
+  input: string,
+): ThaanaKeyBinding | undefined {
+  return BINDING_LOOKUP.get(input);
+}
+
+export function mapKeyboardInputToThaana(input: string): string {
+  if (!input) {
+    return "";
+  }
+
+  let output = "";
+
+  for (const char of input) {
+    const binding = BINDING_LOOKUP.get(char);
+    if (binding) {
+      output += binding.output;
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+export function projectLatinToThaanaKeyboardSequence(latin: string): string {
+  if (!latin) {
+    return "";
+  }
+
+  const transliterated = transliterateLatinToThaana(latin, {
+    preserveUnknown: true,
+    caseSensitive: false,
+  });
+
+  const keySequence: string[] = [];
+
+  outer: for (const char of transliterated) {
+    for (const [input, binding] of BINDING_LOOKUP) {
+      if (binding.output === char) {
+        keySequence.push(input);
+        continue outer;
+      }
+    }
+
+    keySequence.push(char);
+  }
+
+  return keySequence.join("");
+}

--- a/tools/dhivehi/transliteration-benchmark.ts
+++ b/tools/dhivehi/transliteration-benchmark.ts
@@ -1,0 +1,67 @@
+import transliterationDataset from "./data/transliteration-pairs.json" assert {
+  type: "json",
+};
+import {
+  scoreTransliterationPair,
+  TransliterationDiff,
+} from "./transliteration.ts";
+
+export interface TransliterationSample {
+  latin: string;
+  thaana: string;
+}
+
+export interface TransliterationBenchmarkOptions {
+  /**
+   * Optional limit to evaluate only the first ``limit`` samples.
+   */
+  limit?: number;
+}
+
+export interface TransliterationBenchmarkSummary {
+  total: number;
+  exactMatches: number;
+  accuracy: number;
+  averageScore: number;
+  results: TransliterationDiff[];
+}
+
+const samples: TransliterationSample[] =
+  transliterationDataset satisfies TransliterationSample[];
+
+/**
+ * Evaluate the rule-based transliteration against the curated dataset from
+ * https://github.com/Sofwath/div-transliteration.
+ */
+export function evaluateTransliterationBenchmark(
+  options: TransliterationBenchmarkOptions = {},
+): TransliterationBenchmarkSummary {
+  const { limit } = options;
+  const scopedSamples = typeof limit === "number" && limit > 0
+    ? samples.slice(0, limit)
+    : samples;
+
+  const results = scopedSamples.map((sample) =>
+    scoreTransliterationPair(sample.latin, sample.thaana)
+  );
+
+  const exactMatches =
+    results.filter((result) => result.actual === result.expected)
+      .length;
+  const accuracy = results.length > 0 ? exactMatches / results.length : 0;
+  const averageScore = results.length > 0
+    ? results.reduce((sum, result) => sum + result.score, 0) / results.length
+    : 0;
+
+  return {
+    total: results.length,
+    exactMatches,
+    accuracy,
+    averageScore,
+    results,
+  };
+}
+
+export function getTransliterationSamples(): readonly TransliterationSample[] {
+  return samples;
+}


### PR DESCRIPTION
## Summary
- add the div-transliteration evaluation pairs as a reusable JSON fixture for Dhivehi tooling
- expose a new transliteration benchmark helper that scores the rule-based engine against the dataset
- note the new QA harness requirement in the Dhivehi language processing playbook
- publish Thaana keyboard binding helpers so clients can render virtual layouts and replay sequences for QA
- add Deno regression tests to cover the keyboard bindings and projection utilities
- vendor local Dhivehi assertion helpers to remove remote TLS fetches and align punctuation expectations with the physical Thaana layout

## Testing
- npm run lint
- npm run typecheck
- $(bash scripts/deno_bin.sh) test --no-lock --no-npm --node-modules-dir=false tests/dhivehi


------
https://chatgpt.com/codex/tasks/task_e_68df46131f7483228b50e0d810a805c1