### PR TITLE
Clarify trading ALGO and LOGIC runtime status

### DIFF
--- a/docs/dynamic-trading-algo-vs-logic.md
+++ b/docs/dynamic-trading-algo-vs-logic.md
@@ -57,3 +57,73 @@ determines _why_ to act and ALGO manages _how_ the action is delivered.
 Maintaining a sharp separation between these pillars keeps the system modular:
 LOGIC experiments can evolve rapidly without destabilizing the ALGO rails, while
 ALGO enhancements improve resilience without altering strategic intent.
+
+## Current implementation status
+
+### Dynamic Trading ALGO — execution layer runtime
+
+- **Versioning** – `dynamic/trading/algo/trading_core.py` declares
+  `ALGO_VERSION_INFO = ModelVersion(name="Dynamic Algo", number=VersionNumber(0,
+  2))`,
+  exposing the `0.2` tag everywhere via `DynamicTradingAlgo.version` so
+  downstream systems can pin automation pipelines to the shipped build.
+- **Connector strategy** – `DynamicTradingAlgo` attempts to bootstrap either the
+  MT5 (`integrations.mt5_connector.MT5Connector`) or REST
+  (`integrations.trade_api_connector.TradeAPIConnector`) connector but falls
+  back to an internal paper broker when the dependency graph is not available.
+  This keeps sandbox and CI environments operational without external services
+  while still allowing production builds to wire in live brokers.
+- **Telemetry fallbacks** – Every trade event is routed through
+  `_emit_trade_event`, which tries the optional
+  `integrations.data_collection_api.serialise_for_collection` helper first and
+  then gracefully downgrades to `_fallback_collection_serialise` so execution
+  metadata is never dropped even when collectors are offline.
+- **Live collaboration** – `dynamic/trading/live_sync.py` stitches the ALGO
+  executor together with risk telemetry through `DynamicTradingLiveSync`,
+  ensuring the execution layer can accept governance context, research inputs,
+  and current positions from the LOGIC pillar before firing orders.
+
+| Capability              | Status summary                                                      |
+| ----------------------- | ------------------------------------------------------------------- |
+| Release tag             | `ModelVersion` 0.2, surfaced via `DynamicTradingAlgo.version`.      |
+| Broker integration      | MT5 & REST connectors optional; automatic paper broker fallback.    |
+| Telemetry resilience    | Graceful downgrade from external collectors to in-process fallback. |
+| Live sync orchestration | `DynamicTradingLiveSync` mediates strategy → execution hand-offs.   |
+
+```python
+from dynamic.trading.algo import DynamicTradingAlgo
+
+algo = DynamicTradingAlgo()
+print(algo.version)  # -> "dynamic-algo@0.2"
+```
+
+### Dynamic Trading LOGIC — discretionary risk brain
+
+- **Guardrail primitives** – `dynamic/trading/logic/engine.py` defines the
+  `RiskLimits`, `RiskTelemetry`, and `DynamicRisk` data classes responsible for
+  tracking gross/net exposure, largest position sizing, and 95% VaR for the live
+  book.
+- **Telemetry loop** – When `DynamicRisk.snapshot()` runs it compiles breaches,
+  emits a `RiskTelemetry` payload, and pushes it through `_emit_telemetry`. The
+  method automatically mirrors the ALGO’s behaviour: it prefers
+  `bootstrap_data_collection_api()` and, if unavailable, falls back to
+  structured dictionaries so nothing breaks in offline environments.
+- **Shared lifecycle** – The same `DynamicTradingLiveSync` entrypoint consumes
+  `DynamicRisk` output, letting the LOGIC pillar approve or veto execution in
+  real time based on guardrail health.
+
+| Capability              | Status summary                                                       |
+| ----------------------- | -------------------------------------------------------------------- |
+| Risk surface            | Positions, exposure, and VaR tracked through typed dataclasses.      |
+| Breach detection        | `DynamicRisk.snapshot()` annotates breaches for governance review.   |
+| Telemetry compatibility | Optional collector bootstrap with safe fallbacks mirrors ALGO layer. |
+| Execution handshake     | Live sync module shares LOGIC state with the ALGO executor.          |
+
+```python
+from dynamic.trading.logic import DynamicRisk, RiskLimits
+
+limits = RiskLimits(max_gross_exposure=1_000_000, max_single_position=250_000, max_var=50_000)
+risk = DynamicRisk(limits)
+telemetry = risk.snapshot()  # safe even before positions are ingested
+print(telemetry.gross_exposure)
+```


### PR DESCRIPTION
## Summary
- expand the trading ALGO status section with explicit versioning, connector fallbacks, telemetry handling, and a usage snippet
- document the LOGIC risk engine guardrails, telemetry emission flow, and its live sync handshake with an example snippet

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e040731490832282ca0626a3a470ab