### PR TITLE
feat: add data sharing engine

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -131,6 +131,12 @@ _ENGINE_EXPORTS: Dict[str, Tuple[SymbolExport, ...]] = {
         "generate_training_report",
         "generate_training_summary",
     ),
+    "dynamic_data_sharing": (
+        "SharePolicy",
+        "ShareRecord",
+        "SharePackage",
+        "DynamicDataSharingEngine",
+    ),
     "dynamic_demand": (
         "DynamicDemandEngine",
         "DemandProjection",

--- a/dynamic_data_sharing/__init__.py
+++ b/dynamic_data_sharing/__init__.py
@@ -1,0 +1,303 @@
+"""Dynamic data-sharing orchestration utilities.
+
+This module layers a light-weight sharing façade on top of the
+``dynamic_database`` primitives so curated slices of the knowledge fabric can
+be exported without leaking sensitive payloads.  Policies gate which records
+qualify for sharing, redact disallowed keys, and optionally anonymise record
+identifiers before export.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from dynamic_database import DatabaseRecord, DynamicDatabaseEngine
+
+__all__ = [
+    "SharePolicy",
+    "ShareRecord",
+    "SharePackage",
+    "DynamicDataSharingEngine",
+]
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _normalise_text(value: str) -> str:
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError("value must not be empty")
+    return cleaned
+
+
+def _normalise_identifier(value: str) -> str:
+    return _normalise_text(value).lower()
+
+
+def _normalise_tags(tags: Sequence[str] | None) -> tuple[str, ...]:
+    if not tags:
+        return ()
+    seen: set[str] = set()
+    result: list[str] = []
+    for tag in tags:
+        cleaned = str(tag).strip().lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            result.append(cleaned)
+    return tuple(result)
+
+
+def _normalise_keys(keys: Sequence[str] | None) -> tuple[str, ...]:
+    if not keys:
+        return ()
+    seen: set[str] = set()
+    result: list[str] = []
+    for key in keys:
+        cleaned = str(key).strip()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            result.append(cleaned)
+    return tuple(result)
+
+
+def _anonymise_key(value: str) -> str:
+    digest = sha256(value.encode("utf-8")).hexdigest()[:16]
+    return f"share-{digest}"
+
+
+@dataclass(slots=True)
+class SharePolicy:
+    """Normalised configuration describing a sharing envelope."""
+
+    max_records: int = 128
+    min_confidence: float = 0.5
+    min_relevance: float = 0.4
+    allowed_tags: tuple[str, ...] = field(default_factory=tuple)
+    redact_keys: tuple[str, ...] = field(default_factory=tuple)
+    anonymise_keys: bool = True
+    include_sources: bool = False
+
+    def __post_init__(self) -> None:
+        self.max_records = max(int(self.max_records), 0)
+        if self.max_records == 0:
+            raise ValueError("max_records must be greater than zero")
+        self.min_confidence = _clamp(float(self.min_confidence))
+        self.min_relevance = _clamp(float(self.min_relevance))
+        self.allowed_tags = _normalise_tags(self.allowed_tags)
+        self.redact_keys = _normalise_keys(self.redact_keys)
+        self.anonymise_keys = bool(self.anonymise_keys)
+        self.include_sources = bool(self.include_sources)
+
+    def to_dict(self) -> MutableMapping[str, object]:
+        return {
+            "max_records": self.max_records,
+            "min_confidence": self.min_confidence,
+            "min_relevance": self.min_relevance,
+            "allowed_tags": list(self.allowed_tags),
+            "redact_keys": list(self.redact_keys),
+            "anonymise_keys": self.anonymise_keys,
+            "include_sources": self.include_sources,
+        }
+
+
+@dataclass(slots=True)
+class ShareRecord:
+    """Sanitised representation of a shareable database record."""
+
+    key: str
+    payload: Mapping[str, object]
+    tags: tuple[str, ...]
+    timestamp: datetime
+    sources: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.key = _normalise_text(self.key)
+        self.payload = dict(self.payload)
+        self.tags = _normalise_tags(self.tags)
+        self.timestamp = _ensure_utc(self.timestamp)
+        self.sources = _normalise_keys(self.sources)
+
+    def to_dict(self) -> MutableMapping[str, object]:
+        return {
+            "key": self.key,
+            "payload": dict(self.payload),
+            "tags": list(self.tags),
+            "timestamp": self.timestamp.isoformat(),
+            "sources": list(self.sources),
+        }
+
+
+@dataclass(slots=True)
+class SharePackage:
+    """Materialised bundle ready for downstream distribution."""
+
+    table: str
+    generated_at: datetime
+    policy: SharePolicy
+    records: tuple[ShareRecord, ...]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.table = _normalise_identifier(self.table)
+        self.generated_at = _ensure_utc(self.generated_at)
+        self.records = tuple(self.records)
+        self.metadata = dict(self.metadata)
+
+    @property
+    def record_count(self) -> int:
+        return len(self.records)
+
+    @property
+    def checksum(self) -> str:
+        digest = sha256()
+        digest.update(self.table.encode("utf-8"))
+        digest.update(self.generated_at.isoformat().encode("utf-8"))
+        digest.update(json.dumps(self.policy.to_dict(), sort_keys=True).encode("utf-8"))
+        for record in self.records:
+            digest.update(
+                json.dumps(record.to_dict(), sort_keys=True).encode("utf-8")
+            )
+        digest.update(json.dumps(self.metadata, sort_keys=True).encode("utf-8"))
+        return f"sha256:{digest.hexdigest()}"
+
+    def to_dict(self) -> MutableMapping[str, object]:
+        return {
+            "table": self.table,
+            "generated_at": self.generated_at.isoformat(),
+            "record_count": self.record_count,
+            "checksum": self.checksum,
+            "policy": self.policy.to_dict(),
+            "metadata": dict(self.metadata),
+            "records": [record.to_dict() for record in self.records],
+        }
+
+
+def _sanitise_payload(
+    payload: Mapping[str, object], redact_keys: Sequence[str]
+) -> MutableMapping[str, object]:
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping")
+    return {
+        key: value
+        for key, value in payload.items()
+        if key not in set(redact_keys)
+    }
+
+
+class DynamicDataSharingEngine:
+    """High-level façade that prepares data-share bundles."""
+
+    def __init__(self, *, engine: DynamicDatabaseEngine | None = None) -> None:
+        self._engine = engine or DynamicDatabaseEngine()
+
+    @property
+    def engine(self) -> DynamicDatabaseEngine:
+        return self._engine
+
+    def register_table(
+        self,
+        name: str,
+        *,
+        description: str,
+        tags: Sequence[str] | None = None,
+        owner: str | None = None,
+        sensitivity: float = 0.5,
+    ):
+        return self._engine.register_table(
+            name,
+            description=description,
+            tags=tags,
+            owner=owner,
+            sensitivity=sensitivity,
+        )
+
+    def ingest(self, table: str, record: DatabaseRecord) -> DatabaseRecord:
+        return self._engine.ingest(table, record)
+
+    def bulk_ingest(
+        self, table: str, records: Iterable[DatabaseRecord]
+    ) -> list[DatabaseRecord]:
+        return self._engine.bulk_ingest(table, records)
+
+    def prepare_share(
+        self,
+        table: str,
+        *,
+        policy: SharePolicy,
+        note: str | None = None,
+    ) -> SharePackage:
+        filters_tags = policy.allowed_tags or None
+        query = self._engine.query(
+            table,
+            limit=policy.max_records,
+            min_confidence=policy.min_confidence,
+            min_relevance=policy.min_relevance,
+            tags=filters_tags,
+            order_by="freshness",
+        )
+
+        records: list[ShareRecord] = []
+        for record in query.records:
+            payload = _sanitise_payload(record.payload, policy.redact_keys)
+            key = record.key
+            if policy.anonymise_keys:
+                key = _anonymise_key(record.key)
+            sources = record.sources if policy.include_sources else ()
+            records.append(
+                ShareRecord(
+                    key=key,
+                    payload=payload,
+                    tags=record.tags,
+                    timestamp=record.timestamp,
+                    sources=sources,
+                )
+            )
+
+        metadata: dict[str, object] = {
+            "requested_limit": query.requested_limit,
+            "available": query.available,
+            "total_records": query.total_records,
+            "coverage_ratio": query.coverage_ratio,
+            "mean_confidence": query.mean_confidence,
+            "filters": {
+                "min_confidence": policy.min_confidence,
+                "min_relevance": policy.min_relevance,
+                "allowed_tags": list(policy.allowed_tags),
+            },
+        }
+
+        if note and note.strip():
+            metadata["note"] = note.strip()
+
+        return SharePackage(
+            table=query.table,
+            generated_at=query.issued_at,
+            policy=policy,
+            records=tuple(records),
+            metadata=metadata,
+        )
+
+    def share(
+        self,
+        table: str,
+        *,
+        policy: SharePolicy,
+        note: str | None = None,
+    ) -> Mapping[str, object]:
+        """Convenience helper returning a serialisable payload."""
+
+        package = self.prepare_share(table, policy=policy, note=note)
+        return package.to_dict()
+

--- a/tests_python/test_dynamic_data_sharing.py
+++ b/tests_python/test_dynamic_data_sharing.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dynamic_data_sharing import (
+    DynamicDataSharingEngine,
+    SharePackage,
+    SharePolicy,
+)
+from dynamic_database import DatabaseRecord
+
+
+def _record(
+    key: str,
+    *,
+    confidence: float,
+    relevance: float,
+    tags: tuple[str, ...],
+    payload: dict[str, object],
+    timestamp: datetime | None = None,
+) -> DatabaseRecord:
+    return DatabaseRecord(
+        key=key,
+        payload=payload,
+        confidence=confidence,
+        relevance=relevance,
+        freshness=0.8,
+        weight=1.0,
+        timestamp=timestamp or datetime.now(timezone.utc),
+        tags=tags,
+        sources=("internal-docs",),
+    )
+
+
+def test_prepare_share_applies_policy_and_redactions() -> None:
+    engine = DynamicDataSharingEngine()
+    engine.register_table("knowledge", description="Knowledge base", tags=("public",))
+
+    engine.ingest(
+        "knowledge",
+        _record(
+            "alpha",
+            confidence=0.92,
+            relevance=0.81,
+            tags=("public", "kb"),
+            payload={
+                "title": "Alpha Brief",
+                "summary": "High-level overview",
+                "pii": "secret",
+            },
+        ),
+    )
+
+    engine.ingest(
+        "knowledge",
+        _record(
+            "beta",
+            confidence=0.55,
+            relevance=0.42,
+            tags=("internal",),
+            payload={"title": "Internal memo"},
+        ),
+    )
+
+    policy = SharePolicy(
+        min_confidence=0.8,
+        min_relevance=0.7,
+        allowed_tags=("public",),
+        redact_keys=("pii",),
+        include_sources=False,
+    )
+
+    package = engine.prepare_share(
+        "knowledge", policy=policy, note="External partner sync"
+    )
+
+    assert isinstance(package, SharePackage)
+    assert package.record_count == 1
+    assert package.metadata["note"] == "External partner sync"
+    assert package.metadata["filters"]["allowed_tags"] == ["public"]
+
+    record = package.records[0]
+    assert record.key.startswith("share-")  # anonymised
+    assert record.payload == {"title": "Alpha Brief", "summary": "High-level overview"}
+    assert not record.sources
+
+    payload = package.to_dict()
+    assert payload["checksum"].startswith("sha256:")
+    assert payload["record_count"] == 1
+
+
+def test_share_policy_normalises_inputs() -> None:
+    policy = SharePolicy(
+        max_records=5,
+        min_confidence=1.2,
+        min_relevance=-0.4,
+        allowed_tags=(" Public ", "public", "ops"),
+        redact_keys=(" secret ", "secret", "token"),
+        anonymise_keys=False,
+        include_sources=True,
+    )
+
+    assert policy.max_records == 5
+    assert policy.min_confidence == 1.0
+    assert policy.min_relevance == 0.0
+    assert policy.allowed_tags == ("public", "ops")
+    assert policy.redact_keys == ("secret", "token")
+    assert not policy.anonymise_keys
+    assert policy.include_sources
+
+
+def test_prepare_share_can_include_sources_and_keep_keys() -> None:
+    engine = DynamicDataSharingEngine()
+    engine.register_table("signals", description="Signals", tags=("alpha",))
+
+    timestamp = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    engine.ingest(
+        "signals",
+        _record(
+            "gamma",
+            confidence=0.9,
+            relevance=0.9,
+            tags=("alpha",),
+            payload={"score": 0.78},
+            timestamp=timestamp,
+        ),
+    )
+
+    policy = SharePolicy(
+        max_records=1,
+        min_confidence=0.5,
+        min_relevance=0.5,
+        allowed_tags=(),
+        redact_keys=(),
+        anonymise_keys=False,
+        include_sources=True,
+    )
+
+    package = engine.prepare_share("signals", policy=policy)
+
+    assert package.record_count == 1
+    record = package.records[0]
+    assert record.key == "gamma"
+    assert record.sources == ("internal-docs",)
+    assert record.timestamp == timestamp
+
+
+def test_share_policy_requires_positive_max_records() -> None:
+    with pytest.raises(ValueError):
+        SharePolicy(max_records=0)
+


### PR DESCRIPTION
## Summary
- add a dynamic_data_sharing package that sanitises DynamicDatabase exports via SharePolicy, ShareRecord, SharePackage, and DynamicDataSharingEngine
- expose the new sharing engine through the legacy dynamic/platform/engines shim for compatibility
- add unit tests covering sharing pipelines, policy normalisation, and optional source retention

## Testing
- python -m pytest tests_python/test_dynamic_data_sharing.py

------
https://chatgpt.com/codex/tasks/task_e_68e134d59ecc83228add0fb8f67abd93