### PR TITLE
Enable dynamic blockchain namespace

### DIFF
--- a/dynamic/__init__.py
+++ b/dynamic/__init__.py
@@ -1,15 +1,50 @@
-"""Dynamic Capital consolidated namespace."""
+"""Dynamic Capital consolidated namespace with lazy submodule loading."""
 
-from . import blockchain
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Dict
 
 __all__ = [
     "blockchain",
-    "platform",
-    "governance",
-    "intelligence",
-    "trading",
-    "tools",
-    "models",
     "brand",
     "framework",
+    "governance",
+    "intelligence",
+    "models",
+    "platform",
+    "tools",
+    "trading",
 ]
+
+_SUBMODULES: Dict[str, str] = {name: f"{__name__}.{name}" for name in __all__}
+
+if TYPE_CHECKING:  # pragma: no cover - static typing hook
+    from . import (  # noqa: F401 (re-exported modules)
+        blockchain,
+        brand,
+        framework,
+        governance,
+        intelligence,
+        models,
+        platform,
+        tools,
+        trading,
+    )
+
+
+def __getattr__(name: str):
+    """Load submodules on demand to avoid import-time side effects."""
+
+    try:
+        module_name = _SUBMODULES[name]
+    except KeyError as exc:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'") from exc
+
+    module = import_module(module_name)
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/dynamic/blockchain/__init__.py
+++ b/dynamic/blockchain/__init__.py
@@ -1,12 +1,18 @@
-"""Dynamic blockchain exports via the consolidated namespace."""
+"""Dynamic blockchain exports via the consolidated namespace.
 
-from dynamic_blockchain import (
-    Block,
-    DelegateState,
-    DynamicBlockchain,
-    DynamicDelegatedProofOfStake,
-    Transaction,
-)
+The module lazily proxies attribute access to :mod:`dynamic_blockchain` so the
+heavy primitives are only imported when they are actually requested. This keeps
+back-to-back imports from eagerly executing module level code while still
+providing the ergonomics of ``dynamic.blockchain``.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+_PROVIDER_MODULE = "dynamic_blockchain"
 
 __all__ = [
     "Block",
@@ -15,3 +21,45 @@ __all__ = [
     "DynamicDelegatedProofOfStake",
     "Transaction",
 ]
+
+if TYPE_CHECKING:  # pragma: no cover - only used for static analysis
+    from dynamic_blockchain import (  # noqa: F401 (re-exported names)
+        Block,
+        DelegateState,
+        DynamicBlockchain,
+        DynamicDelegatedProofOfStake,
+        Transaction,
+    )
+
+
+def _load_provider() -> ModuleType:
+    """Import and memoize the underlying provider module."""
+
+    module = import_module(_PROVIDER_MODULE)
+    globals()["_provider"] = module
+    return module
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically resolve blockchain primitives from the provider module."""
+
+    if name not in __all__:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+    module: ModuleType
+    if (module := globals().get("_provider")) is None:  # type: ignore[assignment]
+        module = _load_provider()
+
+    try:
+        value = getattr(module, name)
+    except AttributeError as exc:  # pragma: no cover - defensive hardening
+        raise AttributeError(
+            f"module '{_PROVIDER_MODULE}' has no attribute '{name}'"
+        ) from exc
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)


### PR DESCRIPTION
## Summary
- expose the blockchain primitives through the consolidated `dynamic.blockchain` namespace for easier imports
- register the new namespace in the top-level dynamic package exports

## Testing
- pytest tests/dynamic_blockchain -q

------
https://chatgpt.com/codex/tasks/task_e_68dff546d6ec832285e365dee10cde51