### PR TITLE
feat: enable all dynamic engines

### DIFF
--- a/dynamic/platform/engines/README.md
+++ b/dynamic/platform/engines/README.md
@@ -6,4 +6,6 @@ legacy engine names to their canonical modules.
 
 When new orchestrators are added elsewhere in the repo, register them in the
 `_ENGINE_EXPORTS` mapping so downstream scripts using the old paths continue to
-work during the transition.
+work during the transition.  Call `enable_all_dynamic_engines()` if you need to
+eagerly load every export (for example in tooling that validates engine
+availability at boot time).

--- a/tests/test_dynamic_engines_enable.py
+++ b/tests/test_dynamic_engines_enable.py
@@ -1,0 +1,22 @@
+import dynamic.platform.engines as engines
+
+
+def test_enable_all_dynamic_engines_populates_namespace(recwarn) -> None:
+    loaded = engines.enable_all_dynamic_engines()
+
+    assert not recwarn.list
+
+    exported_names = {
+        name for name in engines.__all__ if name != "enable_all_dynamic_engines"
+    }
+    assert exported_names, "expected exported engine names"
+
+    missing = [name for name in exported_names if not hasattr(engines, name)]
+    assert not missing, f"missing exports: {missing}"
+
+    assert set(loaded) == exported_names
+
+    second = engines.enable_all_dynamic_engines()
+    assert set(second) == exported_names
+    for name in exported_names:
+        assert second[name] is getattr(engines, name)


### PR DESCRIPTION
## Summary
- add an `enable_all_dynamic_engines` helper that preloads every export exposed through the `dynamic.platform.engines` shim
- expose the helper via the shim namespace and extend the README with usage guidance
- add a regression test that verifies the helper loads each exported symbol without warnings

## Testing
- pytest tests/test_dynamic_engines_enable.py

------
https://chatgpt.com/codex/tasks/task_e_68e137a901f083229ee946b35bf76ee3