### PR TITLE
Enable offline access to dynamic chat providers

### DIFF
--- a/apps/web/services/llm/__tests__/providers.test.ts
+++ b/apps/web/services/llm/__tests__/providers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { listProviders } from "../providers";
+import { type ProviderId, type ProviderSummary } from "../types";
+
+function getProvider(id: ProviderSummary["id"]): ProviderSummary {
+  const providers = listProviders();
+  const provider = providers.find((entry) => entry.id === id);
+  if (!provider) {
+    throw new Error(`Provider ${id} not found in listProviders()`);
+  }
+  return provider;
+}
+
+describe("LLM provider availability", () => {
+  it("marks dynamic providers as configured even without env keys", () => {
+    const dynamicIds: ProviderId[] = [
+      "dynamic-ai",
+      "dynamic-agi",
+      "dynamic-ags",
+    ];
+
+    for (const id of dynamicIds) {
+      const provider = getProvider(id);
+      expect(provider.configured).toBe(true);
+    }
+  });
+
+  it("keeps third-party providers gated behind configuration", () => {
+    const externalIds: ProviderId[] = ["openai", "anthropic", "groq"];
+
+    for (const id of externalIds) {
+      const provider = getProvider(id);
+      expect(provider.configured).toBe(false);
+    }
+  });
+});

--- a/apps/web/services/llm/providers.ts
+++ b/apps/web/services/llm/providers.ts
@@ -403,6 +403,9 @@ function mapAnthropicUsage(
 }
 
 function providerConfigured(definition: ProviderDefinition): boolean {
+  if (definition.requiresConfiguration === false) {
+    return true;
+  }
   if (typeof definition.isConfigured === "function") {
     return Boolean(definition.isConfigured());
   }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -12,7 +12,11 @@ const config = {
     },
   },
   test: {
-    include: ["components/**/*.test.tsx", "hooks/**/*.test.tsx"],
+    include: [
+      "components/**/*.test.tsx",
+      "hooks/**/*.test.tsx",
+      "services/**/*.test.ts",
+    ],
     environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.tsx"],


### PR DESCRIPTION
## Summary
- treat dynamic chat providers as configured when credentials aren’t required so the UI can dispatch to their demo fallbacks
- add focused Vitest coverage that checks dynamic providers stay enabled while external providers remain gated
- expand the Vitest include globs to pick up service-layer tests

## Testing
- npm run lint
- npm run typecheck
- node scripts/npm-safe.mjs -w apps/web run test -- --run services/llm/__tests__/providers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfc6fe50588322ace3500443157c74