### PR TITLE
Simplify BeautifulSoup import handling

### DIFF
--- a/collect_tradingview.py
+++ b/collect_tradingview.py
@@ -11,7 +11,12 @@ import sys
 from typing import Iterable, List, Optional
 
 import requests
-from bs4 import BeautifulSoup
+try:
+  from bs4 import BeautifulSoup
+except ModuleNotFoundError as exc:
+  raise ModuleNotFoundError(
+    "BeautifulSoup is required for HTML parsing. Install it with `pip install beautifulsoup4`.",
+  ) from exc
 
 LOGGER = logging.getLogger("tradingview-collector")
 BIAS_KEYWORDS = {


### PR DESCRIPTION
## Summary
- replace the custom importlib-based loader with a guarded BeautifulSoup import in the TradingView collector
- update the Google Drive scraper to use the same guarded import while keeping its type alias for type checking

## Testing
- npm run format
- python -m compileall collect_tradingview.py scripts/scrape_google_drive.py

------
https://chatgpt.com/codex/tasks/task_e_68df8270526c83229d6da306c1ab1e90