### PR TITLE
Enable DynamicImplicitMemory toolkit export

### DIFF
--- a/dynamic_tool_kits/__init__.py
+++ b/dynamic_tool_kits/__init__.py
@@ -217,7 +217,12 @@ _TOOLKIT_EXPORTS: Dict[str, Tuple[str, ...]] = {
     "dynamic_effect": ("EffectImpulse", "EffectContext", "EffectFrame"),
     "dynamic_emoticon": ("EmoticonContext", "EmoticonDesign", "EmoticonPalette", "EmoticonSignal"),
     "dynamic_encryption": ("EncryptionEnvelope", "EncryptionRequest", "KeyMaterial"),
-    "dynamic_implicit_memory": ("ImplicitMemoryReport", "ImplicitMemoryTrace", "MemoryContext"),
+    "dynamic_implicit_memory": (
+        "DynamicImplicitMemory",
+        "ImplicitMemoryReport",
+        "ImplicitMemoryTrace",
+        "MemoryContext",
+    ),
     "dynamic_index": ("IndexConstituent", "IndexSignal", "IndexSnapshot"),
     "dynamic_indicators": (
         "IndicatorDefinition",

--- a/tests/test_dynamic_implicit_memory.py
+++ b/tests/test_dynamic_implicit_memory.py
@@ -112,3 +112,10 @@ def test_generate_report_requires_traces() -> None:
 
     with pytest.raises(RuntimeError):
         engine.generate_report(context)
+
+
+def test_toolkit_exports_engine() -> None:
+    from dynamic_tool_kits import DynamicImplicitMemory as ToolkitExport
+
+    engine = ToolkitExport()
+    assert isinstance(engine, DynamicImplicitMemory)


### PR DESCRIPTION
## Summary
- expose the DynamicImplicitMemory engine through the dynamic_tool_kits aggregation map
- cover the new aggregation surface with a regression test to ensure the toolkit forwards the engine

## Testing
- pytest tests/test_dynamic_implicit_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68dff5a38880832288aebe3bde8d6782