### PR TITLE
Enable dynamic Tonkeeper deep linking

### DIFF
--- a/apps/web/app/token/page.tsx
+++ b/apps/web/app/token/page.tsx
@@ -8,6 +8,7 @@ import {
   Tag,
   Text,
 } from "@/components/dynamic-ui-system";
+import { TonkeeperDeepLinkButtons } from "@/components/web3/TonkeeperDeepLinkButtons";
 import {
   baseURL as siteBaseURL,
   tokenContent,
@@ -135,6 +136,27 @@ export default function TokenPage() {
             );
           })}
         </Row>
+        <Column
+          gap="12"
+          align="center"
+          horizontal="center"
+          className="w-full max-w-2xl"
+        >
+          <TonkeeperDeepLinkButtons
+            address={tokenContent.treasuryWalletAddress}
+            memo="Dynamic Capital Treasury"
+            className="w-full"
+          />
+          <Text
+            variant="body-default-xs"
+            onBackground="neutral-weak"
+            align="center"
+          >
+            Dynamic deep links detect Telegram and mobile contexts to open
+            Tonkeeper natively, while HTTPS and ton:// fallbacks stay ready for
+            desktop wallets and other clients.
+          </Text>
+        </Column>
         <Row gap="16" wrap horizontal="center">
           <Row
             gap="8"

--- a/apps/web/components/web3/TonkeeperDeepLinkButtons.tsx
+++ b/apps/web/components/web3/TonkeeperDeepLinkButtons.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/utils";
+import { Button } from "@/components/ui/button";
+
+import {
+  buildDynamicTransferLink,
+  resolveTonkeeperScheme,
+  TON_STANDARD_SCHEME,
+  TONKEEPER_UNIVERSAL_SCHEME,
+  type TonkeeperTransferOptions,
+} from "../../../../shared/ton/tonkeeper";
+
+type NumericLike = string | number | bigint | null | undefined;
+
+type TonkeeperDeepLinkButtonsProps = {
+  address: string;
+  amountNano?: NumericLike;
+  memo?: string | null;
+  jettonAddress?: string | null;
+  binaryPayload?: string | null;
+  expiresAt?: NumericLike;
+  className?: string;
+};
+
+function normalizeNumeric(value: NumericLike): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return undefined;
+    return Math.trunc(value).toString(10);
+  }
+  return value.toString(10);
+}
+
+function normalizeString(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function resolvePlatformHint(): string | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  const telegramPlatform = (window as unknown as {
+    Telegram?: { WebApp?: { platform?: string } };
+  }).Telegram?.WebApp?.platform;
+
+  if (telegramPlatform && telegramPlatform.trim().length > 0) {
+    return telegramPlatform;
+  }
+
+  if (typeof navigator !== "undefined") {
+    return navigator.platform;
+  }
+
+  return undefined;
+}
+
+export function TonkeeperDeepLinkButtons({
+  address,
+  amountNano,
+  memo,
+  jettonAddress,
+  binaryPayload,
+  expiresAt,
+  className,
+}: TonkeeperDeepLinkButtonsProps) {
+  const sanitizedAddress = address.trim();
+
+  const normalizedAmount = normalizeNumeric(amountNano);
+  const normalizedMemo = normalizeString(memo ?? undefined);
+  const normalizedJetton = normalizeString(jettonAddress ?? undefined);
+  const normalizedPayload = normalizeString(binaryPayload ?? undefined);
+  const normalizedExpiry = normalizeNumeric(expiresAt);
+
+  const baseOptions = useMemo<TonkeeperTransferOptions | null>(
+    () =>
+      sanitizedAddress
+        ? {
+          address: sanitizedAddress,
+          amount: normalizedAmount,
+          text: normalizedMemo,
+          jetton: normalizedJetton,
+          bin: normalizedPayload,
+          exp: normalizedExpiry,
+        }
+        : null,
+    [
+      sanitizedAddress,
+      normalizedAmount,
+      normalizedMemo,
+      normalizedJetton,
+      normalizedPayload,
+      normalizedExpiry,
+    ],
+  );
+
+  const defaultLink = useMemo(
+    () =>
+      baseOptions
+        ? buildDynamicTransferLink(TONKEEPER_UNIVERSAL_SCHEME, baseOptions)
+        : null,
+    [baseOptions],
+  );
+
+  const tonLink = useMemo(
+    () =>
+      baseOptions
+        ? buildDynamicTransferLink(TON_STANDARD_SCHEME, baseOptions)
+        : null,
+    [baseOptions],
+  );
+
+  const [primaryLink, setPrimaryLink] = useState(defaultLink ?? "");
+
+  useEffect(() => {
+    if (!baseOptions || !defaultLink) {
+      setPrimaryLink("");
+      return;
+    }
+
+    const nav = typeof navigator !== "undefined" ? navigator : undefined;
+    const userAgent = nav?.userAgent ?? undefined;
+    const userAgentData = nav && "userAgentData" in nav
+      ? (nav as unknown as { userAgentData?: { mobile?: boolean } })
+        .userAgentData
+      : undefined;
+    const isMobileHint = typeof userAgentData?.mobile === "boolean"
+      ? userAgentData.mobile
+      : undefined;
+
+    const platformHint = resolvePlatformHint();
+
+    const scheme = resolveTonkeeperScheme({
+      prefersApp: true,
+      userAgent: userAgent ?? null,
+      platform: platformHint ?? null,
+      isMobile: isMobileHint,
+    });
+
+    try {
+      setPrimaryLink(buildDynamicTransferLink(scheme, baseOptions));
+    } catch (error) {
+      console.error("[TonkeeperDeepLink] Failed to build dynamic link", error);
+      setPrimaryLink(defaultLink);
+    }
+  }, [baseOptions, defaultLink]);
+
+  if (!baseOptions || !defaultLink || !tonLink) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex w-full flex-col items-center gap-2", className)}>
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+        <Button asChild variant="brand" responsive fullWidth>
+          <a href={primaryLink} rel="noreferrer">
+            Open in Tonkeeper
+          </a>
+        </Button>
+        <Button asChild variant="outline" responsive fullWidth>
+          <a href={defaultLink} target="_blank" rel="noreferrer">
+            Try universal link
+          </a>
+        </Button>
+      </div>
+      <p className="text-center text-xs text-muted-foreground">
+        Need a cross-wallet URI?{" "}
+        <a
+          href={tonLink}
+          className="font-medium underline underline-offset-4"
+          rel="noreferrer"
+        >
+          Use the ton:// variant
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/shared/ton/tonkeeper.ts
+++ b/shared/ton/tonkeeper.ts
@@ -1,0 +1,187 @@
+export const TON_STANDARD_SCHEME = "ton://" as const;
+export const TONKEEPER_APP_SCHEME = "tonkeeper://" as const;
+export const TONKEEPER_UNIVERSAL_SCHEME = "https://app.tonkeeper.com/" as const;
+
+export type TonkeeperScheme =
+  | typeof TON_STANDARD_SCHEME
+  | typeof TONKEEPER_APP_SCHEME
+  | typeof TONKEEPER_UNIVERSAL_SCHEME;
+
+const MOBILE_PLATFORM_HINTS = [
+  "android",
+  "ios",
+  "iphone",
+  "ipad",
+  "ipados",
+] as const;
+
+const DESKTOP_PLATFORM_HINTS = [
+  "mac",
+  "macos",
+  "mac os",
+  "linux",
+  "windows",
+  "tdesktop",
+  "web",
+] as const;
+
+const MOBILE_USER_AGENT_PATTERN =
+  /(android|iphone|ipad|ipod|blackberry|iemobile|opera mini|mobile)/i;
+
+function coalesceBoolean(
+  ...values: Array<boolean | null | undefined>
+): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function detectMobileFromPlatform(platform?: string | null):
+  | boolean
+  | undefined {
+  if (!platform) return undefined;
+  const normalized = platform.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (MOBILE_PLATFORM_HINTS.some((hint) => normalized.includes(hint))) {
+    return true;
+  }
+  if (DESKTOP_PLATFORM_HINTS.some((hint) => normalized.includes(hint))) {
+    return false;
+  }
+  return undefined;
+}
+
+function detectMobileFromUserAgent(userAgent?: string | null):
+  | boolean
+  | undefined {
+  if (!userAgent) return undefined;
+  return MOBILE_USER_AGENT_PATTERN.test(userAgent);
+}
+
+export type ResolveTonkeeperSchemeOptions = {
+  prefersApp?: boolean;
+  isMobile?: boolean;
+  fallback?: TonkeeperScheme;
+  platform?: string | null;
+  userAgent?: string | null;
+};
+
+export function resolveTonkeeperScheme(
+  options: ResolveTonkeeperSchemeOptions = {},
+): TonkeeperScheme {
+  const fallback = options.fallback ?? TONKEEPER_UNIVERSAL_SCHEME;
+  const inferredMobile = coalesceBoolean(
+    options.isMobile,
+    detectMobileFromPlatform(options.platform),
+    detectMobileFromUserAgent(options.userAgent),
+  );
+  const isMobile = inferredMobile ?? false;
+
+  if (options.prefersApp && isMobile) {
+    return TONKEEPER_APP_SCHEME;
+  }
+  if (isMobile) {
+    return TON_STANDARD_SCHEME;
+  }
+  return fallback;
+}
+
+type TonkeeperQueryValue =
+  | string
+  | number
+  | bigint
+  | boolean
+  | null
+  | undefined;
+
+export type TonkeeperQuery = Record<string, TonkeeperQueryValue>;
+
+function ensureHttpSchemeTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function joinSchemeAndPath(scheme: TonkeeperScheme, path: string): string {
+  const sanitizedPath = path.replace(/^\/+/, "").trim();
+  const isHttp = scheme.startsWith("http");
+
+  if (!sanitizedPath) {
+    return isHttp ? ensureHttpSchemeTrailingSlash(scheme) : scheme;
+  }
+
+  if (isHttp) {
+    return `${ensureHttpSchemeTrailingSlash(scheme)}${sanitizedPath}`;
+  }
+
+  return `${scheme}${sanitizedPath}`;
+}
+
+function toQueryValue(value: TonkeeperQueryValue): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    return value.toString(10);
+  }
+  if (typeof value === "bigint") {
+    return value.toString(10);
+  }
+  return value ? "true" : "false";
+}
+
+export function buildTonkeeperLink(
+  scheme: TonkeeperScheme,
+  path: string,
+  query: TonkeeperQuery = {},
+): string {
+  const base = joinSchemeAndPath(scheme, path);
+  const searchParams = new URLSearchParams();
+
+  for (const [key, rawValue] of Object.entries(query)) {
+    const value = toQueryValue(rawValue);
+    if (value === null) continue;
+    if (!key || typeof key !== "string") continue;
+    searchParams.append(key, value);
+  }
+
+  const suffix = searchParams.toString();
+  return suffix ? `${base}?${suffix}` : base;
+}
+
+export type TonkeeperTransferOptions = {
+  address: string;
+  amount?: TonkeeperQueryValue;
+  text?: TonkeeperQueryValue;
+  bin?: TonkeeperQueryValue;
+  jetton?: TonkeeperQueryValue;
+  exp?: TonkeeperQueryValue;
+};
+
+function sanitizeAddress(address: string): string {
+  const trimmed = address.trim();
+  if (!trimmed) {
+    throw new Error("Tonkeeper transfer address is required");
+  }
+  return trimmed;
+}
+
+export function buildDynamicTransferLink(
+  scheme: TonkeeperScheme,
+  { address, amount, text, bin, jetton, exp }: TonkeeperTransferOptions,
+): string {
+  const normalizedAddress = sanitizeAddress(address);
+  const route = `transfer/${normalizedAddress}`;
+
+  return buildTonkeeperLink(scheme, route, {
+    amount,
+    text,
+    bin,
+    jetton,
+    exp,
+  });
+}

--- a/tests/telegram-secret-stub.ts
+++ b/tests/telegram-secret-stub.ts
@@ -1,6 +1,21 @@
+const TELEGRAM_ALLOWED_UPDATES = Object.freeze([
+  "message",
+  "callback_query",
+  "inline_query",
+  "chat_member",
+  "my_chat_member",
+] as const);
+
+export type TelegramAllowedUpdate = typeof TELEGRAM_ALLOWED_UPDATES[number];
+
+export function cloneTelegramAllowedUpdates(): TelegramAllowedUpdate[] {
+  return [...TELEGRAM_ALLOWED_UPDATES];
+}
+
 export function expectedSecret(): Promise<string | null> {
   return Promise.resolve(Deno.env.get("TELEGRAM_WEBHOOK_SECRET") || null);
 }
+
 export function validateTelegramHeader(
   req: Request,
 ): Promise<Response | null> {

--- a/tests/tonkeeper-links.test.ts
+++ b/tests/tonkeeper-links.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import {
+  equal as assertEquals,
+  match as assertMatch,
+  throws as assertThrows,
+} from "node:assert/strict";
+
+import {
+  TONKEEPER_APP_SCHEME,
+  TONKEEPER_UNIVERSAL_SCHEME,
+  TON_STANDARD_SCHEME,
+  buildDynamicTransferLink,
+  buildTonkeeperLink,
+  resolveTonkeeperScheme,
+} from "../shared/ton/tonkeeper.ts";
+
+test("resolveTonkeeperScheme prefers Tonkeeper app on mobile when requested", () => {
+  const scheme = resolveTonkeeperScheme({ prefersApp: true, isMobile: true });
+  assertEquals(scheme, TONKEEPER_APP_SCHEME);
+});
+
+test("resolveTonkeeperScheme falls back to ton:// when mobile without app preference", () => {
+  const scheme = resolveTonkeeperScheme({ isMobile: true });
+  assertEquals(scheme, TON_STANDARD_SCHEME);
+});
+
+test("resolveTonkeeperScheme infers platform hints", () => {
+  const platformScheme = resolveTonkeeperScheme({
+    prefersApp: true,
+    platform: "iOS",
+  });
+  assertEquals(platformScheme, TONKEEPER_APP_SCHEME);
+
+  const userAgentScheme = resolveTonkeeperScheme({
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15",
+    prefersApp: true,
+  });
+  assertEquals(userAgentScheme, TONKEEPER_APP_SCHEME);
+
+  const desktopScheme = resolveTonkeeperScheme({
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+  });
+  assertEquals(desktopScheme, TONKEEPER_UNIVERSAL_SCHEME);
+});
+
+test("buildTonkeeperLink constructs canonical URLs", () => {
+  const link = buildTonkeeperLink(TONKEEPER_UNIVERSAL_SCHEME, "transfer/EQA123", {
+    amount: 1250000000,
+    text: "Desk deposit",
+    empty: "",
+    optional: undefined,
+  });
+  assertEquals(
+    link,
+    "https://app.tonkeeper.com/transfer/EQA123?amount=1250000000&text=Desk+deposit",
+  );
+});
+
+test("buildDynamicTransferLink trims addresses and encodes params", () => {
+  const link = buildDynamicTransferLink(TON_STANDARD_SCHEME, {
+    address: " EQC1234567890 ",
+    text: "Dynamic Capital Treasury",
+    exp: 1_700_000_000,
+  });
+  assertEquals(
+    link,
+    "ton://transfer/EQC1234567890?text=Dynamic+Capital+Treasury&exp=1700000000",
+  );
+});
+
+test("buildDynamicTransferLink rejects missing addresses", () => {
+  assertThrows(
+    () =>
+      buildDynamicTransferLink(TONKEEPER_UNIVERSAL_SCHEME, {
+        address: "   ",
+      }),
+    (error: unknown) => {
+      assertMatch(String(error), /address is required/i);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add shared Tonkeeper deep link utilities and coverage
- expose a Tonkeeper deep link button group on the token page with dynamic fallbacks
- extend the Telegram secret stub used in tests to include allowed update helpers

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e03dcdec788322a35b14f70147be9f