### PR TITLE
Enable automatic trading signal ingestion

### DIFF
--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -78,8 +78,9 @@ the `signals` table that the MT5 bridge consumes.
 
 1. Set `TRADING_SIGNALS_WEBHOOK_SECRET` in the Supabase project environment and
    redeploy the `trading-signal` function so the new value is active.
-2. Confirm the `trading.signals_ingest` feature flag is registered/enabled if
-   downstream processing should run immediately.
+2. The `trading.signals_ingest` feature flag is registered and enabled by
+   default to keep automation active. Update the `features` table if you need to
+   temporarily pause downstream processing.
 3. Update TradingView alerts (or upstream services) to target the Supabase
    Functions URL and include the secret in the `x-tradingview-secret` header.
 4. Verify Supabase has the `signals` table and related RPC helpers deployed via

--- a/supabase/functions/trading-signal/index.ts
+++ b/supabase/functions/trading-signal/index.ts
@@ -46,7 +46,7 @@ export const handler = registerHandler(async (req) => {
   await ensureFeatureRegistered(
     FEATURE_KEY,
     "Allow TradingView alerts to create MT5 signals",
-    false,
+    true,
     { source: "tradingview" },
   );
 


### PR DESCRIPTION
## Summary
- default the `trading.signals_ingest` feature to enabled so TradingView alerts flow into the MT5 automation without manual toggles
- update the trading webhook documentation to note the new default and how to pause ingestion when needed

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dfe9de01a08322a7d270b435df582c