### PR TITLE
Fix case-insensitive merging of Vary headers

### DIFF
--- a/apps/web/utils/http.ts
+++ b/apps/web/utils/http.ts
@@ -62,25 +62,31 @@ const coerceOrigin = (raw?: string | null): string | undefined => {
   }
 };
 
+const splitVaryValues = (input: string | null | undefined): string[] => {
+  if (typeof input !== "string") return [];
+  return input.split(",").map((item) => item.trim()).filter(Boolean);
+};
+
+const appendUniqueCaseInsensitive = (
+  target: string[],
+  values: string[],
+) => {
+  const seen = new Set(target.map((item) => item.toLowerCase()));
+  for (const candidate of values) {
+    const normalized = candidate.toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    target.push(candidate);
+  }
+};
+
 export const mergeVary = (
   existing: string | null | undefined,
   value: string,
 ) => {
-  const existingList = typeof existing === "string"
-    ? existing.split(",").map((item) => item.trim()).filter(Boolean)
-    : [];
-  const valueList = value.split(",").map((item) => item.trim()).filter(Boolean);
-
-  if (existingList.length === 0) {
-    return valueList.join(", ");
-  }
-
-  const merged = [...existingList];
-  for (const candidate of valueList) {
-    if (!merged.includes(candidate)) {
-      merged.push(candidate);
-    }
-  }
+  const merged: string[] = [];
+  appendUniqueCaseInsensitive(merged, splitVaryValues(existing));
+  appendUniqueCaseInsensitive(merged, splitVaryValues(value));
   return merged.join(", ");
 };
 

--- a/supabase/functions/_shared/http.ts
+++ b/supabase/functions/_shared/http.ts
@@ -62,22 +62,28 @@ const coerceOrigin = (raw?: string | null): string | undefined => {
   }
 };
 
+const splitVaryValues = (input: string | null | undefined): string[] => {
+  if (typeof input !== "string") return [];
+  return input.split(",").map((item) => item.trim()).filter(Boolean);
+};
+
+const appendUniqueCaseInsensitive = (
+  target: string[],
+  values: string[],
+) => {
+  const seen = new Set(target.map((item) => item.toLowerCase()));
+  for (const candidate of values) {
+    const normalized = candidate.toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    target.push(candidate);
+  }
+};
+
 const mergeVary = (existing: string | null | undefined, value: string) => {
-  const existingList = typeof existing === "string"
-    ? existing.split(",").map((item) => item.trim()).filter(Boolean)
-    : [];
-  const valueList = value.split(",").map((item) => item.trim()).filter(Boolean);
-
-  if (existingList.length === 0) {
-    return valueList.join(", ");
-  }
-
-  const merged = [...existingList];
-  for (const candidate of valueList) {
-    if (!merged.includes(candidate)) {
-      merged.push(candidate);
-    }
-  }
+  const merged: string[] = [];
+  appendUniqueCaseInsensitive(merged, splitVaryValues(existing));
+  appendUniqueCaseInsensitive(merged, splitVaryValues(value));
   return merged.join(", ");
 };
 

--- a/tests/merge-vary.test.ts
+++ b/tests/merge-vary.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import { equal as assertEqual } from "node:assert/strict";
+
+import { mergeVary } from "../apps/web/utils/http.ts";
+
+test("mergeVary deduplicates vary entries case-insensitively", () => {
+  const merged = mergeVary("Origin, Accept-Encoding", "origin, X-Custom");
+  assertEqual(merged, "Origin, Accept-Encoding, X-Custom");
+});
+
+test("mergeVary collapses duplicates from existing header values", () => {
+  const merged = mergeVary("ORIGIN, accept-encoding, Origin", "ACCEPT-ENCODING, origin");
+  assertEqual(merged, "ORIGIN, accept-encoding");
+});


### PR DESCRIPTION
## Summary
- update the shared mergeVary helper to deduplicate entries using case-insensitive comparison in both web and Supabase runtimes
- add regression tests covering the new Vary header merging behavior

## Testing
- npm run lint
- node --import tsx --test tests/merge-vary.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfacb26a708322b0a94b7887ef3eaa