### PR TITLE
Expose dynamic indexing primitives through engine registry

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -197,7 +197,12 @@ _ENGINE_EXPORTS: Dict[str, Tuple[SymbolExport, ...]] = {
         "UsageCycleResult",
     ),
     "dynamic_implicit_memory": ("DynamicImplicitMemory",),
-    "dynamic_index": ("DynamicIndex",),
+    "dynamic_index": (
+        "DynamicIndex",
+        "IndexConstituent",
+        "IndexSignal",
+        "IndexSnapshot",
+    ),
     "dynamic_immune": (
         "DynamicImmuneEngine",
         "ThreatAssessment",


### PR DESCRIPTION
## Summary
- expose the dynamic indexing dataclasses through the platform engine registry so legacy engine imports gain full index functionality

## Testing
- pytest tests/test_dynamic_index.py

------
https://chatgpt.com/codex/tasks/task_e_68dff28bcb548322a7c56a4aadbccc4b