### PR TITLE
Expose dynamic state symbols in legacy engines shim

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -298,7 +298,12 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_source": ("DynamicSourceEngine",),
     "dynamic_space.engine": ("DynamicSpaceEngine",),
     "dynamic_spheres": ("DynamicSpheresEngine",),
-    "dynamic_states": ("DynamicStateEngine",),
+    "dynamic_states": (
+        "DynamicStateEngine",
+        "StateSignal",
+        "StateDefinition",
+        "StateSnapshot",
+    ),
     "dynamic_stem_cell": ("DynamicStemCell",),
     "dynamic_syncronization": ("DynamicSyncronizationOrchestrator",),
     "dynamic_supply": (

--- a/tests/test_dynamic_states.py
+++ b/tests/test_dynamic_states.py
@@ -6,7 +6,7 @@ import math
 
 import pytest
 
-from dynamic_states import DynamicStateEngine, StateDefinition, StateSignal
+from dynamic_states import DynamicStateEngine, StateDefinition, StateSignal, StateSnapshot
 
 
 @pytest.fixture()
@@ -69,3 +69,17 @@ def test_overview_returns_all_states(engine: DynamicStateEngine) -> None:
     assert set(overview.keys()) == {"alert", "calm"}
     assert overview["alert"].summary.startswith("Alert state")
     assert overview["calm"].value == pytest.approx(0.0)
+
+
+def test_legacy_engines_module_exports_state_symbols() -> None:
+    from dynamic.platform.engines import (  # type: ignore-import-not-found
+        DynamicStateEngine as LegacyEngine,
+        StateDefinition as LegacyDefinition,
+        StateSignal as LegacySignal,
+        StateSnapshot as LegacySnapshot,
+    )
+
+    assert LegacyEngine is DynamicStateEngine
+    assert LegacySignal is StateSignal
+    assert LegacyDefinition is StateDefinition
+    assert LegacySnapshot is StateSnapshot


### PR DESCRIPTION
## Summary
- expose the dynamic state engine and data classes through the legacy dynamic.platform.engines shim
- add a regression test covering the legacy import path for state symbols

## Testing
- pytest tests/test_dynamic_states.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc6e876808322a998ab9612351640