### PR TITLE
Expose engineering helpers via legacy engine shim

### DIFF
--- a/dynamic/platform/engines/__init__.py
+++ b/dynamic/platform/engines/__init__.py
@@ -206,7 +206,10 @@ _ENGINE_EXPORTS: Dict[str, Tuple[SymbolExport, ...]] = {
     "dynamic_engineer": (
         "DynamicEngineer",
         "DynamicEngineerEngine",
+        "EngineeringBlueprint",
+        "EngineeringTask",
         "DynamicEngineerAgent",
+        "DynamicEngineerAgentResult",
         "DynamicEngineerBot",
     ),
     "dynamic.platform.engines.usage": (


### PR DESCRIPTION
## Summary
- expose EngineeringBlueprint, EngineeringTask, and DynamicEngineerAgentResult through the dynamic engine compatibility shim
- keep the dynamic_engineer tuple aligned with the package's public exports so downstream imports keep working

## Testing
- pytest tests/test_dynamic_engines_enable.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e16797bbe88322824b808617014584