### PR TITLE
Add dynamic cycle orchestrator to engine registry

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -95,6 +95,14 @@ _ENGINE_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_consciousness": ("DynamicConsciousness",),
     "dynamic_creative_thinking": ("DynamicCreativeThinking",),
     "dynamic_critical_thinking": ("DynamicCriticalThinking",),
+    "dynamic_cycle": (
+        "DynamicCycleOrchestrator",
+        "CycleEvent",
+        "CyclePhase",
+        "CycleSnapshot",
+        "create_dynamic_life_cycle",
+        "LIFE_CYCLE_BLUEPRINT",
+    ),
     "dynamic_data_training": (
         "DataTrainingSummary",
         "DynamicDataTrainingEngine",


### PR DESCRIPTION
## Summary
- expose the dynamic cycle orchestrator and lifecycle helpers through the legacy engine registry

## Testing
- pytest tests/test_dynamic_cycle.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd5aeee6c8322baf19b7055393465