### PR TITLE
Add documentation for Dynamic Core quantum cycle

### DIFF
--- a/docs/dynamic-core-quantum-cycle.md
+++ b/docs/dynamic-core-quantum-cycle.md
@@ -1,0 +1,62 @@
+# Dynamic Core Quantum Cycle
+
+The Dynamic Core mythology can be mapped to quantum dynamical formalisms that
+capture how information, energy, and state transitions circulate through the
+stack. The Dynamic Core Maiden (DCM), Dynamic Core Hollow (DCH), and Dynamic
+Core Revenant (DCR) mirror a canonical cycle in which a system begins in a pure
+state, exchanges energy with an open environment, and re-emerges after
+measurement in a renewed configuration.
+
+## Archetypal correspondences
+
+| Conceptual Name & Role | Quantum Dynamic Analogy & Key Equations | Physical & Mythological Interpretation |
+| --- | --- | --- |
+| **DCM (Maiden / Kore)** | Time-dependent perturbation theory:  \\
+\( i\hbar \frac{\partial}{\partial t} \lvert \psi(t) \rangle = \hat{H}_0 \lvert \psi(t) \rangle \) (unperturbed)  \\
+\( i\hbar \frac{\partial}{\partial t} \lvert \psi(t) \rangle = (\hat{H}_0 + V(t)) \lvert \psi(t) \rangle \) (perturbed)  \\
+Transition probability: \( P_{k \leftarrow i}(t) = \lvert \langle k \rvert V(t) \lvert i \rangle \rvert^2 \) | A pristine quantum superposition that becomes susceptible to abduction by an external interaction \(V(t)\). The innocence of the Maiden aligns with maximal symmetry and latent potential before the perturbation drives transitions to excited states. |
+| **DCH (Hollow / Underworld)** | Open quantum systems governed by the Lindblad master equation:  \\
+\( \frac{d\rho}{dt} = -\frac{i}{\hbar}[\hat{H}, \rho] + \sum_j (L_j \rho L_j^\dagger - \tfrac{1}{2}\{L_j^\dagger L_j, \rho\}) \)  \\
+Effective non-Hermitian Hamiltonian: \( \hat{H}_\text{eff} = \hat{H}_0 - i\Gamma \) | The Hollow represents coupling to an inaccessible reservoir. Coherence leaks into the environment through the Lindblad jump operators \(L_j\), modelling decay, dissipation, and information loss. The mythic descent corresponds to the irreversible flow into the underworld. |
+| **DCR (Revenant / Persephone)** | Quantum trajectory theory and stochastic state reduction:  \\
+Continuous evolution: \( d\lvert \psi \rangle = -\tfrac{i}{\hbar}\hat{H}\lvert \psi \rangle dt + \sum_j \left( \frac{L_j}{\sqrt{\langle L_j^\dagger L_j \rangle}} - 1 \right) dN_j \lvert \psi \rangle \)  \\
+Measurement collapse: \( \lvert \psi \rangle \rightarrow \frac{M_k \lvert \psi \rangle}{\sqrt{\langle \psi \rvert M_k^\dagger M_k \lvert \psi \rangle}} \) | The Revenant is the state that returns after a quantum jump. Each detected decay event (\(dN_j\)) collapses the wavefunction into a refreshed configuration, echoing Persephone’s seasonal re-emergence with altered symmetry and memory. |
+
+## The dynamical loop
+
+1. **Potential (DCM)** – The Dynamic Core begins in a coherent ground state
+   \(\lvert \psi_0 \rangle\), representing untapped capability and high symmetry.
+   In this phase the system is governed by the unperturbed Hamiltonian
+   \(\hat{H}_0\) and retains full superpositional freedom.
+2. **Perturbation and descent (DCM → DCH)** – An external drive \(V(t)\)
+   introduces transitions and couples the Core to an extended environment. The
+   state is promoted into the density-matrix formalism \(\rho\) as decoherence
+   pathways open via Lindblad operators, signifying the Hollow’s embrace.
+3. **Dissipation (within DCH)** – Non-Hermitian contributions \( -i\Gamma \)
+   encode resource leakage, latency, and entropy production. Operationally, this
+   phase captures telemetry drop-off, actuator back-pressure, and control-plane
+   uncertainty while mythologically tracing the labyrinthine underworld.
+4. **Quantum jump (DCH → DCR)** – A stochastic detection event \(dN_j\)
+   produces a conditioned state update. The Dynamic Core collapses through
+   measurement operators \(M_k\), consolidating the experience of decay into a
+   new eigen-configuration with durable memory of the traversal.
+5. **Renewal (back to DCM)** – The Revenant equilibrates, becoming the next
+   ground state \(\lvert \psi_0' \rangle\). The cycle can restart with modified
+   parameters \(\hat{H}_0'\) or new control protocols, demonstrating adaptive
+   resilience across loops.
+
+## Implementation cues for Dynamic Capital
+
+- **Telemetry orchestration** – Treat pulse ingestion as the perturbative force
+  that dislodges each subsystem from static baselines, aligning streaming
+  metrics with \(V(t)\).
+- **Resilience modelling** – Map service-level decay, queue leakage, and cache
+  invalidation to Lindblad operators to quantify irreversibility within the
+  Hollow.
+- **Incident response** – Frame alert acknowledgements as quantum jumps that
+  collapse operational ambiguity, allowing the Revenant phase to seed improved
+  runbooks and circuit breakers for the next iteration.
+
+This quantum-native framing ensures the Dynamic Core archetypes integrate with
+Dynamic Capital’s mathematical language while preserving the narrative cadence
+of descent, transformation, and return.


### PR DESCRIPTION
## Summary
- document the correspondence between the Dynamic Core archetypes and key quantum dynamical formalisms
- outline the cyclical flow from the Maiden ground state through the Hollow environment to the Revenant renewal
- provide implementation cues for applying the quantum mapping to Dynamic Capital telemetry and incident response practices

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df6b3a38fc832287bf806d63073860