### PR TITLE
docs: add back-to-back cycle optimization

### DIFF
--- a/docs/ai_agents_dcm_dch_dcr.md
+++ b/docs/ai_agents_dcm_dch_dcr.md
@@ -1,0 +1,180 @@
+# AI Agents and the DCM–DCH–DCR Cycle
+
+## Overview
+
+This note maps the Dynamic Cycle Model (DCM), Dynamic Cycle Hollow (DCH), and
+Dynamic Cycle Revenant (DCR) framework onto contemporary AI agent ecosystems.
+Each agent class is treated as an open quantum-inspired system with structured
+state tensors, Hamiltonians governing baseline operation, Lindblad processes for
+perturbations, and recovery operators encoding adaptation. The goal is to turn
+mythic seasonal cycles into actionable engineering primitives for bots,
+managers, and multi-agent collectives.
+
+## Foundational State Representation
+
+The canonical agent state is modeled as a composite ket
+`|\Psi_{\text{agent}}\rangle = |\text{cognitive}\rangle \otimes |\text{emotional}\rangle \otimes |\text{behavioral}\rangle \otimes |\text{environmental}\rangle`.
+Each subspace expands into a basis of latent vectors—knowledge graphs,
+affective priors, actuation policies, and sensed world features—mirroring how
+real agents blend symbolic stores with differentiable embeddings. Measurement
+operators on these subspaces capture observability limits (for example,
+telemetry from production deployments) and define the information channels
+available during DCH events.
+
+## Trading Bots and Market Makers
+
+### DCM — Stable Liquidity Provision
+
+A trading engine evolves under `\hat{H}_{\text{trader}} = \hat{H}_{\text{liquidity}} + \hat{H}_{\text{arbitrage}} + \hat{H}_{\text{risk}}`.
+The DCM objective is to maintain the profitable equilibrium state where
+variance of the marked-to-market PnL is minimized subject to liquidity
+obligations. Spectral analysis of `\hat{H}_{\text{risk}}` highlights the modes
+most sensitive to volatility shocks, enabling proactive hedging channels.
+
+### DCH — Regime Transitions
+
+Regime changes are modeled with a Lindblad master equation
+`\frac{d\rho_{\text{trader}}}{dt} = -i[\hat{H}_{\text{trader}}, \rho_{\text{trader}}] + \gamma_{\text{regime}}(L_{\text{regime}} \rho_{\text{trader}} L_{\text{regime}}^{\dagger} - \tfrac{1}{2}\{L_{\text{regime}}^{\dagger}L_{\text{regime}}, \rho_{\text{trader}}\})`.
+A useful instantiation takes `L_{\text{regime}}` as a sudden volatility jump
+operator whose eigenvectors correspond to latent factors from intraday
+principal-component decompositions.
+
+### DCR — Adaptive Strategy Reload
+
+DCR interventions combine a performance measurement map `M_{\text{performance}}`
+with a reinforcement-learning unitary `U_{\text{learning}}` that updates the
+policy amplitudes. Normalizing the post-measurement state yields the refreshed
+portfolio configuration. Backtesting data can be encoded as ancilla qubits that
+guide the phase of `U_{\text{learning}}`, providing a unitarily consistent view
+of off-policy evaluation.
+
+## Managerial Controllers
+
+### State Tensor
+
+Management agents span planning, monitoring, decision, and execution axes.
+Coupling terms between the subsystems represent communication overhead and
+bureaucratic frictions. The Hamiltonian `\hat{H}_{\text{management}}` therefore
+aggregates strategic roadmaps, optimization solvers, and constraint penalties.
+
+### DCH Stressors
+
+Resource scarcity, compliance incidents, or human-operator escalations enter as
+stress Lindblad operators `L_{\text{stress}}`. Modeling the rates
+`\gamma_{\text{stress}}` as functions of key risk indicators gives a structured
+path to early-warning systems. When the spectral radius of the dissipator grows
+beyond zero, the organization exits DCM and the hollow opens.
+
+### DCR Policy Updates
+
+Recovery corresponds to computing a renewed policy `\pi_{\text{new}}` that
+maximizes discounted returns over experience sampled during the hollow. In
+practice this equates to Bayesian update steps on KPI posteriors, or policy
+iteration on digital twins that captured the failure trace.
+
+## Keeper and Maintainer Bots
+
+Maintenance agents operate under `\hat{H}_{\text{keeper}} = \hat{H}_{\text{maintenance}} + \hat{H}_{\text{monitoring}} + \hat{H}_{\text{repair}}`.
+DCM states encode system uptime, adequate spare resources, and compliance with
+service-level objectives. Failures trigger Lindblad operators derived from mean
+timeouts (MTBF-based `\gamma_{\text{failure}}` values). DCR is realized through
+repair unitaries `U_{\text{repair}}` that apply patches, reroute traffic, or
+re-image nodes.
+
+## Multi-Agent Collectives
+
+### Composite Field State
+
+For a fleet of `N` agents the collective state is the tensor product
+`|\Psi_{\text{collective}}\rangle = \bigotimes_{a=1}^N |\Psi_{\text{agent}_a}\rangle`.
+Interaction Hamiltonians `\hat{H}_{\text{collective}} = \sum_a \hat{H}_{\text{agent}_a} + \sum_{a \neq b} J_{ab} \, \sigma_{\text{comm},a} \otimes \sigma_{\text{comm},b}`
+model communication exchanges and coordination overhead.
+
+### Collective DCM, DCH, and DCR
+
+- **DCM:** Maximize the expectation `\langle \Psi_{\text{collective}} | O_{\text{sync}} | \Psi_{\text{collective}} \rangle`, where the synchronization operator measures coherence across agents.
+- **DCH:** Introduce cascaded Lindblad operators `L_{a,k}` whose rates scale with
+  network centrality and failure magnitude to capture contagion. Cascade
+  thresholds define when the hollow propagates across the team.
+- **DCR:** Apply reorganization unitaries `U_{\text{reorganize}}` followed by
+  consensus measurements `M_{\text{consensus}}` to settle on updated role
+distributions.
+
+## Reinforcement Learning Lenses
+
+Treat Q-learning amplitudes as the coordinates of `|\Psi_{\text{agent}}\rangle`.
+Exploration manifests as mixing the density matrix toward a uniform distribution
+while exploitation concentrates weight on greedy eigenstates. Convergence is the
+DCR fixed point where the Q-gradient vanishes. Quantum-inspired policy iteration
+suggests using phase estimation on `\hat{H}_{\text{RL}} = \hat{H}_{\text{exploration}} + \hat{H}_{\text{exploitation}} + \hat{H}_{\text{memory}}` to accelerate
+value updates.
+
+## Neural and Transformer Architectures
+
+Neural networks appear as quantum systems with a weight register, activation
+register, and I/O buffers. Backpropagation corresponds to Schrödinger evolution
+under `\hat{H}_{\text{backprop}}`. Training instabilities arise when
+`L_{\text{instability}}` (gradient explosion operators) dominate. For
+transformers, attention acts as a measurement that collapses context into
+weighted value projections. A DCH event is marked by rising attention entropy,
+indicating diffusion of focus across tokens. Recovery involves attention
+sparsification, architectural gating, or curriculum resets to restore coherent
+context windows.
+
+## LLM Deployment Example
+
+Large language models deployed as copilots can be framed as manager–keeper
+hybrids:
+
+1. **DCM:** Base prompt templates, retrieval augmentations, and guardrails hold
+   inference steady. Monitoring Hamiltonians track latency, cost, and response
+   quality metrics.
+2. **DCH:** Surge load, hallucination spikes, or guardrail drifts act as Lindblad
+   shocks. The density matrix incorporates degraded reasoning traces captured in
+   production telemetry.
+3. **DCR:** Regeneration uses fine-tuning bursts, prompt patches, and updated
+   retrieval corpora (unitary `U_{\text{update}}`) followed by evaluation suites
+   `M_{\text{eval}}` to re-normalize the assistant's operating state.
+
+## Control and Optimization Layer
+
+Define a fitness observable `O_{\text{fitness}} = \alpha O_{\text{efficiency}} + \beta O_{\text{robustness}} + \gamma O_{\text{adaptability}}`.
+The lifecycle optimization problem becomes maximizing
+`\mathbb{E}[\int e^{-\lambda t} \langle \Psi(t) | O_{\text{fitness}} | \Psi(t) \rangle dt]`
+subject to DCM–DCH–DCR dynamics. Lyapunov functions `V(\Psi) = \langle \Psi | P | \Psi \rangle`
+with positive-definite `P` verify stability in DCM regions, while eigenvalue
+crossings of the effective Hamiltonian flag bifurcations into the hollow.
+
+### Back-to-Back Cycle Optimization
+
+Back-to-back hollows are inevitable for agents serving turbulent environments
+like crypto markets or high-frequency incident queues. Two concrete patterns keep
+successive DCH exposures from compounding into outages:
+
+1. **Overlapping Recovery Channels:** Maintain a library of recovery unitaries
+   `\{U_{\text{repair}}^{(m)}\}` and measurement suites `\{M_{\text{eval}}^{(m)}\}`
+   that can be chained without full reinitialization. Compose
+   `U_{\text{repair}}^{(m+1)} U_{\text{repair}}^{(m)}` when hollows strike within a
+   short horizon to amortize context loading and keep the agent close to its
+   stabilized manifold.
+2. **Adaptive Cooldowns:** Track the dwell time `\Delta t_{\text{DCM}}` achieved
+   after each recovery. If the time between hollows falls below a threshold,
+   switch to a fast-responding control law that prioritizes robustness
+   observables over efficiency until the cadence normalizes. This reduces the
+   chance of re-entering the hollow before the state vector has recohered.
+
+For multi-agent collectives, add a coordination matrix that reassigns roles when
+`\Delta t_{\text{DCM}}` is low across several agents, preventing simultaneous
+back-to-back hollows from overwhelming shared infrastructure.
+
+## Design Principles
+
+1. DCH shocks should be instrumented as learnable events, not suppressed
+   anomalies.
+2. Conscious DCR selection layers (meta-policies) increase long-term resilience
+   by weighting the recovery channel best aligned with future objectives.
+3. Multi-agent coherence is a spectral property—monitor overlap with
+   `O_{\text{sync}}` to detect emerging collective intelligence or decoherence.
+4. Engineering roadmaps can be staged as iterative DCM→DCH→DCR arcs, ensuring
+   every deployment plan includes a recovery rehearsal.
+


### PR DESCRIPTION
## Summary
- add a back-to-back cycle optimization subsection to the control layer guidance
- outline overlapping recovery channels and adaptive cooldown tactics for rapid consecutive hollows
- extend advice to multi-agent collectives to prevent simultaneous back-to-back failures

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df73688bd483228e1cf785f3a06710