### PR TITLE
Enable dynamic physics exports

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -39,6 +39,8 @@ __all__ = [
     "DynamicRecyclingAgent",
     "DynamicNFTAgent",
     "NFTAgentInsight",
+    "DynamicPhysicsAgent",
+    "PhysicsAgentInsight",
     "DynamicDhivehiLanguageAgent",
     "DhivehiLanguageAgentInsight",
     "DynamicBusinessAgent",
@@ -111,6 +113,8 @@ _LAZY = LazyNamespace(
         "DynamicRecyclingAgent": "dynamic_agents.recycling",
         "DynamicNFTAgent": "dynamic_agents.nft_engine",
         "NFTAgentInsight": "dynamic_agents.nft_engine",
+        "DynamicPhysicsAgent": "dynamic_agents.physics_agent",
+        "PhysicsAgentInsight": "dynamic_agents.physics_agent",
         "DynamicDhivehiLanguageAgent": "dynamic_agents.dhivehi_language",
         "DhivehiLanguageAgentInsight": "dynamic_agents.dhivehi_language",
         "DynamicBusinessAgent": "dynamic_agents.business",
@@ -189,6 +193,10 @@ if TYPE_CHECKING:  # pragma: no cover - import-time only
     from dynamic_agents.nft_engine import (
         DynamicNFTAgent,
         NFTAgentInsight,
+    )
+    from dynamic_agents.physics_agent import (
+        DynamicPhysicsAgent,
+        PhysicsAgentInsight,
     )
     from dynamic_agents.dhivehi_language import (
         DhivehiLanguageAgentInsight,

--- a/dynamic_bots/__init__.py
+++ b/dynamic_bots/__init__.py
@@ -32,6 +32,7 @@ _EXPORT_MAP = {
     "dynamic_bots.nft_engine": (
         "DynamicNFTBot",
     ),
+    "dynamic_bots.physics": ("DynamicPhysicsBot",),
     "dynamic_bots.business": ("DynamicBusinessBot",),
     "dynamic_bots.dhivehi_language": ("DynamicDhivehiLanguageBot",),
     "dynamic_bots.elements": (

--- a/dynamic_helpers/__init__.py
+++ b/dynamic_helpers/__init__.py
@@ -35,6 +35,7 @@ _HELPER_EXPORTS = {
         "DynamicHadalpelagicHelper",
     ),
     "dynamic_helpers.nft_engine": ("DynamicNFTHelper",),
+    "dynamic_helpers.physics": ("DynamicPhysicsHelper",),
     "dynamic_helpers.dhivehi_language": ("DynamicDhivehiLanguageHelper",),
     "dynamic_helpers.business": ("DynamicBusinessHelper",),
     "dynamic_helpers.elements": (

--- a/dynamic_keepers/__init__.py
+++ b/dynamic_keepers/__init__.py
@@ -68,6 +68,7 @@ _KEEPER_EXPORTS = {
     ),
     "dynamic_keepers.dhivehi_language": ("DynamicDhivehiLanguageKeeper",),
     "dynamic_keepers.business": ("DynamicBusinessKeeper",),
+    "dynamic_keepers.physics": ("DynamicPhysicsKeeper",),
     "dynamic_keepers.ocean": (
         "DynamicOceanLayerKeeper",
         "DynamicEpipelagicKeeper",


### PR DESCRIPTION
## Summary
- expose the dynamic physics agent through the legacy `dynamic_agents` shim
- re-export the physics helper, keeper, and bot implementations for backward compatible imports

## Testing
- pytest tests_python/test_physics.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc4ef22b88322b5d1be8e526c605d