### PR TITLE
Rely on shared flag defaults for broadcast gating

### DIFF
--- a/shared/feature-flags.ts
+++ b/shared/feature-flags.ts
@@ -1,0 +1,18 @@
+export const FEATURE_FLAG_DEFAULTS = {
+  payments_enabled: true,
+  vip_sync_enabled: true,
+  broadcasts_enabled: true,
+  mini_app_enabled: true,
+} as const satisfies Record<string, boolean>;
+
+export type FeatureFlagName = keyof typeof FEATURE_FLAG_DEFAULTS;
+
+export function getFeatureFlagDefault(
+  name: string,
+  fallback = false,
+): boolean {
+  if (Object.prototype.hasOwnProperty.call(FEATURE_FLAG_DEFAULTS, name)) {
+    return FEATURE_FLAG_DEFAULTS[name as FeatureFlagName];
+  }
+  return fallback;
+}

--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -1,5 +1,6 @@
 import { createClient } from "./client.ts";
 import { maybe } from "./env.ts";
+import { getFeatureFlagDefault } from "../../../shared/feature-flags.ts";
 
 // In-memory fallback map when kv_config table is unavailable
 const memStore = new Map<string, unknown>();
@@ -77,12 +78,16 @@ async function setConfig(key: string, val: unknown): Promise<void> {
   memStore.set(key, val);
 }
 
-export async function getFlag(name: string, def = false): Promise<boolean> {
+export async function getFlag(
+  name: string,
+  def = getFeatureFlagDefault(name, false),
+): Promise<boolean> {
   const snap = await getConfig<{ data: Record<string, boolean> }>(
     "features:published",
     { data: {} },
   );
-  return snap.data[name] ?? def;
+  const fallback = getFeatureFlagDefault(name, def);
+  return snap.data[name] ?? fallback;
 }
 
 export async function setFlag(name: string, val: boolean): Promise<void> {

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -340,7 +340,7 @@ export async function sendMiniAppLink(
 ): Promise<string | null> {
   const { silent } = opts;
   if (!BOT_TOKEN) return null;
-  if (!(await getFlag("mini_app_enabled", true))) {
+  if (!(await getFlag("mini_app_enabled"))) {
     if (!silent) {
       const msg = await getContent("checkout_unavailable") ??
         "<b>Checkout is currently unavailable.</b>\nPlease try again later.";
@@ -388,7 +388,7 @@ export async function sendMiniAppLink(
 }
 
 export async function sendMiniAppOrBotOptions(chatId: number): Promise<void> {
-  const enabled = await getFlag("mini_app_enabled", true);
+  const enabled = await getFlag("mini_app_enabled");
   const url = enabled ? await sendMiniAppLink(chatId, { silent: true }) : null;
   const continueText = await getContent("continue_in_bot_button") ??
     "Continue in Bot";
@@ -1845,7 +1845,7 @@ export async function startReceiptPipeline(
 ): Promise<void> {
   try {
     const chatId = update.message!.chat.id;
-    if (!(await getFlag("vip_sync_enabled", true))) {
+    if (!(await getFlag("vip_sync_enabled"))) {
       const msg = await getContent("vip_sync_disabled") ??
         "VIP sync is currently disabled.";
       await notifyUser(chatId, msg);

--- a/tests/utils-config-env.test.ts
+++ b/tests/utils-config-env.test.ts
@@ -20,6 +20,21 @@ test("utils/config falls back to defaults when Supabase env vars are missing", a
   else delete process.env.SUPABASE_ANON_KEY;
 });
 
+test("known feature flags default to enabled", async () => {
+  const prevUrl = process.env.SUPABASE_URL;
+  const prevKey = process.env.SUPABASE_ANON_KEY;
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_ANON_KEY;
+  const { configClient } = await freshImport(
+    new URL("../apps/web/utils/config.ts", import.meta.url),
+  );
+  equal(await configClient.getFlag("broadcasts_enabled"), true);
+  if (prevUrl !== undefined) process.env.SUPABASE_URL = prevUrl;
+  else delete process.env.SUPABASE_URL;
+  if (prevKey !== undefined) process.env.SUPABASE_ANON_KEY = prevKey;
+  else delete process.env.SUPABASE_ANON_KEY;
+});
+
 test("utils/config rejects null-like env values", async () => {
   const prevUrl = process.env.SUPABASE_URL;
   const prevKey = process.env.SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- rely on the shared feature flag defaults when gating broadcasts so we don't duplicate fallback values
- use the shared defaults for the Telegram mini app and VIP sync checks to keep behavior consistent if defaults change

## Testing
- npm run lint
- npm run typecheck
- npx tsx --test tests/utils-config-env.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dffe69adf88322ac84a05ae0819cde