### PR TITLE
Refine Telegram admin token validation

### DIFF
--- a/apps/web/hooks/__tests__/useTelegramAuth.test.tsx
+++ b/apps/web/hooks/__tests__/useTelegramAuth.test.tsx
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config/supabase", () => ({
+  buildFunctionUrl: vi.fn(() => "https://functions.test/admin-check"),
+  callEdgeFunction: vi.fn(),
+}));
+
+vi.mock("@/hooks/useToast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import { TelegramAuthProvider } from "../useTelegramAuth";
+import { AdminGate } from "@/components/admin/AdminGate";
+import { callEdgeFunction } from "@/config/supabase";
+
+describe("TelegramAuthProvider admin token validation", () => {
+  const callEdgeFunctionMock = vi.mocked(callEdgeFunction);
+
+  beforeEach(() => {
+    callEdgeFunctionMock.mockReset();
+    localStorage.clear();
+  });
+
+  it("renders children when a stored admin token is validated", async () => {
+    callEdgeFunctionMock.mockResolvedValueOnce({ data: { ok: true } });
+
+    localStorage.setItem("dc_admin_token", "valid-token");
+
+    render(
+      <TelegramAuthProvider>
+        <AdminGate>
+          <div>Admin dashboard</div>
+        </AdminGate>
+      </TelegramAuthProvider>,
+    );
+
+    await waitFor(() =>
+      expect(callEdgeFunctionMock).toHaveBeenCalledWith(
+        "ADMIN_CHECK",
+        expect.objectContaining({ method: "GET", token: "valid-token" }),
+      )
+    );
+
+    expect(await screen.findByText("Admin dashboard")).toBeInTheDocument();
+    expect(localStorage.getItem("dc_admin_token")).toBe("valid-token");
+  });
+
+  it("rejects tampered admin tokens and keeps the gate closed", async () => {
+    callEdgeFunctionMock.mockResolvedValueOnce({
+      error: { status: 401, message: "Invalid token" },
+    });
+
+    localStorage.setItem("dc_admin_token", "tampered-token");
+
+    render(
+      <TelegramAuthProvider>
+        <AdminGate>
+          <div>Admin dashboard</div>
+        </AdminGate>
+      </TelegramAuthProvider>,
+    );
+
+    expect(
+      await screen.findByText("Admin token rejected"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Admin dashboard")).not.toBeInTheDocument();
+    expect(localStorage.getItem("dc_admin_token")).toBeNull();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,7 +12,7 @@ const config = {
     },
   },
   test: {
-    include: ["components/**/*.test.tsx"],
+    include: ["components/**/*.test.tsx", "hooks/**/*.test.tsx"],
     environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.tsx"],

--- a/apps/web/vitest.setup.tsx
+++ b/apps/web/vitest.setup.tsx
@@ -35,10 +35,12 @@ vi.mock("@/components/dynamic-ui-system", () => ({
   Badge: createPrimitive("span"),
   Button: createPrimitive("button"),
   Column: createPrimitive("div"),
+  Heading: createPrimitive("h2"),
   Line: createPrimitive("div"),
   Input: createPrimitive("input"),
   Row: createPrimitive("div"),
   Spinner: () => <div data-testid="spinner" />,
+  Tag: createPrimitive("span"),
   Text: createPrimitive("span"),
 }));
 


### PR DESCRIPTION
## Summary
- add a backend-backed `validateAdminToken` helper to the Telegram auth context and persist validation state for stored tokens
- update the admin gate to rely on the shared token validation flow with clear loading and error feedback
- extend vitest configuration and tests to cover valid vs tampered admin tokens

## Testing
- npm run lint
- npm run typecheck
- npx vitest run hooks/__tests__/useTelegramAuth.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dfb29b8b2c8322ab13ded73e848959