### PR TITLE
Expose dynamic protocol planner exports

### DIFF
--- a/algorithms/python/__init__.py
+++ b/algorithms/python/__init__.py
@@ -1,5 +1,8 @@
 """Python trading strategy utilities for Dynamic Capital."""
 
+from types import MappingProxyType
+from typing import Mapping
+
 from . import trade_logic as _trade_logic
 from .alert_notifications import (
     AlertEngine,
@@ -158,10 +161,10 @@ from .desk_sync import (
     summarise_trade_logic,
 )
 from .dynamic_protocol_planner import (
-    CATEGORY_EXECUTORS as PROTOCOL_CATEGORY_EXECUTORS,
-    CATEGORY_KEYS as PROTOCOL_CATEGORY_KEYS,
+    CATEGORY_EXECUTORS as _PROTOCOL_CATEGORY_EXECUTORS,
+    CATEGORY_KEYS as _PROTOCOL_CATEGORY_KEYS,
     DynamicProtocolPlanner,
-    HORIZON_KEYS as PROTOCOL_HORIZON_KEYS,
+    HORIZON_KEYS as _PROTOCOL_HORIZON_KEYS,
     ProtocolDraft,
 )
 from .project_faq_generator import (
@@ -331,6 +334,15 @@ from .trading_algo_enhancement import (
     build_default_roadmap,
     build_trading_algo_enhancement_plan,
     loop_trading_algo_enhancement_plan,
+)
+
+PROTOCOL_CATEGORY_KEYS: tuple[str, ...] = tuple(_PROTOCOL_CATEGORY_KEYS)
+PROTOCOL_HORIZON_KEYS: tuple[str, ...] = tuple(_PROTOCOL_HORIZON_KEYS)
+PROTOCOL_CATEGORY_EXECUTORS: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        category: tuple(executors)
+        for category, executors in _PROTOCOL_CATEGORY_EXECUTORS.items()
+    }
 )
 
 _trade_exports = list(getattr(_trade_logic, "__all__", []))  # type: ignore[attr-defined]

--- a/algorithms/python/tests/test_dynamic_protocol_planner.py
+++ b/algorithms/python/tests/test_dynamic_protocol_planner.py
@@ -4,7 +4,14 @@ from typing import Any, Dict, Iterable, Mapping, Sequence
 
 import pytest
 
+from algorithms.python import (
+    DynamicProtocolPlanner as RootDynamicProtocolPlanner,
+    PROTOCOL_CATEGORY_EXECUTORS as ROOT_PROTOCOL_CATEGORY_EXECUTORS,
+    PROTOCOL_CATEGORY_KEYS as ROOT_PROTOCOL_CATEGORY_KEYS,
+    PROTOCOL_HORIZON_KEYS as ROOT_PROTOCOL_HORIZON_KEYS,
+)
 from algorithms.python.dynamic_protocol_planner import (
+    CATEGORY_EXECUTORS,
     CATEGORY_KEYS,
     DynamicProtocolPlanner,
     HORIZON_KEYS,
@@ -268,4 +275,17 @@ def test_optimize_and_generate_syncs_plan(monkeypatch: pytest.MonkeyPatch) -> No
     assert optimisation_annotations["insights"]["snapshot_count"] == 25
     assert optimisation_annotations["backtest"]["ending_equity"] == 12_500.5
     assert draft.annotations["context_supplied"] is True
+
+
+def test_root_package_exports_hardened_protocol_metadata() -> None:
+    assert RootDynamicProtocolPlanner is DynamicProtocolPlanner
+    assert ROOT_PROTOCOL_CATEGORY_KEYS == CATEGORY_KEYS
+    assert ROOT_PROTOCOL_HORIZON_KEYS == HORIZON_KEYS
+    assert isinstance(ROOT_PROTOCOL_CATEGORY_EXECUTORS, Mapping)
+    assert dict(ROOT_PROTOCOL_CATEGORY_EXECUTORS) == CATEGORY_EXECUTORS
+    assert all(
+        isinstance(owners, tuple) for owners in ROOT_PROTOCOL_CATEGORY_EXECUTORS.values()
+    )
+    with pytest.raises(TypeError):
+        ROOT_PROTOCOL_CATEGORY_EXECUTORS["market_outlook"] = ("Override",)
 


### PR DESCRIPTION
## Summary
- re-export the dynamic protocol planner and protocol metadata from the algorithms package root so downstream callers can opt into protocol workflows

## Testing
- pytest algorithms/python/tests/test_dynamic_protocol_planner.py

------
https://chatgpt.com/codex/tasks/task_e_68dfca2317e88322adfa3fb60bae4369