### PR TITLE
Add benchmark for DynamicTradingAlgo paper simulation

### DIFF
--- a/benchmarks/dynamic_trading_algo_benchmark.py
+++ b/benchmarks/dynamic_trading_algo_benchmark.py
@@ -1,0 +1,291 @@
+"""Benchmark the DynamicTradingAlgo over a synthetic three-month window.
+
+This script exercises :class:`dynamic.trading.algo.trading_core.DynamicTradingAlgo`
+using its paper-trading fallback connector.  For every instrument supported by
+the algorithm we simulate a deterministic stream of trades covering the last
+three months of daily sessions.  The resulting benchmark captures day-level
+history together with aggregate profit and loss statistics (largest win/loss,
+win rate, etc.).
+
+The paper broker inside the trading algorithm relies on Python's global
+``random`` module.  To keep the benchmark reproducible we derive a
+cryptographic seed for every simulated trade, temporarily seed ``random`` with
+that value, execute the trade, and then restore the previous RNG state.
+
+Run the module directly to materialise ``benchmarks/results/dynamic-trading-
+algo-benchmark.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Iterable, Iterator, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:  # pragma: no cover - import side-effect
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+from dynamic.trading.algo.trading_core import (
+    ORDER_ACTION_BUY,
+    ORDER_ACTION_SELL,
+    DynamicTradingAlgo,
+)
+
+
+DEFAULT_HISTORY_DAYS = 90
+DEFAULT_TRADES_PER_DAY = 1
+DEFAULT_LOT_SIZE = 1.0
+DEFAULT_OUTPUT_PATH = Path(__file__).resolve().parent / "results" / "dynamic-trading-algo-benchmark.json"
+
+
+@dataclass(slots=True)
+class TradeRecord:
+    """Summary of an executed trade within the benchmark."""
+
+    symbol: str
+    session_date: date
+    action: str
+    profit: float
+    lot: float | None
+    price: float | None
+    retcode: int
+
+
+def _deterministic_seed(symbol: str, session_date: date, trade_index: int) -> int:
+    """Return a deterministic RNG seed for the trade key."""
+
+    payload = f"{symbol}:{session_date.isoformat()}:{trade_index}".encode("utf-8")
+    digest = hashlib.sha256(payload).digest()
+    return int.from_bytes(digest[:8], "big", signed=False)
+
+
+def _simulate_trade(
+    algo: DynamicTradingAlgo,
+    *,
+    symbol: str,
+    session_date: date,
+    trade_index: int,
+    lot: float,
+) -> TradeRecord:
+    """Execute a deterministic paper trade via ``algo``."""
+
+    seed = _deterministic_seed(symbol, session_date, trade_index)
+    previous_state = random.getstate()
+    try:
+        random.seed(seed)
+        action = ORDER_ACTION_BUY if random.random() >= 0.5 else ORDER_ACTION_SELL
+        result = algo.execute_trade({"action": action}, lot=lot, symbol=symbol)
+    finally:
+        random.setstate(previous_state)
+
+    return TradeRecord(
+        symbol=symbol,
+        session_date=session_date,
+        action=action,
+        profit=round(result.profit, 2),
+        lot=result.lot,
+        price=result.price,
+        retcode=result.retcode,
+    )
+
+
+def _daterange(end_date: date, days: int) -> Iterator[date]:
+    for offset in range(days - 1, -1, -1):
+        yield end_date - timedelta(days=offset)
+
+
+def _summarise_trades(trades: Iterable[TradeRecord]) -> Mapping[str, float | int]:
+    profits = [trade.profit for trade in trades]
+    if not profits:
+        return {
+            "total_trades": 0,
+            "total_profit": 0.0,
+            "gross_profit": 0.0,
+            "gross_loss": 0.0,
+            "win_rate": 0.0,
+            "largest_win": 0.0,
+            "largest_loss": 0.0,
+            "average_win": 0.0,
+            "average_loss": 0.0,
+            "profit_factor": None,
+        }
+
+    wins = [value for value in profits if value > 0]
+    losses = [value for value in profits if value < 0]
+
+    total_profit = round(sum(profits), 2)
+    gross_profit = round(sum(wins), 2)
+    gross_loss = round(sum(losses), 2)
+    win_rate = len(wins) / len(profits) if profits else 0.0
+    profit_factor = None
+    if gross_loss:
+        profit_factor = round(abs(gross_profit / gross_loss), 3)
+
+    average_win = round(mean(wins), 2) if wins else 0.0
+    average_loss = round(mean(losses), 2) if losses else 0.0
+
+    return {
+        "total_trades": len(profits),
+        "total_profit": total_profit,
+        "gross_profit": gross_profit,
+        "gross_loss": gross_loss,
+        "win_rate": round(win_rate, 3),
+        "largest_win": round(max(profits), 2),
+        "largest_loss": round(min(profits), 2),
+        "average_win": average_win,
+        "average_loss": average_loss,
+        "profit_factor": profit_factor,
+    }
+
+
+def run_benchmark(
+    *,
+    days: int = DEFAULT_HISTORY_DAYS,
+    trades_per_day: int = DEFAULT_TRADES_PER_DAY,
+    lot_size: float = DEFAULT_LOT_SIZE,
+) -> Mapping[str, object]:
+    """Run the benchmark and return the structured report."""
+
+    if days <= 0:
+        raise ValueError("days must be positive")
+    if trades_per_day <= 0:
+        raise ValueError("trades_per_day must be positive")
+    if lot_size <= 0:
+        raise ValueError("lot_size must be positive")
+
+    algo = DynamicTradingAlgo()
+    today = datetime.now(timezone.utc).date()
+    start_date = today - timedelta(days=days - 1)
+
+    symbols = sorted(algo.instrument_profiles)
+    symbol_payloads: dict[str, object] = {}
+    portfolio_trades: list[TradeRecord] = []
+
+    for symbol in symbols:
+        instrument_trades: list[TradeRecord] = []
+        daily_history: list[dict[str, object]] = []
+        cumulative_profit = 0.0
+
+        for session_date in _daterange(today, days):
+            day_records: list[TradeRecord] = []
+            for trade_index in range(trades_per_day):
+                record = _simulate_trade(
+                    algo,
+                    symbol=symbol,
+                    session_date=session_date,
+                    trade_index=trade_index,
+                    lot=lot_size,
+                )
+                instrument_trades.append(record)
+                day_records.append(record)
+                portfolio_trades.append(record)
+
+            day_profit = round(sum(item.profit for item in day_records), 2)
+            cumulative_profit = round(cumulative_profit + day_profit, 2)
+            largest_win = round(max(item.profit for item in day_records), 2)
+            largest_loss = round(min(item.profit for item in day_records), 2)
+            daily_history.append(
+                {
+                    "date": session_date.isoformat(),
+                    "profit": day_profit,
+                    "cumulative_profit": cumulative_profit,
+                    "trades": len(day_records),
+                    "wins": sum(1 for item in day_records if item.profit > 0),
+                    "losses": sum(1 for item in day_records if item.profit < 0),
+                    "largest_win": largest_win,
+                    "largest_loss": largest_loss,
+                }
+            )
+
+        summary = _summarise_trades(instrument_trades)
+        best_trade = max(instrument_trades, key=lambda item: item.profit)
+        worst_trade = min(instrument_trades, key=lambda item: item.profit)
+
+        symbol_payloads[symbol] = {
+            "summary": summary,
+            "history": daily_history,
+            "largest_win": {
+                "profit": best_trade.profit,
+                "date": best_trade.session_date.isoformat(),
+                "action": best_trade.action,
+            },
+            "largest_loss": {
+                "profit": worst_trade.profit,
+                "date": worst_trade.session_date.isoformat(),
+                "action": worst_trade.action,
+            },
+        }
+
+    portfolio_summary = _summarise_trades(portfolio_trades)
+    best_portfolio_trade = max(portfolio_trades, key=lambda item: item.profit)
+    worst_portfolio_trade = min(portfolio_trades, key=lambda item: item.profit)
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "start_date": start_date.isoformat(),
+        "end_date": today.isoformat(),
+        "history_days": days,
+        "trades_per_day": trades_per_day,
+        "lot_size": lot_size,
+        "symbols": symbol_payloads,
+        "portfolio": {
+            "summary": portfolio_summary,
+            "largest_win": {
+                "symbol": best_portfolio_trade.symbol,
+                "profit": best_portfolio_trade.profit,
+                "date": best_portfolio_trade.session_date.isoformat(),
+                "action": best_portfolio_trade.action,
+            },
+            "largest_loss": {
+                "symbol": worst_portfolio_trade.symbol,
+                "profit": worst_portfolio_trade.profit,
+                "date": worst_portfolio_trade.session_date.isoformat(),
+                "action": worst_portfolio_trade.action,
+            },
+        },
+    }
+
+    return report
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark DynamicTradingAlgo over a rolling history window")
+    parser.add_argument("--days", type=int, default=DEFAULT_HISTORY_DAYS, help="Number of calendar days to benchmark")
+    parser.add_argument(
+        "--trades-per-day",
+        type=int,
+        default=DEFAULT_TRADES_PER_DAY,
+        help="Number of simulated trades per instrument each day",
+    )
+    parser.add_argument("--lot", type=float, default=DEFAULT_LOT_SIZE, help="Baseline lot size for simulated trades")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Destination file for the benchmark report",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = run_benchmark(days=args.days, trades_per_day=args.trades_per_day, lot_size=args.lot)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/benchmarks/results/dynamic-trading-algo-benchmark.json
+++ b/benchmarks/results/dynamic-trading-algo-benchmark.json
@@ -1,0 +1,13926 @@
+{
+  "generated_at": "2025-10-04T11:45:41.389447+00:00",
+  "start_date": "2025-07-07",
+  "end_date": "2025-10-04",
+  "history_days": 90,
+  "trades_per_day": 1,
+  "lot_size": 1.0,
+  "symbols": {
+    "AUDUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 2152.49,
+        "gross_profit": 10411.63,
+        "gross_loss": -8259.14,
+        "win_rate": 0.544,
+        "largest_win": 437.38,
+        "largest_loss": -445.45,
+        "average_win": 212.48,
+        "average_loss": -201.44,
+        "profit_factor": 1.261
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 410.04,
+          "cumulative_profit": 410.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 410.04,
+          "largest_loss": 410.04
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -412.86,
+          "cumulative_profit": -2.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -412.86,
+          "largest_loss": -412.86
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 310.62,
+          "cumulative_profit": 307.8,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 310.62,
+          "largest_loss": 310.62
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -239.87,
+          "cumulative_profit": 67.93,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -239.87,
+          "largest_loss": -239.87
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -67.11,
+          "cumulative_profit": 0.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -67.11,
+          "largest_loss": -67.11
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -205.91,
+          "cumulative_profit": -205.09,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -205.91,
+          "largest_loss": -205.91
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 99.39,
+          "cumulative_profit": -105.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 99.39,
+          "largest_loss": 99.39
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 69.64,
+          "cumulative_profit": -36.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 69.64,
+          "largest_loss": 69.64
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 315.5,
+          "cumulative_profit": 279.44,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 315.5,
+          "largest_loss": 315.5
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 199.79,
+          "cumulative_profit": 479.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 199.79,
+          "largest_loss": 199.79
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 142.52,
+          "cumulative_profit": 621.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 142.52,
+          "largest_loss": 142.52
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 13.11,
+          "cumulative_profit": 634.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 13.11,
+          "largest_loss": 13.11
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 178.03,
+          "cumulative_profit": 812.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 178.03,
+          "largest_loss": 178.03
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 405.96,
+          "cumulative_profit": 1218.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 405.96,
+          "largest_loss": 405.96
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -58.44,
+          "cumulative_profit": 1160.41,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -58.44,
+          "largest_loss": -58.44
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 231.72,
+          "cumulative_profit": 1392.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 231.72,
+          "largest_loss": 231.72
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -237.55,
+          "cumulative_profit": 1154.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -237.55,
+          "largest_loss": -237.55
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 122.68,
+          "cumulative_profit": 1277.26,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 122.68,
+          "largest_loss": 122.68
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 107.49,
+          "cumulative_profit": 1384.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 107.49,
+          "largest_loss": 107.49
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -57.22,
+          "cumulative_profit": 1327.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -57.22,
+          "largest_loss": -57.22
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -276.66,
+          "cumulative_profit": 1050.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -276.66,
+          "largest_loss": -276.66
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 199.79,
+          "cumulative_profit": 1250.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 199.79,
+          "largest_loss": 199.79
+        },
+        {
+          "date": "2025-07-29",
+          "profit": -5.1,
+          "cumulative_profit": 1245.56,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -5.1,
+          "largest_loss": -5.1
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -70.79,
+          "cumulative_profit": 1174.77,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -70.79,
+          "largest_loss": -70.79
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 257.79,
+          "cumulative_profit": 1432.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 257.79,
+          "largest_loss": 257.79
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -405.76,
+          "cumulative_profit": 1026.8,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -405.76,
+          "largest_loss": -405.76
+        },
+        {
+          "date": "2025-08-02",
+          "profit": -328.51,
+          "cumulative_profit": 698.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -328.51,
+          "largest_loss": -328.51
+        },
+        {
+          "date": "2025-08-03",
+          "profit": -186.66,
+          "cumulative_profit": 511.63,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -186.66,
+          "largest_loss": -186.66
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -97.05,
+          "cumulative_profit": 414.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -97.05,
+          "largest_loss": -97.05
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -149.53,
+          "cumulative_profit": 265.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -149.53,
+          "largest_loss": -149.53
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -224.21,
+          "cumulative_profit": 40.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -224.21,
+          "largest_loss": -224.21
+        },
+        {
+          "date": "2025-08-07",
+          "profit": 105.28,
+          "cumulative_profit": 146.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 105.28,
+          "largest_loss": 105.28
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 161.0,
+          "cumulative_profit": 307.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 161.0,
+          "largest_loss": 161.0
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -51.51,
+          "cumulative_profit": 255.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -51.51,
+          "largest_loss": -51.51
+        },
+        {
+          "date": "2025-08-10",
+          "profit": 368.92,
+          "cumulative_profit": 624.53,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 368.92,
+          "largest_loss": 368.92
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -54.06,
+          "cumulative_profit": 570.47,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -54.06,
+          "largest_loss": -54.06
+        },
+        {
+          "date": "2025-08-12",
+          "profit": -395.69,
+          "cumulative_profit": 174.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -395.69,
+          "largest_loss": -395.69
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -65.88,
+          "cumulative_profit": 108.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -65.88,
+          "largest_loss": -65.88
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 422.19,
+          "cumulative_profit": 531.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 422.19,
+          "largest_loss": 422.19
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 315.73,
+          "cumulative_profit": 846.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 315.73,
+          "largest_loss": 315.73
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 220.07,
+          "cumulative_profit": 1066.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 220.07,
+          "largest_loss": 220.07
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 88.83,
+          "cumulative_profit": 1155.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 88.83,
+          "largest_loss": 88.83
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 95.61,
+          "cumulative_profit": 1251.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 95.61,
+          "largest_loss": 95.61
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 259.81,
+          "cumulative_profit": 1511.14,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 259.81,
+          "largest_loss": 259.81
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -235.48,
+          "cumulative_profit": 1275.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -235.48,
+          "largest_loss": -235.48
+        },
+        {
+          "date": "2025-08-21",
+          "profit": -127.76,
+          "cumulative_profit": 1147.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -127.76,
+          "largest_loss": -127.76
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 194.83,
+          "cumulative_profit": 1342.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 194.83,
+          "largest_loss": 194.83
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 185.91,
+          "cumulative_profit": 1528.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 185.91,
+          "largest_loss": 185.91
+        },
+        {
+          "date": "2025-08-24",
+          "profit": 437.38,
+          "cumulative_profit": 1966.02,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 437.38,
+          "largest_loss": 437.38
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 128.72,
+          "cumulative_profit": 2094.74,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 128.72,
+          "largest_loss": 128.72
+        },
+        {
+          "date": "2025-08-26",
+          "profit": -51.8,
+          "cumulative_profit": 2042.94,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -51.8,
+          "largest_loss": -51.8
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -222.78,
+          "cumulative_profit": 1820.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -222.78,
+          "largest_loss": -222.78
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -100.37,
+          "cumulative_profit": 1719.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -100.37,
+          "largest_loss": -100.37
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 89.17,
+          "cumulative_profit": 1808.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 89.17,
+          "largest_loss": 89.17
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 105.47,
+          "cumulative_profit": 1914.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 105.47,
+          "largest_loss": 105.47
+        },
+        {
+          "date": "2025-08-31",
+          "profit": 289.56,
+          "cumulative_profit": 2203.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 289.56,
+          "largest_loss": 289.56
+        },
+        {
+          "date": "2025-09-01",
+          "profit": 406.14,
+          "cumulative_profit": 2610.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 406.14,
+          "largest_loss": 406.14
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 44.36,
+          "cumulative_profit": 2654.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 44.36,
+          "largest_loss": 44.36
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -445.45,
+          "cumulative_profit": 2209.04,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -445.45,
+          "largest_loss": -445.45
+        },
+        {
+          "date": "2025-09-04",
+          "profit": -426.38,
+          "cumulative_profit": 1782.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -426.38,
+          "largest_loss": -426.38
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 360.97,
+          "cumulative_profit": 2143.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 360.97,
+          "largest_loss": 360.97
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 310.62,
+          "cumulative_profit": 2454.25,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 310.62,
+          "largest_loss": 310.62
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 270.43,
+          "cumulative_profit": 2724.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 270.43,
+          "largest_loss": 270.43
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -59.8,
+          "cumulative_profit": 2664.88,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -59.8,
+          "largest_loss": -59.8
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -82.96,
+          "cumulative_profit": 2581.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -82.96,
+          "largest_loss": -82.96
+        },
+        {
+          "date": "2025-09-10",
+          "profit": -169.98,
+          "cumulative_profit": 2411.94,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -169.98,
+          "largest_loss": -169.98
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 102.69,
+          "cumulative_profit": 2514.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 102.69,
+          "largest_loss": 102.69
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 117.44,
+          "cumulative_profit": 2632.07,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 117.44,
+          "largest_loss": 117.44
+        },
+        {
+          "date": "2025-09-13",
+          "profit": 145.87,
+          "cumulative_profit": 2777.94,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 145.87,
+          "largest_loss": 145.87
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 152.3,
+          "cumulative_profit": 2930.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 152.3,
+          "largest_loss": 152.3
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 277.49,
+          "cumulative_profit": 3207.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 277.49,
+          "largest_loss": 277.49
+        },
+        {
+          "date": "2025-09-16",
+          "profit": -299.74,
+          "cumulative_profit": 2907.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -299.74,
+          "largest_loss": -299.74
+        },
+        {
+          "date": "2025-09-17",
+          "profit": 333.41,
+          "cumulative_profit": 3241.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 333.41,
+          "largest_loss": 333.41
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -177.75,
+          "cumulative_profit": 3063.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -177.75,
+          "largest_loss": -177.75
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 326.59,
+          "cumulative_profit": 3390.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 326.59,
+          "largest_loss": 326.59
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 147.39,
+          "cumulative_profit": 3537.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 147.39,
+          "largest_loss": 147.39
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 124.21,
+          "cumulative_profit": 3661.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 124.21,
+          "largest_loss": 124.21
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -91.16,
+          "cumulative_profit": 3570.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -91.16,
+          "largest_loss": -91.16
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -253.66,
+          "cumulative_profit": 3317.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -253.66,
+          "largest_loss": -253.66
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -388.74,
+          "cumulative_profit": 2928.28,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -388.74,
+          "largest_loss": -388.74
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 405.8,
+          "cumulative_profit": 3334.08,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 405.8,
+          "largest_loss": 405.8
+        },
+        {
+          "date": "2025-09-26",
+          "profit": -209.64,
+          "cumulative_profit": 3124.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -209.64,
+          "largest_loss": -209.64
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -145.86,
+          "cumulative_profit": 2978.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -145.86,
+          "largest_loss": -145.86
+        },
+        {
+          "date": "2025-09-28",
+          "profit": -324.53,
+          "cumulative_profit": 2654.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -324.53,
+          "largest_loss": -324.53
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -364.45,
+          "cumulative_profit": 2289.6,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -364.45,
+          "largest_loss": -364.45
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 198.92,
+          "cumulative_profit": 2488.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 198.92,
+          "largest_loss": 198.92
+        },
+        {
+          "date": "2025-10-01",
+          "profit": 55.3,
+          "cumulative_profit": 2543.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 55.3,
+          "largest_loss": 55.3
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -155.71,
+          "cumulative_profit": 2388.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -155.71,
+          "largest_loss": -155.71
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 99.15,
+          "cumulative_profit": 2487.26,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 99.15,
+          "largest_loss": 99.15
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -334.77,
+          "cumulative_profit": 2152.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -334.77,
+          "largest_loss": -334.77
+        }
+      ],
+      "largest_win": {
+        "profit": 437.38,
+        "date": "2025-08-24",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -445.45,
+        "date": "2025-09-03",
+        "action": "BUY"
+      }
+    },
+    "BNBUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 2536.16,
+        "gross_profit": 10252.15,
+        "gross_loss": -7715.99,
+        "win_rate": 0.533,
+        "largest_win": 349.93,
+        "largest_loss": -357.52,
+        "average_win": 213.59,
+        "average_loss": -183.71,
+        "profit_factor": 1.329
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 10.82,
+          "cumulative_profit": 10.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 10.82,
+          "largest_loss": 10.82
+        },
+        {
+          "date": "2025-07-08",
+          "profit": 140.74,
+          "cumulative_profit": 151.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 140.74,
+          "largest_loss": 140.74
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -117.49,
+          "cumulative_profit": 34.07,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -117.49,
+          "largest_loss": -117.49
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -337.16,
+          "cumulative_profit": -303.09,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -337.16,
+          "largest_loss": -337.16
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 166.52,
+          "cumulative_profit": -136.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 166.52,
+          "largest_loss": 166.52
+        },
+        {
+          "date": "2025-07-12",
+          "profit": 300.96,
+          "cumulative_profit": 164.39,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 300.96,
+          "largest_loss": 300.96
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 310.1,
+          "cumulative_profit": 474.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 310.1,
+          "largest_loss": 310.1
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -303.21,
+          "cumulative_profit": 171.28,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -303.21,
+          "largest_loss": -303.21
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 236.14,
+          "cumulative_profit": 407.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 236.14,
+          "largest_loss": 236.14
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 247.73,
+          "cumulative_profit": 655.15,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 247.73,
+          "largest_loss": 247.73
+        },
+        {
+          "date": "2025-07-17",
+          "profit": -191.1,
+          "cumulative_profit": 464.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -191.1,
+          "largest_loss": -191.1
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 149.11,
+          "cumulative_profit": 613.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 149.11,
+          "largest_loss": 149.11
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 349.93,
+          "cumulative_profit": 963.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 349.93,
+          "largest_loss": 349.93
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 216.7,
+          "cumulative_profit": 1179.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 216.7,
+          "largest_loss": 216.7
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 109.89,
+          "cumulative_profit": 1289.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 109.89,
+          "largest_loss": 109.89
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 139.03,
+          "cumulative_profit": 1428.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 139.03,
+          "largest_loss": 139.03
+        },
+        {
+          "date": "2025-07-23",
+          "profit": 130.07,
+          "cumulative_profit": 1558.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 130.07,
+          "largest_loss": 130.07
+        },
+        {
+          "date": "2025-07-24",
+          "profit": -128.33,
+          "cumulative_profit": 1430.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -128.33,
+          "largest_loss": -128.33
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 92.54,
+          "cumulative_profit": 1522.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 92.54,
+          "largest_loss": 92.54
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -300.5,
+          "cumulative_profit": 1222.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -300.5,
+          "largest_loss": -300.5
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -312.2,
+          "cumulative_profit": 910.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -312.2,
+          "largest_loss": -312.2
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 298.34,
+          "cumulative_profit": 1208.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 298.34,
+          "largest_loss": 298.34
+        },
+        {
+          "date": "2025-07-29",
+          "profit": -148.75,
+          "cumulative_profit": 1059.88,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -148.75,
+          "largest_loss": -148.75
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -245.63,
+          "cumulative_profit": 814.25,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -245.63,
+          "largest_loss": -245.63
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 120.35,
+          "cumulative_profit": 934.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 120.35,
+          "largest_loss": 120.35
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 310.39,
+          "cumulative_profit": 1244.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 310.39,
+          "largest_loss": 310.39
+        },
+        {
+          "date": "2025-08-02",
+          "profit": -206.2,
+          "cumulative_profit": 1038.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -206.2,
+          "largest_loss": -206.2
+        },
+        {
+          "date": "2025-08-03",
+          "profit": -302.57,
+          "cumulative_profit": 736.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -302.57,
+          "largest_loss": -302.57
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -85.85,
+          "cumulative_profit": 650.37,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -85.85,
+          "largest_loss": -85.85
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 117.89,
+          "cumulative_profit": 768.26,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 117.89,
+          "largest_loss": 117.89
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 69.8,
+          "cumulative_profit": 838.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 69.8,
+          "largest_loss": 69.8
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -309.68,
+          "cumulative_profit": 528.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -309.68,
+          "largest_loss": -309.68
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -224.39,
+          "cumulative_profit": 303.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -224.39,
+          "largest_loss": -224.39
+        },
+        {
+          "date": "2025-08-09",
+          "profit": 241.81,
+          "cumulative_profit": 545.8,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 241.81,
+          "largest_loss": 241.81
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -102.96,
+          "cumulative_profit": 442.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -102.96,
+          "largest_loss": -102.96
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 61.63,
+          "cumulative_profit": 504.47,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 61.63,
+          "largest_loss": 61.63
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 69.74,
+          "cumulative_profit": 574.21,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 69.74,
+          "largest_loss": 69.74
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -48.69,
+          "cumulative_profit": 525.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -48.69,
+          "largest_loss": -48.69
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -278.28,
+          "cumulative_profit": 247.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -278.28,
+          "largest_loss": -278.28
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 226.35,
+          "cumulative_profit": 473.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 226.35,
+          "largest_loss": 226.35
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 85.68,
+          "cumulative_profit": 559.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 85.68,
+          "largest_loss": 85.68
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 344.49,
+          "cumulative_profit": 903.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 344.49,
+          "largest_loss": 344.49
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 340.96,
+          "cumulative_profit": 1244.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 340.96,
+          "largest_loss": 340.96
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 324.15,
+          "cumulative_profit": 1568.87,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 324.15,
+          "largest_loss": 324.15
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -105.55,
+          "cumulative_profit": 1463.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -105.55,
+          "largest_loss": -105.55
+        },
+        {
+          "date": "2025-08-21",
+          "profit": -229.72,
+          "cumulative_profit": 1233.6,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -229.72,
+          "largest_loss": -229.72
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 299.53,
+          "cumulative_profit": 1533.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 299.53,
+          "largest_loss": 299.53
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 271.47,
+          "cumulative_profit": 1804.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 271.47,
+          "largest_loss": 271.47
+        },
+        {
+          "date": "2025-08-24",
+          "profit": 207.97,
+          "cumulative_profit": 2012.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 207.97,
+          "largest_loss": 207.97
+        },
+        {
+          "date": "2025-08-25",
+          "profit": -345.36,
+          "cumulative_profit": 1667.21,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -345.36,
+          "largest_loss": -345.36
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 336.98,
+          "cumulative_profit": 2004.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 336.98,
+          "largest_loss": 336.98
+        },
+        {
+          "date": "2025-08-27",
+          "profit": 313.86,
+          "cumulative_profit": 2318.05,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 313.86,
+          "largest_loss": 313.86
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -357.52,
+          "cumulative_profit": 1960.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -357.52,
+          "largest_loss": -357.52
+        },
+        {
+          "date": "2025-08-29",
+          "profit": -147.08,
+          "cumulative_profit": 1813.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -147.08,
+          "largest_loss": -147.08
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -217.35,
+          "cumulative_profit": 1596.1,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -217.35,
+          "largest_loss": -217.35
+        },
+        {
+          "date": "2025-08-31",
+          "profit": 249.19,
+          "cumulative_profit": 1845.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 249.19,
+          "largest_loss": 249.19
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -241.34,
+          "cumulative_profit": 1603.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -241.34,
+          "largest_loss": -241.34
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -188.38,
+          "cumulative_profit": 1415.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -188.38,
+          "largest_loss": -188.38
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 186.49,
+          "cumulative_profit": 1602.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 186.49,
+          "largest_loss": 186.49
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 320.18,
+          "cumulative_profit": 1922.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 320.18,
+          "largest_loss": 320.18
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 195.87,
+          "cumulative_profit": 2118.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 195.87,
+          "largest_loss": 195.87
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 307.57,
+          "cumulative_profit": 2425.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 307.57,
+          "largest_loss": 307.57
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -270.44,
+          "cumulative_profit": 2155.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -270.44,
+          "largest_loss": -270.44
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 256.35,
+          "cumulative_profit": 2411.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 256.35,
+          "largest_loss": 256.35
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -120.55,
+          "cumulative_profit": 2291.04,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -120.55,
+          "largest_loss": -120.55
+        },
+        {
+          "date": "2025-09-10",
+          "profit": -196.42,
+          "cumulative_profit": 2094.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -196.42,
+          "largest_loss": -196.42
+        },
+        {
+          "date": "2025-09-11",
+          "profit": -144.39,
+          "cumulative_profit": 1950.23,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -144.39,
+          "largest_loss": -144.39
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 157.08,
+          "cumulative_profit": 2107.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 157.08,
+          "largest_loss": 157.08
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -26.62,
+          "cumulative_profit": 2080.69,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -26.62,
+          "largest_loss": -26.62
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 189.03,
+          "cumulative_profit": 2269.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 189.03,
+          "largest_loss": 189.03
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 302.21,
+          "cumulative_profit": 2571.93,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 302.21,
+          "largest_loss": 302.21
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 66.42,
+          "cumulative_profit": 2638.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 66.42,
+          "largest_loss": 66.42
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -315.14,
+          "cumulative_profit": 2323.21,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -315.14,
+          "largest_loss": -315.14
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -81.02,
+          "cumulative_profit": 2242.19,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -81.02,
+          "largest_loss": -81.02
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 198.86,
+          "cumulative_profit": 2441.05,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 198.86,
+          "largest_loss": 198.86
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 291.57,
+          "cumulative_profit": 2732.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 291.57,
+          "largest_loss": 291.57
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -113.25,
+          "cumulative_profit": 2619.37,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -113.25,
+          "largest_loss": -113.25
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -43.46,
+          "cumulative_profit": 2575.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -43.46,
+          "largest_loss": -43.46
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -34.1,
+          "cumulative_profit": 2541.81,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -34.1,
+          "largest_loss": -34.1
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -130.94,
+          "cumulative_profit": 2410.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -130.94,
+          "largest_loss": -130.94
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 27.48,
+          "cumulative_profit": 2438.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 27.48,
+          "largest_loss": 27.48
+        },
+        {
+          "date": "2025-09-26",
+          "profit": -178.92,
+          "cumulative_profit": 2259.43,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -178.92,
+          "largest_loss": -178.92
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 348.19,
+          "cumulative_profit": 2607.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 348.19,
+          "largest_loss": 348.19
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 254.63,
+          "cumulative_profit": 2862.25,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 254.63,
+          "largest_loss": 254.63
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -173.2,
+          "cumulative_profit": 2689.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -173.2,
+          "largest_loss": -173.2
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 259.36,
+          "cumulative_profit": 2948.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 259.36,
+          "largest_loss": 259.36
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -69.9,
+          "cumulative_profit": 2878.51,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -69.9,
+          "largest_loss": -69.9
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -208.35,
+          "cumulative_profit": 2670.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -208.35,
+          "largest_loss": -208.35
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -5.18,
+          "cumulative_profit": 2664.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -5.18,
+          "largest_loss": -5.18
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -128.82,
+          "cumulative_profit": 2536.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -128.82,
+          "largest_loss": -128.82
+        }
+      ],
+      "largest_win": {
+        "profit": 349.93,
+        "date": "2025-07-19",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -357.52,
+        "date": "2025-08-28",
+        "action": "BUY"
+      }
+    },
+    "BTCUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 436.33,
+        "gross_profit": 66704.9,
+        "gross_loss": -66268.57,
+        "win_rate": 0.522,
+        "largest_win": 2951.3,
+        "largest_loss": -2995.73,
+        "average_win": 1419.25,
+        "average_loss": -1541.13,
+        "profit_factor": 1.007
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -1931.91,
+          "cumulative_profit": -1931.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1931.91,
+          "largest_loss": -1931.91
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -443.42,
+          "cumulative_profit": -2375.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -443.42,
+          "largest_loss": -443.42
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -1782.89,
+          "cumulative_profit": -4158.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1782.89,
+          "largest_loss": -1782.89
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -2845.45,
+          "cumulative_profit": -7003.67,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2845.45,
+          "largest_loss": -2845.45
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -981.12,
+          "cumulative_profit": -7984.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -981.12,
+          "largest_loss": -981.12
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -1384.74,
+          "cumulative_profit": -9369.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1384.74,
+          "largest_loss": -1384.74
+        },
+        {
+          "date": "2025-07-13",
+          "profit": -1207.12,
+          "cumulative_profit": -10576.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1207.12,
+          "largest_loss": -1207.12
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 122.31,
+          "cumulative_profit": -10454.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 122.31,
+          "largest_loss": 122.31
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 589.76,
+          "cumulative_profit": -9864.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 589.76,
+          "largest_loss": 589.76
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -2944.78,
+          "cumulative_profit": -12809.36,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2944.78,
+          "largest_loss": -2944.78
+        },
+        {
+          "date": "2025-07-17",
+          "profit": -2013.91,
+          "cumulative_profit": -14823.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2013.91,
+          "largest_loss": -2013.91
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -1798.72,
+          "cumulative_profit": -16621.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1798.72,
+          "largest_loss": -1798.72
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 312.31,
+          "cumulative_profit": -16309.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 312.31,
+          "largest_loss": 312.31
+        },
+        {
+          "date": "2025-07-20",
+          "profit": -1026.58,
+          "cumulative_profit": -17336.26,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1026.58,
+          "largest_loss": -1026.58
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -1254.57,
+          "cumulative_profit": -18590.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1254.57,
+          "largest_loss": -1254.57
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -698.69,
+          "cumulative_profit": -19289.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -698.69,
+          "largest_loss": -698.69
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -912.27,
+          "cumulative_profit": -20201.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -912.27,
+          "largest_loss": -912.27
+        },
+        {
+          "date": "2025-07-24",
+          "profit": -1263.23,
+          "cumulative_profit": -21465.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1263.23,
+          "largest_loss": -1263.23
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 923.27,
+          "cumulative_profit": -20541.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 923.27,
+          "largest_loss": 923.27
+        },
+        {
+          "date": "2025-07-26",
+          "profit": 2004.08,
+          "cumulative_profit": -18537.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2004.08,
+          "largest_loss": 2004.08
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -2463.82,
+          "cumulative_profit": -21001.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2463.82,
+          "largest_loss": -2463.82
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 2826.95,
+          "cumulative_profit": -18174.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2826.95,
+          "largest_loss": 2826.95
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 2010.97,
+          "cumulative_profit": -16163.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2010.97,
+          "largest_loss": 2010.97
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -1173.91,
+          "cumulative_profit": -17337.48,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1173.91,
+          "largest_loss": -1173.91
+        },
+        {
+          "date": "2025-07-31",
+          "profit": -2600.42,
+          "cumulative_profit": -19937.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2600.42,
+          "largest_loss": -2600.42
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 946.38,
+          "cumulative_profit": -18991.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 946.38,
+          "largest_loss": 946.38
+        },
+        {
+          "date": "2025-08-02",
+          "profit": -357.61,
+          "cumulative_profit": -19349.13,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -357.61,
+          "largest_loss": -357.61
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 1422.3,
+          "cumulative_profit": -17926.83,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1422.3,
+          "largest_loss": 1422.3
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 487.29,
+          "cumulative_profit": -17439.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 487.29,
+          "largest_loss": 487.29
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 1910.34,
+          "cumulative_profit": -15529.2,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1910.34,
+          "largest_loss": 1910.34
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -661.82,
+          "cumulative_profit": -16191.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -661.82,
+          "largest_loss": -661.82
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -2569.03,
+          "cumulative_profit": -18760.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2569.03,
+          "largest_loss": -2569.03
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 2223.83,
+          "cumulative_profit": -16536.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2223.83,
+          "largest_loss": 2223.83
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -2606.02,
+          "cumulative_profit": -19142.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2606.02,
+          "largest_loss": -2606.02
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -319.44,
+          "cumulative_profit": -19461.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -319.44,
+          "largest_loss": -319.44
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 1117.32,
+          "cumulative_profit": -18344.36,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1117.32,
+          "largest_loss": 1117.32
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 2316.07,
+          "cumulative_profit": -16028.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2316.07,
+          "largest_loss": 2316.07
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -1904.54,
+          "cumulative_profit": -17932.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1904.54,
+          "largest_loss": -1904.54
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 2951.3,
+          "cumulative_profit": -14981.53,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2951.3,
+          "largest_loss": 2951.3
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 1570.15,
+          "cumulative_profit": -13411.38,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1570.15,
+          "largest_loss": 1570.15
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 620.26,
+          "cumulative_profit": -12791.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 620.26,
+          "largest_loss": 620.26
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 760.71,
+          "cumulative_profit": -12030.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 760.71,
+          "largest_loss": 760.71
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 807.32,
+          "cumulative_profit": -11223.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 807.32,
+          "largest_loss": 807.32
+        },
+        {
+          "date": "2025-08-19",
+          "profit": -719.08,
+          "cumulative_profit": -11942.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -719.08,
+          "largest_loss": -719.08
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 1158.63,
+          "cumulative_profit": -10783.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1158.63,
+          "largest_loss": 1158.63
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 2520.84,
+          "cumulative_profit": -8262.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2520.84,
+          "largest_loss": 2520.84
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 2881.94,
+          "cumulative_profit": -5380.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2881.94,
+          "largest_loss": 2881.94
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -930.77,
+          "cumulative_profit": -6311.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -930.77,
+          "largest_loss": -930.77
+        },
+        {
+          "date": "2025-08-24",
+          "profit": 1453.42,
+          "cumulative_profit": -4858.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1453.42,
+          "largest_loss": 1453.42
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 1281.34,
+          "cumulative_profit": -3576.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1281.34,
+          "largest_loss": 1281.34
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 2713.43,
+          "cumulative_profit": -863.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2713.43,
+          "largest_loss": 2713.43
+        },
+        {
+          "date": "2025-08-27",
+          "profit": 814.35,
+          "cumulative_profit": -48.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 814.35,
+          "largest_loss": 814.35
+        },
+        {
+          "date": "2025-08-28",
+          "profit": 751.96,
+          "cumulative_profit": 702.97,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 751.96,
+          "largest_loss": 751.96
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 513.01,
+          "cumulative_profit": 1215.98,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 513.01,
+          "largest_loss": 513.01
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 2625.36,
+          "cumulative_profit": 3841.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2625.36,
+          "largest_loss": 2625.36
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -728.11,
+          "cumulative_profit": 3113.23,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -728.11,
+          "largest_loss": -728.11
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -311.8,
+          "cumulative_profit": 2801.43,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -311.8,
+          "largest_loss": -311.8
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 2398.72,
+          "cumulative_profit": 5200.15,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2398.72,
+          "largest_loss": 2398.72
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 906.08,
+          "cumulative_profit": 6106.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 906.08,
+          "largest_loss": 906.08
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 893.59,
+          "cumulative_profit": 6999.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 893.59,
+          "largest_loss": 893.59
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -854.42,
+          "cumulative_profit": 6145.4,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -854.42,
+          "largest_loss": -854.42
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 523.17,
+          "cumulative_profit": 6668.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 523.17,
+          "largest_loss": 523.17
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -1298.26,
+          "cumulative_profit": 5370.31,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1298.26,
+          "largest_loss": -1298.26
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -2015.11,
+          "cumulative_profit": 3355.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2015.11,
+          "largest_loss": -2015.11
+        },
+        {
+          "date": "2025-09-09",
+          "profit": 489.87,
+          "cumulative_profit": 3845.07,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 489.87,
+          "largest_loss": 489.87
+        },
+        {
+          "date": "2025-09-10",
+          "profit": -2832.66,
+          "cumulative_profit": 1012.41,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2832.66,
+          "largest_loss": -2832.66
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 1790.8,
+          "cumulative_profit": 2803.21,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1790.8,
+          "largest_loss": 1790.8
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 1409.99,
+          "cumulative_profit": 4213.2,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1409.99,
+          "largest_loss": 1409.99
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -2224.74,
+          "cumulative_profit": 1988.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2224.74,
+          "largest_loss": -2224.74
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 323.33,
+          "cumulative_profit": 2311.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 323.33,
+          "largest_loss": 323.33
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 2840.15,
+          "cumulative_profit": 5151.94,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2840.15,
+          "largest_loss": 2840.15
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 2495.27,
+          "cumulative_profit": 7647.21,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2495.27,
+          "largest_loss": 2495.27
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -938.68,
+          "cumulative_profit": 6708.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -938.68,
+          "largest_loss": -938.68
+        },
+        {
+          "date": "2025-09-18",
+          "profit": 820.47,
+          "cumulative_profit": 7529.0,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 820.47,
+          "largest_loss": 820.47
+        },
+        {
+          "date": "2025-09-19",
+          "profit": -2995.73,
+          "cumulative_profit": 4533.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2995.73,
+          "largest_loss": -2995.73
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 2591.44,
+          "cumulative_profit": 7124.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2591.44,
+          "largest_loss": 2591.44
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -780.79,
+          "cumulative_profit": 6343.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -780.79,
+          "largest_loss": -780.79
+        },
+        {
+          "date": "2025-09-22",
+          "profit": 1268.9,
+          "cumulative_profit": 7612.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1268.9,
+          "largest_loss": 1268.9
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -1886.61,
+          "cumulative_profit": 5726.21,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1886.61,
+          "largest_loss": -1886.61
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -1055.2,
+          "cumulative_profit": 4671.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1055.2,
+          "largest_loss": -1055.2
+        },
+        {
+          "date": "2025-09-25",
+          "profit": -82.46,
+          "cumulative_profit": 4588.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -82.46,
+          "largest_loss": -82.46
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 1223.8,
+          "cumulative_profit": 5812.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1223.8,
+          "largest_loss": 1223.8
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 1256.28,
+          "cumulative_profit": 7068.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1256.28,
+          "largest_loss": 1256.28
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 808.61,
+          "cumulative_profit": 7877.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 808.61,
+          "largest_loss": 808.61
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -2541.21,
+          "cumulative_profit": 5336.03,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2541.21,
+          "largest_loss": -2541.21
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 1105.44,
+          "cumulative_profit": 6441.47,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1105.44,
+          "largest_loss": 1105.44
+        },
+        {
+          "date": "2025-10-01",
+          "profit": 921.79,
+          "cumulative_profit": 7363.26,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 921.79,
+          "largest_loss": 921.79
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -2989.3,
+          "cumulative_profit": 4373.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2989.3,
+          "largest_loss": -2989.3
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -1967.44,
+          "cumulative_profit": 2406.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1967.44,
+          "largest_loss": -1967.44
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -1970.19,
+          "cumulative_profit": 436.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1970.19,
+          "largest_loss": -1970.19
+        }
+      ],
+      "largest_win": {
+        "profit": 2951.3,
+        "date": "2025-08-14",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -2995.73,
+        "date": "2025-09-19",
+        "action": "BUY"
+      }
+    },
+    "DCTTON": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -258.76,
+        "gross_profit": 3300.15,
+        "gross_loss": -3558.91,
+        "win_rate": 0.533,
+        "largest_win": 136.77,
+        "largest_loss": -151.71,
+        "average_win": 68.75,
+        "average_loss": -84.74,
+        "profit_factor": 0.927
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 55.9,
+          "cumulative_profit": 55.9,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 55.9,
+          "largest_loss": 55.9
+        },
+        {
+          "date": "2025-07-08",
+          "profit": 8.8,
+          "cumulative_profit": 64.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.8,
+          "largest_loss": 8.8
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 83.0,
+          "cumulative_profit": 147.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 83.0,
+          "largest_loss": 83.0
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -83.73,
+          "cumulative_profit": 63.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -83.73,
+          "largest_loss": -83.73
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 127.04,
+          "cumulative_profit": 191.01,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 127.04,
+          "largest_loss": 127.04
+        },
+        {
+          "date": "2025-07-12",
+          "profit": 18.11,
+          "cumulative_profit": 209.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 18.11,
+          "largest_loss": 18.11
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 120.08,
+          "cumulative_profit": 329.2,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 120.08,
+          "largest_loss": 120.08
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 6.06,
+          "cumulative_profit": 335.26,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 6.06,
+          "largest_loss": 6.06
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 98.59,
+          "cumulative_profit": 433.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 98.59,
+          "largest_loss": 98.59
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 136.77,
+          "cumulative_profit": 570.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 136.77,
+          "largest_loss": 136.77
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 87.22,
+          "cumulative_profit": 657.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 87.22,
+          "largest_loss": 87.22
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 71.93,
+          "cumulative_profit": 729.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 71.93,
+          "largest_loss": 71.93
+        },
+        {
+          "date": "2025-07-19",
+          "profit": -114.69,
+          "cumulative_profit": 615.08,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -114.69,
+          "largest_loss": -114.69
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 8.52,
+          "cumulative_profit": 623.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.52,
+          "largest_loss": 8.52
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 118.65,
+          "cumulative_profit": 742.25,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 118.65,
+          "largest_loss": 118.65
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -32.48,
+          "cumulative_profit": 709.77,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -32.48,
+          "largest_loss": -32.48
+        },
+        {
+          "date": "2025-07-23",
+          "profit": 102.51,
+          "cumulative_profit": 812.28,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 102.51,
+          "largest_loss": 102.51
+        },
+        {
+          "date": "2025-07-24",
+          "profit": -4.6,
+          "cumulative_profit": 807.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -4.6,
+          "largest_loss": -4.6
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -41.12,
+          "cumulative_profit": 766.56,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -41.12,
+          "largest_loss": -41.12
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -60.53,
+          "cumulative_profit": 706.03,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -60.53,
+          "largest_loss": -60.53
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 57.93,
+          "cumulative_profit": 763.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 57.93,
+          "largest_loss": 57.93
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 8.07,
+          "cumulative_profit": 772.03,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.07,
+          "largest_loss": 8.07
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 50.92,
+          "cumulative_profit": 822.95,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 50.92,
+          "largest_loss": 50.92
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 34.19,
+          "cumulative_profit": 857.14,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 34.19,
+          "largest_loss": 34.19
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 123.6,
+          "cumulative_profit": 980.74,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 123.6,
+          "largest_loss": 123.6
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -120.09,
+          "cumulative_profit": 860.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -120.09,
+          "largest_loss": -120.09
+        },
+        {
+          "date": "2025-08-02",
+          "profit": -85.16,
+          "cumulative_profit": 775.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -85.16,
+          "largest_loss": -85.16
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 98.59,
+          "cumulative_profit": 874.08,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 98.59,
+          "largest_loss": 98.59
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 41.52,
+          "cumulative_profit": 915.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 41.52,
+          "largest_loss": 41.52
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -5.24,
+          "cumulative_profit": 910.36,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -5.24,
+          "largest_loss": -5.24
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 41.74,
+          "cumulative_profit": 952.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 41.74,
+          "largest_loss": 41.74
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -75.99,
+          "cumulative_profit": 876.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -75.99,
+          "largest_loss": -75.99
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -64.81,
+          "cumulative_profit": 811.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -64.81,
+          "largest_loss": -64.81
+        },
+        {
+          "date": "2025-08-09",
+          "profit": 112.3,
+          "cumulative_profit": 923.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 112.3,
+          "largest_loss": 112.3
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -75.99,
+          "cumulative_profit": 847.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -75.99,
+          "largest_loss": -75.99
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 70.07,
+          "cumulative_profit": 917.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 70.07,
+          "largest_loss": 70.07
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 95.34,
+          "cumulative_profit": 1013.02,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 95.34,
+          "largest_loss": 95.34
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 26.49,
+          "cumulative_profit": 1039.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 26.49,
+          "largest_loss": 26.49
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 136.3,
+          "cumulative_profit": 1175.81,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 136.3,
+          "largest_loss": 136.3
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 85.5,
+          "cumulative_profit": 1261.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 85.5,
+          "largest_loss": 85.5
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -53.96,
+          "cumulative_profit": 1207.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -53.96,
+          "largest_loss": -53.96
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -28.03,
+          "cumulative_profit": 1179.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -28.03,
+          "largest_loss": -28.03
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 7.2,
+          "cumulative_profit": 1186.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 7.2,
+          "largest_loss": 7.2
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 45.21,
+          "cumulative_profit": 1231.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 45.21,
+          "largest_loss": 45.21
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 59.11,
+          "cumulative_profit": 1290.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 59.11,
+          "largest_loss": 59.11
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 1.49,
+          "cumulative_profit": 1292.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1.49,
+          "largest_loss": 1.49
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 65.55,
+          "cumulative_profit": 1357.88,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 65.55,
+          "largest_loss": 65.55
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 121.02,
+          "cumulative_profit": 1478.9,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 121.02,
+          "largest_loss": 121.02
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -70.79,
+          "cumulative_profit": 1408.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -70.79,
+          "largest_loss": -70.79
+        },
+        {
+          "date": "2025-08-25",
+          "profit": -56.21,
+          "cumulative_profit": 1351.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -56.21,
+          "largest_loss": -56.21
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 89.58,
+          "cumulative_profit": 1441.48,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 89.58,
+          "largest_loss": 89.58
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -140.28,
+          "cumulative_profit": 1301.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -140.28,
+          "largest_loss": -140.28
+        },
+        {
+          "date": "2025-08-28",
+          "profit": 73.01,
+          "cumulative_profit": 1374.21,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 73.01,
+          "largest_loss": 73.01
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 59.22,
+          "cumulative_profit": 1433.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 59.22,
+          "largest_loss": 59.22
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 54.65,
+          "cumulative_profit": 1488.08,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 54.65,
+          "largest_loss": 54.65
+        },
+        {
+          "date": "2025-08-31",
+          "profit": 35.33,
+          "cumulative_profit": 1523.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 35.33,
+          "largest_loss": 35.33
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -74.33,
+          "cumulative_profit": 1449.08,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -74.33,
+          "largest_loss": -74.33
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -133.11,
+          "cumulative_profit": 1315.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -133.11,
+          "largest_loss": -133.11
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -1.67,
+          "cumulative_profit": 1314.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1.67,
+          "largest_loss": -1.67
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 73.22,
+          "cumulative_profit": 1387.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 73.22,
+          "largest_loss": 73.22
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -69.76,
+          "cumulative_profit": 1317.76,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -69.76,
+          "largest_loss": -69.76
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -151.3,
+          "cumulative_profit": 1166.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -151.3,
+          "largest_loss": -151.3
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -78.5,
+          "cumulative_profit": 1087.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -78.5,
+          "largest_loss": -78.5
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -111.53,
+          "cumulative_profit": 976.43,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -111.53,
+          "largest_loss": -111.53
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -54.51,
+          "cumulative_profit": 921.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -54.51,
+          "largest_loss": -54.51
+        },
+        {
+          "date": "2025-09-10",
+          "profit": -136.7,
+          "cumulative_profit": 785.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -136.7,
+          "largest_loss": -136.7
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 8.18,
+          "cumulative_profit": 793.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.18,
+          "largest_loss": 8.18
+        },
+        {
+          "date": "2025-09-12",
+          "profit": -94.26,
+          "cumulative_profit": 699.14,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -94.26,
+          "largest_loss": -94.26
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -140.74,
+          "cumulative_profit": 558.4,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -140.74,
+          "largest_loss": -140.74
+        },
+        {
+          "date": "2025-09-14",
+          "profit": -128.22,
+          "cumulative_profit": 430.18,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -128.22,
+          "largest_loss": -128.22
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 96.63,
+          "cumulative_profit": 526.81,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 96.63,
+          "largest_loss": 96.63
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 67.7,
+          "cumulative_profit": 594.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 67.7,
+          "largest_loss": 67.7
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -132.78,
+          "cumulative_profit": 461.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -132.78,
+          "largest_loss": -132.78
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -110.87,
+          "cumulative_profit": 350.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -110.87,
+          "largest_loss": -110.87
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 97.04,
+          "cumulative_profit": 447.9,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 97.04,
+          "largest_loss": 97.04
+        },
+        {
+          "date": "2025-09-20",
+          "profit": -109.7,
+          "cumulative_profit": 338.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -109.7,
+          "largest_loss": -109.7
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -43.22,
+          "cumulative_profit": 294.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -43.22,
+          "largest_loss": -43.22
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -138.71,
+          "cumulative_profit": 156.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -138.71,
+          "largest_loss": -138.71
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -68.55,
+          "cumulative_profit": 87.72,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -68.55,
+          "largest_loss": -68.55
+        },
+        {
+          "date": "2025-09-24",
+          "profit": 128.79,
+          "cumulative_profit": 216.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 128.79,
+          "largest_loss": 128.79
+        },
+        {
+          "date": "2025-09-25",
+          "profit": -96.56,
+          "cumulative_profit": 119.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -96.56,
+          "largest_loss": -96.56
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 104.5,
+          "cumulative_profit": 224.45,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 104.5,
+          "largest_loss": 104.5
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 55.46,
+          "cumulative_profit": 279.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 55.46,
+          "largest_loss": 55.46
+        },
+        {
+          "date": "2025-09-28",
+          "profit": -148.61,
+          "cumulative_profit": 131.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -148.61,
+          "largest_loss": -148.61
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -63.62,
+          "cumulative_profit": 67.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -63.62,
+          "largest_loss": -63.62
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 31.52,
+          "cumulative_profit": 99.2,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 31.52,
+          "largest_loss": 31.52
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -151.71,
+          "cumulative_profit": -52.51,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -151.71,
+          "largest_loss": -151.71
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -71.36,
+          "cumulative_profit": -123.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -71.36,
+          "largest_loss": -71.36
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -4.76,
+          "cumulative_profit": -128.63,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -4.76,
+          "largest_loss": -4.76
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -130.13,
+          "cumulative_profit": -258.76,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -130.13,
+          "largest_loss": -130.13
+        }
+      ],
+      "largest_win": {
+        "profit": 136.77,
+        "date": "2025-07-16",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -151.71,
+        "date": "2025-10-01",
+        "action": "SELL"
+      }
+    },
+    "ETHUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -3067.42,
+        "gross_profit": 17724.97,
+        "gross_loss": -20792.39,
+        "win_rate": 0.5,
+        "largest_win": 863.38,
+        "largest_loss": -887.54,
+        "average_win": 393.89,
+        "average_loss": -462.05,
+        "profit_factor": 0.852
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -764.83,
+          "cumulative_profit": -764.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -764.83,
+          "largest_loss": -764.83
+        },
+        {
+          "date": "2025-07-08",
+          "profit": 261.43,
+          "cumulative_profit": -503.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 261.43,
+          "largest_loss": 261.43
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -522.04,
+          "cumulative_profit": -1025.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -522.04,
+          "largest_loss": -522.04
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 304.38,
+          "cumulative_profit": -721.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 304.38,
+          "largest_loss": 304.38
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -887.54,
+          "cumulative_profit": -1608.6,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -887.54,
+          "largest_loss": -887.54
+        },
+        {
+          "date": "2025-07-12",
+          "profit": 249.13,
+          "cumulative_profit": -1359.47,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 249.13,
+          "largest_loss": 249.13
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 48.41,
+          "cumulative_profit": -1311.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 48.41,
+          "largest_loss": 48.41
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 705.93,
+          "cumulative_profit": -605.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 705.93,
+          "largest_loss": 705.93
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -152.08,
+          "cumulative_profit": -757.21,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -152.08,
+          "largest_loss": -152.08
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 846.86,
+          "cumulative_profit": 89.65,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 846.86,
+          "largest_loss": 846.86
+        },
+        {
+          "date": "2025-07-17",
+          "profit": -408.35,
+          "cumulative_profit": -318.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -408.35,
+          "largest_loss": -408.35
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -53.84,
+          "cumulative_profit": -372.54,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -53.84,
+          "largest_loss": -53.84
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 863.38,
+          "cumulative_profit": 490.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 863.38,
+          "largest_loss": 863.38
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 61.74,
+          "cumulative_profit": 552.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 61.74,
+          "largest_loss": 61.74
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 556.94,
+          "cumulative_profit": 1109.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 556.94,
+          "largest_loss": 556.94
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 5.64,
+          "cumulative_profit": 1115.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 5.64,
+          "largest_loss": 5.64
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -550.83,
+          "cumulative_profit": 564.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -550.83,
+          "largest_loss": -550.83
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 380.98,
+          "cumulative_profit": 945.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 380.98,
+          "largest_loss": 380.98
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 568.64,
+          "cumulative_profit": 1513.95,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 568.64,
+          "largest_loss": 568.64
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -229.11,
+          "cumulative_profit": 1284.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -229.11,
+          "largest_loss": -229.11
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -271.09,
+          "cumulative_profit": 1013.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -271.09,
+          "largest_loss": -271.09
+        },
+        {
+          "date": "2025-07-28",
+          "profit": -400.52,
+          "cumulative_profit": 613.23,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -400.52,
+          "largest_loss": -400.52
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 166.99,
+          "cumulative_profit": 780.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 166.99,
+          "largest_loss": 166.99
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 37.87,
+          "cumulative_profit": 818.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 37.87,
+          "largest_loss": 37.87
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 775.64,
+          "cumulative_profit": 1593.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 775.64,
+          "largest_loss": 775.64
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -712.03,
+          "cumulative_profit": 881.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -712.03,
+          "largest_loss": -712.03
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 403.85,
+          "cumulative_profit": 1285.55,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 403.85,
+          "largest_loss": 403.85
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 662.28,
+          "cumulative_profit": 1947.83,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 662.28,
+          "largest_loss": 662.28
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -529.21,
+          "cumulative_profit": 1418.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -529.21,
+          "largest_loss": -529.21
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 585.82,
+          "cumulative_profit": 2004.44,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 585.82,
+          "largest_loss": 585.82
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 94.49,
+          "cumulative_profit": 2098.93,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 94.49,
+          "largest_loss": 94.49
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -727.43,
+          "cumulative_profit": 1371.5,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -727.43,
+          "largest_loss": -727.43
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -273.89,
+          "cumulative_profit": 1097.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -273.89,
+          "largest_loss": -273.89
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -475.16,
+          "cumulative_profit": 622.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -475.16,
+          "largest_loss": -475.16
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -482.65,
+          "cumulative_profit": 139.8,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -482.65,
+          "largest_loss": -482.65
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -352.91,
+          "cumulative_profit": -213.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -352.91,
+          "largest_loss": -352.91
+        },
+        {
+          "date": "2025-08-12",
+          "profit": -393.08,
+          "cumulative_profit": -606.19,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -393.08,
+          "largest_loss": -393.08
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 838.14,
+          "cumulative_profit": 231.95,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 838.14,
+          "largest_loss": 838.14
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -810.63,
+          "cumulative_profit": -578.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -810.63,
+          "largest_loss": -810.63
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 14.82,
+          "cumulative_profit": -563.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 14.82,
+          "largest_loss": 14.82
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -418.46,
+          "cumulative_profit": -982.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -418.46,
+          "largest_loss": -418.46
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 532.1,
+          "cumulative_profit": -450.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 532.1,
+          "largest_loss": 532.1
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 254.36,
+          "cumulative_profit": -195.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 254.36,
+          "largest_loss": 254.36
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 327.8,
+          "cumulative_profit": 131.94,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 327.8,
+          "largest_loss": 327.8
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -859.0,
+          "cumulative_profit": -727.06,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -859.0,
+          "largest_loss": -859.0
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 112.95,
+          "cumulative_profit": -614.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 112.95,
+          "largest_loss": 112.95
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 433.86,
+          "cumulative_profit": -180.25,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 433.86,
+          "largest_loss": 433.86
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -417.84,
+          "cumulative_profit": -598.09,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -417.84,
+          "largest_loss": -417.84
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -3.5,
+          "cumulative_profit": -601.59,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -3.5,
+          "largest_loss": -3.5
+        },
+        {
+          "date": "2025-08-25",
+          "profit": -96.46,
+          "cumulative_profit": -698.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -96.46,
+          "largest_loss": -96.46
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 572.5,
+          "cumulative_profit": -125.55,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 572.5,
+          "largest_loss": 572.5
+        },
+        {
+          "date": "2025-08-27",
+          "profit": 4.44,
+          "cumulative_profit": -121.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 4.44,
+          "largest_loss": 4.44
+        },
+        {
+          "date": "2025-08-28",
+          "profit": 109.24,
+          "cumulative_profit": -11.87,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 109.24,
+          "largest_loss": 109.24
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 729.62,
+          "cumulative_profit": 717.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 729.62,
+          "largest_loss": 729.62
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 728.31,
+          "cumulative_profit": 1446.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 728.31,
+          "largest_loss": 728.31
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -88.16,
+          "cumulative_profit": 1357.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -88.16,
+          "largest_loss": -88.16
+        },
+        {
+          "date": "2025-09-01",
+          "profit": 259.58,
+          "cumulative_profit": 1617.48,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 259.58,
+          "largest_loss": 259.58
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -63.78,
+          "cumulative_profit": 1553.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -63.78,
+          "largest_loss": -63.78
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -266.68,
+          "cumulative_profit": 1287.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -266.68,
+          "largest_loss": -266.68
+        },
+        {
+          "date": "2025-09-04",
+          "profit": -763.45,
+          "cumulative_profit": 523.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -763.45,
+          "largest_loss": -763.45
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -494.96,
+          "cumulative_profit": 28.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -494.96,
+          "largest_loss": -494.96
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 722.2,
+          "cumulative_profit": 750.81,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 722.2,
+          "largest_loss": 722.2
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 96.23,
+          "cumulative_profit": 847.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 96.23,
+          "largest_loss": 96.23
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -767.01,
+          "cumulative_profit": 80.03,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -767.01,
+          "largest_loss": -767.01
+        },
+        {
+          "date": "2025-09-09",
+          "profit": 841.81,
+          "cumulative_profit": 921.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 841.81,
+          "largest_loss": 841.81
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 38.09,
+          "cumulative_profit": 959.93,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 38.09,
+          "largest_loss": 38.09
+        },
+        {
+          "date": "2025-09-11",
+          "profit": -67.04,
+          "cumulative_profit": 892.89,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -67.04,
+          "largest_loss": -67.04
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 448.81,
+          "cumulative_profit": 1341.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 448.81,
+          "largest_loss": 448.81
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -203.04,
+          "cumulative_profit": 1138.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -203.04,
+          "largest_loss": -203.04
+        },
+        {
+          "date": "2025-09-14",
+          "profit": -32.47,
+          "cumulative_profit": 1106.19,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -32.47,
+          "largest_loss": -32.47
+        },
+        {
+          "date": "2025-09-15",
+          "profit": -393.41,
+          "cumulative_profit": 712.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -393.41,
+          "largest_loss": -393.41
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 717.58,
+          "cumulative_profit": 1430.36,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 717.58,
+          "largest_loss": 717.58
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -626.06,
+          "cumulative_profit": 804.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -626.06,
+          "largest_loss": -626.06
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -674.32,
+          "cumulative_profit": 129.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -674.32,
+          "largest_loss": -674.32
+        },
+        {
+          "date": "2025-09-19",
+          "profit": -35.58,
+          "cumulative_profit": 94.4,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -35.58,
+          "largest_loss": -35.58
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 69.42,
+          "cumulative_profit": 163.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 69.42,
+          "largest_loss": 69.42
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 295.37,
+          "cumulative_profit": 459.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 295.37,
+          "largest_loss": 295.37
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -736.85,
+          "cumulative_profit": -277.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -736.85,
+          "largest_loss": -736.85
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -785.31,
+          "cumulative_profit": -1062.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -785.31,
+          "largest_loss": -785.31
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -598.4,
+          "cumulative_profit": -1661.37,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -598.4,
+          "largest_loss": -598.4
+        },
+        {
+          "date": "2025-09-25",
+          "profit": -883.26,
+          "cumulative_profit": -2544.63,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -883.26,
+          "largest_loss": -883.26
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 247.94,
+          "cumulative_profit": -2296.69,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 247.94,
+          "largest_loss": 247.94
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 22.43,
+          "cumulative_profit": -2274.26,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 22.43,
+          "largest_loss": 22.43
+        },
+        {
+          "date": "2025-09-28",
+          "profit": -857.26,
+          "cumulative_profit": -3131.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -857.26,
+          "largest_loss": -857.26
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -274.55,
+          "cumulative_profit": -3406.07,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -274.55,
+          "largest_loss": -274.55
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 389.43,
+          "cumulative_profit": -3016.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 389.43,
+          "largest_loss": 389.43
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -835.46,
+          "cumulative_profit": -3852.1,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -835.46,
+          "largest_loss": -835.46
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -552.86,
+          "cumulative_profit": -4404.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -552.86,
+          "largest_loss": -552.86
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 680.99,
+          "cumulative_profit": -3723.97,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 680.99,
+          "largest_loss": 680.99
+        },
+        {
+          "date": "2025-10-04",
+          "profit": 656.55,
+          "cumulative_profit": -3067.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 656.55,
+          "largest_loss": 656.55
+        }
+      ],
+      "largest_win": {
+        "profit": 863.38,
+        "date": "2025-07-19",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -887.54,
+        "date": "2025-07-11",
+        "action": "SELL"
+      }
+    },
+    "EURUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -329.85,
+        "gross_profit": 9070.33,
+        "gross_loss": -9400.18,
+        "win_rate": 0.533,
+        "largest_win": 417.25,
+        "largest_loss": -434.7,
+        "average_win": 188.97,
+        "average_loss": -223.81,
+        "profit_factor": 0.965
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 254.91,
+          "cumulative_profit": 254.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 254.91,
+          "largest_loss": 254.91
+        },
+        {
+          "date": "2025-07-08",
+          "profit": 183.81,
+          "cumulative_profit": 438.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 183.81,
+          "largest_loss": 183.81
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -199.27,
+          "cumulative_profit": 239.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -199.27,
+          "largest_loss": -199.27
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 210.22,
+          "cumulative_profit": 449.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 210.22,
+          "largest_loss": 210.22
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -234.01,
+          "cumulative_profit": 215.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -234.01,
+          "largest_loss": -234.01
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -197.85,
+          "cumulative_profit": 17.81,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -197.85,
+          "largest_loss": -197.85
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 188.16,
+          "cumulative_profit": 205.97,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 188.16,
+          "largest_loss": 188.16
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -283.59,
+          "cumulative_profit": -77.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -283.59,
+          "largest_loss": -283.59
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -16.73,
+          "cumulative_profit": -94.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -16.73,
+          "largest_loss": -16.73
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 147.04,
+          "cumulative_profit": 52.69,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 147.04,
+          "largest_loss": 147.04
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 308.27,
+          "cumulative_profit": 360.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 308.27,
+          "largest_loss": 308.27
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 166.31,
+          "cumulative_profit": 527.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 166.31,
+          "largest_loss": 166.31
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 259.86,
+          "cumulative_profit": 787.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 259.86,
+          "largest_loss": 259.86
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 159.43,
+          "cumulative_profit": 946.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 159.43,
+          "largest_loss": 159.43
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 162.44,
+          "cumulative_profit": 1109.0,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 162.44,
+          "largest_loss": 162.44
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 164.93,
+          "cumulative_profit": 1273.93,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 164.93,
+          "largest_loss": 164.93
+        },
+        {
+          "date": "2025-07-23",
+          "profit": 199.7,
+          "cumulative_profit": 1473.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 199.7,
+          "largest_loss": 199.7
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 105.39,
+          "cumulative_profit": 1579.02,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 105.39,
+          "largest_loss": 105.39
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 43.29,
+          "cumulative_profit": 1622.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 43.29,
+          "largest_loss": 43.29
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -63.09,
+          "cumulative_profit": 1559.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -63.09,
+          "largest_loss": -63.09
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -80.73,
+          "cumulative_profit": 1478.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -80.73,
+          "largest_loss": -80.73
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 326.66,
+          "cumulative_profit": 1805.15,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 326.66,
+          "largest_loss": 326.66
+        },
+        {
+          "date": "2025-07-29",
+          "profit": -154.58,
+          "cumulative_profit": 1650.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -154.58,
+          "largest_loss": -154.58
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -112.7,
+          "cumulative_profit": 1537.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -112.7,
+          "largest_loss": -112.7
+        },
+        {
+          "date": "2025-07-31",
+          "profit": -112.75,
+          "cumulative_profit": 1425.12,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -112.75,
+          "largest_loss": -112.75
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 159.48,
+          "cumulative_profit": 1584.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 159.48,
+          "largest_loss": 159.48
+        },
+        {
+          "date": "2025-08-02",
+          "profit": -55.2,
+          "cumulative_profit": 1529.4,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -55.2,
+          "largest_loss": -55.2
+        },
+        {
+          "date": "2025-08-03",
+          "profit": -182.43,
+          "cumulative_profit": 1346.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -182.43,
+          "largest_loss": -182.43
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 59.88,
+          "cumulative_profit": 1406.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 59.88,
+          "largest_loss": 59.88
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -423.93,
+          "cumulative_profit": 982.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -423.93,
+          "largest_loss": -423.93
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 261.61,
+          "cumulative_profit": 1244.53,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 261.61,
+          "largest_loss": 261.61
+        },
+        {
+          "date": "2025-08-07",
+          "profit": 31.7,
+          "cumulative_profit": 1276.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 31.7,
+          "largest_loss": 31.7
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -366.55,
+          "cumulative_profit": 909.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -366.55,
+          "largest_loss": -366.55
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -129.68,
+          "cumulative_profit": 780.0,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -129.68,
+          "largest_loss": -129.68
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -293.29,
+          "cumulative_profit": 486.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -293.29,
+          "largest_loss": -293.29
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -432.51,
+          "cumulative_profit": 54.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -432.51,
+          "largest_loss": -432.51
+        },
+        {
+          "date": "2025-08-12",
+          "profit": -434.7,
+          "cumulative_profit": -380.5,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -434.7,
+          "largest_loss": -434.7
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 53.05,
+          "cumulative_profit": -327.45,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 53.05,
+          "largest_loss": 53.05
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 251.06,
+          "cumulative_profit": -76.39,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 251.06,
+          "largest_loss": 251.06
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 67.6,
+          "cumulative_profit": -8.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 67.6,
+          "largest_loss": 67.6
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -266.69,
+          "cumulative_profit": -275.48,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -266.69,
+          "largest_loss": -266.69
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -207.84,
+          "cumulative_profit": -483.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -207.84,
+          "largest_loss": -207.84
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 41.73,
+          "cumulative_profit": -441.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 41.73,
+          "largest_loss": 41.73
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 135.26,
+          "cumulative_profit": -306.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 135.26,
+          "largest_loss": 135.26
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -128.19,
+          "cumulative_profit": -434.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -128.19,
+          "largest_loss": -128.19
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 298.88,
+          "cumulative_profit": -135.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 298.88,
+          "largest_loss": 298.88
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -35.81,
+          "cumulative_profit": -171.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -35.81,
+          "largest_loss": -35.81
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 250.68,
+          "cumulative_profit": 79.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 250.68,
+          "largest_loss": 250.68
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -334.09,
+          "cumulative_profit": -254.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -334.09,
+          "largest_loss": -334.09
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 99.55,
+          "cumulative_profit": -155.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 99.55,
+          "largest_loss": 99.55
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 389.56,
+          "cumulative_profit": 234.25,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 389.56,
+          "largest_loss": 389.56
+        },
+        {
+          "date": "2025-08-27",
+          "profit": 103.82,
+          "cumulative_profit": 338.07,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 103.82,
+          "largest_loss": 103.82
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -121.52,
+          "cumulative_profit": 216.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -121.52,
+          "largest_loss": -121.52
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 389.04,
+          "cumulative_profit": 605.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 389.04,
+          "largest_loss": 389.04
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 217.33,
+          "cumulative_profit": 822.92,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 217.33,
+          "largest_loss": 217.33
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -426.62,
+          "cumulative_profit": 396.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -426.62,
+          "largest_loss": -426.62
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -317.55,
+          "cumulative_profit": 78.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -317.55,
+          "largest_loss": -317.55
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -100.32,
+          "cumulative_profit": -21.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -100.32,
+          "largest_loss": -100.32
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -242.04,
+          "cumulative_profit": -263.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -242.04,
+          "largest_loss": -242.04
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 75.91,
+          "cumulative_profit": -187.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 75.91,
+          "largest_loss": 75.91
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -357.15,
+          "cumulative_profit": -544.85,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -357.15,
+          "largest_loss": -357.15
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -423.79,
+          "cumulative_profit": -968.64,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -423.79,
+          "largest_loss": -423.79
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 366.51,
+          "cumulative_profit": -602.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 366.51,
+          "largest_loss": 366.51
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 407.9,
+          "cumulative_profit": -194.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 407.9,
+          "largest_loss": 407.9
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -334.5,
+          "cumulative_profit": -528.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -334.5,
+          "largest_loss": -334.5
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 37.67,
+          "cumulative_profit": -491.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 37.67,
+          "largest_loss": 37.67
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 276.05,
+          "cumulative_profit": -215.01,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 276.05,
+          "largest_loss": 276.05
+        },
+        {
+          "date": "2025-09-12",
+          "profit": -419.54,
+          "cumulative_profit": -634.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -419.54,
+          "largest_loss": -419.54
+        },
+        {
+          "date": "2025-09-13",
+          "profit": 19.99,
+          "cumulative_profit": -614.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 19.99,
+          "largest_loss": 19.99
+        },
+        {
+          "date": "2025-09-14",
+          "profit": -8.17,
+          "cumulative_profit": -622.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -8.17,
+          "largest_loss": -8.17
+        },
+        {
+          "date": "2025-09-15",
+          "profit": -245.45,
+          "cumulative_profit": -868.18,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -245.45,
+          "largest_loss": -245.45
+        },
+        {
+          "date": "2025-09-16",
+          "profit": -352.17,
+          "cumulative_profit": -1220.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -352.17,
+          "largest_loss": -352.17
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -338.81,
+          "cumulative_profit": -1559.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -338.81,
+          "largest_loss": -338.81
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -121.02,
+          "cumulative_profit": -1680.18,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -121.02,
+          "largest_loss": -121.02
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 68.78,
+          "cumulative_profit": -1611.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 68.78,
+          "largest_loss": 68.78
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 334.37,
+          "cumulative_profit": -1277.03,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 334.37,
+          "largest_loss": 334.37
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 74.85,
+          "cumulative_profit": -1202.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 74.85,
+          "largest_loss": 74.85
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -291.53,
+          "cumulative_profit": -1493.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -291.53,
+          "largest_loss": -291.53
+        },
+        {
+          "date": "2025-09-23",
+          "profit": 1.17,
+          "cumulative_profit": -1492.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1.17,
+          "largest_loss": 1.17
+        },
+        {
+          "date": "2025-09-24",
+          "profit": 148.45,
+          "cumulative_profit": -1344.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 148.45,
+          "largest_loss": 148.45
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 23.78,
+          "cumulative_profit": -1320.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 23.78,
+          "largest_loss": 23.78
+        },
+        {
+          "date": "2025-09-26",
+          "profit": -326.25,
+          "cumulative_profit": -1646.56,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -326.25,
+          "largest_loss": -326.25
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -51.89,
+          "cumulative_profit": -1698.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -51.89,
+          "largest_loss": -51.89
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 328.85,
+          "cumulative_profit": -1369.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 328.85,
+          "largest_loss": 328.85
+        },
+        {
+          "date": "2025-09-29",
+          "profit": 414.17,
+          "cumulative_profit": -955.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 414.17,
+          "largest_loss": 414.17
+        },
+        {
+          "date": "2025-09-30",
+          "profit": -79.19,
+          "cumulative_profit": -1034.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -79.19,
+          "largest_loss": -79.19
+        },
+        {
+          "date": "2025-10-01",
+          "profit": 45.98,
+          "cumulative_profit": -988.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 45.98,
+          "largest_loss": 45.98
+        },
+        {
+          "date": "2025-10-02",
+          "profit": 338.0,
+          "cumulative_profit": -650.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 338.0,
+          "largest_loss": 338.0
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 417.25,
+          "cumulative_profit": -233.39,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 417.25,
+          "largest_loss": 417.25
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -96.46,
+          "cumulative_profit": -329.85,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -96.46,
+          "largest_loss": -96.46
+        }
+      ],
+      "largest_win": {
+        "profit": 417.25,
+        "date": "2025-10-03",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -434.7,
+        "date": "2025-08-12",
+        "action": "BUY"
+      }
+    },
+    "GBPUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 2326.98,
+        "gross_profit": 13973.95,
+        "gross_loss": -11646.97,
+        "win_rate": 0.522,
+        "largest_win": 533.51,
+        "largest_loss": -545.55,
+        "average_win": 297.32,
+        "average_loss": -270.86,
+        "profit_factor": 1.2
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -314.03,
+          "cumulative_profit": -314.03,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -314.03,
+          "largest_loss": -314.03
+        },
+        {
+          "date": "2025-07-08",
+          "profit": 16.46,
+          "cumulative_profit": -297.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 16.46,
+          "largest_loss": 16.46
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 229.92,
+          "cumulative_profit": -67.65,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 229.92,
+          "largest_loss": 229.92
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 257.25,
+          "cumulative_profit": 189.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 257.25,
+          "largest_loss": 257.25
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -77.8,
+          "cumulative_profit": 111.8,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -77.8,
+          "largest_loss": -77.8
+        },
+        {
+          "date": "2025-07-12",
+          "profit": 517.11,
+          "cumulative_profit": 628.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 517.11,
+          "largest_loss": 517.11
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 341.7,
+          "cumulative_profit": 970.61,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 341.7,
+          "largest_loss": 341.7
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -463.32,
+          "cumulative_profit": 507.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -463.32,
+          "largest_loss": -463.32
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -471.79,
+          "cumulative_profit": 35.5,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -471.79,
+          "largest_loss": -471.79
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 120.41,
+          "cumulative_profit": 155.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 120.41,
+          "largest_loss": 120.41
+        },
+        {
+          "date": "2025-07-17",
+          "profit": -228.17,
+          "cumulative_profit": -72.26,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -228.17,
+          "largest_loss": -228.17
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -403.85,
+          "cumulative_profit": -476.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -403.85,
+          "largest_loss": -403.85
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 349.09,
+          "cumulative_profit": -127.02,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 349.09,
+          "largest_loss": 349.09
+        },
+        {
+          "date": "2025-07-20",
+          "profit": -545.55,
+          "cumulative_profit": -672.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -545.55,
+          "largest_loss": -545.55
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -333.49,
+          "cumulative_profit": -1006.06,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -333.49,
+          "largest_loss": -333.49
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -315.76,
+          "cumulative_profit": -1321.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -315.76,
+          "largest_loss": -315.76
+        },
+        {
+          "date": "2025-07-23",
+          "profit": 495.06,
+          "cumulative_profit": -826.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 495.06,
+          "largest_loss": 495.06
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 449.95,
+          "cumulative_profit": -376.81,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 449.95,
+          "largest_loss": 449.95
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -404.65,
+          "cumulative_profit": -781.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -404.65,
+          "largest_loss": -404.65
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -103.55,
+          "cumulative_profit": -885.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -103.55,
+          "largest_loss": -103.55
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 144.72,
+          "cumulative_profit": -740.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 144.72,
+          "largest_loss": 144.72
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 500.2,
+          "cumulative_profit": -240.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 500.2,
+          "largest_loss": 500.2
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 181.06,
+          "cumulative_profit": -59.03,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 181.06,
+          "largest_loss": 181.06
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 90.39,
+          "cumulative_profit": 31.36,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 90.39,
+          "largest_loss": 90.39
+        },
+        {
+          "date": "2025-07-31",
+          "profit": -90.76,
+          "cumulative_profit": -59.4,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -90.76,
+          "largest_loss": -90.76
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 371.57,
+          "cumulative_profit": 312.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 371.57,
+          "largest_loss": 371.57
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 433.79,
+          "cumulative_profit": 745.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 433.79,
+          "largest_loss": 433.79
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 280.22,
+          "cumulative_profit": 1026.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 280.22,
+          "largest_loss": 280.22
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -440.79,
+          "cumulative_profit": 585.39,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -440.79,
+          "largest_loss": -440.79
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 21.98,
+          "cumulative_profit": 607.37,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 21.98,
+          "largest_loss": 21.98
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 513.26,
+          "cumulative_profit": 1120.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 513.26,
+          "largest_loss": 513.26
+        },
+        {
+          "date": "2025-08-07",
+          "profit": 470.16,
+          "cumulative_profit": 1590.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 470.16,
+          "largest_loss": 470.16
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 46.15,
+          "cumulative_profit": 1636.94,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 46.15,
+          "largest_loss": 46.15
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -47.13,
+          "cumulative_profit": 1589.81,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -47.13,
+          "largest_loss": -47.13
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -40.84,
+          "cumulative_profit": 1548.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -40.84,
+          "largest_loss": -40.84
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -65.05,
+          "cumulative_profit": 1483.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -65.05,
+          "largest_loss": -65.05
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 397.14,
+          "cumulative_profit": 1881.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 397.14,
+          "largest_loss": 397.14
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -314.77,
+          "cumulative_profit": 1566.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -314.77,
+          "largest_loss": -314.77
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 4.14,
+          "cumulative_profit": 1570.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 4.14,
+          "largest_loss": 4.14
+        },
+        {
+          "date": "2025-08-15",
+          "profit": -88.43,
+          "cumulative_profit": 1482.0,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -88.43,
+          "largest_loss": -88.43
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -73.85,
+          "cumulative_profit": 1408.15,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -73.85,
+          "largest_loss": -73.85
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -221.49,
+          "cumulative_profit": 1186.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -221.49,
+          "largest_loss": -221.49
+        },
+        {
+          "date": "2025-08-18",
+          "profit": -532.37,
+          "cumulative_profit": 654.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -532.37,
+          "largest_loss": -532.37
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 400.48,
+          "cumulative_profit": 1054.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 400.48,
+          "largest_loss": 400.48
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 363.37,
+          "cumulative_profit": 1418.14,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 363.37,
+          "largest_loss": 363.37
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 482.31,
+          "cumulative_profit": 1900.45,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 482.31,
+          "largest_loss": 482.31
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -408.19,
+          "cumulative_profit": 1492.26,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -408.19,
+          "largest_loss": -408.19
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -242.48,
+          "cumulative_profit": 1249.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -242.48,
+          "largest_loss": -242.48
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -381.94,
+          "cumulative_profit": 867.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -381.94,
+          "largest_loss": -381.94
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 46.34,
+          "cumulative_profit": 914.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 46.34,
+          "largest_loss": 46.34
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 477.23,
+          "cumulative_profit": 1391.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 477.23,
+          "largest_loss": 477.23
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -359.16,
+          "cumulative_profit": 1032.25,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -359.16,
+          "largest_loss": -359.16
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -350.55,
+          "cumulative_profit": 681.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -350.55,
+          "largest_loss": -350.55
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 396.98,
+          "cumulative_profit": 1078.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 396.98,
+          "largest_loss": 396.98
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -33.51,
+          "cumulative_profit": 1045.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -33.51,
+          "largest_loss": -33.51
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -101.09,
+          "cumulative_profit": 944.08,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -101.09,
+          "largest_loss": -101.09
+        },
+        {
+          "date": "2025-09-01",
+          "profit": 432.04,
+          "cumulative_profit": 1376.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 432.04,
+          "largest_loss": 432.04
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 149.77,
+          "cumulative_profit": 1525.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 149.77,
+          "largest_loss": 149.77
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -303.31,
+          "cumulative_profit": 1222.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -303.31,
+          "largest_loss": -303.31
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 525.95,
+          "cumulative_profit": 1748.53,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 525.95,
+          "largest_loss": 525.95
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 127.74,
+          "cumulative_profit": 1876.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 127.74,
+          "largest_loss": 127.74
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -482.03,
+          "cumulative_profit": 1394.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -482.03,
+          "largest_loss": -482.03
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -408.75,
+          "cumulative_profit": 985.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -408.75,
+          "largest_loss": -408.75
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -440.26,
+          "cumulative_profit": 545.23,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -440.26,
+          "largest_loss": -440.26
+        },
+        {
+          "date": "2025-09-09",
+          "profit": 210.1,
+          "cumulative_profit": 755.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 210.1,
+          "largest_loss": 210.1
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 301.98,
+          "cumulative_profit": 1057.31,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 301.98,
+          "largest_loss": 301.98
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 186.17,
+          "cumulative_profit": 1243.48,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 186.17,
+          "largest_loss": 186.17
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 146.36,
+          "cumulative_profit": 1389.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 146.36,
+          "largest_loss": 146.36
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -150.46,
+          "cumulative_profit": 1239.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -150.46,
+          "largest_loss": -150.46
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 194.91,
+          "cumulative_profit": 1434.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 194.91,
+          "largest_loss": 194.91
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 425.37,
+          "cumulative_profit": 1859.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 425.37,
+          "largest_loss": 425.37
+        },
+        {
+          "date": "2025-09-16",
+          "profit": -103.92,
+          "cumulative_profit": 1755.74,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -103.92,
+          "largest_loss": -103.92
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -331.69,
+          "cumulative_profit": 1424.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -331.69,
+          "largest_loss": -331.69
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -149.2,
+          "cumulative_profit": 1274.85,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -149.2,
+          "largest_loss": -149.2
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 503.01,
+          "cumulative_profit": 1777.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 503.01,
+          "largest_loss": 503.01
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 190.43,
+          "cumulative_profit": 1968.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 190.43,
+          "largest_loss": 190.43
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -92.61,
+          "cumulative_profit": 1875.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -92.61,
+          "largest_loss": -92.61
+        },
+        {
+          "date": "2025-09-22",
+          "profit": 230.08,
+          "cumulative_profit": 2105.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 230.08,
+          "largest_loss": 230.08
+        },
+        {
+          "date": "2025-09-23",
+          "profit": 124.34,
+          "cumulative_profit": 2230.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 124.34,
+          "largest_loss": 124.34
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -491.54,
+          "cumulative_profit": 1738.56,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -491.54,
+          "largest_loss": -491.54
+        },
+        {
+          "date": "2025-09-25",
+          "profit": -67.39,
+          "cumulative_profit": 1671.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -67.39,
+          "largest_loss": -67.39
+        },
+        {
+          "date": "2025-09-26",
+          "profit": -398.71,
+          "cumulative_profit": 1272.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -398.71,
+          "largest_loss": -398.71
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 63.7,
+          "cumulative_profit": 1336.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 63.7,
+          "largest_loss": 63.7
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 184.03,
+          "cumulative_profit": 1520.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 184.03,
+          "largest_loss": 184.03
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -195.75,
+          "cumulative_profit": 1324.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -195.75,
+          "largest_loss": -195.75
+        },
+        {
+          "date": "2025-09-30",
+          "profit": -95.74,
+          "cumulative_profit": 1228.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -95.74,
+          "largest_loss": -95.74
+        },
+        {
+          "date": "2025-10-01",
+          "profit": 526.87,
+          "cumulative_profit": 1755.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 526.87,
+          "largest_loss": 526.87
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -481.25,
+          "cumulative_profit": 1274.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -481.25,
+          "largest_loss": -481.25
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 533.51,
+          "cumulative_profit": 1807.83,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 533.51,
+          "largest_loss": 533.51
+        },
+        {
+          "date": "2025-10-04",
+          "profit": 519.15,
+          "cumulative_profit": 2326.98,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 519.15,
+          "largest_loss": 519.15
+        }
+      ],
+      "largest_win": {
+        "profit": 533.51,
+        "date": "2025-10-03",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -545.55,
+        "date": "2025-07-20",
+        "action": "BUY"
+      }
+    },
+    "NZDUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -1451.82,
+        "gross_profit": 7923.37,
+        "gross_loss": -9375.19,
+        "win_rate": 0.5,
+        "largest_win": 348.0,
+        "largest_loss": -399.6,
+        "average_win": 176.07,
+        "average_loss": -208.34,
+        "profit_factor": 0.845
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -65.53,
+          "cumulative_profit": -65.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -65.53,
+          "largest_loss": -65.53
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -298.84,
+          "cumulative_profit": -364.37,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -298.84,
+          "largest_loss": -298.84
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -329.54,
+          "cumulative_profit": -693.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -329.54,
+          "largest_loss": -329.54
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -43.65,
+          "cumulative_profit": -737.56,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -43.65,
+          "largest_loss": -43.65
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -250.4,
+          "cumulative_profit": -987.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -250.4,
+          "largest_loss": -250.4
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -122.98,
+          "cumulative_profit": -1110.94,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -122.98,
+          "largest_loss": -122.98
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 212.09,
+          "cumulative_profit": -898.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 212.09,
+          "largest_loss": 212.09
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -112.14,
+          "cumulative_profit": -1010.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -112.14,
+          "largest_loss": -112.14
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -105.73,
+          "cumulative_profit": -1116.72,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -105.73,
+          "largest_loss": -105.73
+        },
+        {
+          "date": "2025-07-16",
+          "profit": 164.93,
+          "cumulative_profit": -951.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 164.93,
+          "largest_loss": 164.93
+        },
+        {
+          "date": "2025-07-17",
+          "profit": -221.41,
+          "cumulative_profit": -1173.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -221.41,
+          "largest_loss": -221.41
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 257.04,
+          "cumulative_profit": -916.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 257.04,
+          "largest_loss": 257.04
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 158.65,
+          "cumulative_profit": -757.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 158.65,
+          "largest_loss": 158.65
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 249.81,
+          "cumulative_profit": -507.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 249.81,
+          "largest_loss": 249.81
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -237.03,
+          "cumulative_profit": -744.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -237.03,
+          "largest_loss": -237.03
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -115.4,
+          "cumulative_profit": -860.13,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -115.4,
+          "largest_loss": -115.4
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -370.59,
+          "cumulative_profit": -1230.72,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -370.59,
+          "largest_loss": -370.59
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 120.38,
+          "cumulative_profit": -1110.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 120.38,
+          "largest_loss": 120.38
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 197.24,
+          "cumulative_profit": -913.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 197.24,
+          "largest_loss": 197.24
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -199.05,
+          "cumulative_profit": -1112.15,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -199.05,
+          "largest_loss": -199.05
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -290.02,
+          "cumulative_profit": -1402.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -290.02,
+          "largest_loss": -290.02
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 213.54,
+          "cumulative_profit": -1188.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 213.54,
+          "largest_loss": 213.54
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 232.76,
+          "cumulative_profit": -955.87,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 232.76,
+          "largest_loss": 232.76
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -356.87,
+          "cumulative_profit": -1312.74,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -356.87,
+          "largest_loss": -356.87
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 269.69,
+          "cumulative_profit": -1043.05,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 269.69,
+          "largest_loss": 269.69
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 182.11,
+          "cumulative_profit": -860.94,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 182.11,
+          "largest_loss": 182.11
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 184.53,
+          "cumulative_profit": -676.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 184.53,
+          "largest_loss": 184.53
+        },
+        {
+          "date": "2025-08-03",
+          "profit": -336.05,
+          "cumulative_profit": -1012.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -336.05,
+          "largest_loss": -336.05
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 260.99,
+          "cumulative_profit": -751.47,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 260.99,
+          "largest_loss": 260.99
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 32.61,
+          "cumulative_profit": -718.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 32.61,
+          "largest_loss": 32.61
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -95.29,
+          "cumulative_profit": -814.15,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -95.29,
+          "largest_loss": -95.29
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -399.6,
+          "cumulative_profit": -1213.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -399.6,
+          "largest_loss": -399.6
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -390.57,
+          "cumulative_profit": -1604.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -390.57,
+          "largest_loss": -390.57
+        },
+        {
+          "date": "2025-08-09",
+          "profit": 310.15,
+          "cumulative_profit": -1294.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 310.15,
+          "largest_loss": 310.15
+        },
+        {
+          "date": "2025-08-10",
+          "profit": 142.81,
+          "cumulative_profit": -1151.36,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 142.81,
+          "largest_loss": 142.81
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -288.05,
+          "cumulative_profit": -1439.41,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -288.05,
+          "largest_loss": -288.05
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 176.25,
+          "cumulative_profit": -1263.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 176.25,
+          "largest_loss": 176.25
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -135.32,
+          "cumulative_profit": -1398.48,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -135.32,
+          "largest_loss": -135.32
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -374.71,
+          "cumulative_profit": -1773.19,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -374.71,
+          "largest_loss": -374.71
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 14.61,
+          "cumulative_profit": -1758.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 14.61,
+          "largest_loss": 14.61
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -88.02,
+          "cumulative_profit": -1846.6,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -88.02,
+          "largest_loss": -88.02
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -237.85,
+          "cumulative_profit": -2084.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -237.85,
+          "largest_loss": -237.85
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 183.93,
+          "cumulative_profit": -1900.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 183.93,
+          "largest_loss": 183.93
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 140.85,
+          "cumulative_profit": -1759.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 140.85,
+          "largest_loss": 140.85
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 135.17,
+          "cumulative_profit": -1624.5,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 135.17,
+          "largest_loss": 135.17
+        },
+        {
+          "date": "2025-08-21",
+          "profit": -315.79,
+          "cumulative_profit": -1940.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -315.79,
+          "largest_loss": -315.79
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -37.32,
+          "cumulative_profit": -1977.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -37.32,
+          "largest_loss": -37.32
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -319.74,
+          "cumulative_profit": -2297.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -319.74,
+          "largest_loss": -319.74
+        },
+        {
+          "date": "2025-08-24",
+          "profit": 184.69,
+          "cumulative_profit": -2112.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 184.69,
+          "largest_loss": 184.69
+        },
+        {
+          "date": "2025-08-25",
+          "profit": -87.56,
+          "cumulative_profit": -2200.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -87.56,
+          "largest_loss": -87.56
+        },
+        {
+          "date": "2025-08-26",
+          "profit": -132.37,
+          "cumulative_profit": -2332.59,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -132.37,
+          "largest_loss": -132.37
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -164.25,
+          "cumulative_profit": -2496.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -164.25,
+          "largest_loss": -164.25
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -62.49,
+          "cumulative_profit": -2559.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -62.49,
+          "largest_loss": -62.49
+        },
+        {
+          "date": "2025-08-29",
+          "profit": -164.5,
+          "cumulative_profit": -2723.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -164.5,
+          "largest_loss": -164.5
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -158.51,
+          "cumulative_profit": -2882.34,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -158.51,
+          "largest_loss": -158.51
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -339.83,
+          "cumulative_profit": -3222.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -339.83,
+          "largest_loss": -339.83
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -129.58,
+          "cumulative_profit": -3351.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -129.58,
+          "largest_loss": -129.58
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 320.95,
+          "cumulative_profit": -3030.8,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 320.95,
+          "largest_loss": 320.95
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -16.57,
+          "cumulative_profit": -3047.37,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -16.57,
+          "largest_loss": -16.57
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 183.98,
+          "cumulative_profit": -2863.39,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 183.98,
+          "largest_loss": 183.98
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 56.95,
+          "cumulative_profit": -2806.44,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 56.95,
+          "largest_loss": 56.95
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 153.86,
+          "cumulative_profit": -2652.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 153.86,
+          "largest_loss": 153.86
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -215.74,
+          "cumulative_profit": -2868.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -215.74,
+          "largest_loss": -215.74
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 23.09,
+          "cumulative_profit": -2845.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 23.09,
+          "largest_loss": 23.09
+        },
+        {
+          "date": "2025-09-09",
+          "profit": 88.62,
+          "cumulative_profit": -2756.61,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 88.62,
+          "largest_loss": 88.62
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 35.0,
+          "cumulative_profit": -2721.61,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 35.0,
+          "largest_loss": 35.0
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 348.0,
+          "cumulative_profit": -2373.61,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 348.0,
+          "largest_loss": 348.0
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 303.03,
+          "cumulative_profit": -2070.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 303.03,
+          "largest_loss": 303.03
+        },
+        {
+          "date": "2025-09-13",
+          "profit": 77.25,
+          "cumulative_profit": -1993.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 77.25,
+          "largest_loss": 77.25
+        },
+        {
+          "date": "2025-09-14",
+          "profit": -325.78,
+          "cumulative_profit": -2319.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -325.78,
+          "largest_loss": -325.78
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 91.19,
+          "cumulative_profit": -2227.92,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 91.19,
+          "largest_loss": 91.19
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 59.1,
+          "cumulative_profit": -2168.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 59.1,
+          "largest_loss": 59.1
+        },
+        {
+          "date": "2025-09-17",
+          "profit": 304.05,
+          "cumulative_profit": -1864.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 304.05,
+          "largest_loss": 304.05
+        },
+        {
+          "date": "2025-09-18",
+          "profit": 278.14,
+          "cumulative_profit": -1586.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 278.14,
+          "largest_loss": 278.14
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 202.87,
+          "cumulative_profit": -1383.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 202.87,
+          "largest_loss": 202.87
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 171.91,
+          "cumulative_profit": -1211.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 171.91,
+          "largest_loss": 171.91
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 229.67,
+          "cumulative_profit": -982.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 229.67,
+          "largest_loss": 229.67
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -153.47,
+          "cumulative_profit": -1135.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -153.47,
+          "largest_loss": -153.47
+        },
+        {
+          "date": "2025-09-23",
+          "profit": 91.46,
+          "cumulative_profit": -1044.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 91.46,
+          "largest_loss": 91.46
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -313.86,
+          "cumulative_profit": -1358.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -313.86,
+          "largest_loss": -313.86
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 161.32,
+          "cumulative_profit": -1196.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 161.32,
+          "largest_loss": 161.32
+        },
+        {
+          "date": "2025-09-26",
+          "profit": -191.92,
+          "cumulative_profit": -1388.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -191.92,
+          "largest_loss": -191.92
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 10.58,
+          "cumulative_profit": -1378.07,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 10.58,
+          "largest_loss": 10.58
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 303.53,
+          "cumulative_profit": -1074.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 303.53,
+          "largest_loss": 303.53
+        },
+        {
+          "date": "2025-09-29",
+          "profit": 133.63,
+          "cumulative_profit": -940.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 133.63,
+          "largest_loss": 133.63
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 270.36,
+          "cumulative_profit": -670.55,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 270.36,
+          "largest_loss": 270.36
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -172.95,
+          "cumulative_profit": -843.5,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -172.95,
+          "largest_loss": -172.95
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -158.44,
+          "cumulative_profit": -1001.94,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -158.44,
+          "largest_loss": -158.44
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -227.08,
+          "cumulative_profit": -1229.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -227.08,
+          "largest_loss": -227.08
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -222.8,
+          "cumulative_profit": -1451.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -222.8,
+          "largest_loss": -222.8
+        }
+      ],
+      "largest_win": {
+        "profit": 348.0,
+        "date": "2025-09-11",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -399.6,
+        "date": "2025-08-07",
+        "action": "BUY"
+      }
+    },
+    "TONUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 609.46,
+        "gross_profit": 5110.78,
+        "gross_loss": -4501.32,
+        "win_rate": 0.522,
+        "largest_win": 206.96,
+        "largest_loss": -211.38,
+        "average_win": 108.74,
+        "average_loss": -104.68,
+        "profit_factor": 1.135
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 168.04,
+          "cumulative_profit": 168.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 168.04,
+          "largest_loss": 168.04
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -197.75,
+          "cumulative_profit": -29.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -197.75,
+          "largest_loss": -197.75
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 106.3,
+          "cumulative_profit": 76.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 106.3,
+          "largest_loss": 106.3
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -156.14,
+          "cumulative_profit": -79.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -156.14,
+          "largest_loss": -156.14
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 193.51,
+          "cumulative_profit": 113.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 193.51,
+          "largest_loss": 193.51
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -82.94,
+          "cumulative_profit": 31.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -82.94,
+          "largest_loss": -82.94
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 144.73,
+          "cumulative_profit": 175.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 144.73,
+          "largest_loss": 144.73
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -71.8,
+          "cumulative_profit": 103.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -71.8,
+          "largest_loss": -71.8
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -8.59,
+          "cumulative_profit": 95.36,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -8.59,
+          "largest_loss": -8.59
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -32.68,
+          "cumulative_profit": 62.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -32.68,
+          "largest_loss": -32.68
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 176.1,
+          "cumulative_profit": 238.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 176.1,
+          "largest_loss": 176.1
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -145.8,
+          "cumulative_profit": 92.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -145.8,
+          "largest_loss": -145.8
+        },
+        {
+          "date": "2025-07-19",
+          "profit": -169.53,
+          "cumulative_profit": -76.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -169.53,
+          "largest_loss": -169.53
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 160.21,
+          "cumulative_profit": 83.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 160.21,
+          "largest_loss": 160.21
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -91.0,
+          "cumulative_profit": -7.34,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -91.0,
+          "largest_loss": -91.0
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -102.51,
+          "cumulative_profit": -109.85,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -102.51,
+          "largest_loss": -102.51
+        },
+        {
+          "date": "2025-07-23",
+          "profit": 195.61,
+          "cumulative_profit": 85.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 195.61,
+          "largest_loss": 195.61
+        },
+        {
+          "date": "2025-07-24",
+          "profit": -199.42,
+          "cumulative_profit": -113.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -199.42,
+          "largest_loss": -199.42
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 31.06,
+          "cumulative_profit": -82.6,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 31.06,
+          "largest_loss": 31.06
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -211.38,
+          "cumulative_profit": -293.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -211.38,
+          "largest_loss": -211.38
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 128.36,
+          "cumulative_profit": -165.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 128.36,
+          "largest_loss": 128.36
+        },
+        {
+          "date": "2025-07-28",
+          "profit": -119.79,
+          "cumulative_profit": -285.41,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -119.79,
+          "largest_loss": -119.79
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 48.43,
+          "cumulative_profit": -236.98,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 48.43,
+          "largest_loss": 48.43
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 65.23,
+          "cumulative_profit": -171.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 65.23,
+          "largest_loss": 65.23
+        },
+        {
+          "date": "2025-07-31",
+          "profit": -188.82,
+          "cumulative_profit": -360.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -188.82,
+          "largest_loss": -188.82
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -24.44,
+          "cumulative_profit": -385.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -24.44,
+          "largest_loss": -24.44
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 26.01,
+          "cumulative_profit": -359.0,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 26.01,
+          "largest_loss": 26.01
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 144.45,
+          "cumulative_profit": -214.55,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 144.45,
+          "largest_loss": 144.45
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 176.41,
+          "cumulative_profit": -38.14,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 176.41,
+          "largest_loss": 176.41
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 146.49,
+          "cumulative_profit": 108.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 146.49,
+          "largest_loss": 146.49
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -55.89,
+          "cumulative_profit": 52.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -55.89,
+          "largest_loss": -55.89
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -49.79,
+          "cumulative_profit": 2.67,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -49.79,
+          "largest_loss": -49.79
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -154.34,
+          "cumulative_profit": -151.67,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -154.34,
+          "largest_loss": -154.34
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -174.34,
+          "cumulative_profit": -326.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -174.34,
+          "largest_loss": -174.34
+        },
+        {
+          "date": "2025-08-10",
+          "profit": 11.74,
+          "cumulative_profit": -314.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 11.74,
+          "largest_loss": 11.74
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 41.36,
+          "cumulative_profit": -272.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 41.36,
+          "largest_loss": 41.36
+        },
+        {
+          "date": "2025-08-12",
+          "profit": -4.93,
+          "cumulative_profit": -277.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -4.93,
+          "largest_loss": -4.93
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -129.45,
+          "cumulative_profit": -407.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -129.45,
+          "largest_loss": -129.45
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 147.66,
+          "cumulative_profit": -259.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 147.66,
+          "largest_loss": 147.66
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 48.2,
+          "cumulative_profit": -211.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 48.2,
+          "largest_loss": 48.2
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -44.91,
+          "cumulative_profit": -256.34,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -44.91,
+          "largest_loss": -44.91
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -16.63,
+          "cumulative_profit": -272.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -16.63,
+          "largest_loss": -16.63
+        },
+        {
+          "date": "2025-08-18",
+          "profit": -146.48,
+          "cumulative_profit": -419.45,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -146.48,
+          "largest_loss": -146.48
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 74.29,
+          "cumulative_profit": -345.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 74.29,
+          "largest_loss": 74.29
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 118.11,
+          "cumulative_profit": -227.05,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 118.11,
+          "largest_loss": 118.11
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 199.77,
+          "cumulative_profit": -27.28,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 199.77,
+          "largest_loss": 199.77
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -63.01,
+          "cumulative_profit": -90.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -63.01,
+          "largest_loss": -63.01
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -109.37,
+          "cumulative_profit": -199.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -109.37,
+          "largest_loss": -109.37
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -127.09,
+          "cumulative_profit": -326.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -127.09,
+          "largest_loss": -127.09
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 15.53,
+          "cumulative_profit": -311.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 15.53,
+          "largest_loss": 15.53
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 156.7,
+          "cumulative_profit": -154.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 156.7,
+          "largest_loss": 156.7
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -184.13,
+          "cumulative_profit": -338.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -184.13,
+          "largest_loss": -184.13
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -181.4,
+          "cumulative_profit": -520.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -181.4,
+          "largest_loss": -181.4
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 141.97,
+          "cumulative_profit": -378.08,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 141.97,
+          "largest_loss": 141.97
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -92.34,
+          "cumulative_profit": -470.42,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -92.34,
+          "largest_loss": -92.34
+        },
+        {
+          "date": "2025-08-31",
+          "profit": 5.59,
+          "cumulative_profit": -464.83,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 5.59,
+          "largest_loss": 5.59
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -104.17,
+          "cumulative_profit": -569.0,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -104.17,
+          "largest_loss": -104.17
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 180.21,
+          "cumulative_profit": -388.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 180.21,
+          "largest_loss": 180.21
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 203.12,
+          "cumulative_profit": -185.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 203.12,
+          "largest_loss": 203.12
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 157.19,
+          "cumulative_profit": -28.48,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 157.19,
+          "largest_loss": 157.19
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 26.45,
+          "cumulative_profit": -2.03,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 26.45,
+          "largest_loss": 26.45
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 113.84,
+          "cumulative_profit": 111.81,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 113.84,
+          "largest_loss": 113.84
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 8.48,
+          "cumulative_profit": 120.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.48,
+          "largest_loss": 8.48
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -95.12,
+          "cumulative_profit": 25.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -95.12,
+          "largest_loss": -95.12
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -167.31,
+          "cumulative_profit": -142.14,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -167.31,
+          "largest_loss": -167.31
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 206.96,
+          "cumulative_profit": 64.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 206.96,
+          "largest_loss": 206.96
+        },
+        {
+          "date": "2025-09-11",
+          "profit": -49.49,
+          "cumulative_profit": 15.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -49.49,
+          "largest_loss": -49.49
+        },
+        {
+          "date": "2025-09-12",
+          "profit": -9.75,
+          "cumulative_profit": 5.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -9.75,
+          "largest_loss": -9.75
+        },
+        {
+          "date": "2025-09-13",
+          "profit": 4.84,
+          "cumulative_profit": 10.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 4.84,
+          "largest_loss": 4.84
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 93.4,
+          "cumulative_profit": 103.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 93.4,
+          "largest_loss": 93.4
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 85.64,
+          "cumulative_profit": 189.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 85.64,
+          "largest_loss": 85.64
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 92.48,
+          "cumulative_profit": 281.94,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 92.48,
+          "largest_loss": 92.48
+        },
+        {
+          "date": "2025-09-17",
+          "profit": 61.8,
+          "cumulative_profit": 343.74,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 61.8,
+          "largest_loss": 61.8
+        },
+        {
+          "date": "2025-09-18",
+          "profit": 107.19,
+          "cumulative_profit": 450.93,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 107.19,
+          "largest_loss": 107.19
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 190.08,
+          "cumulative_profit": 641.01,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 190.08,
+          "largest_loss": 190.08
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 98.45,
+          "cumulative_profit": 739.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 98.45,
+          "largest_loss": 98.45
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 147.27,
+          "cumulative_profit": 886.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 147.27,
+          "largest_loss": 147.27
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -126.29,
+          "cumulative_profit": 760.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -126.29,
+          "largest_loss": -126.29
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -2.73,
+          "cumulative_profit": 757.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2.73,
+          "largest_loss": -2.73
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -51.71,
+          "cumulative_profit": 706.0,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -51.71,
+          "largest_loss": -51.71
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 148.46,
+          "cumulative_profit": 854.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 148.46,
+          "largest_loss": 148.46
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 44.27,
+          "cumulative_profit": 898.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 44.27,
+          "largest_loss": 44.27
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -154.65,
+          "cumulative_profit": 744.08,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -154.65,
+          "largest_loss": -154.65
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 119.02,
+          "cumulative_profit": 863.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 119.02,
+          "largest_loss": 119.02
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -70.13,
+          "cumulative_profit": 792.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -70.13,
+          "largest_loss": -70.13
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 104.25,
+          "cumulative_profit": 897.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 104.25,
+          "largest_loss": 104.25
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -21.51,
+          "cumulative_profit": 875.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -21.51,
+          "largest_loss": -21.51
+        },
+        {
+          "date": "2025-10-02",
+          "profit": 45.52,
+          "cumulative_profit": 921.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 45.52,
+          "largest_loss": 45.52
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -120.84,
+          "cumulative_profit": 800.39,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -120.84,
+          "largest_loss": -120.84
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -190.93,
+          "cumulative_profit": 609.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -190.93,
+          "largest_loss": -190.93
+        }
+      ],
+      "largest_win": {
+        "profit": 206.96,
+        "date": "2025-09-10",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -211.38,
+        "date": "2025-07-26",
+        "action": "SELL"
+      }
+    },
+    "USDCAD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -1514.01,
+        "gross_profit": 8822.22,
+        "gross_loss": -10336.23,
+        "win_rate": 0.489,
+        "largest_win": 397.55,
+        "largest_loss": -399.14,
+        "average_win": 200.5,
+        "average_loss": -224.7,
+        "profit_factor": 0.854
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -253.7,
+          "cumulative_profit": -253.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -253.7,
+          "largest_loss": -253.7
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -159.51,
+          "cumulative_profit": -413.21,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -159.51,
+          "largest_loss": -159.51
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 59.55,
+          "cumulative_profit": -353.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 59.55,
+          "largest_loss": 59.55
+        },
+        {
+          "date": "2025-07-10",
+          "profit": -168.62,
+          "cumulative_profit": -522.28,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -168.62,
+          "largest_loss": -168.62
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -282.43,
+          "cumulative_profit": -804.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -282.43,
+          "largest_loss": -282.43
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -381.93,
+          "cumulative_profit": -1186.64,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -381.93,
+          "largest_loss": -381.93
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 86.22,
+          "cumulative_profit": -1100.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 86.22,
+          "largest_loss": 86.22
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 24.3,
+          "cumulative_profit": -1076.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 24.3,
+          "largest_loss": 24.3
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -304.22,
+          "cumulative_profit": -1380.34,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -304.22,
+          "largest_loss": -304.22
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -356.73,
+          "cumulative_profit": -1737.07,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -356.73,
+          "largest_loss": -356.73
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 308.07,
+          "cumulative_profit": -1429.0,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 308.07,
+          "largest_loss": 308.07
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -25.99,
+          "cumulative_profit": -1454.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -25.99,
+          "largest_loss": -25.99
+        },
+        {
+          "date": "2025-07-19",
+          "profit": -310.07,
+          "cumulative_profit": -1765.06,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -310.07,
+          "largest_loss": -310.07
+        },
+        {
+          "date": "2025-07-20",
+          "profit": -399.14,
+          "cumulative_profit": -2164.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -399.14,
+          "largest_loss": -399.14
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -188.27,
+          "cumulative_profit": -2352.47,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -188.27,
+          "largest_loss": -188.27
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 120.24,
+          "cumulative_profit": -2232.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 120.24,
+          "largest_loss": 120.24
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -271.82,
+          "cumulative_profit": -2504.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -271.82,
+          "largest_loss": -271.82
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 396.16,
+          "cumulative_profit": -2107.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 396.16,
+          "largest_loss": 396.16
+        },
+        {
+          "date": "2025-07-25",
+          "profit": 377.27,
+          "cumulative_profit": -1730.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 377.27,
+          "largest_loss": 377.27
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -328.17,
+          "cumulative_profit": -2058.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -328.17,
+          "largest_loss": -328.17
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 36.92,
+          "cumulative_profit": -2021.87,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 36.92,
+          "largest_loss": 36.92
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 127.55,
+          "cumulative_profit": -1894.32,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 127.55,
+          "largest_loss": 127.55
+        },
+        {
+          "date": "2025-07-29",
+          "profit": -356.53,
+          "cumulative_profit": -2250.85,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -356.53,
+          "largest_loss": -356.53
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 336.43,
+          "cumulative_profit": -1914.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 336.43,
+          "largest_loss": 336.43
+        },
+        {
+          "date": "2025-07-31",
+          "profit": -324.95,
+          "cumulative_profit": -2239.37,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -324.95,
+          "largest_loss": -324.95
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -254.12,
+          "cumulative_profit": -2493.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -254.12,
+          "largest_loss": -254.12
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 24.29,
+          "cumulative_profit": -2469.2,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 24.29,
+          "largest_loss": 24.29
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 343.21,
+          "cumulative_profit": -2125.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 343.21,
+          "largest_loss": 343.21
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -169.95,
+          "cumulative_profit": -2295.94,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -169.95,
+          "largest_loss": -169.95
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -350.97,
+          "cumulative_profit": -2646.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -350.97,
+          "largest_loss": -350.97
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -381.06,
+          "cumulative_profit": -3027.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -381.06,
+          "largest_loss": -381.06
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -165.19,
+          "cumulative_profit": -3193.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -165.19,
+          "largest_loss": -165.19
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 17.75,
+          "cumulative_profit": -3175.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 17.75,
+          "largest_loss": 17.75
+        },
+        {
+          "date": "2025-08-09",
+          "profit": 179.26,
+          "cumulative_profit": -2996.15,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 179.26,
+          "largest_loss": 179.26
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -218.72,
+          "cumulative_profit": -3214.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -218.72,
+          "largest_loss": -218.72
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -235.09,
+          "cumulative_profit": -3449.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -235.09,
+          "largest_loss": -235.09
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 182.69,
+          "cumulative_profit": -3267.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 182.69,
+          "largest_loss": 182.69
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -115.64,
+          "cumulative_profit": -3382.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -115.64,
+          "largest_loss": -115.64
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -182.56,
+          "cumulative_profit": -3565.47,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -182.56,
+          "largest_loss": -182.56
+        },
+        {
+          "date": "2025-08-15",
+          "profit": -120.8,
+          "cumulative_profit": -3686.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -120.8,
+          "largest_loss": -120.8
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 259.35,
+          "cumulative_profit": -3426.92,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 259.35,
+          "largest_loss": 259.35
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 42.74,
+          "cumulative_profit": -3384.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 42.74,
+          "largest_loss": 42.74
+        },
+        {
+          "date": "2025-08-18",
+          "profit": -271.92,
+          "cumulative_profit": -3656.1,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -271.92,
+          "largest_loss": -271.92
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 49.19,
+          "cumulative_profit": -3606.91,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 49.19,
+          "largest_loss": 49.19
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 71.52,
+          "cumulative_profit": -3535.39,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 71.52,
+          "largest_loss": 71.52
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 184.59,
+          "cumulative_profit": -3350.8,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 184.59,
+          "largest_loss": 184.59
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 356.33,
+          "cumulative_profit": -2994.47,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 356.33,
+          "largest_loss": 356.33
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 383.72,
+          "cumulative_profit": -2610.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 383.72,
+          "largest_loss": 383.72
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -105.98,
+          "cumulative_profit": -2716.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -105.98,
+          "largest_loss": -105.98
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 262.76,
+          "cumulative_profit": -2453.97,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 262.76,
+          "largest_loss": 262.76
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 397.55,
+          "cumulative_profit": -2056.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 397.55,
+          "largest_loss": 397.55
+        },
+        {
+          "date": "2025-08-27",
+          "profit": 93.31,
+          "cumulative_profit": -1963.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 93.31,
+          "largest_loss": 93.31
+        },
+        {
+          "date": "2025-08-28",
+          "profit": 301.05,
+          "cumulative_profit": -1662.06,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 301.05,
+          "largest_loss": 301.05
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 336.2,
+          "cumulative_profit": -1325.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 336.2,
+          "largest_loss": 336.2
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -94.68,
+          "cumulative_profit": -1420.54,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -94.68,
+          "largest_loss": -94.68
+        },
+        {
+          "date": "2025-08-31",
+          "profit": 254.96,
+          "cumulative_profit": -1165.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 254.96,
+          "largest_loss": 254.96
+        },
+        {
+          "date": "2025-09-01",
+          "profit": 251.24,
+          "cumulative_profit": -914.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 251.24,
+          "largest_loss": 251.24
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 84.99,
+          "cumulative_profit": -829.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 84.99,
+          "largest_loss": 84.99
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 283.31,
+          "cumulative_profit": -546.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 283.31,
+          "largest_loss": 283.31
+        },
+        {
+          "date": "2025-09-04",
+          "profit": -94.35,
+          "cumulative_profit": -640.39,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -94.35,
+          "largest_loss": -94.35
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 71.75,
+          "cumulative_profit": -568.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 71.75,
+          "largest_loss": 71.75
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -105.72,
+          "cumulative_profit": -674.36,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -105.72,
+          "largest_loss": -105.72
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 335.34,
+          "cumulative_profit": -339.02,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 335.34,
+          "largest_loss": 335.34
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 28.19,
+          "cumulative_profit": -310.83,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 28.19,
+          "largest_loss": 28.19
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -318.05,
+          "cumulative_profit": -628.88,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -318.05,
+          "largest_loss": -318.05
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 111.47,
+          "cumulative_profit": -517.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 111.47,
+          "largest_loss": 111.47
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 121.97,
+          "cumulative_profit": -395.44,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 121.97,
+          "largest_loss": 121.97
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 263.4,
+          "cumulative_profit": -132.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 263.4,
+          "largest_loss": 263.4
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -7.74,
+          "cumulative_profit": -139.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -7.74,
+          "largest_loss": -7.74
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 278.88,
+          "cumulative_profit": 139.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 278.88,
+          "largest_loss": 278.88
+        },
+        {
+          "date": "2025-09-15",
+          "profit": -272.0,
+          "cumulative_profit": -132.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -272.0,
+          "largest_loss": -272.0
+        },
+        {
+          "date": "2025-09-16",
+          "profit": -76.21,
+          "cumulative_profit": -209.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -76.21,
+          "largest_loss": -76.21
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -355.41,
+          "cumulative_profit": -564.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -355.41,
+          "largest_loss": -355.41
+        },
+        {
+          "date": "2025-09-18",
+          "profit": 181.24,
+          "cumulative_profit": -383.28,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 181.24,
+          "largest_loss": 181.24
+        },
+        {
+          "date": "2025-09-19",
+          "profit": -338.33,
+          "cumulative_profit": -721.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -338.33,
+          "largest_loss": -338.33
+        },
+        {
+          "date": "2025-09-20",
+          "profit": -276.88,
+          "cumulative_profit": -998.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -276.88,
+          "largest_loss": -276.88
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -327.72,
+          "cumulative_profit": -1326.21,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -327.72,
+          "largest_loss": -327.72
+        },
+        {
+          "date": "2025-09-22",
+          "profit": 57.22,
+          "cumulative_profit": -1268.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 57.22,
+          "largest_loss": 57.22
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -151.71,
+          "cumulative_profit": -1420.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -151.71,
+          "largest_loss": -151.71
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -40.03,
+          "cumulative_profit": -1460.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -40.03,
+          "largest_loss": -40.03
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 295.21,
+          "cumulative_profit": -1165.52,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 295.21,
+          "largest_loss": 295.21
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 373.82,
+          "cumulative_profit": -791.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 373.82,
+          "largest_loss": 373.82
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -258.03,
+          "cumulative_profit": -1049.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -258.03,
+          "largest_loss": -258.03
+        },
+        {
+          "date": "2025-09-28",
+          "profit": -67.13,
+          "cumulative_profit": -1116.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -67.13,
+          "largest_loss": -67.13
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -163.43,
+          "cumulative_profit": -1280.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -163.43,
+          "largest_loss": -163.43
+        },
+        {
+          "date": "2025-09-30",
+          "profit": -199.18,
+          "cumulative_profit": -1479.47,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -199.18,
+          "largest_loss": -199.18
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -365.1,
+          "cumulative_profit": -1844.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -365.1,
+          "largest_loss": -365.1
+        },
+        {
+          "date": "2025-10-02",
+          "profit": 320.08,
+          "cumulative_profit": -1524.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 320.08,
+          "largest_loss": 320.08
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 150.93,
+          "cumulative_profit": -1373.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 150.93,
+          "largest_loss": 150.93
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -140.45,
+          "cumulative_profit": -1514.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -140.45,
+          "largest_loss": -140.45
+        }
+      ],
+      "largest_win": {
+        "profit": 397.55,
+        "date": "2025-08-26",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -399.14,
+        "date": "2025-07-20",
+        "action": "SELL"
+      }
+    },
+    "USDCHF": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -1974.66,
+        "gross_profit": 8062.15,
+        "gross_loss": -10036.81,
+        "win_rate": 0.444,
+        "largest_win": 376.49,
+        "largest_loss": -379.97,
+        "average_win": 201.55,
+        "average_loss": -200.74,
+        "profit_factor": 0.803
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 376.49,
+          "cumulative_profit": 376.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 376.49,
+          "largest_loss": 376.49
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -338.3,
+          "cumulative_profit": 38.19,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -338.3,
+          "largest_loss": -338.3
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 115.76,
+          "cumulative_profit": 153.95,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 115.76,
+          "largest_loss": 115.76
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 291.58,
+          "cumulative_profit": 445.53,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 291.58,
+          "largest_loss": 291.58
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 109.62,
+          "cumulative_profit": 555.15,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 109.62,
+          "largest_loss": 109.62
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -159.36,
+          "cumulative_profit": 395.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -159.36,
+          "largest_loss": -159.36
+        },
+        {
+          "date": "2025-07-13",
+          "profit": -129.06,
+          "cumulative_profit": 266.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -129.06,
+          "largest_loss": -129.06
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -15.08,
+          "cumulative_profit": 251.65,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -15.08,
+          "largest_loss": -15.08
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -337.15,
+          "cumulative_profit": -85.5,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -337.15,
+          "largest_loss": -337.15
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -163.01,
+          "cumulative_profit": -248.51,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -163.01,
+          "largest_loss": -163.01
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 192.34,
+          "cumulative_profit": -56.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 192.34,
+          "largest_loss": 192.34
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 54.77,
+          "cumulative_profit": -1.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 54.77,
+          "largest_loss": 54.77
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 186.67,
+          "cumulative_profit": 185.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 186.67,
+          "largest_loss": 186.67
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 7.97,
+          "cumulative_profit": 193.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 7.97,
+          "largest_loss": 7.97
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 59.48,
+          "cumulative_profit": 252.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 59.48,
+          "largest_loss": 59.48
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -276.99,
+          "cumulative_profit": -24.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -276.99,
+          "largest_loss": -276.99
+        },
+        {
+          "date": "2025-07-23",
+          "profit": 67.92,
+          "cumulative_profit": 43.65,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 67.92,
+          "largest_loss": 67.92
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 152.77,
+          "cumulative_profit": 196.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 152.77,
+          "largest_loss": 152.77
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -184.84,
+          "cumulative_profit": 11.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -184.84,
+          "largest_loss": -184.84
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -40.73,
+          "cumulative_profit": -29.15,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -40.73,
+          "largest_loss": -40.73
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -359.42,
+          "cumulative_profit": -388.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -359.42,
+          "largest_loss": -359.42
+        },
+        {
+          "date": "2025-07-28",
+          "profit": -379.97,
+          "cumulative_profit": -768.54,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -379.97,
+          "largest_loss": -379.97
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 68.98,
+          "cumulative_profit": -699.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 68.98,
+          "largest_loss": 68.98
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -220.39,
+          "cumulative_profit": -919.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -220.39,
+          "largest_loss": -220.39
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 46.84,
+          "cumulative_profit": -873.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 46.84,
+          "largest_loss": 46.84
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 364.89,
+          "cumulative_profit": -508.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 364.89,
+          "largest_loss": 364.89
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 31.73,
+          "cumulative_profit": -476.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 31.73,
+          "largest_loss": 31.73
+        },
+        {
+          "date": "2025-08-03",
+          "profit": -127.28,
+          "cumulative_profit": -603.77,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -127.28,
+          "largest_loss": -127.28
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 328.93,
+          "cumulative_profit": -274.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 328.93,
+          "largest_loss": 328.93
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -367.18,
+          "cumulative_profit": -642.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -367.18,
+          "largest_loss": -367.18
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 194.93,
+          "cumulative_profit": -447.09,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 194.93,
+          "largest_loss": 194.93
+        },
+        {
+          "date": "2025-08-07",
+          "profit": 350.11,
+          "cumulative_profit": -96.98,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 350.11,
+          "largest_loss": 350.11
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -152.88,
+          "cumulative_profit": -249.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -152.88,
+          "largest_loss": -152.88
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -206.24,
+          "cumulative_profit": -456.1,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -206.24,
+          "largest_loss": -206.24
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -241.89,
+          "cumulative_profit": -697.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -241.89,
+          "largest_loss": -241.89
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 133.36,
+          "cumulative_profit": -564.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 133.36,
+          "largest_loss": 133.36
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 8.88,
+          "cumulative_profit": -555.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.88,
+          "largest_loss": 8.88
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 336.0,
+          "cumulative_profit": -219.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 336.0,
+          "largest_loss": 336.0
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -239.14,
+          "cumulative_profit": -458.89,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -239.14,
+          "largest_loss": -239.14
+        },
+        {
+          "date": "2025-08-15",
+          "profit": -180.82,
+          "cumulative_profit": -639.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -180.82,
+          "largest_loss": -180.82
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 196.38,
+          "cumulative_profit": -443.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 196.38,
+          "largest_loss": 196.38
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -263.77,
+          "cumulative_profit": -707.1,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -263.77,
+          "largest_loss": -263.77
+        },
+        {
+          "date": "2025-08-18",
+          "profit": -21.75,
+          "cumulative_profit": -728.85,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -21.75,
+          "largest_loss": -21.75
+        },
+        {
+          "date": "2025-08-19",
+          "profit": -372.14,
+          "cumulative_profit": -1100.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -372.14,
+          "largest_loss": -372.14
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 167.53,
+          "cumulative_profit": -933.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 167.53,
+          "largest_loss": 167.53
+        },
+        {
+          "date": "2025-08-21",
+          "profit": -376.27,
+          "cumulative_profit": -1309.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -376.27,
+          "largest_loss": -376.27
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 326.02,
+          "cumulative_profit": -983.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 326.02,
+          "largest_loss": 326.02
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 344.17,
+          "cumulative_profit": -639.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 344.17,
+          "largest_loss": 344.17
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -359.73,
+          "cumulative_profit": -999.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -359.73,
+          "largest_loss": -359.73
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 327.22,
+          "cumulative_profit": -672.05,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 327.22,
+          "largest_loss": 327.22
+        },
+        {
+          "date": "2025-08-26",
+          "profit": -209.43,
+          "cumulative_profit": -881.48,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -209.43,
+          "largest_loss": -209.43
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -347.86,
+          "cumulative_profit": -1229.34,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -347.86,
+          "largest_loss": -347.86
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -134.12,
+          "cumulative_profit": -1363.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -134.12,
+          "largest_loss": -134.12
+        },
+        {
+          "date": "2025-08-29",
+          "profit": -288.89,
+          "cumulative_profit": -1652.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -288.89,
+          "largest_loss": -288.89
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -286.7,
+          "cumulative_profit": -1939.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -286.7,
+          "largest_loss": -286.7
+        },
+        {
+          "date": "2025-08-31",
+          "profit": 344.42,
+          "cumulative_profit": -1594.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 344.42,
+          "largest_loss": 344.42
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -250.06,
+          "cumulative_profit": -1844.69,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -250.06,
+          "largest_loss": -250.06
+        },
+        {
+          "date": "2025-09-02",
+          "profit": 359.91,
+          "cumulative_profit": -1484.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 359.91,
+          "largest_loss": 359.91
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 360.44,
+          "cumulative_profit": -1124.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 360.44,
+          "largest_loss": 360.44
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 257.72,
+          "cumulative_profit": -866.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 257.72,
+          "largest_loss": 257.72
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 176.6,
+          "cumulative_profit": -690.02,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 176.6,
+          "largest_loss": 176.6
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -5.22,
+          "cumulative_profit": -695.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -5.22,
+          "largest_loss": -5.22
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -68.23,
+          "cumulative_profit": -763.47,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -68.23,
+          "largest_loss": -68.23
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -161.88,
+          "cumulative_profit": -925.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -161.88,
+          "largest_loss": -161.88
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -132.07,
+          "cumulative_profit": -1057.42,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -132.07,
+          "largest_loss": -132.07
+        },
+        {
+          "date": "2025-09-10",
+          "profit": -80.53,
+          "cumulative_profit": -1137.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -80.53,
+          "largest_loss": -80.53
+        },
+        {
+          "date": "2025-09-11",
+          "profit": -88.43,
+          "cumulative_profit": -1226.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -88.43,
+          "largest_loss": -88.43
+        },
+        {
+          "date": "2025-09-12",
+          "profit": -194.2,
+          "cumulative_profit": -1420.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -194.2,
+          "largest_loss": -194.2
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -98.3,
+          "cumulative_profit": -1518.88,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -98.3,
+          "largest_loss": -98.3
+        },
+        {
+          "date": "2025-09-14",
+          "profit": -288.5,
+          "cumulative_profit": -1807.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -288.5,
+          "largest_loss": -288.5
+        },
+        {
+          "date": "2025-09-15",
+          "profit": -139.92,
+          "cumulative_profit": -1947.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -139.92,
+          "largest_loss": -139.92
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 342.71,
+          "cumulative_profit": -1604.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 342.71,
+          "largest_loss": 342.71
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -16.42,
+          "cumulative_profit": -1621.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -16.42,
+          "largest_loss": -16.42
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -282.05,
+          "cumulative_profit": -1903.06,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -282.05,
+          "largest_loss": -282.05
+        },
+        {
+          "date": "2025-09-19",
+          "profit": -66.68,
+          "cumulative_profit": -1969.74,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -66.68,
+          "largest_loss": -66.68
+        },
+        {
+          "date": "2025-09-20",
+          "profit": -243.48,
+          "cumulative_profit": -2213.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -243.48,
+          "largest_loss": -243.48
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 22.8,
+          "cumulative_profit": -2190.42,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 22.8,
+          "largest_loss": 22.8
+        },
+        {
+          "date": "2025-09-22",
+          "profit": 354.75,
+          "cumulative_profit": -1835.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 354.75,
+          "largest_loss": 354.75
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -110.77,
+          "cumulative_profit": -1946.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -110.77,
+          "largest_loss": -110.77
+        },
+        {
+          "date": "2025-09-24",
+          "profit": 292.76,
+          "cumulative_profit": -1653.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 292.76,
+          "largest_loss": 292.76
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 39.1,
+          "cumulative_profit": -1614.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 39.1,
+          "largest_loss": 39.1
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 53.87,
+          "cumulative_profit": -1560.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 53.87,
+          "largest_loss": 53.87
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -134.4,
+          "cumulative_profit": -1695.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -134.4,
+          "largest_loss": -134.4
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 44.94,
+          "cumulative_profit": -1650.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 44.94,
+          "largest_loss": 44.94
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -169.45,
+          "cumulative_profit": -1819.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -169.45,
+          "largest_loss": -169.45
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 355.26,
+          "cumulative_profit": -1464.36,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 355.26,
+          "largest_loss": 355.26
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -369.45,
+          "cumulative_profit": -1833.81,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -369.45,
+          "largest_loss": -369.45
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -192.43,
+          "cumulative_profit": -2026.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -192.43,
+          "largest_loss": -192.43
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 215.53,
+          "cumulative_profit": -1810.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 215.53,
+          "largest_loss": 215.53
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -163.95,
+          "cumulative_profit": -1974.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -163.95,
+          "largest_loss": -163.95
+        }
+      ],
+      "largest_win": {
+        "profit": 376.49,
+        "date": "2025-07-07",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -379.97,
+        "date": "2025-07-28",
+        "action": "BUY"
+      }
+    },
+    "USDJPY": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 2064.41,
+        "gross_profit": 11323.23,
+        "gross_loss": -9258.82,
+        "win_rate": 0.533,
+        "largest_win": 493.9,
+        "largest_loss": -480.79,
+        "average_win": 235.9,
+        "average_loss": -220.45,
+        "profit_factor": 1.223
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -388.93,
+          "cumulative_profit": -388.93,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -388.93,
+          "largest_loss": -388.93
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -13.98,
+          "cumulative_profit": -402.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -13.98,
+          "largest_loss": -13.98
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 455.54,
+          "cumulative_profit": 52.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 455.54,
+          "largest_loss": 455.54
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 70.8,
+          "cumulative_profit": 123.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 70.8,
+          "largest_loss": 70.8
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 167.97,
+          "cumulative_profit": 291.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 167.97,
+          "largest_loss": 167.97
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -414.22,
+          "cumulative_profit": -122.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -414.22,
+          "largest_loss": -414.22
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 278.48,
+          "cumulative_profit": 155.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 278.48,
+          "largest_loss": 278.48
+        },
+        {
+          "date": "2025-07-14",
+          "profit": -220.52,
+          "cumulative_profit": -64.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -220.52,
+          "largest_loss": -220.52
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 258.56,
+          "cumulative_profit": 193.7,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 258.56,
+          "largest_loss": 258.56
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -332.27,
+          "cumulative_profit": -138.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -332.27,
+          "largest_loss": -332.27
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 194.92,
+          "cumulative_profit": 56.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 194.92,
+          "largest_loss": 194.92
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 361.9,
+          "cumulative_profit": 418.25,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 361.9,
+          "largest_loss": 361.9
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 478.61,
+          "cumulative_profit": 896.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 478.61,
+          "largest_loss": 478.61
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 42.36,
+          "cumulative_profit": 939.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 42.36,
+          "largest_loss": 42.36
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 312.07,
+          "cumulative_profit": 1251.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 312.07,
+          "largest_loss": 312.07
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 131.36,
+          "cumulative_profit": 1382.65,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 131.36,
+          "largest_loss": 131.36
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -296.78,
+          "cumulative_profit": 1085.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -296.78,
+          "largest_loss": -296.78
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 38.47,
+          "cumulative_profit": 1124.34,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 38.47,
+          "largest_loss": 38.47
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -112.46,
+          "cumulative_profit": 1011.88,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -112.46,
+          "largest_loss": -112.46
+        },
+        {
+          "date": "2025-07-26",
+          "profit": 16.3,
+          "cumulative_profit": 1028.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 16.3,
+          "largest_loss": 16.3
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 242.33,
+          "cumulative_profit": 1270.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 242.33,
+          "largest_loss": 242.33
+        },
+        {
+          "date": "2025-07-28",
+          "profit": -94.62,
+          "cumulative_profit": 1175.89,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -94.62,
+          "largest_loss": -94.62
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 493.9,
+          "cumulative_profit": 1669.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 493.9,
+          "largest_loss": 493.9
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 285.9,
+          "cumulative_profit": 1955.69,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 285.9,
+          "largest_loss": 285.9
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 114.42,
+          "cumulative_profit": 2070.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 114.42,
+          "largest_loss": 114.42
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -406.45,
+          "cumulative_profit": 1663.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -406.45,
+          "largest_loss": -406.45
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 232.69,
+          "cumulative_profit": 1896.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 232.69,
+          "largest_loss": 232.69
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 189.84,
+          "cumulative_profit": 2086.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 189.84,
+          "largest_loss": 189.84
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 16.22,
+          "cumulative_profit": 2102.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 16.22,
+          "largest_loss": 16.22
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -349.78,
+          "cumulative_profit": 1752.63,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -349.78,
+          "largest_loss": -349.78
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 145.48,
+          "cumulative_profit": 1898.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 145.48,
+          "largest_loss": 145.48
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -376.84,
+          "cumulative_profit": 1521.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -376.84,
+          "largest_loss": -376.84
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 29.91,
+          "cumulative_profit": 1551.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 29.91,
+          "largest_loss": 29.91
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -8.22,
+          "cumulative_profit": 1542.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -8.22,
+          "largest_loss": -8.22
+        },
+        {
+          "date": "2025-08-10",
+          "profit": 398.27,
+          "cumulative_profit": 1941.23,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 398.27,
+          "largest_loss": 398.27
+        },
+        {
+          "date": "2025-08-11",
+          "profit": -164.33,
+          "cumulative_profit": 1776.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -164.33,
+          "largest_loss": -164.33
+        },
+        {
+          "date": "2025-08-12",
+          "profit": -339.78,
+          "cumulative_profit": 1437.12,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -339.78,
+          "largest_loss": -339.78
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 95.5,
+          "cumulative_profit": 1532.62,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 95.5,
+          "largest_loss": 95.5
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -480.79,
+          "cumulative_profit": 1051.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -480.79,
+          "largest_loss": -480.79
+        },
+        {
+          "date": "2025-08-15",
+          "profit": -67.6,
+          "cumulative_profit": 984.23,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -67.6,
+          "largest_loss": -67.6
+        },
+        {
+          "date": "2025-08-16",
+          "profit": -30.21,
+          "cumulative_profit": 954.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -30.21,
+          "largest_loss": -30.21
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 88.27,
+          "cumulative_profit": 1042.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 88.27,
+          "largest_loss": 88.27
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 71.68,
+          "cumulative_profit": 1113.97,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 71.68,
+          "largest_loss": 71.68
+        },
+        {
+          "date": "2025-08-19",
+          "profit": -210.86,
+          "cumulative_profit": 903.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -210.86,
+          "largest_loss": -210.86
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -125.73,
+          "cumulative_profit": 777.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -125.73,
+          "largest_loss": -125.73
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 257.89,
+          "cumulative_profit": 1035.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 257.89,
+          "largest_loss": 257.89
+        },
+        {
+          "date": "2025-08-22",
+          "profit": 188.0,
+          "cumulative_profit": 1223.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 188.0,
+          "largest_loss": 188.0
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -135.83,
+          "cumulative_profit": 1087.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -135.83,
+          "largest_loss": -135.83
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -65.88,
+          "cumulative_profit": 1021.56,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -65.88,
+          "largest_loss": -65.88
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 329.12,
+          "cumulative_profit": 1350.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 329.12,
+          "largest_loss": 329.12
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 278.11,
+          "cumulative_profit": 1628.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 278.11,
+          "largest_loss": 278.11
+        },
+        {
+          "date": "2025-08-27",
+          "profit": 214.34,
+          "cumulative_profit": 1843.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 214.34,
+          "largest_loss": 214.34
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -462.58,
+          "cumulative_profit": 1380.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -462.58,
+          "largest_loss": -462.58
+        },
+        {
+          "date": "2025-08-29",
+          "profit": -293.3,
+          "cumulative_profit": 1087.25,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -293.3,
+          "largest_loss": -293.3
+        },
+        {
+          "date": "2025-08-30",
+          "profit": -225.25,
+          "cumulative_profit": 862.0,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -225.25,
+          "largest_loss": -225.25
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -76.71,
+          "cumulative_profit": 785.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -76.71,
+          "largest_loss": -76.71
+        },
+        {
+          "date": "2025-09-01",
+          "profit": 431.53,
+          "cumulative_profit": 1216.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 431.53,
+          "largest_loss": 431.53
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -125.99,
+          "cumulative_profit": 1090.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -125.99,
+          "largest_loss": -125.99
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 419.5,
+          "cumulative_profit": 1510.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 419.5,
+          "largest_loss": 419.5
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 248.33,
+          "cumulative_profit": 1758.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 248.33,
+          "largest_loss": 248.33
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -41.08,
+          "cumulative_profit": 1717.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -41.08,
+          "largest_loss": -41.08
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 248.29,
+          "cumulative_profit": 1965.87,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 248.29,
+          "largest_loss": 248.29
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -467.17,
+          "cumulative_profit": 1498.7,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -467.17,
+          "largest_loss": -467.17
+        },
+        {
+          "date": "2025-09-08",
+          "profit": -305.36,
+          "cumulative_profit": 1193.34,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -305.36,
+          "largest_loss": -305.36
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -189.85,
+          "cumulative_profit": 1003.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -189.85,
+          "largest_loss": -189.85
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 446.43,
+          "cumulative_profit": 1449.92,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 446.43,
+          "largest_loss": 446.43
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 83.75,
+          "cumulative_profit": 1533.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 83.75,
+          "largest_loss": 83.75
+        },
+        {
+          "date": "2025-09-12",
+          "profit": -100.66,
+          "cumulative_profit": 1433.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -100.66,
+          "largest_loss": -100.66
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -117.98,
+          "cumulative_profit": 1315.03,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -117.98,
+          "largest_loss": -117.98
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 199.4,
+          "cumulative_profit": 1514.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 199.4,
+          "largest_loss": 199.4
+        },
+        {
+          "date": "2025-09-15",
+          "profit": -15.81,
+          "cumulative_profit": 1498.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -15.81,
+          "largest_loss": -15.81
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 429.37,
+          "cumulative_profit": 1927.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 429.37,
+          "largest_loss": 429.37
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -324.75,
+          "cumulative_profit": 1603.24,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -324.75,
+          "largest_loss": -324.75
+        },
+        {
+          "date": "2025-09-18",
+          "profit": 270.64,
+          "cumulative_profit": 1873.88,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 270.64,
+          "largest_loss": 270.64
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 296.57,
+          "cumulative_profit": 2170.45,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 296.57,
+          "largest_loss": 296.57
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 19.9,
+          "cumulative_profit": 2190.35,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 19.9,
+          "largest_loss": 19.9
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -469.68,
+          "cumulative_profit": 1720.67,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -469.68,
+          "largest_loss": -469.68
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -317.66,
+          "cumulative_profit": 1403.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -317.66,
+          "largest_loss": -317.66
+        },
+        {
+          "date": "2025-09-23",
+          "profit": 357.17,
+          "cumulative_profit": 1760.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 357.17,
+          "largest_loss": 357.17
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -96.34,
+          "cumulative_profit": 1663.84,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -96.34,
+          "largest_loss": -96.34
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 438.67,
+          "cumulative_profit": 2102.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 438.67,
+          "largest_loss": 438.67
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 21.48,
+          "cumulative_profit": 2123.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 21.48,
+          "largest_loss": 21.48
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -139.61,
+          "cumulative_profit": 1984.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -139.61,
+          "largest_loss": -139.61
+        },
+        {
+          "date": "2025-09-28",
+          "profit": -354.59,
+          "cumulative_profit": 1629.79,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -354.59,
+          "largest_loss": -354.59
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -260.37,
+          "cumulative_profit": 1369.42,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -260.37,
+          "largest_loss": -260.37
+        },
+        {
+          "date": "2025-09-30",
+          "profit": -16.14,
+          "cumulative_profit": 1353.28,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -16.14,
+          "largest_loss": -16.14
+        },
+        {
+          "date": "2025-10-01",
+          "profit": 462.18,
+          "cumulative_profit": 1815.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 462.18,
+          "largest_loss": 462.18
+        },
+        {
+          "date": "2025-10-02",
+          "profit": 103.15,
+          "cumulative_profit": 1918.61,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 103.15,
+          "largest_loss": 103.15
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -221.86,
+          "cumulative_profit": 1696.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -221.86,
+          "largest_loss": -221.86
+        },
+        {
+          "date": "2025-10-04",
+          "profit": 367.66,
+          "cumulative_profit": 2064.41,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 367.66,
+          "largest_loss": 367.66
+        }
+      ],
+      "largest_win": {
+        "profit": 493.9,
+        "date": "2025-07-29",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -480.79,
+        "date": "2025-08-14",
+        "action": "SELL"
+      }
+    },
+    "XAGUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -773.5,
+        "gross_profit": 29580.21,
+        "gross_loss": -30353.71,
+        "win_rate": 0.489,
+        "largest_win": 1494.52,
+        "largest_loss": -1494.03,
+        "average_win": 672.28,
+        "average_loss": -659.86,
+        "profit_factor": 0.975
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -617.92,
+          "cumulative_profit": -617.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -617.92,
+          "largest_loss": -617.92
+        },
+        {
+          "date": "2025-07-08",
+          "profit": 637.85,
+          "cumulative_profit": 19.93,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 637.85,
+          "largest_loss": 637.85
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -679.39,
+          "cumulative_profit": -659.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -679.39,
+          "largest_loss": -679.39
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 1336.24,
+          "cumulative_profit": 676.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1336.24,
+          "largest_loss": 1336.24
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 778.73,
+          "cumulative_profit": 1455.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 778.73,
+          "largest_loss": 778.73
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -441.4,
+          "cumulative_profit": 1014.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -441.4,
+          "largest_loss": -441.4
+        },
+        {
+          "date": "2025-07-13",
+          "profit": 29.56,
+          "cumulative_profit": 1043.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 29.56,
+          "largest_loss": 29.56
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 1225.04,
+          "cumulative_profit": 2268.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1225.04,
+          "largest_loss": 1225.04
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 55.16,
+          "cumulative_profit": 2323.87,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 55.16,
+          "largest_loss": 55.16
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -670.38,
+          "cumulative_profit": 1653.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -670.38,
+          "largest_loss": -670.38
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 1494.52,
+          "cumulative_profit": 3148.01,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1494.52,
+          "largest_loss": 1494.52
+        },
+        {
+          "date": "2025-07-18",
+          "profit": 590.23,
+          "cumulative_profit": 3738.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 590.23,
+          "largest_loss": 590.23
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 862.86,
+          "cumulative_profit": 4601.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 862.86,
+          "largest_loss": 862.86
+        },
+        {
+          "date": "2025-07-20",
+          "profit": 48.03,
+          "cumulative_profit": 4649.13,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 48.03,
+          "largest_loss": 48.03
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -210.18,
+          "cumulative_profit": 4438.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -210.18,
+          "largest_loss": -210.18
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -209.12,
+          "cumulative_profit": 4229.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -209.12,
+          "largest_loss": -209.12
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -562.75,
+          "cumulative_profit": 3667.08,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -562.75,
+          "largest_loss": -562.75
+        },
+        {
+          "date": "2025-07-24",
+          "profit": -944.1,
+          "cumulative_profit": 2722.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -944.1,
+          "largest_loss": -944.1
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -146.52,
+          "cumulative_profit": 2576.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -146.52,
+          "largest_loss": -146.52
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -472.5,
+          "cumulative_profit": 2103.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -472.5,
+          "largest_loss": -472.5
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 442.69,
+          "cumulative_profit": 2546.65,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 442.69,
+          "largest_loss": 442.69
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 424.92,
+          "cumulative_profit": 2971.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 424.92,
+          "largest_loss": 424.92
+        },
+        {
+          "date": "2025-07-29",
+          "profit": -1019.29,
+          "cumulative_profit": 1952.28,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1019.29,
+          "largest_loss": -1019.29
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 1230.29,
+          "cumulative_profit": 3182.57,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1230.29,
+          "largest_loss": 1230.29
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 722.22,
+          "cumulative_profit": 3904.79,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 722.22,
+          "largest_loss": 722.22
+        },
+        {
+          "date": "2025-08-01",
+          "profit": -93.27,
+          "cumulative_profit": 3811.52,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -93.27,
+          "largest_loss": -93.27
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 1409.34,
+          "cumulative_profit": 5220.86,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1409.34,
+          "largest_loss": 1409.34
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 942.9,
+          "cumulative_profit": 6163.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 942.9,
+          "largest_loss": 942.9
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -1117.64,
+          "cumulative_profit": 5046.12,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1117.64,
+          "largest_loss": -1117.64
+        },
+        {
+          "date": "2025-08-05",
+          "profit": 599.56,
+          "cumulative_profit": 5645.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 599.56,
+          "largest_loss": 599.56
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -500.0,
+          "cumulative_profit": 5145.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -500.0,
+          "largest_loss": -500.0
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -699.52,
+          "cumulative_profit": 4446.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -699.52,
+          "largest_loss": -699.52
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 77.57,
+          "cumulative_profit": 4523.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 77.57,
+          "largest_loss": 77.57
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -1069.2,
+          "cumulative_profit": 3454.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1069.2,
+          "largest_loss": -1069.2
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -335.24,
+          "cumulative_profit": 3119.29,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -335.24,
+          "largest_loss": -335.24
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 1237.49,
+          "cumulative_profit": 4356.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1237.49,
+          "largest_loss": 1237.49
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 1088.94,
+          "cumulative_profit": 5445.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1088.94,
+          "largest_loss": 1088.94
+        },
+        {
+          "date": "2025-08-13",
+          "profit": -1299.14,
+          "cumulative_profit": 4146.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1299.14,
+          "largest_loss": -1299.14
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -337.63,
+          "cumulative_profit": 3808.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -337.63,
+          "largest_loss": -337.63
+        },
+        {
+          "date": "2025-08-15",
+          "profit": -199.51,
+          "cumulative_profit": 3609.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -199.51,
+          "largest_loss": -199.51
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 920.34,
+          "cumulative_profit": 4529.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 920.34,
+          "largest_loss": 920.34
+        },
+        {
+          "date": "2025-08-17",
+          "profit": -647.92,
+          "cumulative_profit": 3881.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -647.92,
+          "largest_loss": -647.92
+        },
+        {
+          "date": "2025-08-18",
+          "profit": 811.82,
+          "cumulative_profit": 4693.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 811.82,
+          "largest_loss": 811.82
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 775.59,
+          "cumulative_profit": 5469.27,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 775.59,
+          "largest_loss": 775.59
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -456.85,
+          "cumulative_profit": 5012.42,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -456.85,
+          "largest_loss": -456.85
+        },
+        {
+          "date": "2025-08-21",
+          "profit": -1153.8,
+          "cumulative_profit": 3858.62,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1153.8,
+          "largest_loss": -1153.8
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -647.11,
+          "cumulative_profit": 3211.51,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -647.11,
+          "largest_loss": -647.11
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -199.73,
+          "cumulative_profit": 3011.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -199.73,
+          "largest_loss": -199.73
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -90.23,
+          "cumulative_profit": 2921.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -90.23,
+          "largest_loss": -90.23
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 770.25,
+          "cumulative_profit": 3691.8,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 770.25,
+          "largest_loss": 770.25
+        },
+        {
+          "date": "2025-08-26",
+          "profit": -1417.11,
+          "cumulative_profit": 2274.69,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1417.11,
+          "largest_loss": -1417.11
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -358.96,
+          "cumulative_profit": 1915.73,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -358.96,
+          "largest_loss": -358.96
+        },
+        {
+          "date": "2025-08-28",
+          "profit": 1162.8,
+          "cumulative_profit": 3078.53,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1162.8,
+          "largest_loss": 1162.8
+        },
+        {
+          "date": "2025-08-29",
+          "profit": 306.36,
+          "cumulative_profit": 3384.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 306.36,
+          "largest_loss": 306.36
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 696.82,
+          "cumulative_profit": 4081.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 696.82,
+          "largest_loss": 696.82
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -1215.02,
+          "cumulative_profit": 2866.69,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1215.02,
+          "largest_loss": -1215.02
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -422.8,
+          "cumulative_profit": 2443.89,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -422.8,
+          "largest_loss": -422.8
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -593.54,
+          "cumulative_profit": 1850.35,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -593.54,
+          "largest_loss": -593.54
+        },
+        {
+          "date": "2025-09-03",
+          "profit": 566.21,
+          "cumulative_profit": 2416.56,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 566.21,
+          "largest_loss": 566.21
+        },
+        {
+          "date": "2025-09-04",
+          "profit": -604.74,
+          "cumulative_profit": 1811.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -604.74,
+          "largest_loss": -604.74
+        },
+        {
+          "date": "2025-09-05",
+          "profit": 511.56,
+          "cumulative_profit": 2323.38,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 511.56,
+          "largest_loss": 511.56
+        },
+        {
+          "date": "2025-09-06",
+          "profit": 975.29,
+          "cumulative_profit": 3298.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 975.29,
+          "largest_loss": 975.29
+        },
+        {
+          "date": "2025-09-07",
+          "profit": -652.51,
+          "cumulative_profit": 2646.16,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -652.51,
+          "largest_loss": -652.51
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 1010.94,
+          "cumulative_profit": 3657.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1010.94,
+          "largest_loss": 1010.94
+        },
+        {
+          "date": "2025-09-09",
+          "profit": 210.97,
+          "cumulative_profit": 3868.07,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 210.97,
+          "largest_loss": 210.97
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 1152.11,
+          "cumulative_profit": 5020.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1152.11,
+          "largest_loss": 1152.11
+        },
+        {
+          "date": "2025-09-11",
+          "profit": -375.22,
+          "cumulative_profit": 4644.96,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -375.22,
+          "largest_loss": -375.22
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 212.77,
+          "cumulative_profit": 4857.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 212.77,
+          "largest_loss": 212.77
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -798.82,
+          "cumulative_profit": 4058.91,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -798.82,
+          "largest_loss": -798.82
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 713.93,
+          "cumulative_profit": 4772.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 713.93,
+          "largest_loss": 713.93
+        },
+        {
+          "date": "2025-09-15",
+          "profit": -1055.82,
+          "cumulative_profit": 3717.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1055.82,
+          "largest_loss": -1055.82
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 178.69,
+          "cumulative_profit": 3895.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 178.69,
+          "largest_loss": 178.69
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -226.59,
+          "cumulative_profit": 3669.12,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -226.59,
+          "largest_loss": -226.59
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -1494.03,
+          "cumulative_profit": 2175.09,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1494.03,
+          "largest_loss": -1494.03
+        },
+        {
+          "date": "2025-09-19",
+          "profit": -625.16,
+          "cumulative_profit": 1549.93,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -625.16,
+          "largest_loss": -625.16
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 378.5,
+          "cumulative_profit": 1928.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 378.5,
+          "largest_loss": 378.5
+        },
+        {
+          "date": "2025-09-21",
+          "profit": -621.72,
+          "cumulative_profit": 1306.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -621.72,
+          "largest_loss": -621.72
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -1393.13,
+          "cumulative_profit": -86.42,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1393.13,
+          "largest_loss": -1393.13
+        },
+        {
+          "date": "2025-09-23",
+          "profit": 269.88,
+          "cumulative_profit": 183.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 269.88,
+          "largest_loss": 269.88
+        },
+        {
+          "date": "2025-09-24",
+          "profit": 185.22,
+          "cumulative_profit": 368.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 185.22,
+          "largest_loss": 185.22
+        },
+        {
+          "date": "2025-09-25",
+          "profit": -242.81,
+          "cumulative_profit": 125.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -242.81,
+          "largest_loss": -242.81
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 525.32,
+          "cumulative_profit": 651.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 525.32,
+          "largest_loss": 525.32
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -1347.93,
+          "cumulative_profit": -696.74,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1347.93,
+          "largest_loss": -1347.93
+        },
+        {
+          "date": "2025-09-28",
+          "profit": -33.59,
+          "cumulative_profit": -730.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -33.59,
+          "largest_loss": -33.59
+        },
+        {
+          "date": "2025-09-29",
+          "profit": 65.87,
+          "cumulative_profit": -664.46,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 65.87,
+          "largest_loss": 65.87
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 240.03,
+          "cumulative_profit": -424.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 240.03,
+          "largest_loss": 240.03
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -1407.62,
+          "cumulative_profit": -1832.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1407.62,
+          "largest_loss": -1407.62
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -646.25,
+          "cumulative_profit": -2478.3,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -646.25,
+          "largest_loss": -646.25
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 842.26,
+          "cumulative_profit": -1636.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 842.26,
+          "largest_loss": 842.26
+        },
+        {
+          "date": "2025-10-04",
+          "profit": 862.54,
+          "cumulative_profit": -773.5,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 862.54,
+          "largest_loss": 862.54
+        }
+      ],
+      "largest_win": {
+        "profit": 1494.52,
+        "date": "2025-07-17",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -1494.03,
+        "date": "2025-09-18",
+        "action": "SELL"
+      }
+    },
+    "XAUUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": 12652.01,
+        "gross_profit": 59354.5,
+        "gross_loss": -46702.49,
+        "win_rate": 0.556,
+        "largest_win": 2449.39,
+        "largest_loss": -2349.74,
+        "average_win": 1187.09,
+        "average_loss": -1167.56,
+        "profit_factor": 1.271
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": -111.67,
+          "cumulative_profit": -111.67,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -111.67,
+          "largest_loss": -111.67
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -239.09,
+          "cumulative_profit": -350.76,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -239.09,
+          "largest_loss": -239.09
+        },
+        {
+          "date": "2025-07-09",
+          "profit": 413.75,
+          "cumulative_profit": 62.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 413.75,
+          "largest_loss": 413.75
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 82.29,
+          "cumulative_profit": 145.28,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 82.29,
+          "largest_loss": 82.29
+        },
+        {
+          "date": "2025-07-11",
+          "profit": 1502.9,
+          "cumulative_profit": 1648.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1502.9,
+          "largest_loss": 1502.9
+        },
+        {
+          "date": "2025-07-12",
+          "profit": 2299.58,
+          "cumulative_profit": 3947.76,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2299.58,
+          "largest_loss": 2299.58
+        },
+        {
+          "date": "2025-07-13",
+          "profit": -2039.99,
+          "cumulative_profit": 1907.77,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2039.99,
+          "largest_loss": -2039.99
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 1420.86,
+          "cumulative_profit": 3328.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1420.86,
+          "largest_loss": 1420.86
+        },
+        {
+          "date": "2025-07-15",
+          "profit": -1938.83,
+          "cumulative_profit": 1389.8,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1938.83,
+          "largest_loss": -1938.83
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -44.6,
+          "cumulative_profit": 1345.2,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -44.6,
+          "largest_loss": -44.6
+        },
+        {
+          "date": "2025-07-17",
+          "profit": 738.57,
+          "cumulative_profit": 2083.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 738.57,
+          "largest_loss": 738.57
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -495.17,
+          "cumulative_profit": 1588.6,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -495.17,
+          "largest_loss": -495.17
+        },
+        {
+          "date": "2025-07-19",
+          "profit": -277.07,
+          "cumulative_profit": 1311.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -277.07,
+          "largest_loss": -277.07
+        },
+        {
+          "date": "2025-07-20",
+          "profit": -2056.11,
+          "cumulative_profit": -744.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2056.11,
+          "largest_loss": -2056.11
+        },
+        {
+          "date": "2025-07-21",
+          "profit": 193.51,
+          "cumulative_profit": -551.07,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 193.51,
+          "largest_loss": 193.51
+        },
+        {
+          "date": "2025-07-22",
+          "profit": -1967.99,
+          "cumulative_profit": -2519.06,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1967.99,
+          "largest_loss": -1967.99
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -2102.6,
+          "cumulative_profit": -4621.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2102.6,
+          "largest_loss": -2102.6
+        },
+        {
+          "date": "2025-07-24",
+          "profit": 1625.22,
+          "cumulative_profit": -2996.44,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1625.22,
+          "largest_loss": 1625.22
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -642.46,
+          "cumulative_profit": -3638.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -642.46,
+          "largest_loss": -642.46
+        },
+        {
+          "date": "2025-07-26",
+          "profit": 742.94,
+          "cumulative_profit": -2895.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 742.94,
+          "largest_loss": 742.94
+        },
+        {
+          "date": "2025-07-27",
+          "profit": -1916.75,
+          "cumulative_profit": -4812.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1916.75,
+          "largest_loss": -1916.75
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 2449.39,
+          "cumulative_profit": -2363.32,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2449.39,
+          "largest_loss": 2449.39
+        },
+        {
+          "date": "2025-07-29",
+          "profit": 728.81,
+          "cumulative_profit": -1634.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 728.81,
+          "largest_loss": 728.81
+        },
+        {
+          "date": "2025-07-30",
+          "profit": -300.15,
+          "cumulative_profit": -1934.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -300.15,
+          "largest_loss": -300.15
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 695.98,
+          "cumulative_profit": -1238.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 695.98,
+          "largest_loss": 695.98
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 821.35,
+          "cumulative_profit": -417.33,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 821.35,
+          "largest_loss": 821.35
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 2019.49,
+          "cumulative_profit": 1602.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2019.49,
+          "largest_loss": 2019.49
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 1169.68,
+          "cumulative_profit": 2771.84,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1169.68,
+          "largest_loss": 1169.68
+        },
+        {
+          "date": "2025-08-04",
+          "profit": 585.87,
+          "cumulative_profit": 3357.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 585.87,
+          "largest_loss": 585.87
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -1625.22,
+          "cumulative_profit": 1732.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1625.22,
+          "largest_loss": -1625.22
+        },
+        {
+          "date": "2025-08-06",
+          "profit": -1532.56,
+          "cumulative_profit": 199.93,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1532.56,
+          "largest_loss": -1532.56
+        },
+        {
+          "date": "2025-08-07",
+          "profit": 1056.55,
+          "cumulative_profit": 1256.48,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1056.55,
+          "largest_loss": 1056.55
+        },
+        {
+          "date": "2025-08-08",
+          "profit": 1754.23,
+          "cumulative_profit": 3010.71,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1754.23,
+          "largest_loss": 1754.23
+        },
+        {
+          "date": "2025-08-09",
+          "profit": -548.83,
+          "cumulative_profit": 2461.88,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -548.83,
+          "largest_loss": -548.83
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -1805.77,
+          "cumulative_profit": 656.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1805.77,
+          "largest_loss": -1805.77
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 1567.99,
+          "cumulative_profit": 2224.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1567.99,
+          "largest_loss": 1567.99
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 1375.51,
+          "cumulative_profit": 3599.61,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1375.51,
+          "largest_loss": 1375.51
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 1740.13,
+          "cumulative_profit": 5339.74,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1740.13,
+          "largest_loss": 1740.13
+        },
+        {
+          "date": "2025-08-14",
+          "profit": 2069.15,
+          "cumulative_profit": 7408.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2069.15,
+          "largest_loss": 2069.15
+        },
+        {
+          "date": "2025-08-15",
+          "profit": 1726.91,
+          "cumulative_profit": 9135.8,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1726.91,
+          "largest_loss": 1726.91
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 911.95,
+          "cumulative_profit": 10047.75,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 911.95,
+          "largest_loss": 911.95
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 9.74,
+          "cumulative_profit": 10057.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 9.74,
+          "largest_loss": 9.74
+        },
+        {
+          "date": "2025-08-18",
+          "profit": -739.38,
+          "cumulative_profit": 9318.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -739.38,
+          "largest_loss": -739.38
+        },
+        {
+          "date": "2025-08-19",
+          "profit": 140.06,
+          "cumulative_profit": 9458.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 140.06,
+          "largest_loss": 140.06
+        },
+        {
+          "date": "2025-08-20",
+          "profit": -1502.2,
+          "cumulative_profit": 7955.97,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1502.2,
+          "largest_loss": -1502.2
+        },
+        {
+          "date": "2025-08-21",
+          "profit": -90.29,
+          "cumulative_profit": 7865.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -90.29,
+          "largest_loss": -90.29
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -364.59,
+          "cumulative_profit": 7501.09,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -364.59,
+          "largest_loss": -364.59
+        },
+        {
+          "date": "2025-08-23",
+          "profit": 2017.42,
+          "cumulative_profit": 9518.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2017.42,
+          "largest_loss": 2017.42
+        },
+        {
+          "date": "2025-08-24",
+          "profit": -278.12,
+          "cumulative_profit": 9240.39,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -278.12,
+          "largest_loss": -278.12
+        },
+        {
+          "date": "2025-08-25",
+          "profit": 1465.9,
+          "cumulative_profit": 10706.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1465.9,
+          "largest_loss": 1465.9
+        },
+        {
+          "date": "2025-08-26",
+          "profit": 395.85,
+          "cumulative_profit": 11102.14,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 395.85,
+          "largest_loss": 395.85
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -1495.7,
+          "cumulative_profit": 9606.44,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1495.7,
+          "largest_loss": -1495.7
+        },
+        {
+          "date": "2025-08-28",
+          "profit": -723.17,
+          "cumulative_profit": 8883.27,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -723.17,
+          "largest_loss": -723.17
+        },
+        {
+          "date": "2025-08-29",
+          "profit": -511.4,
+          "cumulative_profit": 8371.87,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -511.4,
+          "largest_loss": -511.4
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 637.77,
+          "cumulative_profit": 9009.64,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 637.77,
+          "largest_loss": 637.77
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -1679.78,
+          "cumulative_profit": 7329.86,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1679.78,
+          "largest_loss": -1679.78
+        },
+        {
+          "date": "2025-09-01",
+          "profit": 318.38,
+          "cumulative_profit": 7648.24,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 318.38,
+          "largest_loss": 318.38
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -673.46,
+          "cumulative_profit": 6974.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -673.46,
+          "largest_loss": -673.46
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -856.24,
+          "cumulative_profit": 6118.54,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -856.24,
+          "largest_loss": -856.24
+        },
+        {
+          "date": "2025-09-04",
+          "profit": 2219.96,
+          "cumulative_profit": 8338.5,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2219.96,
+          "largest_loss": 2219.96
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -899.48,
+          "cumulative_profit": 7439.02,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -899.48,
+          "largest_loss": -899.48
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -495.27,
+          "cumulative_profit": 6943.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -495.27,
+          "largest_loss": -495.27
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 885.25,
+          "cumulative_profit": 7829.0,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 885.25,
+          "largest_loss": 885.25
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 957.14,
+          "cumulative_profit": 8786.14,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 957.14,
+          "largest_loss": 957.14
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -2121.31,
+          "cumulative_profit": 6664.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2121.31,
+          "largest_loss": -2121.31
+        },
+        {
+          "date": "2025-09-10",
+          "profit": 135.16,
+          "cumulative_profit": 6799.99,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 135.16,
+          "largest_loss": 135.16
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 2222.02,
+          "cumulative_profit": 9022.01,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2222.02,
+          "largest_loss": 2222.02
+        },
+        {
+          "date": "2025-09-12",
+          "profit": 653.77,
+          "cumulative_profit": 9675.78,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 653.77,
+          "largest_loss": 653.77
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -1207.69,
+          "cumulative_profit": 8468.09,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1207.69,
+          "largest_loss": -1207.69
+        },
+        {
+          "date": "2025-09-14",
+          "profit": 2094.42,
+          "cumulative_profit": 10562.51,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2094.42,
+          "largest_loss": 2094.42
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 734.78,
+          "cumulative_profit": 11297.29,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 734.78,
+          "largest_loss": 734.78
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 2374.48,
+          "cumulative_profit": 13671.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2374.48,
+          "largest_loss": 2374.48
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -1958.22,
+          "cumulative_profit": 11713.55,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1958.22,
+          "largest_loss": -1958.22
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -2349.74,
+          "cumulative_profit": 9363.81,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -2349.74,
+          "largest_loss": -2349.74
+        },
+        {
+          "date": "2025-09-19",
+          "profit": 326.3,
+          "cumulative_profit": 9690.11,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 326.3,
+          "largest_loss": 326.3
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 692.93,
+          "cumulative_profit": 10383.04,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 692.93,
+          "largest_loss": 692.93
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 2057.88,
+          "cumulative_profit": 12440.92,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2057.88,
+          "largest_loss": 2057.88
+        },
+        {
+          "date": "2025-09-22",
+          "profit": -711.12,
+          "cumulative_profit": 11729.8,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -711.12,
+          "largest_loss": -711.12
+        },
+        {
+          "date": "2025-09-23",
+          "profit": -1694.3,
+          "cumulative_profit": 10035.5,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1694.3,
+          "largest_loss": -1694.3
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -1841.04,
+          "cumulative_profit": 8194.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1841.04,
+          "largest_loss": -1841.04
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 907.09,
+          "cumulative_profit": 9101.55,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 907.09,
+          "largest_loss": 907.09
+        },
+        {
+          "date": "2025-09-26",
+          "profit": 1380.11,
+          "cumulative_profit": 10481.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1380.11,
+          "largest_loss": 1380.11
+        },
+        {
+          "date": "2025-09-27",
+          "profit": -1957.84,
+          "cumulative_profit": 8523.82,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1957.84,
+          "largest_loss": -1957.84
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 1139.5,
+          "cumulative_profit": 9663.32,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1139.5,
+          "largest_loss": 1139.5
+        },
+        {
+          "date": "2025-09-29",
+          "profit": 1470.22,
+          "cumulative_profit": 11133.54,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1470.22,
+          "largest_loss": 1470.22
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 1307.84,
+          "cumulative_profit": 12441.38,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 1307.84,
+          "largest_loss": 1307.84
+        },
+        {
+          "date": "2025-10-01",
+          "profit": 799.51,
+          "cumulative_profit": 13240.89,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 799.51,
+          "largest_loss": 799.51
+        },
+        {
+          "date": "2025-10-02",
+          "profit": -989.29,
+          "cumulative_profit": 12251.6,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -989.29,
+          "largest_loss": -989.29
+        },
+        {
+          "date": "2025-10-03",
+          "profit": 2318.41,
+          "cumulative_profit": 14570.01,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2318.41,
+          "largest_loss": 2318.41
+        },
+        {
+          "date": "2025-10-04",
+          "profit": -1918.0,
+          "cumulative_profit": 12652.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -1918.0,
+          "largest_loss": -1918.0
+        }
+      ],
+      "largest_win": {
+        "profit": 2449.39,
+        "date": "2025-07-28",
+        "action": "BUY"
+      },
+      "largest_loss": {
+        "profit": -2349.74,
+        "date": "2025-09-18",
+        "action": "SELL"
+      }
+    },
+    "XRPUSD": {
+      "summary": {
+        "total_trades": 90,
+        "total_profit": -1540.48,
+        "gross_profit": 1956.32,
+        "gross_loss": -3496.8,
+        "win_rate": 0.444,
+        "largest_win": 116.69,
+        "largest_loss": -121.89,
+        "average_win": 48.91,
+        "average_loss": -69.94,
+        "profit_factor": 0.559
+      },
+      "history": [
+        {
+          "date": "2025-07-07",
+          "profit": 7.4,
+          "cumulative_profit": 7.4,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 7.4,
+          "largest_loss": 7.4
+        },
+        {
+          "date": "2025-07-08",
+          "profit": -29.3,
+          "cumulative_profit": -21.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -29.3,
+          "largest_loss": -29.3
+        },
+        {
+          "date": "2025-07-09",
+          "profit": -35.21,
+          "cumulative_profit": -57.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -35.21,
+          "largest_loss": -35.21
+        },
+        {
+          "date": "2025-07-10",
+          "profit": 60.84,
+          "cumulative_profit": 3.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 60.84,
+          "largest_loss": 60.84
+        },
+        {
+          "date": "2025-07-11",
+          "profit": -112.3,
+          "cumulative_profit": -108.57,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -112.3,
+          "largest_loss": -112.3
+        },
+        {
+          "date": "2025-07-12",
+          "profit": -3.89,
+          "cumulative_profit": -112.46,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -3.89,
+          "largest_loss": -3.89
+        },
+        {
+          "date": "2025-07-13",
+          "profit": -99.52,
+          "cumulative_profit": -211.98,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -99.52,
+          "largest_loss": -99.52
+        },
+        {
+          "date": "2025-07-14",
+          "profit": 36.21,
+          "cumulative_profit": -175.77,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 36.21,
+          "largest_loss": 36.21
+        },
+        {
+          "date": "2025-07-15",
+          "profit": 98.59,
+          "cumulative_profit": -77.18,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 98.59,
+          "largest_loss": 98.59
+        },
+        {
+          "date": "2025-07-16",
+          "profit": -70.31,
+          "cumulative_profit": -147.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -70.31,
+          "largest_loss": -70.31
+        },
+        {
+          "date": "2025-07-17",
+          "profit": -3.91,
+          "cumulative_profit": -151.4,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -3.91,
+          "largest_loss": -3.91
+        },
+        {
+          "date": "2025-07-18",
+          "profit": -55.01,
+          "cumulative_profit": -206.41,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -55.01,
+          "largest_loss": -55.01
+        },
+        {
+          "date": "2025-07-19",
+          "profit": 2.78,
+          "cumulative_profit": -203.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 2.78,
+          "largest_loss": 2.78
+        },
+        {
+          "date": "2025-07-20",
+          "profit": -77.2,
+          "cumulative_profit": -280.83,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -77.2,
+          "largest_loss": -77.2
+        },
+        {
+          "date": "2025-07-21",
+          "profit": -56.32,
+          "cumulative_profit": -337.15,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -56.32,
+          "largest_loss": -56.32
+        },
+        {
+          "date": "2025-07-22",
+          "profit": 92.72,
+          "cumulative_profit": -244.43,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 92.72,
+          "largest_loss": 92.72
+        },
+        {
+          "date": "2025-07-23",
+          "profit": -61.62,
+          "cumulative_profit": -306.05,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -61.62,
+          "largest_loss": -61.62
+        },
+        {
+          "date": "2025-07-24",
+          "profit": -77.66,
+          "cumulative_profit": -383.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -77.66,
+          "largest_loss": -77.66
+        },
+        {
+          "date": "2025-07-25",
+          "profit": -14.87,
+          "cumulative_profit": -398.58,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -14.87,
+          "largest_loss": -14.87
+        },
+        {
+          "date": "2025-07-26",
+          "profit": -107.09,
+          "cumulative_profit": -505.67,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -107.09,
+          "largest_loss": -107.09
+        },
+        {
+          "date": "2025-07-27",
+          "profit": 8.98,
+          "cumulative_profit": -496.69,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.98,
+          "largest_loss": 8.98
+        },
+        {
+          "date": "2025-07-28",
+          "profit": 61.54,
+          "cumulative_profit": -435.15,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 61.54,
+          "largest_loss": 61.54
+        },
+        {
+          "date": "2025-07-29",
+          "profit": -83.8,
+          "cumulative_profit": -518.95,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -83.8,
+          "largest_loss": -83.8
+        },
+        {
+          "date": "2025-07-30",
+          "profit": 82.29,
+          "cumulative_profit": -436.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 82.29,
+          "largest_loss": 82.29
+        },
+        {
+          "date": "2025-07-31",
+          "profit": 0.69,
+          "cumulative_profit": -435.97,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 0.69,
+          "largest_loss": 0.69
+        },
+        {
+          "date": "2025-08-01",
+          "profit": 13.59,
+          "cumulative_profit": -422.38,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 13.59,
+          "largest_loss": 13.59
+        },
+        {
+          "date": "2025-08-02",
+          "profit": 47.79,
+          "cumulative_profit": -374.59,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 47.79,
+          "largest_loss": 47.79
+        },
+        {
+          "date": "2025-08-03",
+          "profit": 116.69,
+          "cumulative_profit": -257.9,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 116.69,
+          "largest_loss": 116.69
+        },
+        {
+          "date": "2025-08-04",
+          "profit": -55.02,
+          "cumulative_profit": -312.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -55.02,
+          "largest_loss": -55.02
+        },
+        {
+          "date": "2025-08-05",
+          "profit": -42.83,
+          "cumulative_profit": -355.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -42.83,
+          "largest_loss": -42.83
+        },
+        {
+          "date": "2025-08-06",
+          "profit": 7.58,
+          "cumulative_profit": -348.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 7.58,
+          "largest_loss": 7.58
+        },
+        {
+          "date": "2025-08-07",
+          "profit": -49.02,
+          "cumulative_profit": -397.19,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -49.02,
+          "largest_loss": -49.02
+        },
+        {
+          "date": "2025-08-08",
+          "profit": -92.82,
+          "cumulative_profit": -490.01,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -92.82,
+          "largest_loss": -92.82
+        },
+        {
+          "date": "2025-08-09",
+          "profit": 55.54,
+          "cumulative_profit": -434.47,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 55.54,
+          "largest_loss": 55.54
+        },
+        {
+          "date": "2025-08-10",
+          "profit": -13.91,
+          "cumulative_profit": -448.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -13.91,
+          "largest_loss": -13.91
+        },
+        {
+          "date": "2025-08-11",
+          "profit": 78.65,
+          "cumulative_profit": -369.73,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 78.65,
+          "largest_loss": 78.65
+        },
+        {
+          "date": "2025-08-12",
+          "profit": 17.1,
+          "cumulative_profit": -352.63,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 17.1,
+          "largest_loss": 17.1
+        },
+        {
+          "date": "2025-08-13",
+          "profit": 47.95,
+          "cumulative_profit": -304.68,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 47.95,
+          "largest_loss": 47.95
+        },
+        {
+          "date": "2025-08-14",
+          "profit": -53.5,
+          "cumulative_profit": -358.18,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -53.5,
+          "largest_loss": -53.5
+        },
+        {
+          "date": "2025-08-15",
+          "profit": -74.59,
+          "cumulative_profit": -432.77,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -74.59,
+          "largest_loss": -74.59
+        },
+        {
+          "date": "2025-08-16",
+          "profit": 24.92,
+          "cumulative_profit": -407.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 24.92,
+          "largest_loss": 24.92
+        },
+        {
+          "date": "2025-08-17",
+          "profit": 51.63,
+          "cumulative_profit": -356.22,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 51.63,
+          "largest_loss": 51.63
+        },
+        {
+          "date": "2025-08-18",
+          "profit": -119.53,
+          "cumulative_profit": -475.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -119.53,
+          "largest_loss": -119.53
+        },
+        {
+          "date": "2025-08-19",
+          "profit": -106.97,
+          "cumulative_profit": -582.72,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -106.97,
+          "largest_loss": -106.97
+        },
+        {
+          "date": "2025-08-20",
+          "profit": 91.55,
+          "cumulative_profit": -491.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 91.55,
+          "largest_loss": 91.55
+        },
+        {
+          "date": "2025-08-21",
+          "profit": 105.0,
+          "cumulative_profit": -386.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 105.0,
+          "largest_loss": 105.0
+        },
+        {
+          "date": "2025-08-22",
+          "profit": -88.05,
+          "cumulative_profit": -474.22,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -88.05,
+          "largest_loss": -88.05
+        },
+        {
+          "date": "2025-08-23",
+          "profit": -103.53,
+          "cumulative_profit": -577.75,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -103.53,
+          "largest_loss": -103.53
+        },
+        {
+          "date": "2025-08-24",
+          "profit": 15.31,
+          "cumulative_profit": -562.44,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 15.31,
+          "largest_loss": 15.31
+        },
+        {
+          "date": "2025-08-25",
+          "profit": -60.73,
+          "cumulative_profit": -623.17,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -60.73,
+          "largest_loss": -60.73
+        },
+        {
+          "date": "2025-08-26",
+          "profit": -88.73,
+          "cumulative_profit": -711.9,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -88.73,
+          "largest_loss": -88.73
+        },
+        {
+          "date": "2025-08-27",
+          "profit": -51.71,
+          "cumulative_profit": -763.61,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -51.71,
+          "largest_loss": -51.71
+        },
+        {
+          "date": "2025-08-28",
+          "profit": 64.49,
+          "cumulative_profit": -699.12,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 64.49,
+          "largest_loss": 64.49
+        },
+        {
+          "date": "2025-08-29",
+          "profit": -74.81,
+          "cumulative_profit": -773.93,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -74.81,
+          "largest_loss": -74.81
+        },
+        {
+          "date": "2025-08-30",
+          "profit": 15.27,
+          "cumulative_profit": -758.66,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 15.27,
+          "largest_loss": 15.27
+        },
+        {
+          "date": "2025-08-31",
+          "profit": -116.03,
+          "cumulative_profit": -874.69,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -116.03,
+          "largest_loss": -116.03
+        },
+        {
+          "date": "2025-09-01",
+          "profit": -95.42,
+          "cumulative_profit": -970.11,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -95.42,
+          "largest_loss": -95.42
+        },
+        {
+          "date": "2025-09-02",
+          "profit": -42.57,
+          "cumulative_profit": -1012.68,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -42.57,
+          "largest_loss": -42.57
+        },
+        {
+          "date": "2025-09-03",
+          "profit": -112.03,
+          "cumulative_profit": -1124.71,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -112.03,
+          "largest_loss": -112.03
+        },
+        {
+          "date": "2025-09-04",
+          "profit": -10.78,
+          "cumulative_profit": -1135.49,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -10.78,
+          "largest_loss": -10.78
+        },
+        {
+          "date": "2025-09-05",
+          "profit": -96.17,
+          "cumulative_profit": -1231.66,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -96.17,
+          "largest_loss": -96.17
+        },
+        {
+          "date": "2025-09-06",
+          "profit": -31.67,
+          "cumulative_profit": -1263.33,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -31.67,
+          "largest_loss": -31.67
+        },
+        {
+          "date": "2025-09-07",
+          "profit": 66.23,
+          "cumulative_profit": -1197.1,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 66.23,
+          "largest_loss": 66.23
+        },
+        {
+          "date": "2025-09-08",
+          "profit": 102.73,
+          "cumulative_profit": -1094.37,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 102.73,
+          "largest_loss": 102.73
+        },
+        {
+          "date": "2025-09-09",
+          "profit": -58.76,
+          "cumulative_profit": -1153.13,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -58.76,
+          "largest_loss": -58.76
+        },
+        {
+          "date": "2025-09-10",
+          "profit": -84.41,
+          "cumulative_profit": -1237.54,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -84.41,
+          "largest_loss": -84.41
+        },
+        {
+          "date": "2025-09-11",
+          "profit": 9.96,
+          "cumulative_profit": -1227.58,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 9.96,
+          "largest_loss": 9.96
+        },
+        {
+          "date": "2025-09-12",
+          "profit": -63.95,
+          "cumulative_profit": -1291.53,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -63.95,
+          "largest_loss": -63.95
+        },
+        {
+          "date": "2025-09-13",
+          "profit": -25.7,
+          "cumulative_profit": -1317.23,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -25.7,
+          "largest_loss": -25.7
+        },
+        {
+          "date": "2025-09-14",
+          "profit": -18.55,
+          "cumulative_profit": -1335.78,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -18.55,
+          "largest_loss": -18.55
+        },
+        {
+          "date": "2025-09-15",
+          "profit": 20.06,
+          "cumulative_profit": -1315.72,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 20.06,
+          "largest_loss": 20.06
+        },
+        {
+          "date": "2025-09-16",
+          "profit": 115.53,
+          "cumulative_profit": -1200.19,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 115.53,
+          "largest_loss": 115.53
+        },
+        {
+          "date": "2025-09-17",
+          "profit": -121.89,
+          "cumulative_profit": -1322.08,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -121.89,
+          "largest_loss": -121.89
+        },
+        {
+          "date": "2025-09-18",
+          "profit": -78.18,
+          "cumulative_profit": -1400.26,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -78.18,
+          "largest_loss": -78.18
+        },
+        {
+          "date": "2025-09-19",
+          "profit": -114.06,
+          "cumulative_profit": -1514.32,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -114.06,
+          "largest_loss": -114.06
+        },
+        {
+          "date": "2025-09-20",
+          "profit": 21.34,
+          "cumulative_profit": -1492.98,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 21.34,
+          "largest_loss": 21.34
+        },
+        {
+          "date": "2025-09-21",
+          "profit": 97.81,
+          "cumulative_profit": -1395.17,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 97.81,
+          "largest_loss": 97.81
+        },
+        {
+          "date": "2025-09-22",
+          "profit": 62.21,
+          "cumulative_profit": -1332.96,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 62.21,
+          "largest_loss": 62.21
+        },
+        {
+          "date": "2025-09-23",
+          "profit": 8.29,
+          "cumulative_profit": -1324.67,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 8.29,
+          "largest_loss": 8.29
+        },
+        {
+          "date": "2025-09-24",
+          "profit": -95.22,
+          "cumulative_profit": -1419.89,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -95.22,
+          "largest_loss": -95.22
+        },
+        {
+          "date": "2025-09-25",
+          "profit": 31.57,
+          "cumulative_profit": -1388.32,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 31.57,
+          "largest_loss": 31.57
+        },
+        {
+          "date": "2025-09-26",
+          "profit": -87.67,
+          "cumulative_profit": -1475.99,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -87.67,
+          "largest_loss": -87.67
+        },
+        {
+          "date": "2025-09-27",
+          "profit": 29.14,
+          "cumulative_profit": -1446.85,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 29.14,
+          "largest_loss": 29.14
+        },
+        {
+          "date": "2025-09-28",
+          "profit": 17.03,
+          "cumulative_profit": -1429.82,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 17.03,
+          "largest_loss": 17.03
+        },
+        {
+          "date": "2025-09-29",
+          "profit": -66.33,
+          "cumulative_profit": -1496.15,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -66.33,
+          "largest_loss": -66.33
+        },
+        {
+          "date": "2025-09-30",
+          "profit": 41.66,
+          "cumulative_profit": -1454.49,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 41.66,
+          "largest_loss": 41.66
+        },
+        {
+          "date": "2025-10-01",
+          "profit": -108.89,
+          "cumulative_profit": -1563.38,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -108.89,
+          "largest_loss": -108.89
+        },
+        {
+          "date": "2025-10-02",
+          "profit": 76.22,
+          "cumulative_profit": -1487.16,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 76.22,
+          "largest_loss": 76.22
+        },
+        {
+          "date": "2025-10-03",
+          "profit": -104.76,
+          "cumulative_profit": -1591.92,
+          "trades": 1,
+          "wins": 0,
+          "losses": 1,
+          "largest_win": -104.76,
+          "largest_loss": -104.76
+        },
+        {
+          "date": "2025-10-04",
+          "profit": 51.44,
+          "cumulative_profit": -1540.48,
+          "trades": 1,
+          "wins": 1,
+          "losses": 0,
+          "largest_win": 51.44,
+          "largest_loss": 51.44
+        }
+      ],
+      "largest_win": {
+        "profit": 116.69,
+        "date": "2025-08-03",
+        "action": "SELL"
+      },
+      "largest_loss": {
+        "profit": -121.89,
+        "date": "2025-09-17",
+        "action": "SELL"
+      }
+    }
+  },
+  "portfolio": {
+    "summary": {
+      "total_trades": 1350,
+      "total_profit": 11867.34,
+      "gross_profit": 263570.86,
+      "gross_loss": -251703.52,
+      "win_rate": 0.511,
+      "largest_win": 2951.3,
+      "largest_loss": -2995.73,
+      "average_win": 381.99,
+      "average_loss": -381.37,
+      "profit_factor": 1.047
+    },
+    "largest_win": {
+      "symbol": "BTCUSD",
+      "profit": 2951.3,
+      "date": "2025-08-14",
+      "action": "BUY"
+    },
+    "largest_loss": {
+      "symbol": "BTCUSD",
+      "profit": -2995.73,
+      "date": "2025-09-19",
+      "action": "BUY"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reproducible benchmark driver that simulates three months of paper trades for every DynamicTradingAlgo instrument
- persist the generated benchmark report with per-symbol daily history and aggregate profit/loss rollups

## Testing
- pytest tests/test_dynamic_trading_algo.py

------
https://chatgpt.com/codex/tasks/task_e_68e107c8633c832285e753c9f8271d9a