### PR TITLE
Harden promo auto-generate authentication

### DIFF
--- a/supabase/functions/_tests/promo-auto-generate.test.ts
+++ b/supabase/functions/_tests/promo-auto-generate.test.ts
@@ -1,0 +1,45 @@
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
+import { assertEquals } from "std/assert/mod.ts";
+
+const functionUrl =
+  "http://localhost/functions/v1/promo-auto-generate" as const;
+
+Deno.test("promo-auto-generate requires secret configuration", async () => {
+  Deno.env.delete("PROMO_AUTOGEN_SECRET");
+
+  const { handler } = await import(
+    `../promo-auto-generate/index.ts?cache=${crypto.randomUUID()}`
+  );
+
+  const response = await handler(new Request(functionUrl, { method: "POST" }));
+  assertEquals(response.status, 401);
+  const body = await response.json() as { ok: boolean; error: string };
+  assertEquals(body.ok, false);
+  assertEquals(body.error, "Promo generator secret is not configured");
+
+  Deno.env.delete("PROMO_AUTOGEN_SECRET");
+});
+
+Deno.test("promo-auto-generate rejects invalid secret", async () => {
+  Deno.env.set("PROMO_AUTOGEN_SECRET", "expected-secret");
+
+  const { handler } = await import(
+    `../promo-auto-generate/index.ts?cache=${crypto.randomUUID()}`
+  );
+
+  const response = await handler(
+    new Request(functionUrl, {
+      method: "POST",
+      headers: { authorization: "Bearer wrong-secret" },
+    }),
+  );
+
+  assertEquals(response.status, 401);
+  const body = await response.json() as { ok: boolean; error: string };
+  assertEquals(body.ok, false);
+  assertEquals(body.error, "Invalid promo generator secret");
+
+  Deno.env.delete("PROMO_AUTOGEN_SECRET");
+});

--- a/supabase/functions/telegram-bot/admin-handlers/index.ts
+++ b/supabase/functions/telegram-bot/admin-handlers/index.ts
@@ -1769,9 +1769,24 @@ export async function handleAutoGeneratePromo(
   _userId: string,
 ): Promise<void> {
   try {
+    const promoSecret = optionalEnv("PROMO_AUTOGEN_SECRET");
+    if (!promoSecret) {
+      console.error(
+        "PROMO_AUTOGEN_SECRET is not configured; cannot trigger promo-auto-generate.",
+      );
+      await sendMessage(
+        chatId,
+        "❌ Promo generator is not configured. Please contact an administrator.",
+      );
+      return;
+    }
+
     const { data, error } = await supabaseAdmin.functions.invoke(
       "promo-auto-generate",
-      { body: { force: false } },
+      {
+        body: { force: false },
+        headers: { "x-api-key": promoSecret },
+      },
     );
 
     if (error) {


### PR DESCRIPTION
## Summary
- require PROMO_AUTOGEN_SECRET for promo-auto-generate requests and surface clear errors when it is missing
- include the promo secret when the Telegram admin handler triggers promo-auto-generate and alert operators if it is not configured
- add regression tests covering missing and invalid secret scenarios

## Testing
- npx deno test --sloppy-imports --no-lock --no-npm --node-modules-dir=false --unsafely-ignore-certificate-errors -A --no-check supabase/functions/_tests/promo-auto-generate.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e10fd540408322b8d1ea4294a976ae