### PR TITLE
Expose Dynamic Ultimate Reality symbols in toolkits and engines

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -425,7 +425,12 @@ _ENGINE_EXPORTS: Dict[str, Tuple[SymbolExport, ...]] = {
         "TrainerContext",
         "TrainingSignal",
     ),
-    "dynamic_ultimate_reality": ("DynamicUltimateReality",),
+    "dynamic_ultimate_reality": (
+        "DynamicUltimateReality",
+        "NonDualContext",
+        "UltimateRealitySignal",
+        "UltimateRealityState",
+    ),
     "dynamic_volume": ("DynamicVolumeAlgo",),
     "dynamic_wisdom": ("DynamicWisdomEngine",),
     "dynamic.platform.web3": (

--- a/dynamic_tool_kits/__init__.py
+++ b/dynamic_tool_kits/__init__.py
@@ -270,7 +270,12 @@ _TOOLKIT_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "ThinkingFrame",
         "ThinkingSignal",
     ),
-    "dynamic_ultimate_reality": ("NonDualContext", "UltimateRealitySignal", "UltimateRealityState"),
+    "dynamic_ultimate_reality": (
+        "DynamicUltimateReality",
+        "NonDualContext",
+        "UltimateRealitySignal",
+        "UltimateRealityState",
+    ),
     "dynamic_volume": ("BookLevel", "VolumeAlert", "VolumeSnapshot", "VolumeThresholds"),
     "dynamic_wisdom": ("WisdomContext", "WisdomFrame", "WisdomSignal"),
 }

--- a/tests/test_dynamic_tool_kits.py
+++ b/tests/test_dynamic_tool_kits.py
@@ -68,6 +68,26 @@ def test_dynamic_cap_theorem_toolkit_exports() -> None:
     )
 
 
+def test_dynamic_ultimate_reality_toolkit_exports_engine() -> None:
+    toolkits = dynamic_tool_kits.available_toolkits()
+
+    assert "dynamic_ultimate_reality" in toolkits
+    exports = set(toolkits["dynamic_ultimate_reality"])
+    expected = {
+        "DynamicUltimateReality",
+        "NonDualContext",
+        "UltimateRealitySignal",
+        "UltimateRealityState",
+    }
+    assert expected.issubset(exports)
+    assert (
+        dynamic_tool_kits.resolve_toolkit_symbol(
+            "DynamicUltimateReality", module_name="dynamic_ultimate_reality"
+        )
+        is dynamic_tool_kits.DynamicUltimateReality
+    )
+
+
 def test_available_toolkits_include_module_dunder_all_exports() -> None:
     toolkits = dynamic_tool_kits.available_toolkits()
 

--- a/tests/test_dynamic_tools_namespace.py
+++ b/tests/test_dynamic_tools_namespace.py
@@ -21,6 +21,16 @@ def test_dynamic_tools_handles_symbol_collisions() -> None:
     assert tools.BloodAgent is dynamic_tool_kits.BloodAgent
 
 
+def test_dynamic_tools_exposes_dynamic_ultimate_reality() -> None:
+    tools = importlib.import_module("dynamic.tools")
+
+    assert "DynamicUltimateReality" in tools.__all__
+    assert tools.DynamicUltimateReality is dynamic_tool_kits.DynamicUltimateReality
+    assert tools.NonDualContext is dynamic_tool_kits.NonDualContext
+    assert tools.UltimateRealitySignal is dynamic_tool_kits.UltimateRealitySignal
+    assert tools.UltimateRealityState is dynamic_tool_kits.UltimateRealityState
+
+
 def test_refresh_tool_exports_synchronises_directory_listing() -> None:
     tools = importlib.import_module("dynamic.tools")
 

--- a/tests/test_dynamic_ultimate_reality.py
+++ b/tests/test_dynamic_ultimate_reality.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from dynamic_ultimate_reality import (
@@ -137,3 +139,13 @@ def test_dynamic_ultimate_reality_requires_weight() -> None:
 
     with pytest.raises(RuntimeError):
         engine.realise(context)
+
+
+def test_platform_engines_expose_ultimate_reality_symbols() -> None:
+    engines = importlib.import_module("dynamic.platform.engines")
+    module = importlib.import_module("dynamic_ultimate_reality")
+
+    assert engines.DynamicUltimateReality is module.DynamicUltimateReality
+    assert engines.NonDualContext is module.NonDualContext
+    assert engines.UltimateRealitySignal is module.UltimateRealitySignal
+    assert engines.UltimateRealityState is module.UltimateRealityState


### PR DESCRIPTION
## Summary
- add DynamicUltimateReality and related dataclasses to the dynamic_ultimate_reality toolkit exports and platform engine registry
- verify dynamic.tools re-exports the ultimate reality engine symbols and that the toolkit catalog exposes the engine

## Testing
- pytest tests/test_dynamic_tool_kits.py tests/test_dynamic_tools_namespace.py tests/test_dynamic_ultimate_reality.py

------
https://chatgpt.com/codex/tasks/task_e_68e0411624888322a42f0ad5fda6e29e