### PR TITLE
Align dynamic REST resource handler context typing

### DIFF
--- a/apps/web/app/api/dynamic-rest/resources/[resource]/route.ts
+++ b/apps/web/app/api/dynamic-rest/resources/[resource]/route.ts
@@ -123,16 +123,13 @@ type RouteContext = {
   params: RouteParams;
 };
 
-function extractResource(params?: RouteParams): string | undefined {
-  const resource = params?.resource;
+function extractResource(params: RouteParams): string | undefined {
+  const resource = params.resource;
   if (!resource) return undefined;
   return Array.isArray(resource) ? resource[0] : resource;
 }
 
-export async function GET(
-  req: NextRequest,
-  { params }: RouteContext = { params: {} },
-) {
+export async function GET(req: NextRequest, { params }: RouteContext) {
   const definition = resolveResource(extractResource(params));
 
   if (!definition) {


### PR DESCRIPTION
## Summary
- require the RouteContext parameter for the dynamic REST GET handler so it matches Next.js expectations
- simplify resource extraction to accept the guaranteed params object while still tolerating missing slugs

## Testing
- npm run format
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e31171d9608322a0fc828a2eaaed57