### PR TITLE
Add createClientForRequest stub for receipt edge function tests

### DIFF
--- a/supabase/functions/_tests/web-app-analytics.test.ts
+++ b/supabase/functions/_tests/web-app-analytics.test.ts
@@ -1,0 +1,100 @@
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
+import { assertEquals } from "std/assert/mod.ts";
+import type { SupabaseClient } from "../_shared/client.ts";
+import { incrementDailyButtonClicks } from "../web-app-analytics/index.ts";
+
+type StoredClicks = Record<string, number | string>;
+
+function createDailyAnalyticsMock(
+  initial: Record<string, StoredClicks> = {},
+) {
+  const rows = new Map<string, StoredClicks>(
+    Object.entries(initial).map(([date, clicks]) => [date, { ...clicks }]),
+  );
+
+  const supabase = {
+    from(table: string) {
+      if (table !== "daily_analytics") {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      let selectedDate: string | null = null;
+
+      return {
+        select() {
+          return this;
+        },
+        eq(_column: string, value: string) {
+          selectedDate = value;
+          return this;
+        },
+        async maybeSingle() {
+          if (!selectedDate) {
+            throw new Error("Date filter must be applied before maybeSingle");
+          }
+
+          const entry = rows.get(selectedDate);
+          return {
+            data: entry
+              ? { date: selectedDate, button_clicks: { ...entry } }
+              : null,
+            error: null,
+          };
+        },
+        async upsert(
+          row: { date: string; button_clicks: Record<string, number> },
+        ) {
+          rows.set(row.date, { ...row.button_clicks });
+          return { data: null, error: null };
+        },
+      };
+    },
+  };
+
+  return {
+    supabase: supabase as unknown as SupabaseClient,
+    getClicks(date: string): Record<string, number> | undefined {
+      const entry = rows.get(date);
+      if (!entry) return undefined;
+      return Object.entries(entry).reduce<Record<string, number>>(
+        (acc, [k, v]) => {
+          const numericValue = typeof v === "number" ? v : Number(v ?? 0);
+          acc[k] = Number.isFinite(numericValue) ? numericValue : 0;
+          return acc;
+        },
+        {},
+      );
+    },
+  };
+}
+
+Deno.test("incrementDailyButtonClicks creates a new record when missing", async () => {
+  const mock = createDailyAnalyticsMock();
+  const date = "2024-10-03";
+
+  const updated = await incrementDailyButtonClicks(
+    mock.supabase,
+    date,
+    "cta_click",
+  );
+
+  assertEquals(updated, { cta_click: 1 });
+  assertEquals(mock.getClicks(date), { cta_click: 1 });
+});
+
+Deno.test("incrementDailyButtonClicks normalizes existing counters", async () => {
+  const mock = createDailyAnalyticsMock({
+    "2024-10-02": { cta_click: "2", hero_view: 5 },
+  });
+
+  const updated = await incrementDailyButtonClicks(
+    mock.supabase,
+    "2024-10-02",
+    "cta_click",
+  );
+
+  assertEquals(updated, { cta_click: 3, hero_view: 5 });
+  assertEquals(mock.getClicks("2024-10-02"), { cta_click: 3, hero_view: 5 });
+});

--- a/tests/supabase-client-stub.ts
+++ b/tests/supabase-client-stub.ts
@@ -1180,6 +1180,30 @@ export function createClient() {
   return new SupabaseStub(stubState) as unknown as { [key: string]: unknown };
 }
 
+type RequestLike = Pick<Request, "headers">;
+
+type RequestClientOptions = {
+  role?: "anon" | "service";
+  requireAuthorization?: boolean;
+  [key: string]: unknown;
+};
+
+export function createClientForRequest(
+  req: RequestLike,
+  options?: RequestClientOptions,
+) {
+  if (options?.requireAuthorization) {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      throw new Error(
+        "Missing Authorization header for createClientForRequest",
+      );
+    }
+  }
+
+  return createClient();
+}
+
 export type SupabaseClient = ReturnType<typeof createClient>;
 
 export function createSupabaseClient(..._args: unknown[]) {


### PR DESCRIPTION
## Summary
- add a `createClientForRequest` helper to the Supabase test stub so receipt function tests can import it
- enforce the authorization requirement flag in the stub to mirror the production helper contract

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dfab37103c83229660ffb4ad235691