### PR TITLE
Improve TON site status probing throughput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "posthog-js": "^1.268.8",
         "prismjs": "^1.30.0",
         "recharts": "^3.2.1",
-        "sonner": "^2.0.7"
+        "sonner": "^2.0.7",
+        "undici": "^6.22.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -24629,6 +24630,15 @@
     "node_modules/uncrypto": {
       "version": "0.1.3",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "posthog-js": "^1.268.8",
     "prismjs": "^1.30.0",
     "recharts": "^3.2.1",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "undici": "^6.22.0"
   },
   "devDependencies": {
     "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
## Summary
- stream gateway responses and trim previews to avoid loading full TON site payloads
- add configurable concurrency and argument parsing safeguards to the site-status CLI
- emit a tsx shebang so the probe can run standalone outside npm scripts

## Testing
- npm run format
- npm run lint
- npm run typecheck
- npm run ton:site-status -- --timeout=1000 --concurrency=2 *(fails in this environment because the external gateways are unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ae5c73348322a28172682c83eff0