### PR TITLE
Fix Next.js cache configuration for dynamic REST routes

### DIFF
--- a/apps/web/app/api/dynamic-api/route.ts
+++ b/apps/web/app/api/dynamic-api/route.ts
@@ -13,13 +13,11 @@ import { corsHeaders, jsonResponse, methodNotAllowed } from "@/utils/http.ts";
 const ROUTE_ENDPOINT = DYNAMIC_API_ENDPOINT;
 const CACHE_KEY = "dynamic-api-response";
 
-export const revalidate = DYNAMIC_API_CACHE_TTL_SECONDS;
-
 const getDynamicApiResponse = unstable_cache(
   async () => buildDynamicApiResponse(),
   [CACHE_KEY],
   {
-    revalidate,
+    revalidate: DYNAMIC_API_CACHE_TTL_SECONDS,
     tags: [DYNAMIC_API_CACHE_TAG],
   },
 );

--- a/apps/web/app/api/dynamic-rest/route.ts
+++ b/apps/web/app/api/dynamic-rest/route.ts
@@ -14,13 +14,11 @@ const ROUTE_ENDPOINT = DYNAMIC_REST_ENDPOINTS.root;
 const ROUTE_NAME = ROUTE_ENDPOINT.path;
 const CACHE_KEY = "dynamic-rest-response";
 
-export const revalidate = DYNAMIC_REST_CACHE_TTL_SECONDS;
-
 const getDynamicRestResponse = unstable_cache(
   () => buildDynamicRestResponse(),
   [CACHE_KEY],
   {
-    revalidate,
+    revalidate: DYNAMIC_REST_CACHE_TTL_SECONDS,
     tags: [DYNAMIC_REST_CACHE_TAG],
   },
 );


### PR DESCRIPTION
## Summary
- remove route-level `revalidate` exports so Next.js no longer rejects imported TTL constants
- keep cache revalidation via `unstable_cache` by wiring constants directly into the cache options
- align the dynamic REST resource handler signature with Next.js expectations and use the generic Request type for HEAD responses

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e23ca590748322877aa746f87cce50