### PR TITLE
Expose creative thinking engine in toolkit

### DIFF
--- a/dynamic_tool_kits/__init__.py
+++ b/dynamic_tool_kits/__init__.py
@@ -179,7 +179,12 @@ _TOOLKIT_EXPORTS: Dict[str, Tuple[str, ...]] = {
         "ConsciousnessState",
         "DynamicConsciousness",
     ),
-    "dynamic_creative_thinking": ("CreativeContext", "CreativeFrame", "CreativeSignal"),
+    "dynamic_creative_thinking": (
+        "CreativeContext",
+        "CreativeFrame",
+        "CreativeSignal",
+        "DynamicCreativeThinking",
+    ),
     "dynamic_critical_thinking": ("CriticalEvaluation", "CriticalSignal", "EvaluationContext"),
     "dynamic_development_team": (
         "DevelopmentAgentResult",

--- a/tests/test_dynamic_tool_kits.py
+++ b/tests/test_dynamic_tool_kits.py
@@ -88,6 +88,26 @@ def test_dynamic_ultimate_reality_toolkit_exports_engine() -> None:
     )
 
 
+def test_dynamic_creative_thinking_toolkit_exports_engine() -> None:
+    toolkits = dynamic_tool_kits.available_toolkits()
+
+    assert "dynamic_creative_thinking" in toolkits
+    exports = set(toolkits["dynamic_creative_thinking"])
+    expected = {
+        "CreativeContext",
+        "CreativeFrame",
+        "CreativeSignal",
+        "DynamicCreativeThinking",
+    }
+    assert expected.issubset(exports)
+    assert (
+        dynamic_tool_kits.resolve_toolkit_symbol(
+            "DynamicCreativeThinking", module_name="dynamic_creative_thinking"
+        )
+        is dynamic_tool_kits.DynamicCreativeThinking
+    )
+
+
 def test_available_toolkits_include_module_dunder_all_exports() -> None:
     toolkits = dynamic_tool_kits.available_toolkits()
 


### PR DESCRIPTION
## Summary
- expose the `DynamicCreativeThinking` engine through the `dynamic_tool_kits` aggregate namespace
- add regression coverage ensuring the creative thinking toolkit exports the engine alongside its data models

## Testing
- pytest tests/test_dynamic_tool_kits.py

------
https://chatgpt.com/codex/tasks/task_e_68e081add0288322bc9e1f8f8b0c37be