### PR TITLE
Fix dynamic playbook exports and guard quantum numpy dependency

### DIFF
--- a/dynamic_playbook/__init__.py
+++ b/dynamic_playbook/__init__.py
@@ -1,10 +1,46 @@
-"""Dynamic playbook facade for governance utilities."""
+"""Dynamic playbook facade for governance utilities.
+
+This module intentionally exposes the high level playbook primitives that are
+implemented inside :mod:`dynamic.governance.ags`.  Several downstream
+workflows – including the NFY playbook regression tests – import these objects
+directly from :mod:`dynamic_playbook`.  A recent refactor limited the exports
+to only the AGS helpers which caused ``ImportError`` exceptions in those
+consumers.  Restoring the broader facade keeps the public API stable while the
+implementation details remain nested inside ``dynamic.governance``.
+"""
 
 from __future__ import annotations
 
-from dynamic.governance.ags.dynamic_ags import (
+from dynamic.governance.ags import (
     DEFAULT_DYNAMIC_AGS_ENTRIES,
+    DEFAULT_DYNAMIC_NFY_ENTRIES,
+    DynamicPlaybookAgent,
+    DynamicPlaybookBot,
+    DynamicPlaybookEngine,
+    DynamicPlaybookHelper,
+    DynamicPlaybookKeeper,
+    PlaybookBlueprint,
+    PlaybookContext,
+    PlaybookDisciplineInsight,
+    PlaybookEntry,
+    PlaybookSynchronizer,
     build_dynamic_ags_playbook,
+    build_dynamic_nfy_market_dimensions_playbook,
 )
 
-__all__ = ["DEFAULT_DYNAMIC_AGS_ENTRIES", "build_dynamic_ags_playbook"]
+__all__ = [
+    "DEFAULT_DYNAMIC_AGS_ENTRIES",
+    "DEFAULT_DYNAMIC_NFY_ENTRIES",
+    "DynamicPlaybookAgent",
+    "DynamicPlaybookBot",
+    "DynamicPlaybookEngine",
+    "DynamicPlaybookHelper",
+    "DynamicPlaybookKeeper",
+    "PlaybookBlueprint",
+    "PlaybookContext",
+    "PlaybookDisciplineInsight",
+    "PlaybookEntry",
+    "PlaybookSynchronizer",
+    "build_dynamic_ags_playbook",
+    "build_dynamic_nfy_market_dimensions_playbook",
+]


### PR DESCRIPTION
## Summary
- restore the dynamic_playbook facade so downstream tests can import the NFY defaults and playbook engine classes
- make the conscious collapse module tolerate missing numpy by providing a friendly stub and neutral type aliases

## Testing
- `pytest tests/test_dynamic_playbook_engine.py tests/test_dynamic_nfy_playbook.py tests/test_dynamic_quantum_engine.py tests/test_dynamic_quantum_training.py`


------
https://chatgpt.com/codex/tasks/task_e_68df7d57acf48322b2cab5979668986e