### PR TITLE
Add proof namespace adapter

### DIFF
--- a/dynamic/__init__.py
+++ b/dynamic/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "governance",
     "intelligence",
     "models",
+    "proof",
     "platform",
     "tools",
     "trading",

--- a/dynamic/proof/__init__.py
+++ b/dynamic/proof/__init__.py
@@ -1,0 +1,63 @@
+"""Dynamic proof exports via the consolidated namespace."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+_PROVIDER_MODULE = "dynamic_proof"
+
+__all__ = [
+    "DynamicProofAssembler",
+    "EvidenceInsight",
+    "EvidenceRecord",
+    "OutstandingCriterion",
+    "ProofAssessment",
+    "ProofContext",
+    "ProofCriterion",
+]
+
+if TYPE_CHECKING:  # pragma: no cover - only used for static analysis
+    from dynamic_proof import (  # noqa: F401 (re-exported names)
+        DynamicProofAssembler,
+        EvidenceInsight,
+        EvidenceRecord,
+        OutstandingCriterion,
+        ProofAssessment,
+        ProofContext,
+        ProofCriterion,
+    )
+
+
+def _load_provider() -> ModuleType:
+    """Import and memoize the underlying proof provider module."""
+
+    module = import_module(_PROVIDER_MODULE)
+    globals()["_provider"] = module
+    return module
+
+
+def __getattr__(name: str) -> Any:
+    """Proxy attribute access to the :mod:`dynamic_proof` provider."""
+
+    if name not in __all__:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+    module: ModuleType
+    if (module := globals().get("_provider")) is None:  # type: ignore[assignment]
+        module = _load_provider()
+
+    try:
+        value = getattr(module, name)
+    except AttributeError as exc:  # pragma: no cover - defensive hardening
+        raise AttributeError(
+            f"module '{_PROVIDER_MODULE}' has no attribute '{name}'"
+        ) from exc
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/tests/test_dynamic_proof_namespace.py
+++ b/tests/test_dynamic_proof_namespace.py
@@ -1,0 +1,7 @@
+from dynamic import proof
+
+
+def test_dynamic_proof_namespace_exports() -> None:
+    assert hasattr(proof, "DynamicProofAssembler")
+    assert hasattr(proof, "ProofCriterion")
+    assert callable(proof.DynamicProofAssembler)


### PR DESCRIPTION
## Summary
- expose dynamic proof functionality through the consolidated `dynamic.proof` namespace
- implement a lazy proxy that forwards exports to the existing `dynamic_proof` provider
- add a regression test to ensure the namespace exposes the expected proof assembler

## Testing
- pytest tests/test_dynamic_proof_namespace.py

------
https://chatgpt.com/codex/tasks/task_e_68e0987bfe7083228e6bee4c488eae4c