### PR TITLE
Add open-source data tooling guide

### DIFF
--- a/docs/open-source-data-tools.md
+++ b/docs/open-source-data-tools.md
@@ -14,6 +14,109 @@ with trusted open-source tools you can adopt immediately.
 | Version and track your datasets          | [DVC](https://dvc.org/)                                                                         | Adds Git-like versioning to data, experiments, and models.                                               |
 | Find/load existing datasets easily       | [Hugging Face Datasets](https://huggingface.co/docs/datasets)                                   | Provides thousands of ready-to-use datasets with streaming and caching.                                  |
 
+## Enable Every Recommended Tool
+
+Follow these enablement steps to get each tool running quickly in a standard
+Python-first workflow. Replace `python3` with `python` if your environment
+defaults to Python 3.
+
+### Scrapy & Beautiful Soup
+
+1. Create and activate a virtual environment.
+   ```bash
+   python3 -m venv .venv && source .venv/bin/activate
+   ```
+2. Install both packages and start a Scrapy project scaffold.
+   ```bash
+   pip install scrapy beautifulsoup4
+   scrapy startproject my_spider
+   ```
+3. Add Beautiful Soup parsing inside your Scrapy spider for complex HTML
+   extraction.
+
+### pdfplumber
+
+1. Install the library along with optional table extras.
+   ```bash
+   pip install "pdfplumber[table]"
+   ```
+2. Verify extraction by running the built-in CLI against a sample PDF.
+   ```bash
+   pdfplumber my.pdf --pages 1-3
+   ```
+
+### PaddleOCR
+
+1. Install the runtime and dependencies (PaddleOCR and PaddlePaddle).
+   ```bash
+   pip install "paddlepaddle==2.6.1" "paddleocr>=2.7"
+   ```
+2. Run the quick-start command to confirm OCR works with bundled models.
+   ```bash
+   paddleocr --image_dir ./sample.jpg --lang en
+   ```
+
+### yt-dlp
+
+1. Install the downloader and upgrade FFmpeg if you need advanced transcoding.
+   ```bash
+   pip install yt-dlp
+   ```
+2. Test a download and capture JSON metadata for downstream processing.
+   ```bash
+   yt-dlp -J https://www.youtube.com/watch?v=BaW_jenozKc
+   ```
+
+### CVAT
+
+1. Clone the official repository and start the Docker Compose stack.
+   ```bash
+   git clone https://github.com/opencv/cvat.git
+   cd cvat && docker compose up -d
+   ```
+2. Visit `http://localhost:8080` to create an admin account and import labeling
+   tasks.
+
+### Label Studio & Doccano
+
+1. Install both services into a Python environment.
+   ```bash
+   pip install label-studio doccano
+   ```
+2. Launch each server separately (they default to different ports) and walk
+   through the onboarding wizards.
+   ```bash
+   label-studio start
+   doccano init && doccano createuser --username admin --password changeme --email admin@example.com
+   doccano webserver --port 8001
+   ```
+
+### DVC
+
+1. Install DVC with support for your preferred remote (S3 example shown).
+   ```bash
+   pip install "dvc[s3]"
+   ```
+2. Initialize tracking inside your repository and connect a remote.
+   ```bash
+   dvc init
+   dvc remote add -d storage s3://my-bucket/path
+   ```
+
+### Hugging Face Datasets
+
+1. Install the datasets library with optional data processing extras.
+   ```bash
+   pip install "datasets[streaming]"
+   ```
+2. Load a dataset to validate your setup and enable local caching.
+   ```python
+   from datasets import load_dataset
+
+   ds = load_dataset("ag_news", split="train")
+   print(ds[0])
+   ```
+
 ## Next Steps
 
 1. Identify your immediate data workflow needs.


### PR DESCRIPTION
## Summary
- add a quick-reference guide mapping common data-related goals to recommended open-source tools
- outline next steps to help teams evaluate and adopt the suggested tooling

## Testing
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e11f933e788322b4d02f614df7f9b5