### PR TITLE
feat(token): surface token highlights and market metrics

### DIFF
--- a/apps/web/app/token/page.tsx
+++ b/apps/web/app/token/page.tsx
@@ -13,6 +13,7 @@ import {
   tokenContent,
   tokenDescriptor,
 } from "@/resources";
+import { cn } from "@/utils";
 
 const normalizeBaseURL = (value: string) =>
   value.endsWith("/") ? value.slice(0, -1) : value;
@@ -38,6 +39,12 @@ export function generateMetadata() {
 }
 
 const formatNumber = (value: number) => value.toLocaleString("en-US");
+const formatCurrency = (value: number) =>
+  value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
 
 export default function TokenPage() {
   return (
@@ -72,6 +79,62 @@ export default function TokenPage() {
         >
           {tokenContent.intro}
         </Text>
+        <Row
+          gap="16"
+          wrap
+          horizontal="center"
+          className="w-full max-w-5xl"
+        >
+          {tokenContent.highlights.map((highlight) => {
+            const linkProps = highlight.href
+              ? {
+                as: "a" as const,
+                href: highlight.href,
+                target: "_blank",
+                rel: "noreferrer",
+              }
+              : {};
+
+            return (
+              <Column
+                key={highlight.label}
+                gap="12"
+                padding="16"
+                radius="l"
+                background="surface"
+                border="neutral-alpha-medium"
+                className="min-w-[240px] flex-1 bg-background/70 shadow-lg shadow-primary/5"
+              >
+                <Row gap="8" vertical="center">
+                  <Icon name={highlight.icon} onBackground="brand-medium" />
+                  <Text variant="label-strong-s" onBackground="neutral-strong">
+                    {highlight.label}
+                  </Text>
+                </Row>
+                <Text
+                  {...linkProps}
+                  variant="heading-strong-xs"
+                  onBackground="neutral-strong"
+                  className={cn(
+                    "font-mono",
+                    highlight.href
+                      ? "transition-colors hover:text-brand-medium"
+                      : undefined,
+                  )}
+                >
+                  {highlight.value}
+                </Text>
+                <Text
+                  variant="body-default-s"
+                  onBackground="neutral-weak"
+                  wrap="balance"
+                >
+                  {highlight.description}
+                </Text>
+              </Column>
+            );
+          })}
+        </Row>
         <Row gap="16" wrap horizontal="center">
           <Row
             gap="8"
@@ -97,6 +160,34 @@ export default function TokenPage() {
             <Icon name="sparkles" onBackground="brand-medium" />
             <Text variant="label-strong-s">
               Decimals {tokenDescriptor.decimals}
+            </Text>
+          </Row>
+          <Row
+            gap="8"
+            background="page"
+            border="neutral-alpha-medium"
+            radius="l"
+            padding="12"
+            vertical="center"
+          >
+            <Icon name="currencyDollar" onBackground="brand-medium" />
+            <Text variant="label-strong-s">
+              Market cap {formatCurrency(tokenContent.marketCapUsd)}
+            </Text>
+          </Row>
+          <Row
+            gap="8"
+            background="page"
+            border="neutral-alpha-medium"
+            radius="l"
+            padding="12"
+            vertical="center"
+          >
+            <Icon name="chartPie" onBackground="brand-medium" />
+            <Text variant="label-strong-s">
+              Circulating supply {formatNumber(tokenContent.circulatingSupply)}
+              {" "}
+              {tokenDescriptor.symbol}
             </Text>
           </Row>
         </Row>

--- a/apps/web/resources/icons.ts
+++ b/apps/web/resources/icons.ts
@@ -6,7 +6,9 @@ import {
   HiArrowTopRightOnSquare,
   HiArrowUpRight,
   HiCalendarDays,
+  HiChartPie,
   HiCheckCircle,
+  HiCurrencyDollar,
   HiEnvelope,
   HiMapPin,
   HiOutlineDocument,
@@ -17,6 +19,7 @@ import {
   HiOutlineRocketLaunch,
   HiPhone,
   HiSparkles,
+  HiWallet,
 } from "react-icons/hi2";
 
 import {
@@ -65,6 +68,7 @@ export const iconLibrary: Record<string, IconType> = {
   home: PiHouseDuotone,
   gallery: PiImageDuotone,
   crown: PiCrownSimpleDuotone,
+  wallet: HiWallet,
   discord: FaDiscord,
   eye: HiOutlineEye,
   eyeOff: HiOutlineEyeSlash,
@@ -93,6 +97,8 @@ export const iconLibrary: Record<string, IconType> = {
   reddit: FaReddit,
   telegram: FaTelegram,
   tradingview: SiTradingview,
+  currencyDollar: HiCurrencyDollar,
+  chartPie: HiChartPie,
 };
 
 export type IconLibrary = typeof iconLibrary;

--- a/apps/web/resources/token.ts
+++ b/apps/web/resources/token.ts
@@ -3,6 +3,33 @@ import jettonMetadata from "../../../dynamic-capital-ton/contracts/jetton/metada
 };
 import type { IconName } from "./icons";
 
+const TGE_CIRCULATING_SUPPLY = 13_000_000;
+const TGE_MARKET_CAP_USD = 13_000_000;
+const OPERATIONS_TREASURY_WALLET =
+  "EQD1zAJPYZMYf3Y9B4SL7fRLFU-Vg5V7RcLMnEu2H_cNOPDD";
+const OPERATIONS_TREASURY_EXPLORER_URL =
+  `https://tonviewer.com/${OPERATIONS_TREASURY_WALLET}`;
+
+const formatNumber = (value: number) =>
+  new Intl.NumberFormat("en-US").format(value);
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const shortenTonAddress = (value: string, visible = 6) => {
+  if (value.length <= visible * 2) {
+    return value;
+  }
+
+  const head = value.slice(0, visible);
+  const tail = value.slice(-visible);
+  return `${head}…${tail}`;
+};
+
 type DexPool = {
   dex: string;
   pair: string;
@@ -15,6 +42,14 @@ type SupplySplit = {
   value: string;
   description: string;
   icon: IconName;
+};
+
+type TokenHighlight = {
+  label: string;
+  value: string;
+  description: string;
+  icon: IconName;
+  href?: string;
 };
 
 type LockTier = {
@@ -34,7 +69,12 @@ type TokenContent = {
   supplySplits: readonly SupplySplit[];
   lockTiers: readonly LockTier[];
   dexPools: readonly DexPool[];
+  highlights: readonly TokenHighlight[];
   sameAs: readonly string[];
+  circulatingSupply: number;
+  marketCapUsd: number;
+  treasuryWalletAddress: string;
+  treasuryWalletUrl: string;
 };
 
 type TokenDescriptor = {
@@ -66,6 +106,37 @@ const tokenUtilities = [
   "Stake into the auto-invest pool to participate in weekly performance.",
   "Vote on treasury moves through the 48-hour guarded governance window.",
 ] as const;
+
+const tokenHighlights = [
+  {
+    label: "Dynamic Capital Token",
+    value: `${tokenDescriptor.symbol} on TON`,
+    description: "Utility and governance jetton anchored to desk performance.",
+    icon: "sparkles",
+  },
+  {
+    label: "Treasury TON wallet",
+    value: shortenTonAddress(OPERATIONS_TREASURY_WALLET),
+    description:
+      "Operations multisig safeguarding buybacks, burns, and rewards.",
+    icon: "wallet",
+    href: OPERATIONS_TREASURY_EXPLORER_URL,
+  },
+  {
+    label: "Market cap",
+    value: formatCurrency(TGE_MARKET_CAP_USD),
+    description:
+      "Fully collateralised by Dynamic Capital desk assets at launch.",
+    icon: "currencyDollar",
+  },
+  {
+    label: "Circulating supply",
+    value: `${formatNumber(TGE_CIRCULATING_SUPPLY)} ${tokenDescriptor.symbol}`,
+    description:
+      "TGE float powering staking, rewards, and liquidity programmes.",
+    icon: "chartPie",
+  },
+] as const satisfies readonly TokenHighlight[];
 
 const tokenSupplySplits = [
   {
@@ -144,7 +215,12 @@ const tokenContent: TokenContent = {
   supplySplits: tokenSupplySplits,
   lockTiers: tokenLockTiers,
   dexPools: tokenDexPools,
+  highlights: tokenHighlights,
   sameAs: tokenSameAs,
+  circulatingSupply: TGE_CIRCULATING_SUPPLY,
+  marketCapUsd: TGE_MARKET_CAP_USD,
+  treasuryWalletAddress: OPERATIONS_TREASURY_WALLET,
+  treasuryWalletUrl: OPERATIONS_TREASURY_EXPLORER_URL,
 };
 
 export { tokenContent, tokenDescriptor };


### PR DESCRIPTION
## Summary
- expose Dynamic Capital Token metadata for circulating supply, market cap, and the operations treasury wallet
- add dedicated highlight cards that surface token, TON wallet, market cap, and supply data on the token page
- extend the shared icon library with wallet and finance glyphs used by the new highlights

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dfc352c33c8322927c000bde89fc56