### PR TITLE
Harden Supabase policies against anonymous access

### DIFF
--- a/supabase/migrations/20260201090000_restrict_public_policies.sql
+++ b/supabase/migrations/20260201090000_restrict_public_policies.sql
@@ -14,737 +14,178 @@ BEGIN
 END
 $$;
 
--- Restrict helper policies that previously defaulted to the public role
+-- Make sure the cron tables enforce RLS before adjusting their policies
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_tables WHERE schemaname = 'cron' AND tablename = 'job'
+  ) THEN
+    EXECUTE 'ALTER TABLE cron.job ENABLE ROW LEVEL SECURITY;';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_tables WHERE schemaname = 'cron' AND tablename = 'job_run_details'
+  ) THEN
+    EXECUTE 'ALTER TABLE cron.job_run_details ENABLE ROW LEVEL SECURITY;';
+  END IF;
+END
+$$;
+
+-- Consolidate policy role updates so we only touch existing policies
 DO $$
 DECLARE
-  t text;
+  ddl text;
 BEGIN
-  FOREACH t IN ARRAY ARRAY[
-    'bot_content','bot_settings','bot_users','broadcast_messages',
-    'channel_memberships','contact_links','conversion_tracking','daily_analytics',
-    'education_categories','education_enrollments','education_packages','media_files',
-    'payments','promo_analytics','promotions','subscription_plans',
-    'user_interactions','user_package_assignments','user_sessions',
-    'user_subscriptions','user_surveys','admin_logs'
-  ]
+  FOR ddl IN
+    WITH policy_targets AS (
+      SELECT
+        'public'::text AS schema_name,
+        table_name,
+        'allow_service_or_admin_all'::text AS policy_name,
+        ARRAY['authenticated']::text[] AS roles
+      FROM unnest(ARRAY[
+        'admin_logs',
+        'bot_content','bot_settings','bot_users','broadcast_messages',
+        'channel_memberships','contact_links','conversion_tracking','daily_analytics',
+        'education_categories','education_enrollments','education_packages','media_files',
+        'payments','promo_analytics','promotions','subscription_plans',
+        'user_interactions','user_package_assignments','user_sessions',
+        'user_subscriptions','user_surveys'
+      ]) AS table_name
+      UNION ALL
+      SELECT * FROM (VALUES
+        -- Cron policies
+        ('cron','job','cron_job_policy', ARRAY['service_role']::text[]),
+        ('cron','job_run_details','cron_job_run_details_policy', ARRAY['service_role']::text[]),
+
+        -- Storage bucket access
+        ('storage','objects','Admins can delete broadcast media', ARRAY['authenticated']::text[]),
+        ('storage','objects','Admins can view broadcast media', ARRAY['authenticated']::text[]),
+        ('storage','objects','Anyone can view temp uploads', ARRAY['authenticated']::text[]),
+        ('storage','objects','Bot can delete media', ARRAY['service_role']::text[]),
+        ('storage','objects','Bot can update media', ARRAY['service_role']::text[]),
+        ('storage','objects','Bot can update receipts', ARRAY['service_role']::text[]),
+        ('storage','objects','Bot can view media', ARRAY['service_role']::text[]),
+        ('storage','objects','Bot can view receipts', ARRAY['service_role']::text[]),
+        ('storage','objects','Public read access for miniapp files', ARRAY['authenticated']::text[]),
+        ('storage','objects','Service role can delete temp uploads', ARRAY['service_role']::text[]),
+
+        -- Public schema tightening
+        ('public','abuse_bans','Deny anonymous access to abuse_bans', ARRAY['authenticated']::text[]),
+        ('public','abuse_bans','Service role can manage abuse_bans', ARRAY['service_role']::text[]),
+        ('public','admin_logs','Admins can view admin logs', ARRAY['authenticated']::text[]),
+        ('public','auto_reply_templates','Bot can manage auto reply templates', ARRAY['service_role']::text[]),
+        ('public','auto_reply_templates','Bot can view active auto reply templates', ARRAY['authenticated']::text[]),
+        ('public','bank_accounts','Admins can manage bank accounts', ARRAY['authenticated']::text[]),
+        ('public','bank_accounts','Only admins can view bank accounts', ARRAY['authenticated']::text[]),
+        ('public','bot_content','Anyone can view active bot content', ARRAY['authenticated']::text[]),
+        ('public','bot_sessions','Admins can view all sessions', ARRAY['authenticated']::text[]),
+        ('public','bot_sessions','Users can view their own sessions', ARRAY['authenticated']::text[]),
+        ('public','bot_settings','Authenticated users can read active settings', ARRAY['authenticated']::text[]),
+        ('public','bot_settings','Service role can manage bot settings', ARRAY['service_role']::text[]),
+        ('public','bot_users','Admins can view all bot users', ARRAY['authenticated']::text[]),
+        ('public','bot_users','Users can view their own bot user record', ARRAY['authenticated']::text[]),
+        ('public','broadcast_messages','Service role can manage broadcast messages', ARRAY['service_role']::text[]),
+        ('public','channel_memberships','Admins can manage all memberships', ARRAY['authenticated']::text[]),
+        ('public','channel_memberships','Users can view their own memberships', ARRAY['authenticated']::text[]),
+        ('public','chat_messages','Service role can manage all chat messages', ARRAY['service_role']::text[]),
+        ('public','chat_messages','Users can view messages from their sessions', ARRAY['authenticated']::text[]),
+        ('public','chat_sessions','Service role can manage all chat sessions', ARRAY['service_role']::text[]),
+        ('public','chat_sessions','Users can update their own chat sessions', ARRAY['authenticated']::text[]),
+        ('public','chat_sessions','Users can view their own chat sessions', ARRAY['authenticated']::text[]),
+        ('public','contact_links','Anyone can view active contact links', ARRAY['authenticated']::text[]),
+        ('public','contact_links','Bot can manage contact links', ARRAY['service_role']::text[]),
+        ('public','conversion_tracking','Service role can manage conversion tracking', ARRAY['service_role']::text[]),
+        ('public','daily_analytics','Service role can manage daily analytics', ARRAY['service_role']::text[]),
+        ('public','domain_resolution_cache','Anyone can read domain cache', ARRAY['authenticated']::text[]),
+        ('public','domain_resolution_cache','Service role can manage domain cache', ARRAY['service_role']::text[]),
+        ('public','education_categories','Anyone can view active categories', ARRAY['authenticated']::text[]),
+        ('public','education_categories','Bot can manage categories', ARRAY['service_role']::text[]),
+        ('public','education_enrollments','Admins can manage all education enrollments', ARRAY['authenticated']::text[]),
+        ('public','education_enrollments','Service role can manage education enrollments', ARRAY['service_role']::text[]),
+        ('public','education_enrollments','Users can update own enrollments only', ARRAY['authenticated']::text[]),
+        ('public','education_enrollments','Users can view own enrollments only', ARRAY['authenticated']::text[]),
+        ('public','education_packages','Anyone can view active packages', ARRAY['authenticated']::text[]),
+        ('public','education_packages','Bot can manage packages', ARRAY['service_role']::text[]),
+        ('public','email_campaigns','Admins can manage campaigns', ARRAY['authenticated']::text[]),
+        ('public','email_campaigns','Users can view their own campaigns', ARRAY['authenticated']::text[]),
+        ('public','email_recipients','Admins can manage recipients', ARRAY['authenticated']::text[]),
+        ('public','email_recipients','Users can view recipients of their campaigns', ARRAY['authenticated']::text[]),
+        ('public','email_templates','Admins can manage templates', ARRAY['authenticated']::text[]),
+        ('public','email_templates','Anyone can view active templates', ARRAY['authenticated']::text[]),
+        ('public','enrollment_audit_log','Only admins can view all enrollment audit logs', ARRAY['authenticated']::text[]),
+        ('public','enrollment_audit_log','Users can view own enrollment audit logs', ARRAY['authenticated']::text[]),
+        ('public','kv_config','Deny anonymous access to kv_config', ARRAY['authenticated']::text[]),
+        ('public','kv_config','Service role can manage kv_config', ARRAY['service_role']::text[]),
+        ('public','media_files','Admins can view all media files', ARRAY['authenticated']::text[]),
+        ('public','media_files','Users can view their own media files', ARRAY['authenticated']::text[]),
+        ('public','payment_intents','Service role can manage payment intents', ARRAY['service_role']::text[]),
+        ('public','payment_intents','Users can view their own payment intents', ARRAY['authenticated']::text[]),
+        ('public','payments','Admins can view all payments', ARRAY['authenticated']::text[]),
+        ('public','payments','Users can view their own payments', ARRAY['authenticated']::text[]),
+        ('public','plan_channels','Admins can manage plan channels', ARRAY['authenticated']::text[]),
+        ('public','plan_channels','Public can view plan channels', ARRAY['authenticated']::text[]),
+        ('public','profiles','Admins can update all profiles', ARRAY['authenticated']::text[]),
+        ('public','profiles','Admins can view all profiles', ARRAY['authenticated']::text[]),
+        ('public','profiles','Users can update their own profile', ARRAY['authenticated']::text[]),
+        ('public','profiles','Users can view their own profile', ARRAY['authenticated']::text[]),
+        ('public','promo_analytics','Service role can manage promo analytics', ARRAY['service_role']::text[]),
+        ('public','promotion_usage','Service role can manage promotion usage', ARRAY['service_role']::text[]),
+        ('public','promotions','Anyone can view active promotions', ARRAY['authenticated']::text[]),
+        ('public','promotions','Bot can manage promotions', ARRAY['service_role']::text[]),
+        ('public','session_audit_log','Only admins can view session audit logs', ARRAY['authenticated']::text[]),
+        ('public','session_audit_log','Users can view own session audit logs', ARRAY['authenticated']::text[]),
+        ('public','subdomain_claims','Admins can manage all claims', ARRAY['authenticated']::text[]),
+        ('public','subdomain_claims','Users can view their own claims', ARRAY['authenticated']::text[]),
+        ('public','subscription_audit_log','Only admins can view subscription audit logs', ARRAY['authenticated']::text[]),
+        ('public','subscription_plans','Anyone can view subscription plans', ARRAY['authenticated']::text[]),
+        ('public','ton_subdomains','Admins can view all subdomains', ARRAY['authenticated']::text[]),
+        ('public','ton_subdomains','Service role can manage subdomains', ARRAY['service_role']::text[]),
+        ('public','ton_subdomains','Users can view their own subdomains', ARRAY['authenticated']::text[]),
+        ('public','ton_transactions','Admins can view all transactions', ARRAY['authenticated']::text[]),
+        ('public','ton_transactions','Service role can manage transactions', ARRAY['service_role']::text[]),
+        ('public','ton_transactions','Users can view their own transactions', ARRAY['authenticated']::text[]),
+        ('public','user_analytics','Admins can view all analytics', ARRAY['authenticated']::text[]),
+        ('public','user_interactions','Admins can view all interactions', ARRAY['authenticated']::text[]),
+        ('public','user_interactions','Users can view their own interactions', ARRAY['authenticated']::text[]),
+        ('public','user_package_assignments','Admins can manage all assignments', ARRAY['authenticated']::text[]),
+        ('public','user_package_assignments','Users can view their own assignments', ARRAY['authenticated']::text[]),
+        ('public','user_sessions','Admins can manage all user sessions', ARRAY['authenticated']::text[]),
+        ('public','user_sessions','Service role can manage user sessions', ARRAY['service_role']::text[]),
+        ('public','user_sessions','Users can update own sessions only', ARRAY['authenticated']::text[]),
+        ('public','user_sessions','Users can view own sessions only', ARRAY['authenticated']::text[]),
+        ('public','user_subscriptions','Admins can manage all subscriptions', ARRAY['authenticated']::text[]),
+        ('public','user_subscriptions','Admins can view all subscriptions', ARRAY['authenticated']::text[]),
+        ('public','user_subscriptions','Service role can manage user subscriptions', ARRAY['service_role']::text[]),
+        ('public','user_subscriptions','Users can update their own subscription details', ARRAY['authenticated']::text[]),
+        ('public','user_subscriptions','Users can view their own subscriptions', ARRAY['authenticated']::text[]),
+        ('public','user_surveys','Service role can manage user surveys', ARRAY['service_role']::text[])
+      ) AS explicit(schema_name, table_name, policy_name, roles)
+    ),
+    policy_role_lists AS (
+      SELECT
+        pt.schema_name,
+        pt.table_name,
+        pt.policy_name,
+        string_agg(format('%I', role_name), ', ' ORDER BY ord) AS role_list
+      FROM policy_targets pt
+      CROSS JOIN LATERAL unnest(pt.roles) WITH ORDINALITY AS roles(role_name, ord)
+      GROUP BY pt.schema_name, pt.table_name, pt.policy_name
+    )
+    SELECT format(
+      'ALTER POLICY %I ON %I.%I TO %s;',
+      pr.policy_name,
+      pr.schema_name,
+      pr.table_name,
+      pr.role_list
+    )
+    FROM policy_role_lists pr
+    JOIN pg_policies p
+      ON p.schemaname = pr.schema_name
+     AND p.tablename = pr.table_name
+     AND p.policyname = pr.policy_name
   LOOP
-    IF EXISTS (
-      SELECT 1
-      FROM pg_policies
-      WHERE schemaname = 'public'
-        AND tablename = t
-        AND policyname = 'allow_service_or_admin_all'
-    ) THEN
-      EXECUTE format(
-        'ALTER POLICY allow_service_or_admin_all ON public.%I TO authenticated;',
-        t
-      );
-    END IF;
+    EXECUTE ddl;
   END LOOP;
-END
-$$;
-
--- Update specific policies so they no longer target the implicit public role
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'kv_config'
-      AND policyname = 'Service role can manage kv_config'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage kv_config" ON public.kv_config TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'kv_config'
-      AND policyname = 'Deny anonymous access to kv_config'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Deny anonymous access to kv_config" ON public.kv_config TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'abuse_bans'
-      AND policyname = 'Service role can manage abuse_bans'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage abuse_bans" ON public.abuse_bans TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'abuse_bans'
-      AND policyname = 'Deny anonymous access to abuse_bans'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Deny anonymous access to abuse_bans" ON public.abuse_bans TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'auto_reply_templates'
-      AND policyname = 'Bot can manage auto reply templates'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Bot can manage auto reply templates" ON public.auto_reply_templates TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'auto_reply_templates'
-      AND policyname = 'Bot can view active auto reply templates'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Bot can view active auto reply templates" ON public.auto_reply_templates TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bot_content'
-      AND policyname = 'Anyone can view active bot content'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view active bot content" ON public.bot_content TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bank_accounts'
-      AND policyname = 'Only admins can view bank accounts'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Only admins can view bank accounts" ON public.bank_accounts TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bank_accounts'
-      AND policyname = 'Admins can manage bank accounts'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage bank accounts" ON public.bank_accounts TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'plan_channels'
-      AND policyname = 'Admins can manage plan channels'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage plan channels" ON public.plan_channels TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'plan_channels'
-      AND policyname = 'Public can view plan channels'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Public can view plan channels" ON public.plan_channels TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bot_settings'
-      AND policyname = 'Service role can manage bot settings'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage bot settings" ON public.bot_settings TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bot_settings'
-      AND policyname = 'Authenticated users can read active settings'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Authenticated users can read active settings" ON public.bot_settings TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bot_users'
-      AND policyname = 'Admins can view all bot users'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all bot users" ON public.bot_users TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'bot_users'
-      AND policyname = 'Users can view their own bot user record'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own bot user record" ON public.bot_users TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'broadcast_messages'
-      AND policyname = 'Service role can manage broadcast messages'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage broadcast messages" ON public.broadcast_messages TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'channel_memberships'
-      AND policyname = 'Admins can manage all memberships'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage all memberships" ON public.channel_memberships TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'channel_memberships'
-      AND policyname = 'Users can view their own memberships'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own memberships" ON public.channel_memberships TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'chat_messages'
-      AND policyname = 'Service role can manage all chat messages'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage all chat messages" ON public.chat_messages TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'chat_messages'
-      AND policyname = 'Users can view messages from their sessions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view messages from their sessions" ON public.chat_messages TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'chat_sessions'
-      AND policyname = 'Service role can manage all chat sessions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage all chat sessions" ON public.chat_sessions TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'chat_sessions'
-      AND policyname = 'Users can update their own chat sessions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can update their own chat sessions" ON public.chat_sessions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'chat_sessions'
-      AND policyname = 'Users can view their own chat sessions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own chat sessions" ON public.chat_sessions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'contact_links'
-      AND policyname = 'Anyone can view active contact links'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view active contact links" ON public.contact_links TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'contact_links'
-      AND policyname = 'Bot can manage contact links'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Bot can manage contact links" ON public.contact_links TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'conversion_tracking'
-      AND policyname = 'Service role can manage conversion tracking'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage conversion tracking" ON public.conversion_tracking TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'daily_analytics'
-      AND policyname = 'Service role can manage daily analytics'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage daily analytics" ON public.daily_analytics TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'domain_resolution_cache'
-      AND policyname = 'Anyone can read domain cache'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can read domain cache" ON public.domain_resolution_cache TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'domain_resolution_cache'
-      AND policyname = 'Service role can manage domain cache'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage domain cache" ON public.domain_resolution_cache TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'education_categories'
-      AND policyname = 'Anyone can view active categories'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view active categories" ON public.education_categories TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'education_categories'
-      AND policyname = 'Bot can manage categories'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Bot can manage categories" ON public.education_categories TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'education_enrollments'
-      AND policyname = 'Admins can manage all education enrollments'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage all education enrollments" ON public.education_enrollments TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'education_enrollments'
-      AND policyname = 'Service role can manage education enrollments'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage education enrollments" ON public.education_enrollments TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'education_packages'
-      AND policyname = 'Anyone can view active packages'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view active packages" ON public.education_packages TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'education_packages'
-      AND policyname = 'Bot can manage packages'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Bot can manage packages" ON public.education_packages TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'email_campaigns'
-      AND policyname = 'Admins can manage campaigns'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage campaigns" ON public.email_campaigns TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'email_campaigns'
-      AND policyname = 'Users can view their own campaigns'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own campaigns" ON public.email_campaigns TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'email_recipients'
-      AND policyname = 'Admins can manage recipients'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage recipients" ON public.email_recipients TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'email_recipients'
-      AND policyname = 'Users can view recipients of their campaigns'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view recipients of their campaigns" ON public.email_recipients TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'email_templates'
-      AND policyname = 'Admins can manage templates'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage templates" ON public.email_templates TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'email_templates'
-      AND policyname = 'Anyone can view active templates'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view active templates" ON public.email_templates TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'enrollment_audit_log'
-      AND policyname = 'Only admins can view all enrollment audit logs'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Only admins can view all enrollment audit logs" ON public.enrollment_audit_log TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'enrollment_audit_log'
-      AND policyname = 'Users can view own enrollment audit logs'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view own enrollment audit logs" ON public.enrollment_audit_log TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'media_files'
-      AND policyname = 'Admins can view all media files'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all media files" ON public.media_files TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'media_files'
-      AND policyname = 'Users can view their own media files'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own media files" ON public.media_files TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'payment_intents'
-      AND policyname = 'Service role can manage payment intents'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage payment intents" ON public.payment_intents TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'payment_intents'
-      AND policyname = 'Users can view their own payment intents'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own payment intents" ON public.payment_intents TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'payments'
-      AND policyname = 'Admins can view all payments'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all payments" ON public.payments TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'payments'
-      AND policyname = 'Users can view their own payments'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own payments" ON public.payments TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'promo_analytics'
-      AND policyname = 'Service role can manage promo analytics'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage promo analytics" ON public.promo_analytics TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'promotion_usage'
-      AND policyname = 'Service role can manage promotion usage'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage promotion usage" ON public.promotion_usage TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'promotions'
-      AND policyname = 'Anyone can view active promotions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view active promotions" ON public.promotions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'promotions'
-      AND policyname = 'Bot can manage promotions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Bot can manage promotions" ON public.promotions TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'session_audit_log'
-      AND policyname = 'Only admins can view session audit logs'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Only admins can view session audit logs" ON public.session_audit_log TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'session_audit_log'
-      AND policyname = 'Users can view own session audit logs'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view own session audit logs" ON public.session_audit_log TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'subdomain_claims'
-      AND policyname = 'Admins can manage all claims'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage all claims" ON public.subdomain_claims TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'subdomain_claims'
-      AND policyname = 'Users can view their own claims'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own claims" ON public.subdomain_claims TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'subscription_audit_log'
-      AND policyname = 'Only admins can view subscription audit logs'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Only admins can view subscription audit logs" ON public.subscription_audit_log TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'subscription_plans'
-      AND policyname = 'Anyone can view subscription plans'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Anyone can view subscription plans" ON public.subscription_plans TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'ton_subdomains'
-      AND policyname = 'Admins can view all subdomains'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all subdomains" ON public.ton_subdomains TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'ton_subdomains'
-      AND policyname = 'Service role can manage subdomains'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage subdomains" ON public.ton_subdomains TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'ton_subdomains'
-      AND policyname = 'Users can view their own subdomains'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own subdomains" ON public.ton_subdomains TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'ton_transactions'
-      AND policyname = 'Admins can view all transactions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all transactions" ON public.ton_transactions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'ton_transactions'
-      AND policyname = 'Service role can manage transactions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage transactions" ON public.ton_transactions TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'ton_transactions'
-      AND policyname = 'Users can view their own transactions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Users can view their own transactions" ON public.ton_transactions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_analytics'
-      AND policyname = 'Admins can view all analytics'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all analytics" ON public.user_analytics TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_package_assignments'
-      AND policyname = 'Admins can manage all assignments'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage all assignments" ON public.user_package_assignments TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_sessions'
-      AND policyname = 'Admins can manage all user sessions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage all user sessions" ON public.user_sessions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_sessions'
-      AND policyname = 'Service role can manage user sessions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage user sessions" ON public.user_sessions TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_subscriptions'
-      AND policyname = 'Admins can manage all subscriptions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can manage all subscriptions" ON public.user_subscriptions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_subscriptions'
-      AND policyname = 'Admins can view all subscriptions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Admins can view all subscriptions" ON public.user_subscriptions TO authenticated;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_subscriptions'
-      AND policyname = 'Service role can manage user subscriptions'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage user subscriptions" ON public.user_subscriptions TO service_role;';
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'public'
-      AND tablename = 'user_surveys'
-      AND policyname = 'Service role can manage user surveys'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Service role can manage user surveys" ON public.user_surveys TO service_role;';
-  END IF;
-END
-$$;
-
--- Harden cron schema policies to service role only
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'cron' AND tablename = 'job') THEN
-    EXECUTE 'ALTER TABLE cron.job ENABLE ROW LEVEL SECURITY;';
-    IF EXISTS (
-      SELECT 1 FROM pg_policies
-      WHERE schemaname = 'cron'
-        AND tablename = 'job'
-        AND policyname = 'cron_job_policy'
-    ) THEN
-      EXECUTE 'ALTER POLICY cron_job_policy ON cron.job TO service_role;';
-    END IF;
-  END IF;
-
-  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'cron' AND tablename = 'job_run_details') THEN
-    EXECUTE 'ALTER TABLE cron.job_run_details ENABLE ROW LEVEL SECURITY;';
-    IF EXISTS (
-      SELECT 1 FROM pg_policies
-      WHERE schemaname = 'cron'
-        AND tablename = 'job_run_details'
-        AND policyname = 'cron_job_run_details_policy'
-    ) THEN
-      EXECUTE 'ALTER POLICY cron_job_run_details_policy ON cron.job_run_details TO service_role;';
-    END IF;
-  END IF;
-END
-$$;
-
--- Lock down storage bucket policies so only authenticated users can read miniapp files
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_policies
-    WHERE schemaname = 'storage'
-      AND tablename = 'objects'
-      AND policyname = 'Public read access for miniapp files'
-  ) THEN
-    EXECUTE 'ALTER POLICY "Public read access for miniapp files" ON storage.objects TO authenticated;';
-  END IF;
 END
 $$;


### PR DESCRIPTION
## Summary
- move the pg_net extension into a dedicated `extensions` schema to keep the public schema minimal
- tighten Supabase RLS policies so they explicitly target authenticated and service roles rather than inheriting access from `public`
- lock down cron and storage policies to service and authenticated roles only to silence anonymous-access warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e16fcc1e848322989acf0a4a270c47