### PR TITLE
Optimize Google Vision OCR rendering workflow

### DIFF
--- a/dynamic_natural_language_processing/__init__.py
+++ b/dynamic_natural_language_processing/__init__.py
@@ -10,6 +10,14 @@ from .dhivehi import (
     DhivehiTransliterator,
     detect_script,
 )
+from .google_vision_ocr import (
+    BoundingBox,
+    DocumentBlock,
+    DocumentOCRResult,
+    GoogleVisionOCR,
+    Vertex,
+    parse_document_blocks,
+)
 
 __all__ = [
     "DhivehiLanguageProfile",
@@ -20,4 +28,10 @@ __all__ = [
     "DhivehiTokenizer",
     "DhivehiTransliterator",
     "detect_script",
+    "BoundingBox",
+    "DocumentBlock",
+    "DocumentOCRResult",
+    "GoogleVisionOCR",
+    "Vertex",
+    "parse_document_blocks",
 ]

--- a/dynamic_natural_language_processing/google_vision_ocr.py
+++ b/dynamic_natural_language_processing/google_vision_ocr.py
@@ -1,0 +1,280 @@
+"""Utilities for working with Google Cloud Vision OCR results.
+
+This module provides a small adapter around the `document_text_detection`
+response structure returned by the Google Cloud Vision API. The official sample
+implementation from `Sofwath/GoogleCloudVisionOCR` demonstrates a procedural
+script that prints raw OCR output. The helpers below encapsulate that workflow
+into a reusable class with type-safe dataclasses that are easy to unit test.
+
+The utilities are deliberately written so they can be exercised without the
+``google-cloud-vision`` or ``Pillow`` packages being installed. During testing
+we inject lightweight stubs, while in production the adapters dynamically load
+the optional dependencies when needed.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator, Sequence
+
+
+_VISION_MODULE: Any | None = None
+_PIL_MODULES: tuple[Any, Any] | None = None
+
+
+@dataclass(frozen=True)
+class Vertex:
+    """Represents a single vertex in image coordinates."""
+
+    x: int
+    y: int
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """A rectangular bounding box composed of four vertices."""
+
+    vertices: tuple[Vertex, Vertex, Vertex, Vertex]
+
+    def as_xy_tuples(self) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[int, int]]:
+        """Return the polygon as ``(x, y)`` tuples suitable for drawing."""
+
+        points = [(vertex.x, vertex.y) for vertex in self.vertices]
+        return points[0], points[1], points[2], points[3]
+
+
+@dataclass(frozen=True)
+class DocumentBlock:
+    """A block of OCR text along with its confidence and bounding box."""
+
+    text: str
+    confidence: float
+    bounding_box: BoundingBox
+
+
+@dataclass(frozen=True)
+class DocumentOCRResult:
+    """Aggregate OCR output for a processed image."""
+
+    blocks: tuple[DocumentBlock, ...]
+    full_text: str
+
+
+def parse_document_blocks(annotation: Any) -> Iterator[DocumentBlock]:
+    """Yield :class:`DocumentBlock` entries from a Vision annotation object.
+
+    The Google Vision API nests OCR results as Pages → Blocks → Paragraphs →
+    Words → Symbols. We flatten that structure into block-level summaries while
+    preserving the block confidence score and bounding polygon.
+    """
+
+    pages: Iterable[Any] = getattr(annotation, "pages", []) or []
+    for page in pages:
+        blocks: Iterable[Any] = getattr(page, "blocks", []) or []
+        for block in blocks:
+            block_text_parts: list[str] = []
+            paragraphs: Iterable[Any] = getattr(block, "paragraphs", []) or []
+            for paragraph in paragraphs:
+                words: Iterable[Any] = getattr(paragraph, "words", []) or []
+                for word in words:
+                    symbols: Iterable[Any] = getattr(word, "symbols", []) or []
+                    symbol_text = "".join(str(getattr(symbol, "text", "")) for symbol in symbols)
+                    if symbol_text:
+                        block_text_parts.append(symbol_text)
+
+            block_text = " ".join(block_text_parts).strip()
+            confidence_raw = getattr(block, "confidence", 0.0)
+            confidence = float(confidence_raw or 0.0)
+            bounding_box = _normalize_bounding_box(getattr(block, "bounding_box", None))
+            yield DocumentBlock(text=block_text, confidence=confidence, bounding_box=bounding_box)
+
+
+def _normalize_bounding_box(bounding_box: Any) -> BoundingBox:
+    """Convert a Vision bounding polygon into a :class:`BoundingBox`."""
+
+    vertices: Iterable[Any] = getattr(bounding_box, "vertices", []) or []
+    normalized_vertices: list[Vertex] = [
+        Vertex(int(getattr(vertex, "x", 0) or 0), int(getattr(vertex, "y", 0) or 0))
+        for vertex in vertices
+    ]
+
+    # Google Vision always returns four vertices, but we defensively pad or trim
+    # to maintain the expected structure.
+    while len(normalized_vertices) < 4:
+        normalized_vertices.append(Vertex(0, 0))
+    if len(normalized_vertices) > 4:
+        normalized_vertices = normalized_vertices[:4]
+
+    return BoundingBox(vertices=tuple(normalized_vertices))
+
+
+class GoogleVisionOCR:
+    """High-level helper for running Google Cloud Vision OCR.
+
+    Parameters
+    ----------
+    language_hints:
+        Optional sequence of BCP-47 language codes passed to the Vision API to
+        improve OCR accuracy for specific scripts (for example, ``("dv",)`` for
+        Thaana text).
+    client:
+        Pre-configured ``ImageAnnotatorClient`` instance. When omitted the
+        client is constructed lazily the first time :meth:`process_image` is
+        called.
+    image_factory:
+        Callable that receives raw bytes and returns the object passed to the
+        ``document_text_detection`` call. This allows unit tests to inject
+        lightweight stubs without the real Vision SDK.
+    image_context_factory:
+        Callable that receives the language hints and returns the ``image_context``
+        argument for ``document_text_detection``. Defaults to creating a
+        ``vision.ImageContext`` when the Vision SDK is available.
+    """
+
+    def __init__(
+        self,
+        language_hints: Sequence[str] | None = None,
+        *,
+        client: Any | None = None,
+        image_factory: Callable[[bytes], Any] | None = None,
+        image_context_factory: Callable[[Sequence[str]], Any] | None = None,
+    ) -> None:
+        self._language_hints = tuple(language_hints or ())
+        self._client = client
+        self._image_factory = image_factory
+        self._image_context_factory = image_context_factory
+        self._cached_image_context: Any | None = None
+
+    def process_image(
+        self,
+        image_path: str | Path,
+        *,
+        output_text_path: str | Path | None = None,
+        output_image_path: str | Path | None = None,
+    ) -> DocumentOCRResult:
+        """Run OCR on ``image_path`` and optionally persist artifacts."""
+
+        client = self._ensure_client()
+        path = Path(image_path)
+        image_bytes = path.read_bytes()
+        image = self._build_image(image_bytes)
+        image_context = self._build_image_context()
+
+        response = client.document_text_detection(image=image, image_context=image_context)
+        _raise_for_error(response)
+
+        annotation = getattr(response, "full_text_annotation", None)
+        if annotation is None:
+            blocks: tuple[DocumentBlock, ...] = ()
+            full_text = ""
+        else:
+            blocks = tuple(parse_document_blocks(annotation))
+            full_text = str(getattr(annotation, "text", "")).strip()
+            if not full_text:
+                full_text = "\n".join(block.text for block in blocks if block.text)
+
+        if output_text_path:
+            Path(output_text_path).write_text(full_text, encoding="utf-8")
+
+        if output_image_path and blocks:
+            self._render_bounding_boxes(image_bytes, blocks, Path(output_image_path))
+
+        return DocumentOCRResult(blocks=blocks, full_text=full_text)
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+
+        vision_module = _load_google_vision()
+        self._client = vision_module.ImageAnnotatorClient()
+        return self._client
+
+    def _build_image(self, image_bytes: bytes) -> Any:
+        if self._image_factory is not None:
+            return self._image_factory(image_bytes)
+
+        vision_module = _load_google_vision()
+        return vision_module.Image(content=image_bytes)
+
+    def _build_image_context(self) -> Any | None:
+        if not self._language_hints:
+            return None
+
+        if self._image_context_factory is not None:
+            return self._image_context_factory(self._language_hints)
+
+        if self._cached_image_context is None:
+            vision_module = _load_google_vision()
+            self._cached_image_context = vision_module.ImageContext(
+                language_hints=list(self._language_hints)
+            )
+        return self._cached_image_context
+
+    def _render_bounding_boxes(
+        self,
+        image_bytes: bytes,
+        blocks: Sequence[DocumentBlock],
+        output_path: Path,
+    ) -> None:
+        image_module, draw_module = _load_pillow()
+        image = image_module.open(BytesIO(image_bytes))
+        draw = draw_module.Draw(image)
+
+        for block in blocks:
+            draw.polygon(list(block.bounding_box.as_xy_tuples()), outline="green")
+
+        image.save(output_path)
+
+
+def _raise_for_error(response: Any) -> None:
+    error = getattr(response, "error", None)
+    message = getattr(error, "message", "") if error else ""
+    if message:
+        raise RuntimeError(f"Google Vision OCR request failed: {message}")
+
+
+def _load_google_vision() -> Any:
+    global _VISION_MODULE
+    if _VISION_MODULE is not None:
+        return _VISION_MODULE
+
+    try:
+        module = importlib.import_module("google.cloud.vision")
+    except ModuleNotFoundError as error:  # pragma: no cover - exercised in tests
+        raise RuntimeError(
+            "google-cloud-vision is required for OCR processing. Install the package "
+            "with 'pip install google-cloud-vision'."
+        ) from error
+
+    _VISION_MODULE = module
+    return module
+
+
+def _load_pillow() -> tuple[Any, Any]:
+    global _PIL_MODULES
+    if _PIL_MODULES is not None:
+        return _PIL_MODULES
+
+    try:
+        image = importlib.import_module("PIL.Image")
+        draw = importlib.import_module("PIL.ImageDraw")
+    except ModuleNotFoundError as error:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "Pillow is required to render OCR bounding boxes. Install it with 'pip install Pillow'."
+        ) from error
+    _PIL_MODULES = (image, draw)
+    return _PIL_MODULES
+
+
+__all__ = [
+    "BoundingBox",
+    "DocumentBlock",
+    "DocumentOCRResult",
+    "GoogleVisionOCR",
+    "Vertex",
+    "parse_document_blocks",
+]
+

--- a/tests_python/test_google_vision_ocr_adapter.py
+++ b/tests_python/test_google_vision_ocr_adapter.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import dynamic_natural_language_processing.google_vision_ocr as google_vision_ocr_module
+from dynamic_natural_language_processing.google_vision_ocr import (
+    BoundingBox,
+    DocumentOCRResult,
+    GoogleVisionOCR,
+    parse_document_blocks,
+)
+
+
+@dataclass
+class _StubSymbol:
+    text: str
+
+
+@dataclass
+class _StubWord:
+    symbols: Sequence[_StubSymbol]
+    confidence: float = 0.0
+
+
+@dataclass
+class _StubParagraph:
+    words: Sequence[_StubWord]
+    confidence: float = 0.0
+
+
+@dataclass
+class _StubVertex:
+    x: int
+    y: int
+
+
+@dataclass
+class _StubBlock:
+    paragraphs: Sequence[_StubParagraph]
+    bounding_box: Any
+    confidence: float = 0.0
+
+
+@dataclass
+class _StubPage:
+    blocks: Sequence[_StubBlock]
+
+
+@dataclass
+class _StubAnnotation:
+    pages: Sequence[_StubPage]
+    text: str = ""
+
+
+class _StubResponse:
+    def __init__(self, annotation: _StubAnnotation, message: str = "") -> None:
+        self.full_text_annotation = annotation
+        self.error = type("_Error", (), {"message": message})()
+
+
+class _StubImage:
+    def __init__(self) -> None:
+        self.saved_path: Path | None = None
+
+    def save(self, path: Path) -> None:
+        self.saved_path = path
+
+
+class _StubImageModule:
+    def __init__(self) -> None:
+        self.open_calls: list[bytes] = []
+        self.last_image: _StubImage | None = None
+
+    def open(self, source: Any) -> _StubImage:
+        if hasattr(source, "getvalue"):
+            data = source.getvalue()
+        elif hasattr(source, "read"):
+            data = source.read()
+        else:
+            data = source
+        self.open_calls.append(data)
+        self.last_image = _StubImage()
+        return self.last_image
+
+
+class _StubDrawInstance:
+    def __init__(self) -> None:
+        self.polygons: list[tuple[tuple[int, int], ...]] = []
+
+    def polygon(self, points: Sequence[tuple[int, int]], *, outline: str) -> None:
+        self.polygons.append(tuple(points))
+
+
+class _StubDrawModule:
+    def __init__(self) -> None:
+        self.instances: list[_StubDrawInstance] = []
+
+    def Draw(self, image: Any) -> _StubDrawInstance:
+        instance = _StubDrawInstance()
+        self.instances.append(instance)
+        return instance
+
+
+class _StubClient:
+    def __init__(self, response: _StubResponse) -> None:
+        self._response = response
+        self.requests: list[tuple[bytes, Sequence[str] | None]] = []
+
+    def document_text_detection(self, *, image: dict[str, bytes], image_context: dict[str, Sequence[str]] | None = None):
+        self.requests.append((image["content"], image_context["language_hints"] if image_context else None))
+        return self._response
+
+
+def test_parse_document_blocks_flattens_nested_structure() -> None:
+    annotation = _StubAnnotation(
+        pages=[
+            _StubPage(
+                blocks=[
+                    _StubBlock(
+                        paragraphs=[
+                            _StubParagraph(
+                                words=[
+                                    _StubWord(symbols=[_StubSymbol("Alpha")], confidence=0.9),
+                                    _StubWord(symbols=[_StubSymbol("Beta")], confidence=0.9),
+                                ],
+                            )
+                        ],
+                        bounding_box=type(
+                            "_BoundingBox",
+                            (),
+                            {
+                                "vertices": [
+                                    _StubVertex(0, 0),
+                                    _StubVertex(10, 0),
+                                    _StubVertex(10, 10),
+                                    _StubVertex(0, 10),
+                                ]
+                            },
+                        )(),
+                        confidence=0.85,
+                    )
+                ]
+            )
+        ]
+    )
+
+    blocks = list(parse_document_blocks(annotation))
+    assert len(blocks) == 1
+    assert blocks[0].text == "Alpha Beta"
+    assert blocks[0].confidence == pytest.approx(0.85)
+    assert isinstance(blocks[0].bounding_box, BoundingBox)
+
+
+def test_process_image_writes_text_and_returns_result(tmp_path: Path) -> None:
+    annotation = _StubAnnotation(
+        pages=[
+            _StubPage(
+                blocks=[
+                    _StubBlock(
+                        paragraphs=[
+                            _StubParagraph(
+                                words=[
+                                    _StubWord(symbols=[_StubSymbol("Hello")], confidence=0.9),
+                                    _StubWord(symbols=[_StubSymbol("World")], confidence=0.9),
+                                ],
+                            )
+                        ],
+                        bounding_box=type("_BoundingBox", (), {"vertices": [_StubVertex(0, 0)] * 4})(),
+                        confidence=0.95,
+                    )
+                ]
+            )
+        ],
+        text="Hello World",
+    )
+    response = _StubResponse(annotation)
+    client = _StubClient(response)
+    ocr = GoogleVisionOCR(
+        language_hints=("dv",),
+        client=client,
+        image_factory=lambda content: {"content": content},
+        image_context_factory=lambda hints: {"language_hints": list(hints)},
+    )
+
+    image_path = tmp_path / "image.bin"
+    image_path.write_bytes(b"fake image bytes")
+    text_path = tmp_path / "output.txt"
+
+    result = ocr.process_image(image_path, output_text_path=text_path)
+
+    assert isinstance(result, DocumentOCRResult)
+    assert [block.text for block in result.blocks] == ["Hello World"]
+    assert text_path.read_text(encoding="utf-8") == "Hello World"
+    assert client.requests == [(b"fake image bytes", ["dv"])]
+
+
+def test_process_image_requires_google_sdk_when_client_missing(tmp_path: Path) -> None:
+    image_path = tmp_path / "image.bin"
+    image_path.write_bytes(b"data")
+    ocr = GoogleVisionOCR(language_hints=("dv",))
+
+    with pytest.raises(RuntimeError, match="google-cloud-vision is required"):
+        ocr.process_image(image_path)
+
+
+def test_process_image_renders_bounding_boxes_without_reopening_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bounding_box = type(
+        "_BoundingBox",
+        (),
+        {
+            "vertices": [
+                _StubVertex(0, 0),
+                _StubVertex(10, 0),
+                _StubVertex(10, 10),
+                _StubVertex(0, 10),
+            ]
+        },
+    )()
+    annotation = _StubAnnotation(
+        pages=[
+            _StubPage(
+                blocks=[
+                    _StubBlock(
+                        paragraphs=[
+                            _StubParagraph(
+                                words=[_StubWord(symbols=[_StubSymbol("Text")])]
+                            )
+                        ],
+                        bounding_box=bounding_box,
+                        confidence=0.75,
+                    )
+                ]
+            )
+        ]
+    )
+    response = _StubResponse(annotation)
+    client = _StubClient(response)
+
+    image_module = _StubImageModule()
+    draw_module = _StubDrawModule()
+    monkeypatch.setattr(google_vision_ocr_module, "_PIL_MODULES", (image_module, draw_module))
+
+    ocr = GoogleVisionOCR(
+        client=client,
+        image_factory=lambda content: {"content": content},
+    )
+
+    image_bytes = b"binary image contents"
+    image_path = tmp_path / "image.bin"
+    image_path.write_bytes(image_bytes)
+    output_path = tmp_path / "output.png"
+
+    ocr.process_image(image_path, output_image_path=output_path)
+
+    assert image_module.open_calls == [image_bytes]
+    assert image_module.last_image is not None
+    assert image_module.last_image.saved_path == output_path
+    assert draw_module.instances
+    assert draw_module.instances[0].polygons == [
+        (
+            (0, 0),
+            (10, 0),
+            (10, 10),
+            (0, 10),
+        )
+    ]
+
+
+def test_process_image_reuses_cached_image_context_for_back_to_back_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    annotation = _StubAnnotation(
+        pages=[
+            _StubPage(
+                blocks=[
+                    _StubBlock(
+                        paragraphs=[
+                            _StubParagraph(
+                                words=[
+                                    _StubWord(symbols=[_StubSymbol("One")]),
+                                ]
+                            )
+                        ],
+                        bounding_box=type("_BoundingBox", (), {"vertices": [_StubVertex(0, 0)] * 4})(),
+                    )
+                ]
+            )
+        ],
+        text="One",
+    )
+    response = _StubResponse(annotation)
+
+    class _StubVisionClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, Any]] = []
+
+        def document_text_detection(self, *, image: Any, image_context: Any | None = None) -> _StubResponse:
+            self.calls.append((image, image_context))
+            return response
+
+    client = _StubVisionClient()
+    context_calls: list[Any] = []
+
+    vision_module = types.ModuleType("google.cloud.vision")
+    vision_module.ImageAnnotatorClient = lambda: client
+    vision_module.Image = lambda content: {"content": content}
+
+    def _stub_image_context(*, language_hints: list[str]) -> dict[str, list[str]]:
+        context = {"language_hints": language_hints}
+        context_calls.append(context)
+        return context
+
+    vision_module.ImageContext = _stub_image_context
+
+    google_package = types.ModuleType("google")
+    cloud_package = types.ModuleType("google.cloud")
+    cloud_package.vision = vision_module
+    google_package.cloud = cloud_package
+
+    monkeypatch.setitem(sys.modules, "google", google_package)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_package)
+    monkeypatch.setitem(sys.modules, "google.cloud.vision", vision_module)
+    monkeypatch.setattr(google_vision_ocr_module, "_VISION_MODULE", None)
+
+    ocr = GoogleVisionOCR(language_hints=("dv",))
+
+    image_path = tmp_path / "image.bin"
+    image_path.write_bytes(b"bytes")
+
+    ocr.process_image(image_path)
+    ocr.process_image(image_path)
+
+    assert len(context_calls) == 1
+    assert len(client.calls) == 2
+    assert client.calls[0][1] is client.calls[1][1]
+
+
+def test_render_bounding_boxes_reuses_cached_pillow_modules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    annotation = _StubAnnotation(
+        pages=[
+            _StubPage(
+                blocks=[
+                    _StubBlock(
+                        paragraphs=[_StubParagraph(words=[_StubWord(symbols=[_StubSymbol("Text")])])],
+                        bounding_box=type("_BoundingBox", (), {"vertices": [_StubVertex(0, 0)] * 4})(),
+                    )
+                ]
+            )
+        ],
+        text="Text",
+    )
+    response = _StubResponse(annotation)
+    client = _StubClient(response)
+
+    image_module = _StubImageModule()
+    draw_module = _StubDrawModule()
+
+    original_import_module = importlib.import_module
+    load_counts: dict[str, int] = {"PIL.Image": 0, "PIL.ImageDraw": 0}
+
+    def _stub_import_module(name: str, package: str | None = None) -> Any:
+        if name in load_counts:
+            load_counts[name] += 1
+            return image_module if name == "PIL.Image" else draw_module
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", _stub_import_module)
+    monkeypatch.setattr(google_vision_ocr_module, "_PIL_MODULES", None)
+
+    ocr = GoogleVisionOCR(
+        client=client,
+        image_factory=lambda content: {"content": content},
+    )
+
+    image_path = tmp_path / "image.bin"
+    image_path.write_bytes(b"image")
+    output_path = tmp_path / "out.png"
+
+    ocr.process_image(image_path, output_image_path=output_path)
+    ocr.process_image(image_path, output_image_path=output_path)
+
+    assert load_counts == {"PIL.Image": 1, "PIL.ImageDraw": 1}
+    assert image_module.open_calls == [b"image", b"image"]


### PR DESCRIPTION
## Summary
- reuse the in-memory image bytes when drawing Google Vision OCR bounding boxes to avoid rereading files
- extend the Google Vision OCR adapter tests with Pillow stubs to verify the optimized rendering path
- cache the Google Vision image context and optional dependency modules so back-to-back OCR calls skip redundant setup
- add regression tests covering cached Vision context reuse and Pillow module loading

## Testing
- pytest tests_python/test_google_vision_ocr_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68df466b07248322a40f3ede3649c2ff