### PR TITLE
Enable dynamic atom exports across shims

### DIFF
--- a/dynamic_agents/__init__.py
+++ b/dynamic_agents/__init__.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 from ._lazy import LazyNamespace
 
 __all__ = [
+    "AtomAgentInsight",
     "Agent",
     "AgentResult",
     "BloodAgent",
@@ -28,6 +29,7 @@ __all__ = [
     "DynamicChatAgent",
     "DynamicArchitectAgent",
     "DynamicArchitectAgentResult",
+    "DynamicAtomAgent",
     "DynamicEngineerAgent",
     "DynamicEngineerAgentResult",
     "DynamicOceanLayerAgent",
@@ -105,11 +107,13 @@ _LAZY = LazyNamespace(
     "dynamic.intelligence.ai_apps",
     __all__,
     overrides={
+        "AtomAgentInsight": "dynamic_agents.atom",
         "run_dynamic_agent_cycle": "algorithms.python.dynamic_ai_sync",
         "DynamicEngineerAgent": "dynamic_engineer.agent",
         "DynamicEngineerAgentResult": "dynamic_engineer.agent",
         "DynamicArchitectAgent": "dynamic_architect.agent",
         "DynamicArchitectAgentResult": "dynamic_architect.agent",
+        "DynamicAtomAgent": "dynamic_agents.atom",
         "DynamicRecyclingAgent": "dynamic_agents.recycling",
         "DynamicNFTAgent": "dynamic_agents.nft_engine",
         "NFTAgentInsight": "dynamic_agents.nft_engine",
@@ -163,6 +167,7 @@ _LAZY = LazyNamespace(
 )
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
+    from dynamic_agents.atom import AtomAgentInsight, DynamicAtomAgent
     from algorithms.python.dynamic_ai_sync import run_dynamic_agent_cycle
     from dynamic.intelligence.ai_apps import (
         Agent,

--- a/dynamic_helpers/__init__.py
+++ b/dynamic_helpers/__init__.py
@@ -34,6 +34,7 @@ _HELPER_EXPORTS = {
         "DynamicAbyssopelagicHelper",
         "DynamicHadalpelagicHelper",
     ),
+    "dynamic_helpers.atom": ("DynamicAtomHelper",),
     "dynamic_helpers.nft_engine": ("DynamicNFTHelper",),
     "dynamic_helpers.physics": ("DynamicPhysicsHelper",),
     "dynamic_helpers.dhivehi_language": ("DynamicDhivehiLanguageHelper",),

--- a/dynamic_keepers/__init__.py
+++ b/dynamic_keepers/__init__.py
@@ -69,6 +69,7 @@ _KEEPER_EXPORTS = {
     "dynamic_keepers.dhivehi_language": ("DynamicDhivehiLanguageKeeper",),
     "dynamic_keepers.business": ("DynamicBusinessKeeper",),
     "dynamic_keepers.physics": ("DynamicPhysicsKeeper",),
+    "dynamic_keepers.atom": ("DynamicAtomKeeper",),
     "dynamic_keepers.ocean": (
         "DynamicOceanLayerKeeper",
         "DynamicEpipelagicKeeper",


### PR DESCRIPTION
## Summary
- expose `DynamicAtomAgent`/`AtomAgentInsight` through the legacy `dynamic_agents` namespace so the dynamic atom stack can be imported from the compatibility shim
- surface the dynamic atom helper and keeper implementations via the existing `dynamic_helpers` and `dynamic_keepers` lazy maps to keep feature parity across shims

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dfd0b940a48322abe0430db37e8c38