### PR TITLE
Add closeGenesis payload helper script and documentation

### DIFF
--- a/docs/onchain/close-genesis.md
+++ b/docs/onchain/close-genesis.md
@@ -1,0 +1,61 @@
+# Closing the DCT Jetton Genesis Window
+
+Once the 100 million DCT genesis allocation is minted, the jetton master must
+receive the `closeGenesis` message so that any further mint attempts are
+permanently rejected. This runbook explains how to craft and deliver that
+message from the admin wallet.
+
+## Preconditions
+
+- The full genesis allocation has been minted and reconciled against the
+  distribution schedule.
+- You can sign transactions from the multisig (or custodial wallet) configured
+  as the jetton master `admin`.
+- The jetton master address is confirmed from the deployment dossier (see
+  [`docs/onchain/jetton-minter.md`](./jetton-minter.md)).
+
+## Generate the payload
+
+Use the helper script to build the opcode payload required by the contract:
+
+```bash
+npx tsx scripts/ton/close-genesis.ts --deeplink EQAHMNCDJmEK8yEt1IbaJP1xl2-wd21f1Gpt_57Z1uCPPzE6
+```
+
+The command prints the `closeGenesis` message body in both base64 and hex, and
+produces a `ton://transfer/...` deep link aimed at the jetton master address.
+Share the base64 string with any custodial signer that prefers raw payloads, or
+open the deep link directly in Tonkeeper / Tonhub to prefill the transaction.
+
+- Omit `--deeplink` to generate just the base64 / hex body.
+- Pass `--query-id <number>` if you need to stamp a 64-bit query identifier for
+  multisig bookkeeping.
+- Use `--amount <tons>` or `--nanotons <value>` when the admin wallet must send
+  additional TON alongside the message (not required in normal operations).
+
+## Submit from Ton Console
+
+1. Connect to [Ton Console](https://tonconsole.com/) with the workspace that
+   manages Dynamic Capital’s jetton operations.
+2. Open **Tokens → Jetton Minter** and search for the DCT jetton master.
+3. Click **Send message** in the action bar, choose the connected admin wallet,
+   and paste the base64 payload produced above into the **Body** field. Leave
+   the TON amount at `0.0` unless instructed otherwise.
+4. Confirm the TonConnect prompt. The transaction should settle within a few
+   seconds.
+
+## Post-close verification
+
+After the transaction lands on-chain:
+
+1. Reload the jetton card in Ton Console or tonviewer to ensure the master
+   account reflects the new inbound message.
+2. Attempting another mint should now fail with `"genesis closed"`. You can
+   confirm this by running a dry-run mint inside Ton Console (do **not** submit
+   it) or by calling the master contract’s `get_jetton_data` method and checking
+   that `mintable = false`.
+3. Record the transaction hash in the operations log and update the
+   `docs/onchain/jetton-minter.md` dossier if this is part of a redeployment.
+
+With `closeGenesis` executed, all further supply changes must flow through the
+contract’s timelocked governance paths.

--- a/docs/onchain/jetton-minter.md
+++ b/docs/onchain/jetton-minter.md
@@ -40,6 +40,9 @@ balances so auditors can independently replay the queries.
 - `closeGenesis` was executed after minting the 100M genesis allocation,
   permanently disabling unrestricted minting as described in
   [`dynamic-capital-ton/contracts/README.md`](../../dynamic-capital-ton/contracts/README.md).
+  For redeployments, follow the runbook in
+  [`docs/onchain/close-genesis.md`](./close-genesis.md) to craft and submit the
+  management message once the genesis supply is minted.
 - Holder-initiated burns remain active; the Supabase `process-subscription`
   function routes burn tranches through `burnDCT` and logs the resulting
   transaction hashes for finance review (see

--- a/scripts/ton/close-genesis.ts
+++ b/scripts/ton/close-genesis.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { Buffer } from "node:buffer";
+import process from "node:process";
+import { beginCell } from "@ton/core";
+
+const HELP_MESSAGE =
+  `Usage: npx tsx scripts/ton/close-genesis.ts [options]\n\n` +
+  "Build the payload required to invoke closeGenesis on the DCT jetton master.\n" +
+  "The script prints base64/hex encodings and an optional ton://transfer deep link.\n\n" +
+  "Options:\n" +
+  "  --query-id <id>     Optional 64-bit query id to include (defaults to 0).\n" +
+  "  --deeplink <addr>   Generate a ton://transfer deep link targeting <addr>.\n" +
+  "  --amount <tons>     Attach TON value (in whole TON) when building the deep link.\n" +
+  "                      Defaults to 0 TON. Ignored without --deeplink.\n" +
+  "  --nanotons <value>  Attach TON value expressed in nanotons for the deep link.\n" +
+  "                      Overrides --amount when provided.\n" +
+  "  --help              Show this message.\n";
+
+const OP_CLOSE_GENESIS = 0x44435401;
+
+interface CliOptions {
+  queryId: bigint;
+  deepLinkAddress: string | null;
+  amountNano: bigint;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions | null {
+  const options: CliOptions = {
+    queryId: 0n,
+    deepLinkAddress: null,
+    amountNano: 0n,
+  };
+
+  const args = [...argv];
+  while (args.length > 0) {
+    const flag = args.shift();
+    if (!flag) continue;
+
+    switch (flag) {
+      case "--help":
+        return null;
+      case "--query-id": {
+        const value = args.shift();
+        if (!value) {
+          throw new Error("--query-id flag requires a numeric value");
+        }
+        const parsed = BigInt(value);
+        if (parsed < 0n || parsed > 0xffffffffffffffffn) {
+          throw new Error("--query-id must fit within 64 bits");
+        }
+        options.queryId = parsed;
+        break;
+      }
+      case "--deeplink": {
+        const value = args.shift();
+        if (!value) {
+          throw new Error("--deeplink flag requires an address value");
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+          throw new Error("Deep link address must not be empty");
+        }
+        options.deepLinkAddress = trimmed.replace(/^ton:\/\//i, "");
+        break;
+      }
+      case "--amount": {
+        const value = args.shift();
+        if (!value) {
+          throw new Error("--amount flag requires a TON value");
+        }
+        const tons = Number.parseFloat(value);
+        if (!Number.isFinite(tons) || tons < 0) {
+          throw new Error("--amount must be a non-negative number");
+        }
+        const nanotons = BigInt(Math.round(tons * 1_000_000_000));
+        options.amountNano = nanotons;
+        break;
+      }
+      case "--nanotons": {
+        const value = args.shift();
+        if (!value) {
+          throw new Error("--nanotons flag requires an integer value");
+        }
+        const nanotons = BigInt(value);
+        if (nanotons < 0n) {
+          throw new Error("--nanotons must be non-negative");
+        }
+        options.amountNano = nanotons;
+        break;
+      }
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+function buildPayload(queryId: bigint) {
+  const cellBuilder = beginCell()
+    .storeUint(OP_CLOSE_GENESIS, 32)
+    .storeUint(queryId, 64);
+  const cell = cellBuilder.endCell();
+  const boc = cell.toBoc();
+  const base64 = Buffer.from(boc).toString("base64");
+  const hex = Buffer.from(boc).toString("hex");
+  return { base64, hex };
+}
+
+function toUrlSafeBase64(value: string): string {
+  return value.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function formatDeepLink(
+  address: string,
+  payloadBase64: string,
+  amountNano: bigint,
+): string {
+  const params = new URLSearchParams();
+  if (amountNano > 0n) {
+    params.set("amount", amountNano.toString());
+  }
+  params.set("bin", toUrlSafeBase64(payloadBase64));
+  return `ton://transfer/${address}?${params.toString()}`;
+}
+
+async function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (!options) {
+      console.log(HELP_MESSAGE);
+      return;
+    }
+
+    const payload = buildPayload(options.queryId);
+    console.log("closeGenesis payload (base64):", payload.base64);
+    console.log("closeGenesis payload (hex):   ", payload.hex);
+
+    if (options.deepLinkAddress) {
+      const link = formatDeepLink(
+        options.deepLinkAddress,
+        payload.base64,
+        options.amountNano,
+      );
+      console.log("ton://transfer deep link:   ", link);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[close-genesis] ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a `scripts/ton/close-genesis.ts` helper that builds the closeGenesis payload and optional ton://transfer link
- document the close-genesis procedure for the DCT jetton and link it from the on-chain dossier

## Testing
- npx tsx scripts/ton/close-genesis.ts --query-id 42 --deeplink EQAHMNCDJmEK8yEt1IbaJP1xl2-wd21f1Gpt_57Z1uCPPzE6 --amount 0.2


------
https://chatgpt.com/codex/tasks/task_e_68e0f3f26a7483228e98b0f3a9b4f39e