### PR TITLE
Enable gating for Dynamic live data crawlers

### DIFF
--- a/tests_python/test_dynamic_crawlers.py
+++ b/tests_python/test_dynamic_crawlers.py
@@ -212,3 +212,19 @@ def test_build_plan_requires_enabled_crawler(tmp_path: Path) -> None:
     registry.enable("Crawl4AI")
     plan = registry.build_plan("Crawl4AI", job)
     assert plan.commands
+
+
+def test_enable_live_data_crawlers_is_idempotent() -> None:
+    registry = DynamicCrawlerRegistry()
+    register_default_crawlers(registry)
+
+    # register_default_crawlers already enables all live-data capable crawlers
+    assert registry.enable_live_data_crawlers() == ()
+
+    registry.disable("Crawl4AI")
+    registry.disable("Firecrawl")
+
+    reenabled = registry.enable_live_data_crawlers()
+    assert reenabled == ("Crawl4AI", "Firecrawl")
+    assert registry.is_enabled("Crawl4AI")
+    assert registry.is_enabled("Firecrawl")


### PR DESCRIPTION
## Summary
- add enable/disable flags and helpers to the crawler registry and automatically enable the live-data capable specs
- block plan generation for disabled crawlers and expose an optional enabled-only view when listing
- cover the enable/disable workflow with a dedicated test case

## Testing
- pytest tests_python/test_dynamic_crawlers.py

------
https://chatgpt.com/codex/tasks/task_e_68dff1bc1c748322adc22d0d11f4be6a