### PR TITLE
Enable dynamic rendering for API routes

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -2,7 +2,7 @@ import { withApiMetrics } from "@/observability/server-metrics.ts";
 import { corsHeaders, jsonResponse, methodNotAllowed } from "@/utils/http.ts";
 import { healthPayload } from "@/utils/commit.ts";
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 const payload = healthPayload();
 

--- a/apps/web/app/api/hello/route.ts
+++ b/apps/web/app/api/hello/route.ts
@@ -5,7 +5,7 @@ interface HelloResponse {
   message: string;
 }
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   return withApiMetrics(req, "/api/hello", async () => {

--- a/apps/web/app/api/route.ts
+++ b/apps/web/app/api/route.ts
@@ -5,7 +5,7 @@ interface ApiResponse {
   message: string;
 }
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   return withApiMetrics(req, "/api", async () => {

--- a/apps/web/app/api/tonconnect/manifest/route.ts
+++ b/apps/web/app/api/tonconnect/manifest/route.ts
@@ -5,8 +5,7 @@ import { createTonManifest, resolveTonBaseUrl } from "@/config/ton";
 const CACHE_HEADER =
   "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400";
 
-export const dynamic = "force-static";
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export function GET() {
   const baseUrl = resolveTonBaseUrl();


### PR DESCRIPTION
## Summary
- switch the health, hello, root, and TON Connect manifest API handlers to force dynamic rendering
- drop the manifest revalidate value so the route always regenerates its payload

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0005676bc8322bdb008f71bbb3349