### PR TITLE
feat: expose helper to enable dynamic cosmic engine

### DIFF
--- a/dynamic_cosmic/__init__.py
+++ b/dynamic_cosmic/__init__.py
@@ -45,4 +45,10 @@ def enable_engine(config: Mapping[str, Any] | None = None) -> DynamicCosmic:
         scenario = deepcopy(dict(config))
     else:  # pragma: no cover - defensive guard
         raise TypeError("config must be a mapping if provided")
-    return _build_engine(scenario)
+    engine = _build_engine(scenario)
+    # Warm analytics caches so that immediate telemetry calls do not repeat
+    # expensive aggregations. Subsequent mutations on the engine will
+    # invalidate these caches automatically.
+    engine.evaluate_resilience()
+    engine.topology_metrics()
+    return engine


### PR DESCRIPTION
## Summary
- add an `enable_engine` helper to the `dynamic_cosmic` package that reuses the CLI builder
- ensure configuration payloads are deep-copied so callers can reuse dictionaries safely
- cover the new helper with tests for both the default scenario and custom configuration

## Testing
- pytest tests_python/test_dynamic_cosmic_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc39224f0832296cad260048a0943