### PR TITLE
Harden dynamic API trading helper

### DIFF
--- a/algorithms/python/tests/test_api_keeper.py
+++ b/algorithms/python/tests/test_api_keeper.py
@@ -34,25 +34,9 @@ class DummyClient:
 
 def test_api_keeper_sync_tracks_endpoints_and_risks() -> None:
     keeper = DynamicAPIKeeperAlgorithm()
-    trading_api = ApiEndpoint(
-        name="trading-api",
-        method="post",
-        path="/v1/trades",
-        owner="Execution",
-        version="2024-05-01",
-        status="operational",
-        tier="critical",
-        priority=10,
-        documentation_url="https://docs.dynamic.capital/apis/trading",
-        description="Primary trade execution endpoint",
-        consumers=("mobile", "partners"),
-        tags=("core", "ton"),
-    )
-    keeper.register_endpoint(trading_api)
-    keeper.register_schema("trading-api", {"version": "2024-05-01", "checksum": "abc123"})
-    keeper.register_monitor(
-        "trading-api",
-        {
+    keeper.enable_dynamic_api_trading(
+        schema={"version": "2024-05-01", "checksum": "abc123"},
+        monitor={
             "error_rate": 0.004,
             "error_budget": 0.01,
             "p95_latency_ms": 120,
@@ -140,4 +124,60 @@ def test_api_keeper_requires_endpoints() -> None:
     keeper = DynamicAPIKeeperAlgorithm()
     with pytest.raises(ValueError):
         keeper.sync()
+
+
+def test_enable_dynamic_api_trading_registers_defaults() -> None:
+    keeper = DynamicAPIKeeperAlgorithm()
+    keeper.enable_dynamic_api_trading()
+
+    result = keeper.sync()
+
+    assert len(result.endpoints) == 1
+    trading_payload = result.endpoints[0]
+    assert trading_payload["name"] == "trading-api"
+    assert trading_payload["schema"]["checksum"] == "trading-api-20240501"
+    assert trading_payload["monitor"]["error_rate"] == 0.004
+
+    # Calling the helper again should keep a single canonical entry
+    keeper.enable_dynamic_api_trading()
+    deduped = keeper.sync()
+    assert len(deduped.endpoints) == 1
+
+
+def test_enable_dynamic_api_trading_preserves_customisations_between_calls() -> None:
+    keeper = DynamicAPIKeeperAlgorithm()
+    keeper.enable_dynamic_api_trading(
+        schema={"version": "2024-06-01", "checksum": "custom-sum"},
+        monitor={"error_rate": 0.002, "latency_slo_ms": 180},
+        endpoint_overrides={"priority": 14, "description": "Custom trading endpoint"},
+    )
+
+    # A follow-up call without overrides should keep the earlier customisations.
+    keeper.enable_dynamic_api_trading()
+
+    payload = keeper.sync().endpoints[0]
+    assert payload["priority"] == 14
+    assert payload["description"] == "Custom trading endpoint"
+    assert payload["schema"]["version"] == "2024-06-01"
+    assert payload["schema"]["checksum"] == "custom-sum"
+    assert payload["monitor"]["error_rate"] == 0.002
+    assert payload["monitor"]["latency_slo_ms"] == 180
+
+
+def test_enable_dynamic_api_trading_merges_monitor_overrides() -> None:
+    keeper = DynamicAPIKeeperAlgorithm()
+    keeper.enable_dynamic_api_trading(monitor={"error_rate": 0.002, "latency_slo_ms": 180})
+
+    keeper.enable_dynamic_api_trading(monitor={"error_rate": 0.001})
+
+    monitor = keeper.sync().endpoints[0]["monitor"]
+    assert monitor["error_rate"] == 0.001
+    # Should retain the previously customised latency SLO instead of resetting to defaults.
+    assert monitor["latency_slo_ms"] == 180
+
+
+def test_enable_dynamic_api_trading_rejects_name_override() -> None:
+    keeper = DynamicAPIKeeperAlgorithm()
+    with pytest.raises(ValueError):
+        keeper.enable_dynamic_api_trading(endpoint_overrides={"name": "other"})
 


### PR DESCRIPTION
## Summary
- preserve custom trading endpoint configuration across repeated enablement by merging defaults with existing registration
- prevent renaming the trading endpoint and reuse the register_endpoint upsert path for safer updates
- extend the API keeper tests to cover preserved overrides, partial monitor updates, and invalid renames

## Testing
- pytest algorithms/python/tests/test_api_keeper.py

------
https://chatgpt.com/codex/tasks/task_e_68dff1a4e4848322b1499a0d909ae480