### PR TITLE
Make theme mint start idempotent

### DIFF
--- a/dynamic-capital-ton/apps/miniapp/app/api/minting/start/route.ts
+++ b/dynamic-capital-ton/apps/miniapp/app/api/minting/start/route.ts
@@ -1,0 +1,10 @@
+import { proxySupabaseEdgeFunction } from "../../_shared/supabase";
+
+export function POST(request: Request) {
+  return proxySupabaseEdgeFunction({
+    request,
+    method: "POST",
+    path: "start-minting",
+    context: "starting theme mint",
+  });
+}

--- a/dynamic-capital-ton/apps/miniapp/app/globals.css
+++ b/dynamic-capital-ton/apps/miniapp/app/globals.css
@@ -543,6 +543,290 @@ button {
   gap: 12px;
 }
 
+.mint-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.mint-card {
+  position: relative;
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background:
+    linear-gradient(160deg, rgba(8, 15, 32, 0.88), rgba(6, 10, 24, 0.72)),
+    rgba(6, 12, 26, 0.55);
+  overflow: hidden;
+  transition:
+    transform 200ms ease,
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    background 220ms ease;
+}
+
+.mint-card::before {
+  content: "";
+  position: absolute;
+  inset: -60% -20% auto auto;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(
+    circle,
+    var(--mint-glow, rgba(97, 209, 255, 0.28)),
+    transparent 70%
+  );
+  opacity: 0.65;
+  pointer-events: none;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.mint-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--mint-accent, var(--ui-accent));
+  box-shadow: 0 22px 42px rgba(7, 12, 24, 0.45);
+}
+
+.mint-card:hover::before {
+  opacity: 0.9;
+  transform: translate3d(8px, -8px, 0);
+}
+
+.mint-card--starting {
+  border-color: var(--mint-accent, var(--ui-accent));
+}
+
+.mint-card--success {
+  border-color: rgba(34, 197, 94, 0.32);
+}
+
+.mint-card--success::before {
+  background: radial-gradient(circle, rgba(34, 197, 94, 0.25), transparent 70%);
+}
+
+.mint-card--error {
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.mint-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mint-card__eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.mint-card__title {
+  margin: 4px 0 0;
+  font-size: 1.05rem;
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.mint-card__priority {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--mint-accent, var(--ui-accent));
+  background: var(--mint-accent-soft, var(--ui-accent-soft));
+  border-radius: 999px;
+  padding: 6px 12px;
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+.mint-card__description {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  font-size: 0.92rem;
+}
+
+.mint-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mint-card__tag {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--mint-accent, var(--ui-accent));
+  background: var(--mint-accent-soft, var(--ui-accent-soft));
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+
+.mint-card__tag--outline {
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.mint-card__meta {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.mint-card__meta > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mint-card__meta dt {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.mint-card__meta dd {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.mint-card__progress {
+  display: grid;
+  gap: 10px;
+}
+
+.mint-card__progress-track {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+}
+
+.mint-card__progress[data-status="starting"] .mint-card__progress-track {
+  background: rgba(97, 209, 255, 0.14);
+}
+
+.mint-card__progress[data-status="success"] .mint-card__progress-track {
+  background: rgba(34, 197, 94, 0.16);
+}
+
+.mint-card__progress[data-status="error"] .mint-card__progress-track {
+  background: rgba(248, 113, 113, 0.16);
+}
+
+.mint-card__progress-bar {
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    var(--mint-accent, var(--ui-accent)),
+    rgba(255, 255, 255, 0.88)
+  );
+  box-shadow: 0 0 16px var(--mint-glow, var(--ui-glow));
+  transition: width 360ms ease;
+}
+
+.mint-card__progress[data-status="success"] .mint-card__progress-bar {
+  background: linear-gradient(90deg, #34d399, rgba(209, 250, 229, 0.9));
+  box-shadow: 0 0 12px rgba(52, 211, 153, 0.5);
+}
+
+.mint-card__progress[data-status="error"] .mint-card__progress-bar {
+  background: linear-gradient(90deg, #f87171, rgba(254, 205, 211, 0.9));
+  box-shadow: 0 0 12px rgba(248, 113, 113, 0.45);
+}
+
+.mint-card__progress-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.mint-card__progress-state {
+  font-weight: 600;
+}
+
+.mint-card__progress-value {
+  font-weight: 600;
+  color: var(--mint-accent, var(--ui-accent));
+}
+
+.mint-card__progress[data-status="success"] .mint-card__progress-value {
+  color: #34d399;
+}
+
+.mint-card__progress[data-status="error"] .mint-card__progress-value {
+  color: #f87171;
+}
+
+.mint-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+}
+
+.mint-card__status--starting {
+  background: var(--mint-accent-soft, rgba(37, 99, 235, 0.18));
+  color: var(--mint-accent, var(--ui-accent));
+}
+
+.mint-card__status--success {
+  background: rgba(34, 197, 94, 0.18);
+  color: #34d399;
+}
+
+.mint-card__status--error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.mint-card__message {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.mint-card__message--error {
+  color: #fca5a5;
+}
+
+.mint-card__action {
+  justify-self: flex-start;
+  font-size: 0.88rem;
+  padding-inline: 18px;
+}
+
+.mint-card__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .plan-detail {
   margin-top: 20px;
   padding: 22px;
@@ -1220,6 +1504,7 @@ button {
   }
 
   .plan-grid,
+  .mint-grid,
   .support-grid,
   .feature-grid {
     grid-template-columns: 1fr;
@@ -1296,6 +1581,29 @@ button {
       rgba(255, 255, 255, 0.95)
     );
     border: 1px solid var(--plan-card-accent, rgba(97, 209, 255, 0.65));
+  }
+
+  .mint-card {
+    background:
+      linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(230, 245, 255, 0.85)),
+      rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba(148, 163, 184, 0.24);
+  }
+
+  .mint-card::before {
+    background: radial-gradient(circle, rgba(97, 209, 255, 0.24), transparent 70%);
+  }
+
+  .mint-card--success::before {
+    background: radial-gradient(circle, rgba(34, 197, 94, 0.22), transparent 70%);
+  }
+
+  .mint-card__progress-track {
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  .mint-card__progress-footer {
+    color: rgba(15, 23, 42, 0.6);
   }
 
   .feature-card,

--- a/dynamic-capital-ton/apps/miniapp/data/theme-mints.ts
+++ b/dynamic-capital-ton/apps/miniapp/data/theme-mints.ts
@@ -1,0 +1,54 @@
+export type ThemeMintPlan = {
+  index: number;
+  name: string;
+  description: string;
+  defaultPriority: number;
+  contentUri: string;
+  launchWindow: string;
+  supply: string;
+  accent: string;
+  accentSoft: string;
+  glow: string;
+};
+
+export const THEME_MINT_PLANS: ThemeMintPlan[] = [
+  {
+    index: 0,
+    name: "Genesis Theme Pass",
+    description:
+      "Founding supporters unlock the launch palette and priority desk routing for the first mint window.",
+    defaultPriority: 100,
+    contentUri: "ipfs://dynamic-capital/theme/genesis.json",
+    launchWindow: "Opens Mar 18 • 18:00 UTC",
+    supply: "Supply 500",
+    accent: "#61d1ff",
+    accentSoft: "rgba(97, 209, 255, 0.16)",
+    glow: "rgba(97, 209, 255, 0.42)",
+  },
+  {
+    index: 1,
+    name: "Growth Theme Pass",
+    description:
+      "Expands the desk's toolkit with growth partner themes and unlocks co-branded surfaces across the mini app.",
+    defaultPriority: 80,
+    contentUri: "ipfs://dynamic-capital/theme/growth.json",
+    launchWindow: "Opens Apr 02 • 16:00 UTC",
+    supply: "Supply 750",
+    accent: "#facc15",
+    accentSoft: "rgba(250, 204, 21, 0.18)",
+    glow: "rgba(250, 204, 21, 0.35)",
+  },
+  {
+    index: 2,
+    name: "Community Theme Pass",
+    description:
+      "Celebrates collector milestones with community-driven art updates and grants priority access to social drops.",
+    defaultPriority: 60,
+    contentUri: "ipfs://dynamic-capital/theme/community.json",
+    launchWindow: "Opens Apr 19 • 20:00 UTC",
+    supply: "Supply 900",
+    accent: "#a855f7",
+    accentSoft: "rgba(168, 85, 247, 0.18)",
+    glow: "rgba(168, 85, 247, 0.32)",
+  },
+];

--- a/dynamic-capital-ton/supabase/functions/start-minting/index.ts
+++ b/dynamic-capital-ton/supabase/functions/start-minting/index.ts
@@ -1,0 +1,213 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+type StartMintRequest = {
+  mintIndex?: number;
+  mint_index?: number;
+  planName?: string;
+  plan_name?: string;
+  initiator?: string;
+  note?: string;
+  contentUri?: string;
+  content_uri?: string;
+  priority?: number;
+  defaultPriority?: number;
+  default_priority?: number;
+};
+
+type ThemeMintRow = {
+  id: string;
+  mint_index: number;
+  name: string;
+  status: string;
+  initiator: string | null;
+  note: string | null;
+  content_uri: string | null;
+  priority: number | null;
+  started_at: string | null;
+  completed_at: string | null;
+  updated_at: string;
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_KEY");
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error("Missing Supabase credentials");
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+type SupabaseClient = typeof supabase;
+
+const RESPONSE_HEADERS = {
+  "Content-Type": "application/json",
+} as const;
+
+function parseMintIndex(payload: StartMintRequest): number | null {
+  const candidate = payload.mintIndex ?? payload.mint_index;
+  if (typeof candidate !== "number") {
+    return null;
+  }
+  if (!Number.isInteger(candidate) || candidate < 0) {
+    return null;
+  }
+  return candidate;
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parsePriority(payload: StartMintRequest): number | undefined {
+  const candidate = payload.priority ??
+    payload.defaultPriority ??
+    payload.default_priority;
+  if (typeof candidate !== "number") {
+    return undefined;
+  }
+  if (!Number.isFinite(candidate)) {
+    return undefined;
+  }
+  return Math.trunc(candidate);
+}
+
+async function logMintStart(
+  client: SupabaseClient,
+  record: ThemeMintRow,
+): Promise<void> {
+  try {
+    await client.from("tx_logs").insert({
+      kind: "theme_mint_start",
+      ref_id: record.id,
+      meta: {
+        mint_index: record.mint_index,
+        name: record.name,
+        initiator: record.initiator,
+      },
+    });
+  } catch (error) {
+    console.error("[start-minting] Failed to log tx", error);
+  }
+}
+
+serve(async (request: Request): Promise<Response> => {
+  if (request.method !== "POST") {
+    return new Response(
+      JSON.stringify({ error: "Method Not Allowed" }),
+      { status: 405, headers: RESPONSE_HEADERS },
+    );
+  }
+
+  let body: StartMintRequest;
+  try {
+    body = await request.json() as StartMintRequest;
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Invalid JSON payload" }),
+      { status: 400, headers: RESPONSE_HEADERS },
+    );
+  }
+
+  const mintIndex = parseMintIndex(body);
+  if (mintIndex === null) {
+    return new Response(
+      JSON.stringify({ error: "mintIndex must be a non-negative integer" }),
+      { status: 400, headers: RESPONSE_HEADERS },
+    );
+  }
+
+  const planName = normalizeOptionalString(body.planName ?? body.plan_name) ??
+    `Theme Mint #${mintIndex}`;
+  const initiator = normalizeOptionalString(body.initiator);
+  const note = normalizeOptionalString(body.note);
+  const contentUri =
+    normalizeOptionalString(body.contentUri ?? body.content_uri);
+  const priority = parsePriority(body);
+  const nowIso = new Date().toISOString();
+
+  try {
+    const { data: existing, error: fetchError } = await supabase
+      .from("theme_pass_mints")
+      .select("id, mint_index, name, status, initiator, note, content_uri, priority, started_at, completed_at, updated_at")
+      .eq("mint_index", mintIndex)
+      .maybeSingle<ThemeMintRow>();
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    if (existing && existing.status === "completed") {
+      return new Response(
+        JSON.stringify({ error: "Mint already completed" }),
+        { status: 409, headers: RESPONSE_HEADERS },
+      );
+    }
+
+    const startedAt = existing?.started_at ?? nowIso;
+
+    const nextInitiator = initiator ?? existing?.initiator ?? null;
+    const nextNote = note ?? existing?.note ?? null;
+    const nextContentUri = contentUri ?? existing?.content_uri ?? null;
+    const nextPriority = priority ?? existing?.priority ?? null;
+
+    const isAlreadyInProgress = existing?.status === "in_progress";
+    const hasMeaningfulChange =
+      !existing ||
+      existing.status !== "in_progress" ||
+      existing.initiator !== nextInitiator ||
+      existing.note !== nextNote ||
+      existing.content_uri !== nextContentUri ||
+      existing.priority !== nextPriority;
+
+    if (!hasMeaningfulChange && existing) {
+      return new Response(
+        JSON.stringify({ ok: true, mint: existing }),
+        { status: 200, headers: RESPONSE_HEADERS },
+      );
+    }
+
+    const upsertPayload = {
+      mint_index: mintIndex,
+      name: planName,
+      status: "in_progress",
+      initiator: nextInitiator,
+      note: nextNote,
+      content_uri: nextContentUri,
+      priority: nextPriority,
+      started_at: startedAt,
+      completed_at: null,
+      updated_at: nowIso,
+    };
+
+    const { data, error: upsertError } = await supabase
+      .from("theme_pass_mints")
+      .upsert(upsertPayload, { onConflict: "mint_index" })
+      .select()
+      .single<ThemeMintRow>();
+
+    if (upsertError) {
+      throw upsertError;
+    }
+
+    if (!isAlreadyInProgress) {
+      await logMintStart(supabase, data);
+    }
+
+    return new Response(
+      JSON.stringify({ ok: true, mint: data }),
+      { status: 200, headers: RESPONSE_HEADERS },
+    );
+  } catch (error) {
+    console.error("[start-minting] Failed to start mint", error);
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 500, headers: RESPONSE_HEADERS },
+    );
+  }
+});

--- a/dynamic-capital-ton/supabase/migrations/20250315000000_create_theme_pass_mints.sql
+++ b/dynamic-capital-ton/supabase/migrations/20250315000000_create_theme_pass_mints.sql
@@ -1,0 +1,16 @@
+create table if not exists theme_pass_mints (
+  id uuid default gen_random_uuid() primary key,
+  mint_index int not null unique,
+  name text not null,
+  status text not null default 'pending',
+  initiator text,
+  note text,
+  content_uri text,
+  priority int,
+  started_at timestamptz,
+  completed_at timestamptz,
+  updated_at timestamptz default now()
+);
+
+create index if not exists theme_pass_mints_status_idx
+  on theme_pass_mints(status);

--- a/dynamic-capital-ton/supabase/schema.sql
+++ b/dynamic-capital-ton/supabase/schema.sql
@@ -76,6 +76,24 @@ create table if not exists tx_logs (
   created_at timestamptz default now()
 );
 
+-- Theme mint tracking
+create table if not exists theme_pass_mints (
+  id uuid default gen_random_uuid() primary key,
+  mint_index int not null unique,
+  name text not null,
+  status text not null default 'pending',
+  initiator text,
+  note text,
+  content_uri text,
+  priority int,
+  started_at timestamptz,
+  completed_at timestamptz,
+  updated_at timestamptz default now()
+);
+
+create index if not exists theme_pass_mints_status_idx
+  on theme_pass_mints(status);
+
 -- Seed default config
 insert into app_config (id, operations_pct, autoinvest_pct, buyback_burn_pct,
                         min_ops_pct, max_ops_pct, min_invest_pct, max_invest_pct,


### PR DESCRIPTION
## Summary
- short-circuit start-minting requests that repeat the same payload while a mint is already in progress
- avoid duplicating tx log inserts by only logging when a mint transitions into progress

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e02504b8348322814ada3cafbdb6c6