### PR TITLE
Expose dynamic framework module

### DIFF
--- a/dynamic/__init__.py
+++ b/dynamic/__init__.py
@@ -8,4 +8,5 @@ __all__ = [
     "tools",
     "models",
     "brand",
+    "framework",
 ]

--- a/dynamic/framework/__init__.py
+++ b/dynamic/framework/__init__.py
@@ -1,0 +1,19 @@
+"""Bridge module exposing the dynamic framework within the :mod:`dynamic` namespace."""
+
+from dynamic_framework import (
+    DynamicFrameworkEngine,
+    FrameworkNode,
+    FrameworkPulse,
+    FrameworkReport,
+    FrameworkSettings,
+    FrameworkSnapshot,
+)
+
+__all__ = [
+    "DynamicFrameworkEngine",
+    "FrameworkNode",
+    "FrameworkPulse",
+    "FrameworkReport",
+    "FrameworkSettings",
+    "FrameworkSnapshot",
+]


### PR DESCRIPTION
## Summary
- add a bridge module under the dynamic namespace that re-exports the dynamic framework engine primitives
- include the framework namespace in the dynamic package exports for easier discovery

## Testing
- pytest tests/test_dynamic_framework.py

------
https://chatgpt.com/codex/tasks/task_e_68dfcf3b47dc832295a3dfaf73ad0cff