### PR TITLE
Enable all dynamic method pillars by default

### DIFF
--- a/dynamic_method/engine.py
+++ b/dynamic_method/engine.py
@@ -307,26 +307,39 @@ class DynamicMethodEngine:
         metrics: Mapping[str, float],
         dominant_drivers: Sequence[str],
     ) -> tuple[str, ...]:
-        pillars: list[str] = ["Mission clarity & stakeholder alignment"]
-        if context.is_innovation_led or metrics["ambiguity"] >= 0.6:
-            pillars.append("Hypothesis-driven discovery loops")
-        if context.is_low_maturity:
-            pillars.append("Capability and playbook uplift")
-        if context.ops_maturity >= 0.6 and metrics["discipline"] >= 0.55:
-            pillars.append("Measured execution discipline")
-        if metrics["leverage"] >= 0.6:
-            pillars.append("Compounding leverage amplification")
-        if metrics["risk"] >= 0.6 or context.is_high_compliance:
-            pillars.append("Embedded governance & risk sensing")
-        if dominant_drivers:
-            pillars.append("Driver focus: " + ", ".join(dominant_drivers))
+        base_pillars: list[str] = [
+            "Mission clarity & stakeholder alignment",
+            "Hypothesis-driven discovery loops",
+            "Capability and playbook uplift",
+            "Measured execution discipline",
+            "Compounding leverage amplification",
+            "Embedded governance & risk sensing",
+        ]
 
-        seen: set[str] = set()
+        priority: list[str] = []
+        if context.is_innovation_led or metrics["ambiguity"] >= 0.6:
+            priority.append("Hypothesis-driven discovery loops")
+        if context.is_low_maturity:
+            priority.append("Capability and playbook uplift")
+        if context.ops_maturity >= 0.6 and metrics["discipline"] >= 0.55:
+            priority.append("Measured execution discipline")
+        if metrics["leverage"] >= 0.6:
+            priority.append("Compounding leverage amplification")
+        if metrics["risk"] >= 0.6 or context.is_high_compliance:
+            priority.append("Embedded governance & risk sensing")
+
         ordered: list[str] = []
-        for pillar in pillars:
+        seen: set[str] = set()
+        for pillar in [*priority, *base_pillars]:
             if pillar not in seen:
                 seen.add(pillar)
                 ordered.append(pillar)
+
+        if dominant_drivers:
+            driver_focus = "Driver focus: " + ", ".join(dominant_drivers)
+            if driver_focus not in seen:
+                ordered.append(driver_focus)
+
         return tuple(ordered)
 
     def _governance_focus(

--- a/tests/test_dynamic_method_engine.py
+++ b/tests/test_dynamic_method_engine.py
@@ -1,0 +1,86 @@
+from dynamic_method import DynamicMethodEngine, MethodContext, MethodSignal
+
+
+def _context(**overrides: float | str) -> MethodContext:
+    params: dict[str, float | str | tuple[str, ...]] = {
+        "mission": "Scale the operating system",
+        "horizon": "Next quarter",
+        "urgency_bias": 0.4,
+        "compliance_pressure": 0.3,
+        "innovation_pull": 0.4,
+        "ops_maturity": 0.5,
+        "dependencies": (),
+        "stakeholders": (),
+    }
+    params.update(overrides)
+    return MethodContext(**params)  # type: ignore[arg-type]
+
+
+def _signal(**overrides: float | str | tuple[str, ...]) -> MethodSignal:
+    params: dict[str, float | str | tuple[str, ...]] = {
+        "driver": "execution",
+        "observation": "Signal registered",
+        "urgency": 0.5,
+        "ambiguity": 0.5,
+        "risk": 0.5,
+        "effort": 0.5,
+        "leverage": 0.5,
+        "discipline": 0.5,
+        "tags": (),
+    }
+    params.update(overrides)
+    return MethodSignal(**params)  # type: ignore[arg-type]
+
+
+def test_blueprint_includes_all_pillars_by_default() -> None:
+    engine = DynamicMethodEngine()
+    blueprint = engine.build_blueprint(_context())
+
+    assert blueprint.pillars == (
+        "Mission clarity & stakeholder alignment",
+        "Hypothesis-driven discovery loops",
+        "Capability and playbook uplift",
+        "Measured execution discipline",
+        "Compounding leverage amplification",
+        "Embedded governance & risk sensing",
+    )
+
+
+def test_blueprint_prioritises_relevant_pillars_and_adds_driver_focus() -> None:
+    engine = DynamicMethodEngine()
+    engine.register(
+        _signal(
+            driver="innovation",
+            ambiguity=0.8,
+            leverage=0.7,
+            risk=0.65,
+            discipline=0.65,
+            tags=("innovation", "governance"),
+        )
+    )
+
+    blueprint = engine.build_blueprint(
+        _context(
+            compliance_pressure=0.7,
+            innovation_pull=0.7,
+            ops_maturity=0.7,
+        )
+    )
+
+    expected_pillars = {
+        "Mission clarity & stakeholder alignment",
+        "Hypothesis-driven discovery loops",
+        "Capability and playbook uplift",
+        "Measured execution discipline",
+        "Compounding leverage amplification",
+        "Embedded governance & risk sensing",
+    }
+
+    assert set(blueprint.pillars[:-1]) == expected_pillars
+    assert blueprint.pillars[:4] == (
+        "Hypothesis-driven discovery loops",
+        "Measured execution discipline",
+        "Compounding leverage amplification",
+        "Embedded governance & risk sensing",
+    )
+    assert blueprint.pillars[-1] == "Driver focus: innovation"


### PR DESCRIPTION
## Summary
- ensure the dynamic method engine always emits the complete pillar catalogue while still prioritising the most relevant focus areas
- surface a driver focus string only once and append it after the core pillars
- add regression tests that cover both the default blueprint and a high-signal scenario

## Testing
- npm run format
- pytest tests/test_dynamic_method_engine.py tests/test_dynamic_pillars.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd5d068b883228513368bee4c2443