### PR TITLE
Fix Supabase client imports for shared hooks

### DIFF
--- a/src/hooks/useCustomLLMChat.ts
+++ b/src/hooks/useCustomLLMChat.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { supabase } from "../integrations/supabase/client";
 
 type Message = {
   role: "user" | "assistant" | "system";

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,1 +1,1 @@
-export * from "@/integrations/supabase/client";
+export * from "../../../apps/web/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- point the shared Supabase client re-export at the actual Next.js implementation using a relative path
- update the custom LLM chat hook to consume the shared client via the local re-export for environments without path aliases

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df9639d23c832288b2c0100c3324e6