### PR TITLE
Fix authenticate route handler typings

### DIFF
--- a/apps/web/app/api/authenticate/route.ts
+++ b/apps/web/app/api/authenticate/route.ts
@@ -61,11 +61,25 @@ export async function POST(req: NextRequest) {
   });
 }
 
-export const GET = methodNotAllowed;
-export const PUT = methodNotAllowed;
-export const PATCH = methodNotAllowed;
-export const DELETE = methodNotAllowed;
-export const HEAD = methodNotAllowed;
+export function GET(req: NextRequest) {
+  return methodNotAllowed(req);
+}
+
+export function PUT(req: NextRequest) {
+  return methodNotAllowed(req);
+}
+
+export function PATCH(req: NextRequest) {
+  return methodNotAllowed(req);
+}
+
+export function DELETE(req: NextRequest) {
+  return methodNotAllowed(req);
+}
+
+export function HEAD(req: NextRequest) {
+  return methodNotAllowed(req);
+}
 export function OPTIONS(req: NextRequest) {
   return new Response(null, { status: 204, headers: corsHeaders(req, "POST") });
 }


### PR DESCRIPTION
## Summary
- wrap the authenticate API route fallback handlers so they accept `NextRequest`
- ensure the fallback handlers delegate to the shared `methodNotAllowed` helper

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df962e4c1c8322ae18a90f42b2ccae