### PR TITLE
Add Forex Factory metadata upload script

### DIFF
--- a/scripts/forexfactory_trading_metadata_to_drive.py
+++ b/scripts/forexfactory_trading_metadata_to_drive.py
@@ -1,10 +1,16 @@
-"""Extract Forex Factory trading metadata and upload it to Google Drive.
+"""Extract Forex Factory trading metadata or educational content.
 
-The scraper attempts to load the public calendar page from
+The calendar scraper attempts to load the public calendar page from
 ``https://www.forexfactory.com/`` by default. When the optional
 ``cloudscraper`` dependency is installed the script can bypass the
 Cloudflare challenge that protects the site. Otherwise the caller can
 provide a direct JSON feed URL via ``--calendar-url``.
+
+Educational content is gathered by loading the Forex Factory news page,
+applying the built-in "Educational News" filter, and parsing the
+resulting headlines. This mode requires ``beautifulsoup4`` for HTML
+parsing in addition to ``cloudscraper`` when Cloudflare protection is
+enabled.
 """
 
 from __future__ import annotations
@@ -14,23 +20,50 @@ import json
 import re
 import sys
 import uuid
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Iterable, Mapping, MutableMapping, Sequence
+from urllib.parse import urljoin
 
 import requests
+from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from dynamic_corpus_extraction.google_drive import parse_drive_share_link
 
 DEFAULT_CALENDAR_URL = "https://www.forexfactory.com/calendar?week=this"
-DEFAULT_FILE_NAME_TEMPLATE = "forexfactory-trading-metadata-{timestamp}.json"
+DEFAULT_NEWS_URL = "https://www.forexfactory.com/news"
+DEFAULT_FILE_NAME_TEMPLATES = {
+    "calendar": "forexfactory-trading-metadata-{timestamp}.json",
+    "education": "forexfactory-education-content-{timestamp}.json",
+}
 
 _IMPACT_PRIORITY = {"Holiday": 0, "Low": 1, "Medium": 2, "High": 3}
 
 _CALENDAR_JSON_PATTERN = re.compile(
     r"""https://[\w./-]*ff_calendar_[^"'\s]+\.json(?:\?[^"'\s]*)?""",
     re.IGNORECASE,
+)
+
+_EDUCATIONAL_CATEGORY_ID = "174"
+_EDUCATION_FORMAT_CHOICES = ("headline", "threads", "large")
+_EDUCATION_SORT_CHOICES = (
+    "latest",
+    "hottest",
+    "latestreplies",
+    "mostreplied",
+    "mostviewed",
+    "latestliked",
+    "mostliked",
+)
+_EDUCATION_PERIOD_CHOICES = (
+    "last12h",
+    "last24h",
+    "last3d",
+    "last7d",
+    "last30d",
 )
 
 
@@ -85,6 +118,84 @@ class TradingEvent:
         return data
 
 
+@dataclass(slots=True)
+class EducationalStory:
+    """Normalised representation of an educational Forex Factory article."""
+
+    story_id: str
+    title: str
+    forex_factory_url: str
+    published_at: str
+    summary: str | None
+    source_name: str | None
+    source_domain: str | None
+    source_url: str | None
+
+    @classmethod
+    def from_element(cls, element: Tag, *, base_url: str) -> "EducationalStory" | None:
+        classes = element.get("class", [])
+        if "flexposts__story" not in classes:
+            return None
+
+        story_id = element.get("data-story-id", "").strip()
+        if not story_id:
+            return None
+
+        title_link = element.select_one("div.flexposts__story-title a")
+        if title_link is None:
+            return None
+
+        title = title_link.get_text(strip=True)
+        if not title:
+            return None
+
+        summary = (title_link.get("title") or "").strip() or None
+        internal_href = title_link.get("href") or ""
+        forex_factory_url = urljoin(base_url, internal_href)
+
+        timestamp_raw = element.get("data-timestamp")
+        published_at = _coerce_timestamp(timestamp_raw)
+
+        source_link = element.select_one("span.flexposts__caption a[data-source]")
+        source_name = None
+        source_domain = None
+        source_url = None
+        if source_link is not None:
+            source_text = source_link.get_text(strip=True)
+            source_name = source_text.removeprefix("From ").strip() or None
+            source_domain = (source_link.get("data-source") or "").strip() or None
+            source_href = source_link.get("href") or ""
+            source_url = urljoin(base_url, source_href) if source_href else None
+
+        return cls(
+            story_id=story_id,
+            title=title,
+            forex_factory_url=forex_factory_url,
+            published_at=published_at,
+            summary=summary,
+            source_name=source_name,
+            source_domain=source_domain,
+            source_url=source_url,
+        )
+
+    def to_json(self) -> MutableMapping[str, object]:
+        data: MutableMapping[str, object] = {
+            "story_id": self.story_id,
+            "title": self.title,
+            "forex_factory_url": self.forex_factory_url,
+            "published_at": self.published_at,
+        }
+        if self.summary:
+            data["summary"] = self.summary
+        if self.source_name:
+            data["source_name"] = self.source_name
+        if self.source_domain:
+            data["source_domain"] = self.source_domain
+        if self.source_url:
+            data["source_url"] = self.source_url
+        return data
+
+
 def _clean_optional_text(value: object) -> str | None:
     if value is None:
         return None
@@ -92,12 +203,32 @@ def _clean_optional_text(value: object) -> str | None:
     return text or None
 
 
+def _coerce_timestamp(raw_timestamp: object) -> str:
+    if isinstance(raw_timestamp, str):
+        raw_timestamp = raw_timestamp.strip()
+    try:
+        timestamp = int(raw_timestamp)
+    except (TypeError, ValueError):
+        return datetime.now(tz=UTC).isoformat()
+    return datetime.fromtimestamp(timestamp, tz=UTC).isoformat()
+
+
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Fetch Forex Factory calendar metadata, normalise the trading-focused "
-            "fields, and upload the resulting JSON document to Google Drive."
+            "Fetch Forex Factory calendar metadata or educational content, "
+            "normalise the results, and optionally upload the JSON document to "
+            "Google Drive."
         )
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("calendar", "education"),
+        default="calendar",
+        help=(
+            "Dataset to extract: 'calendar' collects economic events while "
+            "'education' gathers educational news and analysis."
+        ),
     )
     parser.add_argument(
         "--calendar-url",
@@ -106,6 +237,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "Forex Factory calendar page or JSON endpoint to query. When a HTML"
             " page is supplied the script will extract the embedded JSON feed"
             " automatically."
+        ),
+    )
+    parser.add_argument(
+        "--news-url",
+        default=DEFAULT_NEWS_URL,
+        help=(
+            "Forex Factory news listing used when --mode=education. The scraper "
+            "loads the page and applies the educational filter automatically."
         ),
     )
     parser.add_argument(
@@ -119,6 +258,33 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         nargs="*",
         default=None,
         help="Optional list of currency codes to filter on (e.g. USD EUR GBP).",
+    )
+    parser.add_argument(
+        "--education-format",
+        choices=_EDUCATION_FORMAT_CHOICES,
+        default="headline",
+        help=(
+            "Display format to request when fetching educational stories. "
+            "'headline' yields compact article entries."
+        ),
+    )
+    parser.add_argument(
+        "--education-sort",
+        choices=_EDUCATION_SORT_CHOICES,
+        default="latest",
+        help="Sort order applied to the educational feed (e.g. latest or mostliked).",
+    )
+    parser.add_argument(
+        "--education-period",
+        choices=_EDUCATION_PERIOD_CHOICES,
+        default="last30d",
+        help="Time window to apply when gathering educational content.",
+    )
+    parser.add_argument(
+        "--education-limit",
+        type=int,
+        default=None,
+        help="Optional cap on the number of educational stories returned.",
     )
     parser.add_argument(
         "--access-token",
@@ -179,7 +345,7 @@ def _resolve_folder_id(folder_id: str | None, share_link: str | None) -> str:
 
 
 def _fetch_calendar(url: str, *, timeout: float) -> Sequence[Mapping[str, object]]:
-    session, using_scraper = _make_calendar_session(url)
+    session, using_scraper = _make_forexfactory_session(url)
     response = session.get(url, timeout=timeout)
     if response.status_code != requests.codes.ok:
         hint = ""
@@ -203,7 +369,7 @@ def _fetch_calendar(url: str, *, timeout: float) -> Sequence[Mapping[str, object
             " provided HTML page."
         )
 
-    feed_response = requests.get(feed_url, timeout=timeout)
+    feed_response = session.get(feed_url, timeout=timeout)
     if feed_response.status_code != requests.codes.ok:
         raise SystemExit(
             "Failed to download Forex Factory calendar feed: HTTP "
@@ -225,7 +391,82 @@ def _extract_calendar_feed_url(html: str) -> str | None:
     return None
 
 
-def _make_calendar_session(url: str) -> tuple[requests.Session, bool]:
+def _fetch_education_news(
+    news_url: str,
+    *,
+    timeout: float,
+    education_format: str,
+    education_sort: str,
+    education_period: str,
+    limit: int | None,
+) -> list[EducationalStory]:
+    session, using_scraper = _make_forexfactory_session(news_url)
+    response = session.get(news_url, timeout=timeout)
+    if response.status_code != requests.codes.ok:
+        hint = ""
+        if (not using_scraper) and "forexfactory.com" in news_url:
+            hint = (
+                " Consider installing the 'cloudscraper' package to bypass"
+                " Cloudflare challenges when hitting Forex Factory pages."
+            )
+        raise SystemExit(
+            f"Failed to load Forex Factory news page: HTTP {response.status_code}.{hint}"
+        )
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    form = soup.find("form", {"action": "flex.php", "method": "post"})
+    if form is None:
+        raise SystemExit("Unable to locate the Forex Factory news filter form.")
+
+    form_data: MutableMapping[str, str] = {}
+    for input_el in form.find_all("input"):
+        name = input_el.get("name")
+        if not name:
+            continue
+        input_type = (input_el.get("type") or "").lower()
+        if input_type == "hidden":
+            form_data[name] = input_el.get("value", "")
+
+    if not form_data:
+        raise SystemExit("Forex Factory news form did not provide the expected hidden inputs.")
+
+    form_data["flex[News_newsLeft1][news]"] = _EDUCATIONAL_CATEGORY_ID
+    form_data["flex[News_newsLeft1][format]"] = education_format
+    form_data["flex[News_newsLeft1][sort]"] = education_sort
+    form_data["flex[News_newsLeft1][period]"] = education_period
+
+    post_url = urljoin(news_url, "/flex.php")
+    post_response = session.post(post_url, data=form_data, timeout=timeout)
+    if post_response.status_code != requests.codes.ok:
+        raise SystemExit(
+            "Failed to download Forex Factory education feed: HTTP "
+            f"{post_response.status_code}"
+        )
+
+    try:
+        html_fragment = ET.fromstring(post_response.content).text or ""
+    except ET.ParseError as exc:  # pragma: no cover - defensive branch
+        raise SystemExit(f"Unable to parse Forex Factory response: {exc}") from exc
+
+    snippet_soup = BeautifulSoup(html_fragment, "html.parser")
+    feed = snippet_soup.select_one("ul.flexposts")
+    if feed is None:
+        raise SystemExit(
+            "Unable to locate educational stories within the Forex Factory response."
+        )
+
+    stories: list[EducationalStory] = []
+    for item in feed.select("li.flexposts__story"):
+        story = EducationalStory.from_element(item, base_url=news_url)
+        if story is None:
+            continue
+        stories.append(story)
+        if limit is not None and limit > 0 and len(stories) >= limit:
+            break
+    return stories
+
+
+def _make_forexfactory_session(url: str) -> tuple[requests.Session, bool]:
     if "forexfactory.com" not in url.lower():
         return requests.Session(), False
     try:  # pragma: no cover - optional dependency branch
@@ -263,7 +504,7 @@ def _filter_events(
     return normalised
 
 
-def _build_payload(
+def _build_calendar_payload(
     events: Sequence[TradingEvent],
     *,
     source_url: str,
@@ -282,9 +523,37 @@ def _build_payload(
     }
 
 
-def _default_file_name() -> str:
+def _build_education_payload(
+    stories: Sequence[EducationalStory],
+    *,
+    source_url: str,
+    education_format: str,
+    education_sort: str,
+    education_period: str,
+    limit: int | None,
+) -> MutableMapping[str, object]:
+    return {
+        "fetched_at": datetime.now(tz=UTC).isoformat(),
+        "source": source_url,
+        "category": "Educational News",
+        "filters": {
+            "format": education_format,
+            "sort": education_sort,
+            "period": education_period,
+            "limit": limit,
+        },
+        "story_count": len(stories),
+        "stories": [story.to_json() for story in stories],
+    }
+
+
+def _default_file_name(mode: str) -> str:
     timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-    return DEFAULT_FILE_NAME_TEMPLATE.format(timestamp=timestamp)
+    template = DEFAULT_FILE_NAME_TEMPLATES.get(
+        mode,
+        DEFAULT_FILE_NAME_TEMPLATES["calendar"],
+    )
+    return template.format(timestamp=timestamp)
 
 
 def _maybe_write_local(payload: Mapping[str, object], output: Path | None) -> None:
@@ -385,25 +654,49 @@ def main(argv: Sequence[str] | None = None) -> None:
     else:
         folder_id = _resolve_folder_id(args.folder_id, args.share_link)
 
-    raw_events = _fetch_calendar(args.calendar_url, timeout=args.timeout)
-    events = _filter_events(raw_events, min_impact=args.min_impact, countries=args.countries)
-    payload = _build_payload(
-        events,
-        source_url=args.calendar_url,
-        min_impact=args.min_impact,
-        countries=args.countries,
-    )
+    if args.mode == "education":
+        stories = _fetch_education_news(
+            args.news_url,
+            timeout=args.timeout,
+            education_format=args.education_format,
+            education_sort=args.education_sort,
+            education_period=args.education_period,
+            limit=args.education_limit,
+        )
+        payload = _build_education_payload(
+            stories,
+            source_url=args.news_url,
+            education_format=args.education_format,
+            education_sort=args.education_sort,
+            education_period=args.education_period,
+            limit=args.education_limit,
+        )
+        dataset_label = "Forex Factory educational content"
+    else:
+        raw_events = _fetch_calendar(args.calendar_url, timeout=args.timeout)
+        events = _filter_events(
+            raw_events,
+            min_impact=args.min_impact,
+            countries=args.countries,
+        )
+        payload = _build_calendar_payload(
+            events,
+            source_url=args.calendar_url,
+            min_impact=args.min_impact,
+            countries=args.countries,
+        )
+        dataset_label = "Forex Factory trading metadata"
 
     _maybe_write_local(payload, args.output)
 
     if args.skip_upload:
-        message = "Fetched Forex Factory trading metadata; skipping Google Drive upload."
+        message = f"Fetched {dataset_label}; skipping Google Drive upload."
         if args.output:
             message += f" Local copy written to '{args.output}'."
         print(message)
         return
 
-    file_name = args.file_name or _default_file_name()
+    file_name = args.file_name or _default_file_name(args.mode)
     upload_response = _upload_json_to_drive(
         access_token=args.access_token,
         payload=payload,
@@ -415,7 +708,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     )
 
     print(
-        "Uploaded Forex Factory trading metadata to Google Drive as "
+        f"Uploaded {dataset_label} to Google Drive as "
         f"'{file_name}' (file id: {upload_response.get('id')})."
     )
 


### PR DESCRIPTION
## Summary
- add a CLI utility that fetches Forex Factory calendar metadata, normalises trading-specific fields, and uploads the JSON to Google Drive
- support configurable impact/currency filters, optional local exports, and public link sharing for the uploaded file

## Testing
- python -m compileall scripts/forexfactory_trading_metadata_to_drive.py

------
https://chatgpt.com/codex/tasks/task_e_68df7d2e8e788322bdedf65d6914b126