### PR TITLE
refactor: reorganize dynamic trade and learn workspace layout

### DIFF
--- a/apps/web/app/tools/dynamic-trade-and-learn/page.tsx
+++ b/apps/web/app/tools/dynamic-trade-and-learn/page.tsx
@@ -1,0 +1,33 @@
+import { Column, Heading, Text } from "@/components/dynamic-ui-system";
+
+import { DynamicTradeAndLearn } from "@/components/tools/DynamicTradeAndLearn";
+
+export const metadata = {
+  title: "Dynamic Trade & Learn – Dynamic Capital",
+  description:
+    "Blend live trading telemetry, deliberate practice labs, and mentor cadences inside the Dynamic Trade & Learn workspace.",
+};
+
+export default function DynamicTradeAndLearnPage() {
+  return (
+    <Column gap="32" paddingY="40" align="center" horizontal="center" fillWidth>
+      <Column maxWidth={40} gap="12" align="center" horizontal="center">
+        <Heading variant="display-strong-s" align="center">
+          Dynamic trade &amp; learn
+        </Heading>
+        <Text
+          variant="body-default-m"
+          onBackground="neutral-weak"
+          align="center"
+        >
+          Pair institutional-grade execution tooling with structured learning
+          paths, practice labs, and mentor accountability in a single desk
+          workspace.
+        </Text>
+      </Column>
+      <Column maxWidth={96} fillWidth>
+        <DynamicTradeAndLearn />
+      </Column>
+    </Column>
+  );
+}

--- a/apps/web/components/navigation/SiteFooter.tsx
+++ b/apps/web/components/navigation/SiteFooter.tsx
@@ -11,6 +11,7 @@ import { schema, social } from "@/resources";
 import NAV_ITEMS from "./nav-items";
 
 const QUICK_LINKS = [
+  { label: "Dynamic Trade & Learn", href: "/tools/dynamic-trade-and-learn" },
   { label: "Dynamic GUI optimizer", href: "/tools/dynamic-ui-optimizer" },
   { label: "Dynamic CLI/CD workbench", href: "/tools/dynamic-cli" },
   { label: "Dynamic market review", href: "/tools/dynamic-market-review" },

--- a/apps/web/components/navigation/nav-items.ts
+++ b/apps/web/components/navigation/nav-items.ts
@@ -1,4 +1,5 @@
 import {
+  BookOpen,
   Gauge,
   LayoutDashboard,
   LineChart,
@@ -137,6 +138,19 @@ const extraNavItems: NavItem[] = [
     ariaLabel: `Step ${
       firstExtraStep + 5
     }: Market review. Track FX strength, volatility, and cross-asset watchlists.`,
+    showOnMobile: true,
+  },
+  {
+    id: "trade-and-learn",
+    step: `Step ${firstExtraStep + 6}`,
+    label: "Trade & learn hub",
+    description:
+      "Blend live trade telemetry with mentorship cadences and practice labs.",
+    icon: BookOpen,
+    path: "/tools/dynamic-trade-and-learn",
+    ariaLabel: `Step ${
+      firstExtraStep + 6
+    }: Trade and learn hub. Blend live trade telemetry with mentorship cadences and practice labs.`,
     showOnMobile: true,
   },
 ];

--- a/apps/web/components/tools/DynamicTradeAndLearn.tsx
+++ b/apps/web/components/tools/DynamicTradeAndLearn.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import {
+  Button,
+  Column,
+  Heading,
+  Icon,
+  Line,
+  Row,
+  Tag,
+  Text,
+} from "@/components/dynamic-ui-system";
+import { SignalsWidget } from "@/components/trading/SignalsWidget";
+import { StrengthMeter } from "@/components/trading/StrengthMeter";
+import { WalletCard } from "@/components/trading/WalletCard";
+import { Card } from "@/components/ui/card";
+
+interface ProgressMetric {
+  id: string;
+  label: string;
+  value: string;
+  description: string;
+}
+
+const PROGRESS_METRICS: ProgressMetric[] = [
+  {
+    id: "sessions-logged",
+    label: "Sessions logged",
+    value: "42 this month",
+    description:
+      "Auto-ingested from the trade journal to benchmark consistency and desk participation.",
+  },
+  {
+    id: "win-rate",
+    label: "Desk win rate",
+    value: "63% trailing 7 days",
+    description:
+      "Aggregated from connected accounts with risk-adjusted scoring so mentors know where to focus feedback.",
+  },
+  {
+    id: "playbook-reviews",
+    label: "Playbook reviews",
+    value: "3 pending",
+    description:
+      "Open mentor comments waiting for acknowledgement before the next trading session starts.",
+  },
+];
+
+interface CadenceModule {
+  id: string;
+  title: string;
+  cadence: string;
+  description: string;
+  bullets: string[];
+}
+
+const LEARNING_TRACKS: CadenceModule[] = [
+  {
+    id: "foundations",
+    title: "Foundations & risk discipline",
+    cadence: "Self-paced modules",
+    description:
+      "Install the guardrails every trader follows before sizing their first live position.",
+    bullets: [
+      "Pre-trade checklist covering bias, risk per trade, and session conditions.",
+      "Annotated playbook library for FX, metals, and index setups.",
+      "Glossary and scoring rubric to grade signal quality and execution discipline.",
+    ],
+  },
+  {
+    id: "execution",
+    title: "Execution acceleration",
+    cadence: "Weekly mentor cadence",
+    description:
+      "Pair live desk signals with accountability loops that keep trade quality high.",
+    bullets: [
+      "Live market briefs with priority levels and invalidation triggers.",
+      "Scenario planning drills to rehearse news events and volatility shocks.",
+      "Trade replay prompts that compress lessons into shareable recaps.",
+    ],
+  },
+  {
+    id: "automation",
+    title: "Automation & analytics",
+    cadence: "Project-based",
+    description:
+      "Wire reporting, notifications, and liquidity bridges so repetition scales instead of breaking.",
+    bullets: [
+      "Dynamic CLI/CD blueprints for telemetry exports and playbook updates.",
+      "Supabase workbooks that sync trades, checklists, and mentor notes.",
+      "Routing guardrails that align algorithmic and discretionary flows.",
+    ],
+  },
+];
+
+const PRACTICE_LABS: CadenceModule[] = [
+  {
+    id: "journal-lab",
+    title: "Journal lab",
+    cadence: "After every session",
+    description:
+      "Transform raw fills into an annotated trade journal with automated insights and tags.",
+    bullets: [
+      "Import fills from MT5/Exness or record manual trades on the fly.",
+      "Label mistakes and wins to feed the deliberate practice backlog.",
+      "Generate a mentor-ready summary with lessons and next actions.",
+    ],
+  },
+  {
+    id: "scenario-replay",
+    title: "Scenario replay studio",
+    cadence: "Twice weekly",
+    description:
+      "Run guided rehearsals that pressure-test decision making before the market opens.",
+    bullets: [
+      "Multi-LLM prompts recreate volatility spikes and policy moves.",
+      "Desk risk limits surface in real time so adjustments become muscle memory.",
+      "Action logs export to the trade journal for accountability follow-ups.",
+    ],
+  },
+  {
+    id: "mentor-office-hours",
+    title: "Mentor office hours",
+    cadence: "Live cohort calls",
+    description:
+      "Drop into focused sessions where senior strategists review plays, automation, and mindset.",
+    bullets: [
+      "Desk leads annotate playbook updates directly in your workspace.",
+      "Performance dashboards highlight drawdown recovery priorities.",
+      "Signals, objectives, and support escalations stay in one threaded view.",
+    ],
+  },
+];
+
+interface ReviewCadence {
+  id: string;
+  title: string;
+  summary: string;
+  actions: string[];
+}
+
+const REVIEW_CADENCES: ReviewCadence[] = [
+  {
+    id: "daily-reset",
+    title: "Daily reset",
+    summary:
+      "Close the trading day with a concise readout so the next session begins with clarity.",
+    actions: [
+      "Summarise PnL, risk breaches, and checklist misses in under five minutes.",
+      "Tag new scenarios for rehearsal and assign follow-up owners.",
+      "Update trade readiness score so mentors spot fatigue or overtrading early.",
+    ],
+  },
+  {
+    id: "weekly-sync",
+    title: "Weekly mentor sync",
+    summary:
+      "Zoom out on performance trends and decide which learning track to emphasise next.",
+    actions: [
+      "Compare win rate vs. quality of setups logged in the journal.",
+      "Review automation backlog and unblock integration tasks.",
+      "Highlight standout trades to share with the wider desk community.",
+    ],
+  },
+  {
+    id: "monthly-audit",
+    title: "Monthly audit",
+    summary:
+      "Reconcile account growth, compliance checks, and program milestones before scaling risk.",
+    actions: [
+      "Validate guardrails against treasury and counterparty requirements.",
+      "Refresh mentorship objectives for the upcoming month.",
+      "Publish a consolidated report for investors and leadership stakeholders.",
+    ],
+  },
+];
+
+interface ResourceLink {
+  id: string;
+  label: string;
+  href: string;
+  description: string;
+}
+
+const RESOURCE_LINKS: ResourceLink[] = [
+  {
+    id: "journal",
+    label: "Launch the trade journal",
+    href: "/tools/trade-journal",
+    description:
+      "Capture every trade with AI-generated highlights, risk callouts, and next steps ready to share.",
+  },
+  {
+    id: "academy",
+    label: "Open the academy track",
+    href: "/blog/posts/school-of-pipsology",
+    description:
+      "Start with the School of Pipsology primer to align terminology before mentor sessions.",
+  },
+  {
+    id: "mentorship",
+    label: "Book a mentorship consult",
+    href: "/support",
+    description:
+      "Talk directly with the desk to tailor learning cadences, automation scope, and onboarding.",
+  },
+];
+
+function SectionHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <Column gap="8" maxWidth={64}>
+      <Heading variant="display-strong-xs">{title}</Heading>
+      <Text variant="body-default-m" onBackground="neutral-weak">
+        {description}
+      </Text>
+    </Column>
+  );
+}
+
+function Checklist({ items }: { items: string[] }) {
+  return (
+    <Column as="ul" gap="8">
+      {items.map((item) => (
+        <Row key={item} gap="8" vertical="center">
+          <Icon name="check" onBackground="brand-medium" />
+          <Text as="li" variant="body-default-m">
+            {item}
+          </Text>
+        </Row>
+      ))}
+    </Column>
+  );
+}
+
+function WorkspaceHero() {
+  return (
+    <Column
+      gap="16"
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      shadow="l"
+    >
+      <Row gap="12" vertical="center" wrap>
+        <Heading variant="display-strong-xs">
+          Trade execution meets mentorship
+        </Heading>
+        <Tag size="s" prefixIcon="sparkles">
+          Desk beta
+        </Tag>
+      </Row>
+      <Text variant="body-default-l" onBackground="neutral-weak">
+        The Dynamic Trade &amp; Learn workspace connects live trading telemetry,
+        deliberate practice drills, and mentor cadences so every operator
+        improves with the same playbook.
+      </Text>
+      <Row gap="12" wrap>
+        <Button href="/plans" variant="primary" data-border="rounded">
+          Join the desk
+        </Button>
+        <Button
+          href="/tools/trade-journal"
+          variant="secondary"
+          data-border="rounded"
+        >
+          Launch trade journal
+        </Button>
+      </Row>
+    </Column>
+  );
+}
+
+function ReadinessSection() {
+  return (
+    <Column gap="20" fillWidth>
+      <SectionHeader
+        title="Live trading readiness"
+        description="Monitor capital, signal velocity, and currency bias before opening the next trade idea."
+      />
+      <div className="grid w-full gap-6 xl:grid-cols-3 md:grid-cols-2">
+        <div className="h-full">
+          <WalletCard />
+        </div>
+        <div className="h-full">
+          <SignalsWidget />
+        </div>
+        <div className="h-full">
+          <StrengthMeter />
+        </div>
+      </div>
+      <div className="grid w-full gap-6 md:grid-cols-3">
+        {PROGRESS_METRICS.map((metric) => (
+          <Card key={metric.id} className="h-full p-6">
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-muted-foreground">
+                {metric.label}
+              </span>
+              <span className="text-2xl font-semibold text-primary">
+                {metric.value}
+              </span>
+              <p className="text-sm text-muted-foreground">
+                {metric.description}
+              </p>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </Column>
+  );
+}
+
+function CadenceCard({
+  title,
+  description,
+  cadence,
+  bullets,
+}: CadenceModule) {
+  return (
+    <Column
+      background="surface"
+      border="neutral-alpha-weak"
+      radius="l"
+      padding="l"
+      gap="16"
+    >
+      <Row
+        horizontal="between"
+        vertical="center"
+        s={{ direction: "column", align: "start" }}
+        gap="12"
+      >
+        <Column gap="8">
+          <Heading variant="heading-strong-m">{title}</Heading>
+          <Text variant="body-default-m" onBackground="neutral-weak">
+            {description}
+          </Text>
+        </Column>
+        <Tag size="s" prefixIcon="timer">
+          {cadence}
+        </Tag>
+      </Row>
+      <Checklist items={bullets} />
+    </Column>
+  );
+}
+
+function CadenceSection({
+  title,
+  description,
+  items,
+}: {
+  title: string;
+  description: string;
+  items: CadenceModule[];
+}) {
+  return (
+    <Column gap="20" fillWidth>
+      <SectionHeader title={title} description={description} />
+      <Column gap="16">
+        {items.map((item) => <CadenceCard key={item.id} {...item} />)}
+      </Column>
+    </Column>
+  );
+}
+
+function ReviewCadenceStack() {
+  return (
+    <Column gap="16">
+      {REVIEW_CADENCES.map((cadence, index) => (
+        <Column key={cadence.id} gap="16">
+          <Column gap="12">
+            <Heading variant="heading-strong-s">{cadence.title}</Heading>
+            <Text variant="body-default-m" onBackground="neutral-weak">
+              {cadence.summary}
+            </Text>
+            <Checklist items={cadence.actions} />
+          </Column>
+          {index < REVIEW_CADENCES.length - 1 && (
+            <Line background="neutral-alpha-weak" />
+          )}
+        </Column>
+      ))}
+    </Column>
+  );
+}
+
+function AccountabilitySection() {
+  return (
+    <Column
+      gap="20"
+      background="surface"
+      border="neutral-alpha-medium"
+      radius="l"
+      padding="xl"
+      shadow="m"
+    >
+      <SectionHeader
+        title="Accountability cadence"
+        description="Keep every trader aligned with shared objectives and transparent follow-ups."
+      />
+      <ReviewCadenceStack />
+    </Column>
+  );
+}
+
+function ResourceLinksSection() {
+  return (
+    <Column gap="20" fillWidth>
+      <SectionHeader
+        title="Launch the next action"
+        description="Explore the surfaces that power the Dynamic Trade &amp; Learn experience."
+      />
+      <div className="grid w-full gap-6 md:grid-cols-3">
+        {RESOURCE_LINKS.map((resource) => (
+          <Card
+            key={resource.id}
+            className="flex h-full flex-col justify-between gap-4 p-6"
+          >
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold">{resource.label}</h3>
+              <p className="text-sm text-muted-foreground">
+                {resource.description}
+              </p>
+            </div>
+            <Button
+              href={resource.href}
+              variant="secondary"
+              data-border="rounded"
+            >
+              Explore
+            </Button>
+          </Card>
+        ))}
+      </div>
+    </Column>
+  );
+}
+
+export function DynamicTradeAndLearn() {
+  return (
+    <Column gap="32" fillWidth>
+      <WorkspaceHero />
+      <ReadinessSection />
+      <CadenceSection
+        title="Learning tracks"
+        description="Progress through structured playbooks that layer risk discipline, execution mastery, and automation fluency."
+        items={LEARNING_TRACKS}
+      />
+      <CadenceSection
+        title="Practice labs"
+        description="Convert insights into repetition with labs that mix automation, guided rehearsal, and live mentor feedback."
+        items={PRACTICE_LABS}
+      />
+      <AccountabilitySection />
+      <ResourceLinksSection />
+    </Column>
+  );
+}
+
+export default DynamicTradeAndLearn;


### PR DESCRIPTION
## Summary
- restructure the Dynamic Trade & Learn workspace into dedicated sections with shared headers and checklists for easier navigation
- unify learning track and practice lab data into a common cadence module to reduce duplication and simplify rendering
- streamline accountability and resource link rendering through focused helpers that keep the layout consistent

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0081c57388322a826bf99cf5157b0