### PR TITLE
Improve npm-safe wrapper for build reliability

### DIFF
--- a/scripts/npm-safe.mjs
+++ b/scripts/npm-safe.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
 import { createSanitizedNpmEnv } from "./utils/npm-env.mjs";
 
 const args = process.argv.slice(2);
@@ -11,16 +14,91 @@ if (args.length === 0) {
 
 const env = createSanitizedNpmEnv();
 
-const npmExecPath = env.npm_execpath ?? env.NPM_EXECPATH;
-const npmNodeExecPath = env.npm_node_execpath ?? env.NPM_NODE_EXECPATH;
+function resolveExecPath(candidate) {
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    return undefined;
+  }
 
-const shouldUseNodeWrapper = typeof npmExecPath === "string" &&
-  npmExecPath.endsWith(".js");
+  if (path.isAbsolute(candidate) && existsSync(candidate)) {
+    return candidate;
+  }
 
-const command = shouldUseNodeWrapper
-  ? npmNodeExecPath ?? process.execPath
-  : npmExecPath ?? "npm";
-const commandArgs = shouldUseNodeWrapper ? [npmExecPath, ...args] : args;
+  const searchRoots = [
+    env.PWD,
+    process.cwd(),
+    path.dirname(process.execPath),
+  ].filter(Boolean);
+
+  for (const root of searchRoots) {
+    const resolved = path.resolve(root, candidate);
+    if (existsSync(resolved)) {
+      return resolved;
+    }
+  }
+
+  return candidate;
+}
+
+function coerceLifecycleEvent(npmArgs) {
+  const runIndex = npmArgs.findIndex((arg) =>
+    arg === "run" || arg === "run-script"
+  );
+  if (runIndex === -1) {
+    return undefined;
+  }
+
+  const scriptName = npmArgs[runIndex + 1];
+  return typeof scriptName === "string" ? scriptName : undefined;
+}
+
+const lifecycleEvent = coerceLifecycleEvent(args);
+if (
+  lifecycleEvent && lifecycleEvent.startsWith("build") &&
+  (env.NODE_ENV === undefined || env.NODE_ENV === "")
+) {
+  env.NODE_ENV = "production";
+}
+
+const rawNpmExecPath = env.npm_execpath ?? env.NPM_EXECPATH;
+const rawNodeExecPath = env.npm_node_execpath ?? env.NPM_NODE_EXECPATH;
+
+const npmExecPath = resolveExecPath(rawNpmExecPath);
+const npmNodeExecPath = resolveExecPath(rawNodeExecPath);
+
+const execPathForCheck = typeof npmExecPath === "string"
+  ? npmExecPath
+  : (typeof rawNpmExecPath === "string" ? rawNpmExecPath : undefined);
+
+const executableExtension = typeof execPathForCheck === "string"
+  ? path.extname(execPathForCheck).toLowerCase()
+  : "";
+
+const shouldUseNodeWrapper = [".js", ".mjs", ".cjs"].includes(
+  executableExtension,
+);
+
+let command;
+let commandArgs;
+
+if (shouldUseNodeWrapper && typeof execPathForCheck === "string") {
+  const nodeExecutable = npmNodeExecPath ?? process.execPath;
+  command = nodeExecutable;
+  commandArgs = [
+    resolveExecPath(execPathForCheck) ?? execPathForCheck,
+    ...args,
+  ];
+} else {
+  const fallbackCommand = typeof npmExecPath === "string"
+    ? npmExecPath
+    : (typeof rawNpmExecPath === "string" ? rawNpmExecPath : undefined);
+  command = fallbackCommand ?? "npm";
+  commandArgs = args;
+}
+
+if (typeof command !== "string" || command.length === 0) {
+  console.error("Unable to determine npm executable. Ensure npm is installed.");
+  process.exit(1);
+}
 
 const child = spawn(command, commandArgs, {
   stdio: "inherit",


### PR DESCRIPTION
## Summary
- resolve npm and node executable paths more robustly to prevent ENOENT failures
- default NODE_ENV to production when running build scripts so Next.js builds use production settings
- add safety checks when falling back to npm to aid troubleshooting

## Testing
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e311a85a7c8322952d2a416869e04d