### PR TITLE
Set TonConnect manifest to hosted gateway

### DIFF
--- a/apps/web/config/ton.ts
+++ b/apps/web/config/ton.ts
@@ -18,6 +18,8 @@ const DEFAULT_NETWORK: TonNetwork = "mainnet";
 export const TON_MANIFEST_PATH = "/api/tonconnect/manifest";
 const MANIFEST_ICON_PATH = "/icon-mark.svg";
 const PROD_FALLBACK_ORIGIN = "https://dynamiccapital.ton";
+const PROD_MANIFEST_URL =
+  "https://ton-gateway.dynamic-capital.ondigitalocean.app/dynamiccapital.ton/tonconnect-manifest.json";
 const DEV_FALLBACK_ORIGIN = "http://localhost:3000";
 const APP_NAME = "Dynamic Capital";
 
@@ -89,7 +91,36 @@ export function resolveTonBaseUrl(): string {
 }
 
 export function resolveTonManifestUrl(baseUrl = resolveTonBaseUrl()): string {
-  return new URL(TON_MANIFEST_PATH, baseUrl).toString();
+  const manifestEnv = optionalEnvVar("NEXT_PUBLIC_TON_MANIFEST_URL", [
+    "TON_MANIFEST_URL",
+  ]);
+
+  if (manifestEnv) {
+    try {
+      const hasScheme = manifestEnv.includes("://");
+      const manifestUrl = hasScheme
+        ? new URL(manifestEnv)
+        : new URL(manifestEnv, baseUrl);
+      return manifestUrl.toString();
+    } catch {
+      // Ignore malformed overrides and fall back to defaults below.
+    }
+  }
+
+  try {
+    const base = new URL(baseUrl);
+    const hostname = base.hostname.toLowerCase();
+    if (
+      LOCALHOST_HOSTNAMES.has(hostname) ||
+      hostname.endsWith(".localhost")
+    ) {
+      return new URL(TON_MANIFEST_PATH, baseUrl).toString();
+    }
+  } catch {
+    // If the base URL can't be parsed, fall through to the production default.
+  }
+
+  return PROD_MANIFEST_URL;
 }
 
 export function createTonManifest(

--- a/dynamic-capital-ton/apps/miniapp/app/page.tsx
+++ b/dynamic-capital-ton/apps/miniapp/app/page.tsx
@@ -111,6 +111,9 @@ type NavItem = {
   icon: (props: { active: boolean }) => JSX.Element;
 };
 
+const TONCONNECT_MANIFEST_URL =
+  "https://ton-gateway.dynamic-capital.ondigitalocean.app/dynamiccapital.ton/tonconnect-manifest.json";
+
 const SECTION_IDS: SectionId[] = [
   "overview",
   "plans",
@@ -2191,7 +2194,7 @@ const NAV_ITEMS: NavItem[] = [
 export default function Page() {
   return (
     <TonConnectUIProvider
-      manifestUrl="/tonconnect-manifest.json"
+      manifestUrl={TONCONNECT_MANIFEST_URL}
       walletsListConfiguration={WALLETS_LIST_CONFIGURATION}
     >
       <HomeInner />


### PR DESCRIPTION
## Summary
- default the TonConnect configuration to the hosted manifest while allowing environment overrides
- update the mini app TonConnect provider to use the shared hosted manifest URL

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e029d30f9c8322b604d62a787c65bf