### PR TITLE
Capture TON mini app pricing snapshot

### DIFF
--- a/apps/web/services/plans.ts
+++ b/apps/web/services/plans.ts
@@ -48,6 +48,17 @@ function coerceNumber(value: number | string | null | undefined) {
   return null;
 }
 
+function extractSnapshotNumber(
+  snapshot: Record<string, unknown> | null | undefined,
+  key: string,
+): number | string | null {
+  if (!snapshot) {
+    return null;
+  }
+  const value = snapshot[key];
+  return typeof value === "number" || typeof value === "string" ? value : null;
+}
+
 function normalizePlan(plan: RawPlan | null | undefined): Plan | null {
   if (!plan || typeof plan.id !== "string" || plan.id.trim() === "") {
     return null;
@@ -74,6 +85,12 @@ function normalizePlan(plan: RawPlan | null | undefined): Plan | null {
     )
     : [];
 
+  const snapshot = plan.performance_snapshot ?? null;
+  const tonAmount = coerceNumber(plan.ton_amount) ??
+    coerceNumber(extractSnapshotNumber(snapshot, "ton_amount"));
+  const dctAmount = coerceNumber(plan.dct_amount) ??
+    coerceNumber(extractSnapshotNumber(snapshot, "dct_amount")) ?? displayPrice;
+
   return {
     id: plan.id,
     name: plan.name,
@@ -90,16 +107,16 @@ function normalizePlan(plan: RawPlan | null | undefined): Plan | null {
     pricing_formula: plan.pricing_formula ?? null,
     last_priced_at: plan.last_priced_at ?? null,
     performance_snapshot: plan.performance_snapshot ?? null,
-    ton_amount: coerceNumber(plan.ton_amount),
-    dct_amount: coerceNumber(plan.dct_amount) ?? displayPrice,
+    ton_amount: tonAmount,
+    dct_amount: dctAmount,
     pricing: {
       basePrice,
       displayPrice,
       dynamicPrice,
       lastPricedAt: plan.last_priced_at ?? null,
       formula: plan.pricing_formula ?? null,
-      tonAmount: coerceNumber(plan.ton_amount),
-      dctAmount: coerceNumber(plan.dct_amount) ?? displayPrice,
+      tonAmount,
+      dctAmount,
       performanceSnapshot: plan.performance_snapshot ?? null,
     },
   };

--- a/dynamic-capital-ton/apps/miniapp/app/globals.css
+++ b/dynamic-capital-ton/apps/miniapp/app/globals.css
@@ -904,6 +904,123 @@ button {
   color: var(--text-secondary);
 }
 
+.plan-snapshot {
+  margin-top: 14px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(7, 12, 24, 0.58);
+  box-shadow: 0 12px 28px rgba(5, 12, 26, 0.32);
+  display: grid;
+  gap: 16px;
+}
+
+.plan-snapshot__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.plan-snapshot__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.plan-snapshot__timestamp {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.plan-snapshot__grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.plan-snapshot__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(10, 16, 33, 0.58);
+}
+
+.plan-snapshot__metric-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.plan-snapshot__metric-value {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.plan-snapshot__metric-value--positive {
+  color: #4ade80;
+}
+
+.plan-snapshot__metric-value--negative {
+  color: #f87171;
+}
+
+.plan-snapshot__adjustments {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plan-snapshot__adjustments-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.plan-snapshot__adjustments-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.plan-snapshot__adjustment {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(10, 16, 33, 0.45);
+}
+
+.plan-snapshot__adjustment-name {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.plan-snapshot__adjustment-value {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.plan-snapshot__adjustment-value--positive {
+  color: #4ade80;
+}
+
+.plan-snapshot__adjustment-value--negative {
+  color: #f87171;
+}
+
 .plan-hash {
   margin: 0;
   font-size: 0.82rem;


### PR DESCRIPTION
## Summary
- capture the Supabase performance snapshot when normalising TON plan options and surface it through the mini app state
- render a live pricing snapshot card with display/base/dynamic prices, delta, TON feed and adjustment mix derived from the snapshot
- add styling hooks for the new snapshot metrics to match the existing plan detail aesthetics

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e16e0b2f4c8322a9e8695e83c1eb23