### PR TITLE
Validate DCT metadata and harden token resource

### DIFF
--- a/dynamic-capital-ton/config.yaml
+++ b/dynamic-capital-ton/config.yaml
@@ -2,6 +2,7 @@ token:
   name: Dynamic Capital Token
   symbol: DCT
   decimals: 9
+  address: "0:d29b3e11ac30451be4f58b3c1527bab576902ad662532eb2b0c8c6098a0e96c7"
   maxSupply: 100000000
 
 splits:

--- a/dynamic-capital-ton/contracts/jetton/metadata.json
+++ b/dynamic-capital-ton/contracts/jetton/metadata.json
@@ -3,7 +3,27 @@
   "symbol": "DCT",
   "description": "Dynamic Capital Token (DCT) powers the Dynamic Capital trading desk ecosystem with governance-aligned liquidity, automated buyback-and-burn flows, and staking multipliers coordinated through the Dynamic Capital Mini App.",
   "decimals": 9,
+  "address": "0:d29b3e11ac30451be4f58b3c1527bab576902ad662532eb2b0c8c6098a0e96c7",
+  "image": "https://drive.google.com/uc?export=view&id=1Hg-EGhkM58NOeALgDKqT3PaK3oyd32fA",
   "external_url": "https://dynamic.capital",
+  "sameAs": [
+    "https://dynamic.capital/token",
+    "https://tonviewer.com/jetton/0:d29b3e11ac30451be4f58b3c1527bab576902ad662532eb2b0c8c6098a0e96c7"
+  ],
+  "attributes": [
+    {
+      "trait_type": "Max supply",
+      "value": "100000000"
+    },
+    {
+      "trait_type": "Decimals",
+      "value": 9
+    },
+    {
+      "trait_type": "Governance",
+      "value": "48h guarded window"
+    }
+  ],
   "version": "1.0",
   "standard": "ton.jetton.v1"
 }


### PR DESCRIPTION
## Summary
- validate and normalise the jetton metadata before building the token descriptor so only HTTPS resources and cleaned addresses flow into the web experience
- enrich the on-chain metadata with direct image delivery, sameAs backlinks, and descriptive attributes to improve downstream consumption

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e01f5660288322b8684836a9546260