### PR TITLE
Update TON Connect fallback origin

### DIFF
--- a/apps/web/config/ton.ts
+++ b/apps/web/config/ton.ts
@@ -17,7 +17,7 @@ export type TonConnectManifest = {
 const DEFAULT_NETWORK: TonNetwork = "mainnet";
 export const TON_MANIFEST_PATH = "/api/tonconnect/manifest";
 const MANIFEST_ICON_PATH = "/icon-mark.svg";
-const PROD_FALLBACK_ORIGIN = "https://dynamic-capital-qazf2.ondigitalocean.app";
+const PROD_FALLBACK_ORIGIN = "https://dynamic-capital.ondigitalocean.app";
 const PROD_MANIFEST_URL = new URL(
   "/tonconnect-manifest.json",
   PROD_FALLBACK_ORIGIN,

--- a/apps/web/public/tonconnect-manifest.json
+++ b/apps/web/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://dynamic-capital-qazf2.ondigitalocean.app",
+  "url": "https://dynamic-capital.ondigitalocean.app",
   "name": "Dynamic Capital",
-  "iconUrl": "https://dynamic-capital-qazf2.ondigitalocean.app/icon-mark.svg"
+  "iconUrl": "https://dynamic-capital.ondigitalocean.app/icon-mark.svg"
 }

--- a/dynamic-capital-ton/apps/miniapp/app/page.tsx
+++ b/dynamic-capital-ton/apps/miniapp/app/page.tsx
@@ -122,7 +122,7 @@ type NavItem = {
 };
 
 const TONCONNECT_MANIFEST_URL =
-  "https://dynamic-capital-qazf2.ondigitalocean.app/tonconnect-manifest.json";
+  "https://dynamic-capital.ondigitalocean.app/tonconnect-manifest.json";
 
 const SECTION_IDS: SectionId[] = [
   "overview",

--- a/dynamic-capital-ton/apps/miniapp/public/tonconnect-manifest.json
+++ b/dynamic-capital-ton/apps/miniapp/public/tonconnect-manifest.json
@@ -1,7 +1,7 @@
 {
-  "url": "https://dynamic-capital-qazf2.ondigitalocean.app",
+  "url": "https://dynamic-capital.ondigitalocean.app",
   "name": "Dynamic Capital",
-  "iconUrl": "https://dynamic-capital-qazf2.ondigitalocean.app/icon-mark.svg",
+  "iconUrl": "https://dynamic-capital.ondigitalocean.app/icon-mark.svg",
   "termsOfUseUrl": "https://dynamic.capital/terms",
   "privacyPolicyUrl": "https://dynamic.capital/privacy"
 }

--- a/project.toml
+++ b/project.toml
@@ -30,7 +30,7 @@ version = "0.0.0"
 
   [[build.env]]
     name = "ALLOWED_ORIGINS"
-    value = "https://dynamiccapital.ton,https://www.dynamiccapital.ton,https://dynamic-capital.ondigitalocean.app,https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://ton-gateway.dynamic-capital.ondigitalocean.app,https://ton-gateway.dynamic-capital.lovable.app"
+    value = "https://dynamiccapital.ton,https://www.dynamiccapital.ton,https://dynamic-capital.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://ton-gateway.dynamic-capital.ondigitalocean.app,https://ton-gateway.dynamic-capital.lovable.app"
 
   [[build.env]]
     name = "SITE_URL"

--- a/scripts/digitalocean/site-config-utils.mjs
+++ b/scripts/digitalocean/site-config-utils.mjs
@@ -4,7 +4,6 @@ export const PRODUCTION_ALLOWED_ORIGINS = [
   "https://dynamiccapital.ton",
   "https://www.dynamiccapital.ton",
   "https://dynamic-capital.ondigitalocean.app",
-  "https://dynamic-capital-qazf2.ondigitalocean.app",
   "https://dynamic.capital",
   "https://dynamic-capital.vercel.app",
   "https://dynamic-capital.lovable.app",

--- a/scripts/utils/branding-env.mjs
+++ b/scripts/utils/branding-env.mjs
@@ -4,7 +4,6 @@ export const PRODUCTION_ALLOWED_ORIGIN_LIST = [
   "https://dynamiccapital.ton",
   "https://www.dynamiccapital.ton",
   "https://dynamic-capital.ondigitalocean.app",
-  "https://dynamic-capital-qazf2.ondigitalocean.app",
   "https://dynamic.capital",
   "https://dynamic-capital.vercel.app",
   "https://dynamic-capital.lovable.app",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -9,7 +9,6 @@ project_id = "qeejuomcapbdlhnjqjcc"
     "https://dynamiccapital.ton",
     "https://www.dynamiccapital.ton",
     "https://dynamic-capital.ondigitalocean.app",
-    "https://dynamic-capital-qazf2.ondigitalocean.app",
     "https://dynamic.capital",
     "https://dynamic-capital.vercel.app",
     "https://dynamic-capital.lovable.app",
@@ -19,7 +18,7 @@ project_id = "qeejuomcapbdlhnjqjcc"
   [functions.env]
     SITE_URL = "https://dynamiccapital.ton"
     NEXT_PUBLIC_SITE_URL = "https://dynamiccapital.ton"
-    ALLOWED_ORIGINS = "https://dynamiccapital.ton,https://www.dynamiccapital.ton,https://dynamic-capital.ondigitalocean.app,https://dynamic-capital-qazf2.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://ton-gateway.dynamic-capital.ondigitalocean.app,https://ton-gateway.dynamic-capital.lovable.app"
+    ALLOWED_ORIGINS = "https://dynamiccapital.ton,https://www.dynamiccapital.ton,https://dynamic-capital.ondigitalocean.app,https://dynamic.capital,https://dynamic-capital.vercel.app,https://dynamic-capital.lovable.app,https://ton-gateway.dynamic-capital.ondigitalocean.app,https://ton-gateway.dynamic-capital.lovable.app"
     MINIAPP_ORIGIN = "https://dynamiccapital.ton"
     TELEGRAM_WEBHOOK_URL = "https://dynamiccapital.ton/webhook"
 


### PR DESCRIPTION
## Summary
- point the TON Connect config and manifests to the canonical DigitalOcean host
- remove the retired dynamic-capital-qazf2 domain from deployment and tooling allowlists

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1e67844948322bc152c985d04655c