### PR TITLE
Enable dynamic Telegram dashboard routes

### DIFF
--- a/apps/web/resources/dynamic-ui.config.ts
+++ b/apps/web/resources/dynamic-ui.config.ts
@@ -34,7 +34,7 @@ const routes: RoutesConfig = {
   "/wallet": true,
   "/tools": { enabled: true, includeChildren: true },
   "/styles": true,
-  "/telegram": true,
+  "/telegram": { enabled: true, includeChildren: true },
   "/token": true,
   "/ui/sandbox": true,
   "/work": { enabled: true, includeChildren: true },


### PR DESCRIPTION
## Summary
- allow the `/telegram` route to opt into child paths via the dynamic UI routes config
- keep the operations console available for future nested Telegram dashboard views

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dffef75410832288a040429ff0dd84