### PR TITLE
Add mentorship and promo pricing heuristics to Grok pricing toolkit

### DIFF
--- a/grok-1/tests/test_vip_pricing.py
+++ b/grok-1/tests/test_vip_pricing.py
@@ -116,6 +116,20 @@ def test_generate_promo_incentives_balances_inputs() -> None:
     assert len({offer.promo_code for offer in offers}) == len(offers)
 
 
+def test_generate_promo_incentives_codes_remain_unique_across_tiers() -> None:
+    offers = generate_promo_incentives(
+        base_price=1000.0,
+        urgency_index=0.0,
+        loyalty_score=0.5,
+        inventory_pressure=0.2,
+        count=8,
+        seed=1,
+    )
+
+    codes = [offer.promo_code for offer in offers]
+    assert len(codes) == len(set(codes))
+
+
 def test_build_pricing_blueprint_compiles_sections() -> None:
     blueprint = build_pricing_blueprint(
         vip_config={


### PR DESCRIPTION
## Summary
- extend the Grok VIP pricing helper with mentorship and promotional pricing generators
- expose a blueprint composer that bundles VIP, mentorship, and promo analytics in one response
- cover the new flows with deterministic unit tests for mentorship, promo, and aggregated pricing summaries

## Testing
- pytest grok-1/tests/test_vip_pricing.py


------
https://chatgpt.com/codex/tasks/task_e_68e1ef4499d88322a07ed4aa3aaf8378