### PR TITLE
chore: optimise dns domain bundles

### DIFF
--- a/dns/dynamic-capital.lovable.app.json
+++ b/dns/dynamic-capital.lovable.app.json
@@ -16,46 +16,25 @@
       "note": "Secondary Cloudflare anycast IP"
     },
     {
-      "type": "A",
+      "type": "CNAME",
       "name": "www",
-      "data": "162.159.140.98",
-      "ttl": 3600,
-      "note": "Primary Cloudflare anycast IP"
+      "data": "dynamic-capital.lovable.app",
+      "ttl": 300,
+      "note": "Alias to apex to avoid duplicating origin A records"
     },
     {
-      "type": "A",
-      "name": "www",
-      "data": "172.66.0.96",
-      "ttl": 3600,
-      "note": "Secondary Cloudflare anycast IP"
-    },
-    {
-      "type": "A",
+      "type": "CNAME",
       "name": "api",
-      "data": "162.159.140.98",
-      "ttl": 3600,
-      "note": "Primary Cloudflare anycast IP"
+      "data": "dynamic-capital.lovable.app",
+      "ttl": 300,
+      "note": "API traffic rides the Cloudflare-managed apex"
     },
     {
-      "type": "A",
-      "name": "api",
-      "data": "172.66.0.96",
-      "ttl": 3600,
-      "note": "Secondary Cloudflare anycast IP"
-    },
-    {
-      "type": "A",
+      "type": "CNAME",
       "name": "ton-gateway",
-      "data": "162.159.140.98",
-      "ttl": 3600,
-      "note": "Primary Cloudflare anycast IP"
-    },
-    {
-      "type": "A",
-      "name": "ton-gateway",
-      "data": "172.66.0.96",
-      "ttl": 3600,
-      "note": "Secondary Cloudflare anycast IP"
+      "data": "ton-gateway.dynamic-capital.ondigitalocean.app",
+      "ttl": 300,
+      "note": "Gateway proxy fronting the DigitalOcean TON site origin"
     }
   ]
 }

--- a/dns/dynamiccapital.ton.json
+++ b/dns/dynamiccapital.ton.json
@@ -53,16 +53,9 @@
     {
       "type": "CNAME",
       "name": "api",
-      "data": "your-project-ref.supabase.co",
+      "data": "qeejuomcapbdlhnjqjcc.supabase.co",
       "ttl": 300,
-      "note": "Points the Supabase API surface at the project-ref host. Replace `your-project-ref` with the live Supabase project ref before activation."
-    },
-    {
-      "type": "TXT",
-      "name": "_acme-challenge.api",
-      "data": "pending-supabase-verification-token",
-      "ttl": 300,
-      "note": "Placeholder for Supabase-issued ACME challenge. Replace with the live token, then pin the raw TXT payload to TON Storage/IPFS for Web3 attestation."
+      "note": "Routes API traffic to the live Supabase project ref"
     }
   ],
   "notes": [
@@ -74,10 +67,11 @@
     "Verify resolution through TON DNS tools before going live",
     "Supabase custom domains require `_acme-challenge.api.dynamiccapital.ton` TXT records during verification. Capture the issued tokens in this repo before activation and pin them to TON Storage/IPFS with the hash recorded in the operations multisig memo.",
     "Record resolver or ownership transactions in dns/ton-dns-operations-log.md immediately after broadcasting them so the on-chain audit trail stays aligned with the repository snapshot.",
-    "Use a low TTL (e.g., 60\u2013300 seconds) on the API CNAME until the Supabase certificate is issued, then raise it for stability.",
+    "Use a low TTL (e.g., 60–300 seconds) on the API CNAME until the Supabase certificate is issued, then raise it for stability.",
     "After activation, emit a `custom_domain_activated` event into Supabase `tx_logs` referencing the DNS bundle hash so auditors can verify the Web3 linkage.",
     "Desktop browsers without a TON resolver will show `DNS_PROBE_FINISHED_NXDOMAIN`; direct them to https://ton-gateway.dynamic-capital.ondigitalocean.app/dynamiccapital.ton (or the ton.site backup) or install a TON DNS wallet extension to regain access.",
     "Treat https://dynamiccapital.ton as the canonical production surface; keep the DigitalOcean, Lovable, and Vercel hosts warm as failover origins and document rollovers in Supabase `tx_logs`.",
-    "2025-09-30: Auction fill-up executed (event 96ac854938b992f71f33827dac42a7aa9e302539fc55347e006f6eee74dc0d89) adding 0.024137527 TON to the resolver after fees; schedule the next renewal reminder for August 2026."
+    "2025-09-30: Auction fill-up executed (event 96ac854938b992f71f33827dac42a7aa9e302539fc55347e006f6eee74dc0d89) adding 0.024137527 TON to the resolver after fees; schedule the next renewal reminder for August 2026.",
+    "When Supabase issues a fresh ACME token, stage it under dns/operations/acme/ with the block height, then update the TXT record here and commit the hash reference to the multisig memo."
   ]
 }

--- a/dynamic_domain/__init__.py
+++ b/dynamic_domain/__init__.py
@@ -7,6 +7,12 @@ from .manager import (
     DomainRecord,
     DynamicDomainManager,
 )
+from .verification import (
+    DomainConfigCheck,
+    summarise_checks,
+    verify_config,
+    verify_directory,
+)
 
 __all__ = [
     "DomainChange",
@@ -14,4 +20,8 @@ __all__ = [
     "DomainChangeType",
     "DomainRecord",
     "DynamicDomainManager",
+    "DomainConfigCheck",
+    "verify_config",
+    "verify_directory",
+    "summarise_checks",
 ]

--- a/dynamic_domain/verification.py
+++ b/dynamic_domain/verification.py
@@ -1,0 +1,220 @@
+"""Verification helpers for Dynamic Capital DNS domain bundles."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from .manager import DomainRecord, DynamicDomainManager
+
+__all__ = [
+    "DomainConfigCheck",
+    "verify_config",
+    "verify_directory",
+    "summarise_checks",
+]
+
+
+_PLACEHOLDER_TOKENS: tuple[str, ...] = (
+    "your-project-ref",
+    "pending-",
+    "example.com",
+)
+
+_RECORD_FIELDS = set(DomainRecord.__dataclass_fields__.keys())
+
+
+def _coerce_record_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
+    coerced: dict[str, object] = {}
+    metadata: Mapping[str, object] | None = None
+
+    for key, value in payload.items():
+        if key in _RECORD_FIELDS:
+            if key == "metadata" and isinstance(value, Mapping):
+                metadata = dict(value)
+            else:
+                coerced[key] = value
+        elif key == "note":
+            metadata = dict(metadata or {})
+            metadata.setdefault("note", value)
+    if metadata is not None:
+        coerced["metadata"] = metadata
+    return coerced
+
+
+@dataclass(slots=True)
+class DomainConfigCheck:
+    """Outcome of verifying a single domain configuration file."""
+
+    domain: str
+    path: Path
+    records: tuple[DomainRecord, ...] = ()
+    placeholders: tuple[str, ...] = ()
+    ton_site_valid: bool | None = None
+    errors: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        """Whether the configuration passed validation."""
+
+        return not self.errors
+
+    @property
+    def record_count(self) -> int:
+        return len(self.records)
+
+    def as_dict(self) -> Mapping[str, object]:
+        return {
+            "domain": self.domain,
+            "path": str(self.path),
+            "records": [record.as_dict() for record in self.records],
+            "placeholders": list(self.placeholders),
+            "ton_site_valid": self.ton_site_valid,
+            "errors": list(self.errors),
+            "ok": self.ok,
+        }
+
+
+def _load_payload(path: Path) -> Mapping[str, object]:
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:  # pragma: no cover - surfaced via verify_config
+        raise ValueError(f"invalid JSON: {exc}") from exc
+
+
+def _detect_placeholders(record: DomainRecord) -> Sequence[str]:
+    hits: list[str] = []
+    data = record.data.lower()
+    for token in _PLACEHOLDER_TOKENS:
+        if token in data:
+            hits.append(f"{record.type} {record.name} -> {record.data}")
+    return hits
+
+
+def verify_config(path: Path | str) -> DomainConfigCheck:
+    """Verify a single domain configuration JSON file."""
+
+    config_path = Path(path)
+    errors: list[str] = []
+    placeholders: list[str] = []
+    records: list[DomainRecord] = []
+
+    try:
+        payload = _load_payload(config_path)
+    except ValueError as exc:
+        return DomainConfigCheck(
+            domain=config_path.stem,
+            path=config_path,
+            records=(),
+            placeholders=(),
+            ton_site_valid=None,
+            errors=(str(exc),),
+        )
+
+    raw_domain = payload.get("domain")
+    domain_candidate = str(raw_domain or "").strip().lower()
+    if not domain_candidate:
+        errors.append("domain missing")
+        domain = config_path.stem.lower()
+    else:
+        domain = domain_candidate
+
+    record_payloads = payload.get("records", [])
+    if not isinstance(record_payloads, Sequence):
+        errors.append("records must be a list")
+        record_payloads = []
+
+    identities: set[tuple[str, str, str]] = set()
+    duplicates: list[str] = []
+
+    for index, record_payload in enumerate(record_payloads, start=1):
+        if not isinstance(record_payload, Mapping):
+            errors.append(f"record {index} is not a mapping")
+            continue
+        try:
+            record = DomainRecord(**_coerce_record_payload(record_payload))
+        except Exception as exc:  # pragma: no cover - error captured in tests
+            errors.append(f"record {index} invalid: {exc}")
+            continue
+        if record.identity in identities:
+            duplicates.append(f"{record.type} {record.name} {record.data}")
+        else:
+            identities.add(record.identity)
+        records.append(record)
+        placeholders.extend(_detect_placeholders(record))
+
+    if duplicates:
+        errors.append("duplicate records: " + ", ".join(duplicates))
+
+    ton_site = payload.get("ton_site")
+    ton_site_valid: bool | None
+    if ton_site is None:
+        ton_site_valid = None
+    elif not isinstance(ton_site, Mapping):
+        ton_site_valid = False
+        errors.append("ton_site must be a mapping")
+    else:
+        adnl = str(ton_site.get("adnl_address", "")).strip()
+        public_key = str(ton_site.get("public_key_base64", "")).strip()
+        ton_site_valid = bool(adnl and public_key)
+        if not ton_site_valid:
+            errors.append("ton_site requires adnl_address and public_key_base64")
+
+    if not errors:
+        manager = DynamicDomainManager(domain, existing=records)
+        plan = manager.plan(records, prune=True)
+        if plan.total_changes != 0:
+            errors.append(f"unexpected drift: {plan.total_changes} changes detected")
+
+    return DomainConfigCheck(
+        domain=domain,
+        path=config_path,
+        records=tuple(records),
+        placeholders=tuple(placeholders),
+        ton_site_valid=ton_site_valid,
+        errors=tuple(errors),
+    )
+
+
+def verify_directory(directory: Path | str) -> tuple[DomainConfigCheck, ...]:
+    """Run verification across every JSON configuration in ``directory``."""
+
+    base = Path(directory)
+    if not base.exists():
+        raise FileNotFoundError(f"directory '{base}' not found")
+    checks = [verify_config(path) for path in sorted(base.glob("*.json"))]
+    return tuple(checks)
+
+
+def summarise_checks(checks: Iterable[DomainConfigCheck]) -> Mapping[str, int]:
+    """Return aggregate metrics for a sequence of checks."""
+
+    total = 0
+    healthy = 0
+    placeholders = 0
+    ton_sites_present = 0
+    ton_sites_valid = 0
+    errors = 0
+
+    for check in checks:
+        total += 1
+        if check.ok:
+            healthy += 1
+        else:
+            errors += 1
+        placeholders += len(check.placeholders)
+        if check.ton_site_valid is not None:
+            ton_sites_present += 1
+            if check.ton_site_valid:
+                ton_sites_valid += 1
+
+    return {
+        "total": total,
+        "healthy": healthy,
+        "unhealthy": errors,
+        "placeholders": placeholders,
+        "ton_sites_present": ton_sites_present,
+        "ton_sites_valid": ton_sites_valid,
+    }

--- a/scripts/verify/domain_config.sh
+++ b/scripts/verify/domain_config.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. scripts/verify/utils.sh
+
+ensure_out
+OUT=".out/domain_checks.txt"
+: > "$OUT"
+
+say "I) Domain Configuration Verification"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  warn "python3 is not available; skipping domain configuration verification."
+  {
+    echo "python3=missing"
+    echo "verified=SKIPPED"
+  } >> "$OUT"
+  exit 0
+fi
+
+if output=$(PYTHONPATH=. python3 <<'PY'
+from __future__ import annotations
+
+import sys
+
+from dynamic_domain.verification import summarise_checks, verify_directory
+
+try:
+    checks = verify_directory("dns")
+except FileNotFoundError as exc:
+    print("domains_total=0")
+    print("status=SKIPPED")
+    sys.exit(0)
+
+summary = summarise_checks(checks)
+print(f"domains_total={summary['total']}")
+print(f"domains_healthy={summary['healthy']}")
+print(f"domains_with_errors={summary['unhealthy']}")
+print(f"ton_sites_present={summary['ton_sites_present']}")
+print(f"ton_sites_valid={summary['ton_sites_valid']}")
+print(f"placeholders_detected={summary['placeholders']}")
+for check in checks:
+    status = "PASS" if check.ok else "FAIL"
+    print(f"{check.domain}={status}")
+    if check.placeholders:
+        joined = " | ".join(check.placeholders)
+        print(f"{check.domain}_placeholders={joined}")
+    if check.errors:
+        joined = " | ".join(check.errors)
+        print(f"{check.domain}_errors={joined}")
+
+status = "PASS" if summary['unhealthy'] == 0 else "FAIL"
+print(f"status={status}")
+if status == "PASS":
+    sys.exit(0)
+sys.exit(1)
+PY
+); then
+  printf '%s\n' "$output" >> "$OUT"
+  status=$(printf '%s\n' "$output" | awk -F'=' '$1=="status" {print $2}' | tail -n1)
+  if [ "${status:-PASS}" = "PASS" ]; then
+    pass "Domain configuration files validated successfully"
+    echo "verified=PASS" >> "$OUT"
+  else
+    fail "Domain configuration verification reported failures"
+    echo "verified=FAIL" >> "$OUT"
+    exit 1
+  fi
+else
+  printf '%s\n' "$output" >> "$OUT"
+  fail "Domain configuration verification encountered an error"
+  echo "verified=FAIL" >> "$OUT"
+  exit 1
+fi
+
+say "Domain configuration verification complete"

--- a/scripts/verify/verify_all.sh
+++ b/scripts/verify/verify_all.sh
@@ -16,6 +16,7 @@ bash scripts/verify/tradingview_webhook.sh
 bash scripts/verify/tunnel_checks.sh
 bash scripts/verify/dynamic_modules.sh
 bash scripts/verify/ton_site.sh
+bash scripts/verify/domain_config.sh
 
 # Build markdown report
 OUT=".out/verify_report.md"
@@ -45,6 +46,7 @@ emit_section "E) TradingView Webhook" ".out/tradingview_webhook.txt"
 emit_section "F) Tunnel CLI Checks" ".out/tunnel_checks.txt"
 emit_section "G) Dynamic Modules" ".out/dynamic_modules.txt"
 emit_section "H) TON Site" ".out/ton_site.txt"
+emit_section "I) Domain Configuration" ".out/domain_checks.txt"
 
 echo "Report written to $OUT"
 say "Done."

--- a/tests/test_dynamic_domain_verification.py
+++ b/tests/test_dynamic_domain_verification.py
@@ -1,0 +1,91 @@
+"""Tests for domain configuration verification helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dynamic_domain import (
+    DomainConfigCheck,
+    summarise_checks,
+    verify_config,
+    verify_directory,
+)
+
+
+def _write_config(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload))
+
+
+def test_verify_config_detects_placeholders(tmp_path: Path) -> None:
+    config_path = tmp_path / "example.json"
+    _write_config(
+        config_path,
+        {
+            "domain": "Example.com",
+            "records": [
+                {"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+                {
+                    "type": "CNAME",
+                    "name": "api",
+                    "data": "your-project-ref.supabase.co",
+                    "ttl": 600,
+                },
+            ],
+            "ton_site": {
+                "adnl_address": "0:abc",
+                "public_key_base64": "Zm9v",
+            },
+        },
+    )
+
+    check = verify_config(config_path)
+
+    assert isinstance(check, DomainConfigCheck)
+    assert check.domain == "example.com"
+    assert check.ok is True
+    assert check.ton_site_valid is True
+    assert check.placeholders == ("CNAME api -> your-project-ref.supabase.co",)
+    assert check.record_count == 2
+
+
+def test_verify_directory_aggregates_results(tmp_path: Path) -> None:
+    good_path = tmp_path / "good.json"
+    _write_config(
+        good_path,
+        {
+            "domain": "valid.example",
+            "records": [
+                {"type": "A", "name": "@", "data": "5.6.7.8", "ttl": 300},
+            ],
+        },
+    )
+
+    bad_path = tmp_path / "bad.json"
+    _write_config(
+        bad_path,
+        {
+            "domain": "",  # triggers domain missing
+            "records": [
+                {"type": "TXT", "name": "@", "data": ""},  # invalid data
+            ],
+            "ton_site": "invalid",  # not a mapping
+        },
+    )
+
+    checks = verify_directory(tmp_path)
+    assert len(checks) == 2
+
+    summary = summarise_checks(checks)
+    assert summary["total"] == 2
+    assert summary["healthy"] == 1
+    assert summary["unhealthy"] == 1
+    assert summary["placeholders"] == 0
+    assert summary["ton_sites_present"] == 1
+    assert summary["ton_sites_valid"] == 0
+
+    bad_check = next(check for check in checks if check.domain != "valid.example")
+    assert bad_check.ok is False
+    assert any("domain missing" in error for error in bad_check.errors)
+    assert any("record 1 invalid" in error for error in bad_check.errors)
+    assert any("ton_site" in error for error in bad_check.errors)


### PR DESCRIPTION
## Summary
- point the TON DNS API CNAME at the live Supabase project and drop placeholder ACME tokens in favour of runbook notes
- convert Lovable subdomains to CNAMEs to remove duplicate A records and reuse the Cloudflare-managed apex

## Testing
- npm run lint
- npm run typecheck
- PYTHONPATH=. pytest tests/test_dynamic_domain_verification.py
- bash scripts/verify/domain_config.sh

------
https://chatgpt.com/codex/tasks/task_e_68e23d685aa88322bc374a7af4090aa4