### PR TITLE
Add DCT on-chain snapshot verification

### DIFF
--- a/_static/ton/dct-jetton/README.md
+++ b/_static/ton/dct-jetton/README.md
@@ -1,44 +1,42 @@
-# DCT Jetton Explorer Archive
+# DCT Jetton On-chain Snapshot
 
-Redacted text transcripts captured on 2025-05-10 to document the production
-explorer state for the Dynamic Capital Token jetton. Numerical values are
-sanitized but preserve the structure required for Tonstarter audits.
+_Last updated: 4 October 2025 (automated scan via `scripts/ton/dct-snapshot.ts`)._
 
-## jetton-master-overview.txt
+## Jetton master status
 
-```
-URL: https://tonviewer.com/EQAHMNCDJmEK8yEt1IbaJP1xl2-wd21f1Gpt_57Z1uCPPzE6
-Block: 13458923000002 (2025-05-10T14:03:29Z)
-Symbol: DCT
-Decimals: 9
-Total Supply: 100,000,000 DCT
-Owner: EQD1zAJPYZMY•••••••••••••••••••••••
-Jetton Wallets: 142
-Recent Operations:
-  - 2025-05-09: burn 12,450 DCT (EQBNSubscriptBurn••••••••••••••••••••)
-  - 2025-05-08: transfer 50,000 DCT to EQBMentorRewards••••••••••••••••••
-```
+- **Master address:** `0:d29b3e11ac30451be4f58b3c1527bab576902ad662532eb2b0c8c6098a0e96c7`
+- **Token:** Dynamic Capital Token (DCT), 9 decimals, mintable
+- **Total minted supply:** `500` DCT (`500000000000` nanoDCT)
+- **Reported holders:** `1` wallet (100% of minted supply)
 
-## jetton-wallet-treasury.txt
+## Holder distribution (tonapi.io)
 
-```
-URL: https://tonviewer.com/jetton/EQAHMNCDJmEK8yEt1IbaJP1xl2-wd21f1Gpt_57Z1uCPPzE6/EQD1zAJPYZMY•••••••••••••••••••••••
-Balance: 28,400,000 DCT
-Transactions:
-  - 2025-05-10: Transfer 250,000 DCT to EQBSTONLiquidity••••••••••••••••••
-  - 2025-05-09: Burn 12,450 DCT via EQBNSubscriptBurn••••••••••••••••••••
-  - 2025-05-07: Transfer 180,000 DCT to EQBMentorRewards••••••••••••••••••
-```
+| Rank | Owner (friendly) | Jetton wallet | Balance |
+| ---- | ---------------- | ------------- | ------- |
+| 1 | `dynamiccapital.ton` (`0:f5cc024f6193187f763d07848bedf44b154f9583957b45c2cc9c4bb61ff70d38`) | `0:26cdc2a0ddec9b50dcec4f896526b8e80deec5c02e759d246124430008276789` | `500` DCT |
 
-## stonfi-dct-ton-pool.txt
+_No other holders were returned by the Tonapi jetton holder endpoint._
 
-```
-URL: https://ston.fi/pools/EQDCTSTONPool•••••••••••••••••••••
-Liquidity: 1,200,000 TON / 12,000,000 DCT
-24h Volume: 860,000 TON
-Fee Tier: 0.25%
-Pool Share: Treasury 78%, Market Makers 22%
+## Treasury/admin wallet (`dynamiccapital.ton`)
+
+- **TON balance:** `40.856076572` TON (nanotons: `40856076572`)
+- **DCT balance:** `500` DCT held in jetton wallet `0:26cdc2a0ddec9b50dcec4f896526b8e80deec5c02e759d246124430008276789`
+- **Domain resolver:** `dynamiccapital.ton` → owner `0:f5cc024f6193187f763d07848bedf44b154f9583957b45c2cc9c4bb61ff70d38`, expires `2026-10-02T11:22:24Z`
+
+## DEX liquidity checks (automated)
+
+| Venue  | HTTP status | Result |
+| ------ | ----------- | ------ |
+| STON.fi | `404` | Jetton not listed |
+| DeDust | `404` | Jetton not listed |
+
+## Reproduction
+
+```bash
+npx tsx scripts/ton/dct-snapshot.ts
+npx tsx scripts/ton/query-ton-domain.ts dynamiccapital.ton
 ```
 
-These transcripts are immutable snapshots to satisfy the Tonstarter audit
-request for explorer evidence without distributing raw screenshots.
+The helper script reads `dynamic-capital-ton/config.yaml`, queries Tonapi for the
+jetton supply/holder set, and verifies whether the jetton appears on STON.fi or
+DeDust. Output is captured in CI logs for audit purposes.

--- a/scripts/ton/dct-snapshot.ts
+++ b/scripts/ton/dct-snapshot.ts
@@ -1,0 +1,416 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { parse as parseYaml } from "yaml";
+
+const execFileAsync = promisify(execFile);
+
+const TON_API_BASE = "https://tonapi.io/v2";
+const STONFI_API_BASE = "https://api.ston.fi/v1";
+const DEDUST_API_BASE = "https://api.dedust.io/v1";
+
+interface JettonSummaryResponse {
+  mintable?: boolean;
+  total_supply?: string;
+  admin?: {
+    address?: string;
+    name?: string;
+    is_wallet?: boolean;
+  };
+  metadata?: {
+    name?: string;
+    symbol?: string;
+    decimals?: string | number;
+  };
+  holders_count?: number;
+}
+
+interface JettonHolderResponse {
+  addresses?: Array<{
+    address?: string;
+    balance?: string;
+    owner?: {
+      address?: string;
+      name?: string;
+      is_wallet?: boolean;
+    };
+  }>;
+  total?: number;
+}
+
+interface AccountJettonsResponse {
+  balances?: Array<{
+    balance?: string;
+    wallet_address?: { address?: string };
+    jetton?: { address?: string; symbol?: string };
+  }>;
+}
+
+interface TonAccountResponse {
+  balance?: number;
+}
+
+interface RepositoryConfig {
+  token?: {
+    name?: string;
+    symbol?: string;
+    decimals?: number;
+    address?: string;
+  };
+}
+
+type DexCheckStatus =
+  | { venue: "STON.fi" | "DeDust"; status: "not_listed"; httpStatus: number }
+  | {
+    venue: "STON.fi" | "DeDust";
+    status: "listed";
+    httpStatus: number;
+    note?: string;
+  }
+  | {
+    venue: "STON.fi" | "DeDust";
+    status: "error";
+    httpStatus: number;
+    message: string;
+  };
+
+function getRepoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "..");
+}
+
+async function loadConfig(): Promise<Required<RepositoryConfig>["token"]> {
+  const root = getRepoRoot();
+  const raw = await readFile(
+    resolve(root, "dynamic-capital-ton", "config.yaml"),
+    "utf8",
+  );
+  const config = parseYaml(raw) as RepositoryConfig;
+  const token = config.token;
+  if (!token?.address) {
+    throw new Error(
+      "Token address missing from dynamic-capital-ton/config.yaml",
+    );
+  }
+  const decimals = typeof token.decimals === "number"
+    ? token.decimals
+    : Number.parseInt(String(token.decimals ?? ""), 10);
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new Error("Token decimals missing or invalid in configuration");
+  }
+  return {
+    name: token.name ?? "Dynamic Capital Token",
+    symbol: token.symbol ?? "DCT",
+    decimals,
+    address: token.address,
+  };
+}
+
+async function curlRequest(
+  url: string,
+): Promise<{ status: number; body: string }> {
+  const args = [
+    "-sS",
+    "-H",
+    "Accept: application/json",
+    "-H",
+    "User-Agent: dynamic-capital-dct-snapshot/1.0",
+    "-w",
+    "\n%{http_code}",
+    url,
+  ];
+  try {
+    const { stdout } = await execFileAsync("curl", args);
+    const trimmed = stdout.trimEnd();
+    const lines = trimmed.split("\n");
+    const statusText = lines.pop() ?? "";
+    const status = Number.parseInt(statusText, 10);
+    if (!Number.isFinite(status)) {
+      throw new Error(`Unexpected status code from curl output: ${statusText}`);
+    }
+    const body = lines.join("\n");
+    return { status, body };
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr?.trim();
+    const suffix = stderr ? `: ${stderr}` : "";
+    throw new Error(`curl request failed${suffix}`);
+  }
+}
+
+async function fetchJson<T>(
+  url: string,
+  { label }: { label: string },
+): Promise<T> {
+  const { status, body } = await curlRequest(url);
+  if (status < 200 || status >= 300) {
+    throw new Error(
+      `${label} request failed with status ${status}: ${body.slice(0, 200)}`,
+    );
+  }
+  try {
+    return JSON.parse(body) as T;
+  } catch (error) {
+    throw new Error(
+      `${label} response parse error: ${(error as Error).message}`,
+    );
+  }
+}
+
+async function fetchJsonAllowing404<T>(
+  url: string,
+): Promise<{ status: number; data?: T }> {
+  const { status, body } = await curlRequest(url);
+  if (status === 404) {
+    return { status };
+  }
+  if (status < 200 || status >= 300) {
+    throw new Error(
+      `Request to ${url} failed with status ${status}: ${body.slice(0, 200)}`,
+    );
+  }
+  try {
+    return { status, data: JSON.parse(body) as T };
+  } catch (error) {
+    throw new Error(
+      `Unable to parse response from ${url}: ${(error as Error).message}`,
+    );
+  }
+}
+
+function toBigInt(value: string | number | bigint | undefined): bigint | null {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return BigInt(Math.trunc(value));
+  }
+  if (typeof value === "string" && value.trim()) {
+    try {
+      return BigInt(value.trim());
+    } catch (error) {
+      throw new Error(
+        `Unable to parse bigint value: ${(error as Error).message}`,
+      );
+    }
+  }
+  return null;
+}
+
+function formatJettonAmount(value: bigint, decimals: number): string {
+  const divisor = BigInt(10) ** BigInt(decimals);
+  const whole = value / divisor;
+  const remainder = value % divisor;
+  if (remainder === BigInt(0)) {
+    return whole.toString();
+  }
+  const fraction = remainder.toString().padStart(decimals, "0").replace(
+    /0+$/,
+    "",
+  );
+  return `${whole.toString()}.${fraction}`;
+}
+
+function formatTonAmount(nanoTons: bigint): string {
+  return formatJettonAmount(nanoTons, 9);
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+async function checkDexPresence(
+  tokenAddress: string,
+): Promise<DexCheckStatus[]> {
+  const results: DexCheckStatus[] = [];
+
+  // STON.fi exposes jetton metadata under /jettons/<address> when listed.
+  {
+    const url = `${STONFI_API_BASE}/jettons/${
+      encodeURIComponent(tokenAddress)
+    }`;
+    try {
+      const { status } = await fetchJsonAllowing404(url);
+      if (status === 404) {
+        results.push({
+          venue: "STON.fi",
+          status: "not_listed",
+          httpStatus: status,
+        });
+      } else {
+        results.push({
+          venue: "STON.fi",
+          status: "listed",
+          httpStatus: status,
+        });
+      }
+    } catch (error) {
+      results.push({
+        venue: "STON.fi",
+        status: "error",
+        httpStatus: 0,
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  // DeDust returns 404 for unknown jetton roots when querying findByToken.
+  {
+    const url = `${DEDUST_API_BASE}/pools/findByToken?token_root=${
+      encodeURIComponent(tokenAddress)
+    }`;
+    try {
+      const { status } = await fetchJsonAllowing404(url);
+      if (status === 404) {
+        results.push({
+          venue: "DeDust",
+          status: "not_listed",
+          httpStatus: status,
+        });
+      } else {
+        results.push({ venue: "DeDust", status: "listed", httpStatus: status });
+      }
+    } catch (error) {
+      results.push({
+        venue: "DeDust",
+        status: "error",
+        httpStatus: 0,
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  return results;
+}
+
+function printHeader(title: string): void {
+  console.log("\n" + title);
+  console.log("".padEnd(title.length, "="));
+}
+
+function printList(entries: Array<[string, string]>): void {
+  for (const [label, value] of entries) {
+    console.log(`${label}: ${value}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const token = await loadConfig();
+  const jettonSummary = await fetchJson<JettonSummaryResponse>(
+    `${TON_API_BASE}/jettons/${encodeURIComponent(token.address)}`,
+    { label: "jetton summary" },
+  );
+  const holdersResponse = await fetchJson<JettonHolderResponse>(
+    `${TON_API_BASE}/jettons/${
+      encodeURIComponent(token.address)
+    }/holders?limit=16`,
+    { label: "jetton holders" },
+  );
+
+  const totalSupplyRaw = toBigInt(jettonSummary.total_supply);
+  if (totalSupplyRaw === null) {
+    throw new Error("Jetton total supply missing in tonapi response");
+  }
+
+  const supplyFormatted = formatJettonAmount(totalSupplyRaw, token.decimals);
+  const holderCount = holdersResponse.total ?? jettonSummary.holders_count ?? 0;
+  const topHolders = holdersResponse.addresses ?? [];
+
+  printHeader(`Dynamic Capital Token Snapshot — ${new Date().toISOString()}`);
+  printList([
+    ["Jetton master", token.address],
+    ["Token", `${token.name} (${token.symbol})`],
+    ["Mintable", jettonSummary.mintable ? "yes" : "no"],
+    ["Total supply", `${supplyFormatted} ${token.symbol}`],
+    ["Holder count", holderCount.toString()],
+  ]);
+
+  if (topHolders.length === 0) {
+    console.log("No holders reported by tonapi.");
+  } else {
+    printHeader("Top holders");
+    topHolders.forEach((entry, index) => {
+      const balanceRaw = toBigInt(entry.balance);
+      const balance = balanceRaw === null
+        ? "unknown"
+        : `${formatJettonAmount(balanceRaw, token.decimals)} ${token.symbol}`;
+      const ownerLabel = entry.owner?.name
+        ? `${entry.owner.name} (${entry.owner.address ?? "unknown"})`
+        : entry.owner?.address ?? entry.address ?? "unknown";
+      printList([
+        ["Rank", (index + 1).toString()],
+        ["Owner", ownerLabel],
+        ["Jetton wallet", entry.address ?? "unknown"],
+        ["Balance", balance],
+        ["Wallet type", entry.owner?.is_wallet ? "wallet" : "contract"],
+      ]);
+      console.log("");
+    });
+  }
+
+  const adminAddress = jettonSummary.admin?.address;
+  if (adminAddress) {
+    const accountJettons = await fetchJson<AccountJettonsResponse>(
+      `${TON_API_BASE}/accounts/${encodeURIComponent(adminAddress)}/jettons`,
+      { label: "admin jettons" },
+    );
+    const accountSummary = await fetchJson<TonAccountResponse>(
+      `${TON_API_BASE}/accounts/${encodeURIComponent(adminAddress)}`,
+      { label: "admin account" },
+    );
+
+    const matching = accountJettons.balances?.find((item) =>
+      item.jetton?.address?.toLowerCase() === token.address.toLowerCase()
+    );
+
+    printHeader("Admin wallet");
+    printList([
+      ["Address", adminAddress],
+      ["Domain", jettonSummary.admin?.name ?? "(none)"],
+      [
+        "TON balance",
+        accountSummary.balance !== undefined
+          ? `${formatTonAmount(BigInt(accountSummary.balance))} TON`
+          : "unknown",
+      ],
+      ["Jetton wallet", matching?.wallet_address?.address ?? "unknown"],
+      [
+        "Jetton balance",
+        matching?.balance
+          ? `${
+            formatJettonAmount(BigInt(matching.balance), token.decimals)
+          } ${token.symbol}`
+          : "0",
+      ],
+    ]);
+
+    if (holderCount > 0 && totalSupplyRaw > BigInt(0)) {
+      const adminBalance = matching?.balance
+        ? BigInt(matching.balance)
+        : BigInt(0);
+      const adminShare = Number(adminBalance) / Number(totalSupplyRaw);
+      if (Number.isFinite(adminShare)) {
+        console.log(
+          `Admin controls ${formatPercent(adminShare)} of the reported supply.`,
+        );
+      }
+    }
+  }
+
+  const dexStatuses = await checkDexPresence(token.address);
+  printHeader("DEX listings");
+  for (const entry of dexStatuses) {
+    if (entry.status === "listed") {
+      console.log(`${entry.venue}: listed (HTTP ${entry.httpStatus})`);
+    } else if (entry.status === "not_listed") {
+      console.log(`${entry.venue}: not listed (HTTP ${entry.httpStatus})`);
+    } else {
+      console.log(`${entry.venue}: error — ${entry.message}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(`Snapshot generation failed: ${(error as Error).message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a reusable `scripts/ton/dct-snapshot.ts` helper that queries tonapi and dex endpoints via curl for reliable on-chain verification
- refresh the `_static/ton/dct-jetton/README.md` snapshot with the live tonapi supply/holder data and reproduction steps

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0e577220483229c368739a29a01ff