### PR TITLE
feat(dai): add phase1 mesh factory

### DIFF
--- a/dai_architecture/core_adapters/__init__.py
+++ b/dai_architecture/core_adapters/__init__.py
@@ -12,24 +12,7 @@ from .core8_qwen3 import Qwen3Adapter
 from .core9_minimax_m1 import MiniMaxM1Adapter
 from .core10_zhipu import ZhipuAdapter
 from .core11_hunyuan import HunyuanAdapter
-
-
-def build_phase1_mesh() -> tuple[BaseCoreAdapter, ...]:
-    """Return the default eleven-core mesh configured for Phase 1."""
-
-    return (
-        ChatCPT2Adapter(),
-        GrokAdapter(),
-        DolphinAdapter(),
-        OllamaAdapter(),
-        KimiK2Adapter(),
-        DeepSeekV3Adapter(),
-        DeepSeekR1Adapter(),
-        Qwen3Adapter(),
-        MiniMaxM1Adapter(),
-        ZhipuAdapter(),
-        HunyuanAdapter(),
-    )
+from .factory import PHASE1_CORE_CLASSES, Phase1CoreClass, Phase1Mesh, build_phase1_mesh
 
 
 __all__ = [
@@ -46,5 +29,8 @@ __all__ = [
     "MiniMaxM1Adapter",
     "ZhipuAdapter",
     "HunyuanAdapter",
+    "Phase1CoreClass",
+    "Phase1Mesh",
+    "PHASE1_CORE_CLASSES",
     "build_phase1_mesh",
 ]

--- a/dai_architecture/core_adapters/factory.py
+++ b/dai_architecture/core_adapters/factory.py
@@ -1,0 +1,49 @@
+"""Factory helpers for assembling the Build Phase 1 core mesh."""
+
+from __future__ import annotations
+
+from typing import Tuple, Type
+
+from .base import BaseCoreAdapter
+from .core1_chatcpt2 import ChatCPT2Adapter
+from .core2_grok import GrokAdapter
+from .core3_dolphin import DolphinAdapter
+from .core4_ollama import OllamaAdapter
+from .core5_kimi_k2 import KimiK2Adapter
+from .core6_deepseek_v3 import DeepSeekV3Adapter
+from .core7_deepseek_r1 import DeepSeekR1Adapter
+from .core8_qwen3 import Qwen3Adapter
+from .core9_minimax_m1 import MiniMaxM1Adapter
+from .core10_zhipu import ZhipuAdapter
+from .core11_hunyuan import HunyuanAdapter
+
+Phase1CoreClass = Type[BaseCoreAdapter]
+Phase1Mesh = Tuple[BaseCoreAdapter, ...]
+
+PHASE1_CORE_CLASSES: Tuple[Phase1CoreClass, ...] = (
+    ChatCPT2Adapter,
+    GrokAdapter,
+    DolphinAdapter,
+    OllamaAdapter,
+    KimiK2Adapter,
+    DeepSeekV3Adapter,
+    DeepSeekR1Adapter,
+    Qwen3Adapter,
+    MiniMaxM1Adapter,
+    ZhipuAdapter,
+    HunyuanAdapter,
+)
+
+
+def build_phase1_mesh() -> Phase1Mesh:
+    """Instantiate and return the default eleven-core mesh."""
+
+    return tuple(adapter_cls() for adapter_cls in PHASE1_CORE_CLASSES)
+
+
+__all__ = [
+    "Phase1CoreClass",
+    "Phase1Mesh",
+    "PHASE1_CORE_CLASSES",
+    "build_phase1_mesh",
+]

--- a/dai_architecture/tests/test_phase1_pipeline.py
+++ b/dai_architecture/tests/test_phase1_pipeline.py
@@ -22,6 +22,7 @@ from dai_architecture import (  # noqa: E402 - configured sys.path above
     TaskValidationError,
     build_phase1_mesh,
 )
+from dai_architecture.core_adapters import PHASE1_CORE_CLASSES
 
 
 def _make_envelope(task_id: str, *, intent: str = "accumulate", momentum: float = 0.55) -> TaskEnvelope:
@@ -43,6 +44,21 @@ def _make_envelope(task_id: str, *, intent: str = "accumulate", momentum: float 
 
 
 def test_phase1_mesh_contains_eleven_adapters() -> None:
+    assert len(PHASE1_CORE_CLASSES) == 11
+    assert {adapter.__name__ for adapter in PHASE1_CORE_CLASSES} == {
+        "ChatCPT2Adapter",
+        "GrokAdapter",
+        "DolphinAdapter",
+        "OllamaAdapter",
+        "KimiK2Adapter",
+        "DeepSeekV3Adapter",
+        "DeepSeekR1Adapter",
+        "Qwen3Adapter",
+        "MiniMaxM1Adapter",
+        "ZhipuAdapter",
+        "HunyuanAdapter",
+    }
+
     mesh = build_phase1_mesh()
     assert len(mesh) == 11
     names = {adapter.name for adapter in mesh}


### PR DESCRIPTION
## Summary
- add a dedicated factory module that instantiates the Phase 1 core mesh and exposes its class roster
- re-export the mesh factory metadata from the core adapter package for downstream consumers
- extend the Phase 1 pipeline test to assert the factory advertises all eleven adapters before instantiating them

## Testing
- pytest dai_architecture/tests/test_phase1_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e240881c48832293464df066f0cf82