### PR TITLE
Expose dynamic thinking engine across registries

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -309,7 +309,12 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "SupplySummary",
     ),
     "dynamic_text": ("DynamicTextEngine",),
-    "dynamic_thinking": ("DynamicThinkingEngine",),
+    "dynamic_thinking": (
+        "DynamicThinkingEngine",
+        "ThinkingContext",
+        "ThinkingFrame",
+        "ThinkingSignal",
+    ),
     "dynamic.platform.token": ("DynamicTreasuryAlgo",),
     "dynamic_ton": (
         "DynamicTonEngine",

--- a/dynamic_tool_kits/__init__.py
+++ b/dynamic_tool_kits/__init__.py
@@ -246,7 +246,12 @@ _TOOLKIT_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_stem_cell": ("StemCellContext", "StemCellProfile", "StemCellSignal"),
     "dynamic_syncronization": ("SyncDependency", "SyncEvent", "SyncIncident", "SyncStatusSnapshot", "SyncSystem"),
     "dynamic_text": ("TextFragment", "TextContext", "TextDigest"),
-    "dynamic_thinking": ("ThinkingContext", "ThinkingFrame", "ThinkingSignal"),
+    "dynamic_thinking": (
+        "DynamicThinkingEngine",
+        "ThinkingContext",
+        "ThinkingFrame",
+        "ThinkingSignal",
+    ),
     "dynamic_ultimate_reality": ("NonDualContext", "UltimateRealitySignal", "UltimateRealityState"),
     "dynamic_volume": ("BookLevel", "VolumeAlert", "VolumeSnapshot", "VolumeThresholds"),
     "dynamic_wisdom": ("WisdomContext", "WisdomFrame", "WisdomSignal"),


### PR DESCRIPTION
## Summary
- expose the dynamic thinking engine alongside its context, frame, and signal in the toolkit registry
- surface the same dynamic thinking symbols from the platform engine exports for consumers that rely on the dynamic loader

## Testing
- `pytest tests/test_dynamic_tool_kits.py tests/test_dynamic_thinking_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68dfbc832dd8832295324675cf880693