### PR TITLE
Optimize DCT tokenomics parameters

### DIFF
--- a/docs/dct-intelligence-driven-tokenomics.md
+++ b/docs/dct-intelligence-driven-tokenomics.md
@@ -34,7 +34,10 @@ gains.
 ## 2. Revenue-Driven Buyback Algorithm
 
 Protocol revenues are recycled into DCT to reinforce price support and reward
-productive contributors.
+productive contributors. The treasury budget is pre-configured at a 48/32/20
+split between operating liquidity, compounding auto-invest flows, and direct
+buyback-and-burn, with governance-locked bounds that keep proposals within a
+38–58% operating band, 25–40% reinvestment band, and 15–30% burn band.
 
 - **Formula**: $BB = \phi \cdot R$
 - **Variables**:
@@ -48,6 +51,9 @@ productive contributors.
   3. Automated market operations acquire DCT from designated DEX pools.
   4. Purchased tokens are redistributed to staking vaults, mentorship rewards,
      or AGI training bounties as configured.
+  5. Dynamic adjustments boost buyback budgets by up to 300 bps per epoch when
+     revenue surges beyond 180,000 TON or when intelligence delta momentum
+     exceeds the 1.15 threshold.
 
 ## 3. Market Maker Coordination Algorithm
 
@@ -88,6 +94,23 @@ A unified oracle layer translates live DCT valuations into service access costs.
 | Mentorship Success | Unlocks staking rewards and increases aggregated intelligence scores  |
 | Trading Accuracy   | Improves $\Delta I$ inputs and refines market making heuristics       |
 | User Engagement    | Scales revenue $R$, driving higher buyback volumes and token velocity |
+
+## Treasury & Staking Configuration
+
+- **Liquidity Split Guardrails**: Default treasury routing applies 48% to
+  operations, 32% to auto-invest vaults, and 20% to buyback-and-burn activity.
+  Governance-defined bounds enforce gradual rebalancing and block extreme swings
+  outside the 38–58% / 25–40% / 15–30% envelopes.
+- **Adaptive Budget Boosts**: Revenue surges above 180,000 TON or sustained
+  intelligence momentum ($\Delta I > 1.15$) increment buyback budgets by up to
+  300 bps while protecting a 15,000 TON floor so downside phases continue to be
+  supported.
+- **Staking Tiers**: Bronze, Silver, Gold, and newly added Platinum locks (3, 6,
+  12, and 18 months) deliver 1.2x, 1.5x, 2.0x, and 2.5x multipliers respectively
+  with an additional 75 bps loyalty kicker for restaked positions.
+- **Emission Controls**: Weekly epochs remain capped at 240,000 DCT with a 4.5%
+  annualized inflation target, 150 bps decay factor, and a 60,000 DCT floor to
+  keep contributor rewards predictable even during contraction cycles.
 
 ## Governance Considerations
 

--- a/dynamic-capital-ton/config.yaml
+++ b/dynamic-capital-ton/config.yaml
@@ -6,23 +6,36 @@ token:
   maxSupply: 100000000
 
 splits:
-  operationsPct: 60
-  autoInvestPct: 30
-  buybackBurnPct: 10
+  operationsPct: 48
+  autoInvestPct: 32
+  buybackBurnPct: 20
   bounds:
-    operationsPct: [40, 75]
-    autoInvestPct: [15, 45]
-    buybackBurnPct: [5, 20]
+    operationsPct: [38, 58]
+    autoInvestPct: [25, 40]
+    buybackBurnPct: [15, 30]
+  dynamicAdjustments:
+    revenueSurgeTon: 180000
+    revenueSurgeBoostBps: 250
+    intelligenceMomentumThreshold: 1.15
+    intelligenceBurnBoostBps: 200
+    floorBuybackBudgetTon: 15000
+    maxAdjustmentPerEpochBps: 300
 
 locks:
   bronzeMonths: 3
   silverMonths: 6
   goldMonths: 12
-  multipliers: [1.2, 1.5, 2.0]
+  platinumMonths: 18
+  multipliers: [1.2, 1.5, 2.0, 2.5]
+  loyaltyBonusBps: 75
 
 emissions:
   epochDays: 7
   epochCap: 240000
+  targetAnnualInflationPct: 4.5
+  decayRateBps: 150
+  floorEmission: 60000
+  surgeMultiplier: 1.5
 
 governance:
   # Tonstarter treasury multisig (mainnet).

--- a/supabase/functions/dct-auto-invest/index.ts
+++ b/supabase/functions/dct-auto-invest/index.ts
@@ -71,21 +71,22 @@ interface StakeConfig {
 }
 
 const DEFAULT_SPLITS: SplitConfig = {
-  operationsPct: 60,
-  autoInvestPct: 30,
-  buybackBurnPct: 10,
+  operationsPct: 48,
+  autoInvestPct: 32,
+  buybackBurnPct: 20,
 };
 
 const SPLIT_BOUNDS: Record<keyof SplitConfig, SplitBounds> = {
-  operationsPct: { min: 40, max: 75 },
-  autoInvestPct: { min: 15, max: 45 },
-  buybackBurnPct: { min: 5, max: 20 },
+  operationsPct: { min: 38, max: 58 },
+  autoInvestPct: { min: 25, max: 40 },
+  buybackBurnPct: { min: 15, max: 30 },
 };
 
 const LOCK_CONFIG: Record<string, StakeConfig> = {
   "vip_bronze": { months: 3, multiplier: 1.2 },
   "vip_silver": { months: 6, multiplier: 1.5 },
   "vip_gold": { months: 12, multiplier: 2.0 },
+  "vip_platinum": { months: 18, multiplier: 2.5 },
   "mentorship": { months: 6, multiplier: 1.35 },
 };
 


### PR DESCRIPTION
## Summary
- retuned the DCT treasury allocation splits to 48/32/20 with dynamic adjustment levers, refined emission controls, and updated governance bounds in the TON config
- expanded staking incentives with a platinum lock tier and loyalty bonus while documenting the guardrails in the intelligence-driven tokenomics reference
- aligned the auto-invest edge function defaults and validation ranges with the new treasury mix

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1fbcffa908322be4e117b4dacd6ce