### PR TITLE
Enable dynamic wisdom toolkit engine

### DIFF
--- a/dynamic_tool_kits/__init__.py
+++ b/dynamic_tool_kits/__init__.py
@@ -260,7 +260,12 @@ _TOOLKIT_EXPORTS: Dict[str, Tuple[str, ...]] = {
     ),
     "dynamic_ultimate_reality": ("NonDualContext", "UltimateRealitySignal", "UltimateRealityState"),
     "dynamic_volume": ("BookLevel", "VolumeAlert", "VolumeSnapshot", "VolumeThresholds"),
-    "dynamic_wisdom": ("WisdomContext", "WisdomFrame", "WisdomSignal"),
+    "dynamic_wisdom": (
+        "DynamicWisdomEngine",
+        "WisdomContext",
+        "WisdomFrame",
+        "WisdomSignal",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- expose `DynamicWisdomEngine` through the `dynamic_tool_kits` aggregation so the wisdom engine can be loaded lazily via the legacy namespace

## Testing
- python -m compileall dynamic_tool_kits/__init__.py dynamic_wisdom

------
https://chatgpt.com/codex/tasks/task_e_68dfcee33fc08322bcb0e541bd022d7d