### PR TITLE
Add hybrid workflow helper for Codex

### DIFF
--- a/docs/HYBRID_DEVELOPMENT_WORKFLOW.md
+++ b/docs/HYBRID_DEVELOPMENT_WORKFLOW.md
@@ -36,6 +36,11 @@ graph TD
    DigitalOcean rebuilds from GitHub, keeping the live app current with Dynamic
    and local updates.
 
+> 💡 Run `npm run codex:hybrid` to automate the dependency install, environment
+> sync, optional build/verify steps, and launch the Dynamic development server
+> in one command. Append flags such as `--no-install`, `--no-build`, or
+> `--verify` after `--` to customize the workflow.
+
 ## Notes
 
 - Keep `.env.example` up to date when new variables are introduced.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev:lovable": "node lovable-dev.js",
     "codex:post-pull": "node scripts/codex-workflow.js post-pull",
     "codex:dev": "node scripts/codex-workflow.js dev",
+    "codex:hybrid": "node scripts/codex-workflow.js hybrid",
     "codex:build": "node scripts/codex-workflow.js build",
     "codex:verify": "node scripts/codex-workflow.js verify",
     "lint": "node scripts/npm-safe.mjs -w apps/web run lint",

--- a/scripts/codex-workflow.js
+++ b/scripts/codex-workflow.js
@@ -148,6 +148,37 @@ const tasksByMode = {
       optional: false,
     }),
   ],
+  hybrid: () => [
+    command("Install npm dependencies", "npm install", {
+      skip: skipInstall,
+      optional: false,
+      shared: sharedInstallOptions(),
+    }),
+    command("Sync local environment (npm run sync-env)", "npm run sync-env", {
+      skip: skipSync,
+      optional: true,
+    }),
+    command(
+      "Check required environment variables",
+      "npx tsx scripts/check-env.ts",
+      {
+        skip: skipEnvCheck,
+        optional: false,
+      },
+    ),
+    command("Run Next.js build", "npm run build", {
+      skip: skipBuild,
+      optional: optionalBuild,
+    }),
+    runVerify && !skipVerify
+      ? command("Run repository verification suite", "npm run verify", {
+        optional: false,
+      })
+      : null,
+    command("Start Dynamic development server", "node lovable-dev.js", {
+      optional: false,
+    }),
+  ],
   build: () => [
     command(
       "Check required environment variables",
@@ -306,6 +337,7 @@ function printUsage() {
     "Modes:",
     "  post-pull (default)  Prepare the repo after pulling from Codex CLI.",
     "  dev                  Sync env and start Dynamic dev server.",
+    "  hybrid               Combine post-pull prep with the Dynamic dev server.",
     "  build                Run env checks and Next.js build.",
     "  verify               Run the verification suite.",
     "",


### PR DESCRIPTION
## Summary
- add a hybrid mode to the Codex workflow helper so teams can run post-pull prep and the Dynamic dev server together
- expose the new workflow as `npm run codex:hybrid` for easier access
- document the single-command option in the hybrid development workflow guide

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0609a48d483229515571df936eca8