### PR TITLE
Enable TON subscription API fallback

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/app/api/_shared/supabase.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/_shared/supabase.ts
@@ -1,0 +1,95 @@
+import process from "node:process";
+
+function normalizeEnvString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function pickFirstEnv(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = normalizeEnvString(process.env[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/u, "");
+}
+
+function deriveFunctionsDomain(baseUrl: URL): string {
+  const host = baseUrl.hostname;
+  if (host.includes(".supabase.")) {
+    const functionsHost = host.replace(
+      ".supabase.",
+      ".functions.supabase.",
+    );
+    return `${baseUrl.protocol}//${functionsHost}`;
+  }
+
+  const portSegment = baseUrl.port ? `:${baseUrl.port}` : "";
+  return `${baseUrl.protocol}//${host}${portSegment}/functions/v1`;
+}
+
+export function resolveSupabaseFunctionUrl(): string | undefined {
+  const explicitUrl = pickFirstEnv(["SUPABASE_FN_URL"]);
+  if (explicitUrl) {
+    try {
+      return stripTrailingSlash(new URL(explicitUrl).toString());
+    } catch {
+      return stripTrailingSlash(explicitUrl);
+    }
+  }
+
+  const projectUrlCandidate = pickFirstEnv([
+    "SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_URL",
+  ]);
+
+  if (!projectUrlCandidate) {
+    return undefined;
+  }
+
+  try {
+    const projectUrl = new URL(projectUrlCandidate);
+    return stripTrailingSlash(deriveFunctionsDomain(projectUrl));
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildSupabaseFunctionHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  const anonKey = pickFirstEnv([
+    "SUPABASE_ANON_KEY",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  ]);
+
+  if (anonKey) {
+    headers.Authorization = `Bearer ${anonKey}`;
+    headers.apikey = anonKey;
+  }
+
+  return headers;
+}
+
+export function missingSupabaseConfigResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: "Supabase Edge Function endpoint is not configured",
+    }),
+    {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}

--- a/dynamic-capital-ton/apps/miniapp/app/api/link-wallet/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/link-wallet/route.ts
@@ -1,34 +1,20 @@
-import process from "node:process";
+import {
+  buildSupabaseFunctionHeaders,
+  missingSupabaseConfigResponse,
+  resolveSupabaseFunctionUrl,
+} from "../_shared/supabase";
 
 export async function POST(req: Request) {
-  const supabaseFnUrl = process.env.SUPABASE_FN_URL;
-  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ??
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
+  const supabaseFnUrl = resolveSupabaseFunctionUrl();
   if (!supabaseFnUrl) {
     console.error(
       "[miniapp] Missing SUPABASE_FN_URL env variable when linking wallet",
     );
-    return new Response(
-      JSON.stringify({
-        error: "SUPABASE_FN_URL environment variable is not configured",
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return missingSupabaseConfigResponse();
   }
 
   const body = await req.json();
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (supabaseAnonKey) {
-    headers.Authorization = `Bearer ${supabaseAnonKey}`;
-    headers.apikey = supabaseAnonKey;
-  }
+  const headers = buildSupabaseFunctionHeaders();
 
   const response = await fetch(`${supabaseFnUrl}/link-wallet`, {
     method: "POST",

--- a/dynamic-capital-ton/apps/miniapp/app/api/plans/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/plans/route.ts
@@ -1,31 +1,19 @@
-import process from "node:process";
+import {
+  buildSupabaseFunctionHeaders,
+  missingSupabaseConfigResponse,
+  resolveSupabaseFunctionUrl,
+} from "../_shared/supabase";
 
 export async function GET() {
-  const supabaseFnUrl = process.env.SUPABASE_FN_URL;
-  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ??
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
+  const supabaseFnUrl = resolveSupabaseFunctionUrl();
   if (!supabaseFnUrl) {
     console.error(
       "[miniapp] Missing SUPABASE_FN_URL env variable when loading plans",
     );
-    return new Response(
-      JSON.stringify({
-        error: "SUPABASE_FN_URL environment variable is not configured",
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return missingSupabaseConfigResponse();
   }
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  if (supabaseAnonKey) {
-    headers.apikey = supabaseAnonKey;
-  }
+  const headers = buildSupabaseFunctionHeaders();
 
   const response = await fetch(`${supabaseFnUrl}/plans`, {
     method: "GET",

--- a/dynamic-capital-ton/apps/miniapp/app/api/process-subscription/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/process-subscription/route.ts
@@ -1,34 +1,20 @@
-import process from "node:process";
+import {
+  buildSupabaseFunctionHeaders,
+  missingSupabaseConfigResponse,
+  resolveSupabaseFunctionUrl,
+} from "../_shared/supabase";
 
 export async function POST(req: Request) {
-  const supabaseFnUrl = process.env.SUPABASE_FN_URL;
-  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY ??
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
+  const supabaseFnUrl = resolveSupabaseFunctionUrl();
   if (!supabaseFnUrl) {
     console.error(
       "[miniapp] Missing SUPABASE_FN_URL env variable when processing subscription",
     );
-    return new Response(
-      JSON.stringify({
-        error: "SUPABASE_FN_URL environment variable is not configured",
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return missingSupabaseConfigResponse();
   }
 
   const body = await req.json();
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (supabaseAnonKey) {
-    headers.Authorization = `Bearer ${supabaseAnonKey}`;
-    headers.apikey = supabaseAnonKey;
-  }
+  const headers = buildSupabaseFunctionHeaders();
 
   const response = await fetch(`${supabaseFnUrl}/process-subscription`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the Supabase Edge Function endpoint and auth headers for the TON mini app
- update the link-wallet, plans, and process-subscription API proxies to use the shared helper so they can fall back to the Supabase project URL when SUPABASE_FN_URL is unset

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dffc2dcf608322a58e9d017c76804f