### PR TITLE
Improve RouteGuard preview path normalization

### DIFF
--- a/apps/web/components/dynamic-portfolio/RouteGuard.test.tsx
+++ b/apps/web/components/dynamic-portfolio/RouteGuard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeRouteGuardPathname } from "./RouteGuard";
+
+describe("normalizeRouteGuardPathname", () => {
+  it("returns root for preview hosts that include dots", () => {
+    expect(
+      normalizeRouteGuardPathname(
+        "/_sites/dynamic-capital-qazf2.ondigitalocean.app/",
+      ),
+    ).toBe("/");
+  });
+
+  it("preserves nested paths for preview hosts", () => {
+    expect(
+      normalizeRouteGuardPathname(
+        "/_sites/dynamic-capital-qazf2.ondigitalocean.app/plans/",
+      ),
+    ).toBe("/plans");
+  });
+
+  it("deduplicates repeated slashes after the preview prefix", () => {
+    expect(
+      normalizeRouteGuardPathname(
+        "/_sites/dynamic-capital-qazf2.ondigitalocean.app//plans//details/",
+      ),
+    ).toBe("/plans/details");
+  });
+
+  it("handles preview hosts without a trailing slash", () => {
+    expect(
+      normalizeRouteGuardPathname(
+        "/_sites/dynamic-capital-qazf2.ondigitalocean.app",
+      ),
+    ).toBe("/");
+  });
+
+  it("returns the original path when no preview prefix is present", () => {
+    expect(normalizeRouteGuardPathname("/tools"))
+      .toBe("/tools");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure RouteGuard preview prefix normalization collapses duplicate slashes and always restores a leading slash
- extend normalizeRouteGuardPathname tests to cover repeated slashes and hosts without trailing slashes

## Testing
- npm run lint
- npm run typecheck
- npx vitest run apps/web/components/dynamic-portfolio/RouteGuard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e322a69b308322b6729b4f8a721523