### PR TITLE
feat: orchestrate dynamic module activation

### DIFF
--- a/dynamic/intelligence/ai_apps/__init__.py
+++ b/dynamic/intelligence/ai_apps/__init__.py
@@ -59,6 +59,11 @@ from .dolphin_adapter import (
 )
 from .ollama_adapter import OllamaAdapter, OllamaConfig, OllamaPromptTemplate
 from .kimi_k2_adapter import KimiK2Adapter, KimiK2Config, KimiK2PromptTemplate
+from .activation import (
+    ActivationReport,
+    ModuleActivationPlan,
+    activate_dynamic_stack,
+)
 from .analysis import AnalysisComponent, DynamicAnalysis
 from .consciousness_suite import (
     AwarenessContexts,
@@ -79,7 +84,10 @@ from .infrastructure import (
     ROLE_PALETTE,
     Role,
     RoleSpec,
+    build_comprehensive_infrastructure,
     build_default_infrastructure,
+    discover_dynamic_module_names,
+    guess_module_domain,
 )
 from .phase3 import (
     AgentProfile,
@@ -130,6 +138,9 @@ from .hedge import (
 )
 
 __all__ = [
+    "ActivationReport",
+    "ModuleActivationPlan",
+    "activate_dynamic_stack",
     "Agent",
     "AgentResult",
     "BloodAgent",
@@ -172,6 +183,8 @@ __all__ = [
     "LinkRecommendation",
     "RelationHint",
     "DEFAULT_MODULE_REGISTRATIONS",
+    "discover_dynamic_module_names",
+    "guess_module_domain",
     "get_default_execution_agent",
     "get_default_research_agent",
     "get_default_risk_agent",
@@ -249,4 +262,5 @@ __all__ = [
     "PhaseThreePlan",
     "build_phase_three_plan",
     "build_default_infrastructure",
+    "build_comprehensive_infrastructure",
 ]

--- a/dynamic/intelligence/ai_apps/activation.py
+++ b/dynamic/intelligence/ai_apps/activation.py
@@ -1,0 +1,178 @@
+"""Activation utilities for enabling dynamic modules, engines, and tasks."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Tuple
+
+from dynamic.platform import engines as platform_engines
+from dynamic_task_manager.manager import Task
+
+from .infrastructure import (
+    DEFAULT_MODULE_REGISTRATIONS,
+    DynamicInfrastructure,
+    ModuleDomain,
+    ModuleRecord,
+    build_comprehensive_infrastructure,
+)
+
+
+_DOMAIN_AGENT_RECOMMENDATIONS: Mapping[ModuleDomain, Tuple[str, ...]] = {
+    ModuleDomain.TECHNOLOGY_INFRASTRUCTURE: (
+        "DynamicEngineerAgent",
+        "DynamicArchitectAgent",
+    ),
+    ModuleDomain.AI_COGNITION: (
+        "DynamicQuantumAgent",
+        "DynamicChatAgent",
+    ),
+    ModuleDomain.BUSINESS_OPERATIONS: (
+        "DynamicBusinessAgent",
+        "DynamicArchitectAgent",
+    ),
+    ModuleDomain.FINANCE_MARKETS: (
+        "DynamicTradingAgent",
+        "DynamicRiskAgent",
+    ),
+    ModuleDomain.HUMAN_CREATIVE: (
+        "DynamicPlaybookAgent",
+        "DynamicOceanLayerAgent",
+    ),
+    ModuleDomain.SECURITY_GOVERNANCE: (
+        "DynamicSecurityAgent",
+        "DynamicRiskAgent",
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleActivationPlan:
+    """Activation details for a single module."""
+
+    module: ModuleRecord
+    tasks: Tuple[Task, ...]
+    recommended_agents: Tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "module": self.module.name,
+            "domain": self.module.domain.value,
+            "tasks": [asdict(task) for task in self.tasks],
+            "recommended_agents": list(self.recommended_agents),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ActivationReport:
+    """Summary of the activation process covering engines and modules."""
+
+    engines: Mapping[str, object]
+    modules: Tuple[ModuleActivationPlan, ...]
+    total_engines: int
+    total_modules: int
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "total_engines": self.total_engines,
+            "total_modules": self.total_modules,
+            "engines": sorted(self.engines),
+            "modules": [plan.to_dict() for plan in self.modules],
+        }
+
+
+def _module_tags(module: ModuleRecord) -> Tuple[str, ...]:
+    tags = {module.name, module.domain.name.lower()}
+    return tuple(sorted(tags))
+
+
+def _module_tasks(module: ModuleRecord) -> Tuple[Task, ...]:
+    display = module.name.replace("_", " ").title()
+    joined_responsibilities = ", ".join(module.responsibilities)
+    joined_metrics = ", ".join(module.success_metrics)
+    tags = _module_tags(module)
+
+    tasks: Iterable[Task] = (
+        Task(
+            name=f"{display}: confirm responsibilities",
+            description=(
+                "Review that the module mission remains accurate: "
+                f"{joined_responsibilities}."
+            ),
+            priority=0.7,
+            effort_hours=2.0,
+            tags=tags,
+        ),
+        Task(
+            name=f"{display}: align instrumentation",
+            description=(
+                "Verify metrics and instrumentation pipelines: "
+                f"{joined_metrics}."
+            ),
+            priority=0.6,
+            effort_hours=1.5,
+            tags=tags,
+        ),
+        Task(
+            name=f"{display}: coordinate agent coverage",
+            description=(
+                "Ensure recommended agents are informed and ready to support this module."
+            ),
+            priority=0.5,
+            effort_hours=1.0,
+            tags=tags,
+        ),
+    )
+    return tuple(tasks)
+
+
+def _recommended_agents(module: ModuleRecord) -> Tuple[str, ...]:
+    roster = _DOMAIN_AGENT_RECOMMENDATIONS.get(
+        module.domain, _DOMAIN_AGENT_RECOMMENDATIONS[ModuleDomain.TECHNOLOGY_INFRASTRUCTURE]
+    )
+    return roster
+
+
+def activate_dynamic_stack(
+    *,
+    repo_root: str | Path | None = None,
+    strict_engines: bool = False,
+    include_default_modules: bool = False,
+) -> ActivationReport:
+    """Enable every engine and register modules with activation tasks."""
+
+    infrastructure: DynamicInfrastructure = build_comprehensive_infrastructure(repo_root)
+    engine_exports = platform_engines.enable_all_dynamic_engines(strict=strict_engines)
+    engines = dict(engine_exports)
+
+    default_names = (
+        set()
+        if include_default_modules
+        else {registration.name for registration in DEFAULT_MODULE_REGISTRATIONS}
+    )
+
+    plans: list[ModuleActivationPlan] = []
+    for module in infrastructure.list_modules():
+        if module.name in default_names:
+            continue
+        plans.append(
+            ModuleActivationPlan(
+                module=module,
+                tasks=_module_tasks(module),
+                recommended_agents=_recommended_agents(module),
+            )
+        )
+
+    return ActivationReport(
+        engines=engines,
+        modules=tuple(plans),
+        total_engines=len(engines),
+        total_modules=len(infrastructure.list_modules()),
+    )
+
+
+__all__ = [
+    "ActivationReport",
+    "ModuleActivationPlan",
+    "activate_dynamic_stack",
+]

--- a/tests_python/test_dynamic_activation.py
+++ b/tests_python/test_dynamic_activation.py
@@ -1,0 +1,26 @@
+from dynamic.intelligence.ai_apps.activation import activate_dynamic_stack
+from dynamic.intelligence.ai_apps.infrastructure import DEFAULT_MODULE_REGISTRATIONS
+
+
+def test_activate_dynamic_stack_produces_activation_plans() -> None:
+    report = activate_dynamic_stack()
+
+    assert report.engines
+    assert report.total_engines == len(report.engines)
+    assert report.total_modules >= len(DEFAULT_MODULE_REGISTRATIONS)
+
+    module_names = {plan.module.name for plan in report.modules}
+    assert "dynamic_accounting" in module_names
+    assert "dynamic_supabase" not in module_names  # defaults excluded by default
+
+    accounting_plan = next(plan for plan in report.modules if plan.module.name == "dynamic_accounting")
+    assert accounting_plan.tasks
+    assert all(task.tags for task in accounting_plan.tasks)
+    assert accounting_plan.recommended_agents
+
+
+def test_activate_dynamic_stack_includes_defaults_when_requested() -> None:
+    report = activate_dynamic_stack(include_default_modules=True)
+
+    module_names = {plan.module.name for plan in report.modules}
+    assert "dynamic_supabase" in module_names

--- a/tests_python/test_dynamic_ai_infrastructure.py
+++ b/tests_python/test_dynamic_ai_infrastructure.py
@@ -9,7 +9,10 @@ from dynamic.intelligence.ai_apps.infrastructure import (
     DynamicInfrastructure,
     ModuleDomain,
     Role,
+    build_comprehensive_infrastructure,
     build_default_infrastructure,
+    discover_dynamic_module_names,
+    guess_module_domain,
 )
 
 
@@ -120,3 +123,29 @@ def test_adapter_and_dataset_modules_are_registered() -> None:
     assert datasets.domain is ModuleDomain.AI_COGNITION
     assert any("dataset" in responsibility for responsibility in datasets.responsibilities)
     assert any("DynamicFineTuneDataset" in note for note in datasets.notes)
+
+
+def test_discover_dynamic_module_names_covers_repository_packages() -> None:
+    discovered = discover_dynamic_module_names()
+
+    assert "dynamic_accounting" in discovered
+    assert "dynamic_wallet" in discovered
+    assert all(name.startswith("dynamic_") for name in discovered)
+
+
+def test_guess_module_domain_matches_keywords() -> None:
+    assert guess_module_domain("dynamic_wallet") is ModuleDomain.FINANCE_MARKETS
+    assert guess_module_domain("dynamic_security_engine") is ModuleDomain.SECURITY_GOVERNANCE
+    assert guess_module_domain("dynamic_creative_thinking") is ModuleDomain.HUMAN_CREATIVE
+    assert guess_module_domain("dynamic_cognition") is ModuleDomain.AI_COGNITION
+    assert guess_module_domain("dynamic_task_manager") is ModuleDomain.BUSINESS_OPERATIONS
+    assert guess_module_domain("dynamic_cache") is ModuleDomain.TECHNOLOGY_INFRASTRUCTURE
+
+
+def test_comprehensive_infrastructure_registers_additional_modules() -> None:
+    infrastructure = build_comprehensive_infrastructure()
+    module = infrastructure.get_module("dynamic_accounting")
+
+    assert module.domain is ModuleDomain.BUSINESS_OPERATIONS
+    assert any("Auto-generated" in note for note in module.notes)
+    assert module.success_metrics


### PR DESCRIPTION
## Summary
- add an activation helper that enables every dynamic engine and prepares module task plans
- extend the infrastructure registry with auto-discovery heuristics so every dynamic_* package is registered
- surface the new activation and discovery utilities through the ai_apps namespace with dedicated tests

## Testing
- pytest tests_python/test_dynamic_ai_infrastructure.py tests_python/test_dynamic_activation.py tests/test_dynamic_engines_enable.py
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e1f003e4f08322ae26424fa57c4ab2