### PR TITLE
docs: expand dynamic quantum model framework

### DIFF
--- a/docs/DYNAMIC_QUANTUM_MODEL.md
+++ b/docs/DYNAMIC_QUANTUM_MODEL.md
@@ -1,0 +1,128 @@
+# Dynamic Quantum Hedge Model Framework
+
+## Overview
+
+This playbook expands on institutional quant practices to help build a "dynamic
+quantum" investment program that marries adaptive algorithms with human-aligned
+oversight. It combines lessons from equity stat-arb, quantitative market
+neutral, and macro trend followers while layering in cognitive governance
+tailored to a Quantum Finance AGI.
+
+## Strategic Orientation
+
+- **Primary Objective:** Deliver absolute-return alpha with structural market
+  neutrality across equities, macro futures, and digital assets.
+- **Market Regime Awareness:** Continuously classify volatility, correlation,
+  and liquidity regimes to adapt signal weights and hedging intensity.
+- **Human Oversight Level:** Operate in a collaborative mode—algorithmic
+  autonomy bounded by transparent escalation paths and manual override triggers.
+
+## Comparative Strategy Landscape
+
+| Strategy                                  | Core Principle                                                                                    | Typical Assets                           | Hedging & Dynamic Nature                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Equity Statistical Arbitrage              | Identify short-lived pricing anomalies via factor spreads and microstructure signals.             | Global equities, ADRs, ETFs.             | Market-neutral through paired long/short books with frequent rebalancing and intraday hedges.        |
+| Quantitative Equity Market Neutral (QEMN) | Rank securities with multi-factor models spanning fundamentals, technicals, and alternative data. | Global equities.                         | Optimization neutralizes beta, sectors, and style factors; models recalibrate with new data regimes. |
+| Quant Macro / Managed Futures             | Harvest macro trends, carry, and cross-asset relationships using systematic signals.              | Futures, FX, rates, commodities, crypto. | Algorithmic rotation across global exposures with dynamic position sizing and volatility targeting.  |
+
+## Cognitive Architecture for Quantum Finance AGI
+
+1. **Quantum Researcher Team**
+   - _Bull Analyst:_ Surfaces growth theses and convex payoff opportunities.
+   - _Bear Analyst:_ Stresses downside, liquidity traps, and systemic contagion.
+   - _Debate Protocol:_ Structured argument scoring resolves divergent views
+     before trades graduate to production.
+2. **Strategy Generation Modules**
+   - _First-Principles Reasoner:_ Reduces ideas to foundational market axioms
+     and arbitrage constraints.
+   - _Pattern Synthesis Engine:_ Mines cross-horizon signals, seasonality, and
+     regime transitions.
+   - _Creativity Module:_ Conducts curiosity-driven experiments for novel
+     quantum/classical hybrids.
+3. **Metacognitive Oversight**
+   - Continuous self-audits on model drift, data bias, and unexplained variance.
+   - Learning accelerator prioritizes new datasets or theoretical gaps uncovered
+     during debates.
+   - Bias detection flags confirmation or recency bias across modules.
+
+## Data & Signal Stack
+
+- **Collection & Lineage:** Ingest tick-level market data, fundamental filings,
+  alt data (satellite, ESG, web sentiment) with provenance tagging and latency
+  monitoring.
+- **Processing Pipelines:** Normalize to common schemas, run anomaly detection,
+  and maintain replay buffers for reproducible research.
+- **Quantum-Inspired Features:** Encode portfolio state vectors suitable for
+  hybrid quantum optimizers while maintaining classical fallbacks.
+
+## Model Development Lifecycle
+
+1. **Hypothesis Formation** guided by multi-agent debates and first-principles
+   checks.
+2. **Backtesting Framework** with regime segmentation (crisis, recovery, low-vol
+   regimes) and adversarial stressors.
+3. **Validation Layers** including cross-validation, walk-forward analysis, and
+   simulated execution impact.
+4. **Deployment** via modular risk engines that support intraday reoptimization
+   and circuit breakers.
+
+## Risk Management & Hedging Protocols
+
+- Volatility-scaled position sizing with scenario trees covering secondary and
+  tertiary effects of shocks.
+- Dynamic hedge overlays combining index futures, options, and cross-asset
+  offsets triggered by predictive confidence thresholds.
+- Automated drawdown governance that enforces tiered exposure reductions and
+  liquidity cushions.
+
+## Governance & Human Alignment
+
+- Maintain explainable decision logs, audit trails, and session-level "AGI
+  activation" records capturing market state, objectives, and compute
+  allocation.
+- Require human validation for major strategic shifts, capital allocation
+  step-ups, and novel data onboarding.
+- Implement circuit breakers for model anomalies, with fail-safe reversion to
+  conservative baseline portfolios.
+
+## Performance & Learning Metrics
+
+- **Strategic Innovations Generated:** Track number and adoption rate of new
+  strategies promoted from research to production.
+- **Learning Acceleration Rate:** Measure cycle time from dataset ingestion to
+  live model deployment.
+- **Consensus Quality:** Evaluate success of bull/bear debates against realized
+  outcomes.
+- **Predictive Accuracy:** Benchmark forecast distributions versus realized P&L
+  and risk metrics.
+- **Human-AGI Synergy:** Survey oversight interactions for clarity, trust, and
+  escalation efficacy.
+
+## Implementation Roadmap
+
+1. **Phase 1 – Foundation**
+   - Stand up data lake, lineage tooling, and real-time monitoring dashboards.
+   - Build sandboxed research environment with reproducible notebooks and CI
+     hooks.
+2. **Phase 2 – Strategy Incubation**
+   - Launch equity stat-arb and QEMN pods with shared risk layer.
+   - Begin macro managed futures pilot with volatility targeting experiments.
+3. **Phase 3 – Quantum Augmentation**
+   - Integrate quantum-inspired optimizers for portfolio rebalancing and
+     scenario generation.
+   - Extend metacognitive analytics to score self-detected drift and bias
+     adjustments.
+4. **Phase 4 – Continuous Evolution**
+   - Schedule periodic cognitive audits, knowledge refresh, and controlled
+     forgetting exercises.
+   - Expand social learning loops with human trader feedback and market
+     sentiment assimilation.
+
+## Next Steps
+
+- Prototype a risk command center blending automated hedging with
+  human-in-the-loop governance.
+- Prioritize regime-aware backtests focusing on volatility spikes, correlation
+  crunches, and liquidity droughts.
+- Establish curiosity-driven research sprints to investigate unexplained alpha
+  patterns and refine hybrid quantum-classical workflows.


### PR DESCRIPTION
## Summary
- expand the dynamic quantum model guide with strategic orientation, cognitive architecture, and governance details
- add implementation roadmap, performance metrics, and enhanced next steps for the quantum hedge framework

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e15c1bf3608322be6a5eb91003ca52