### PR TITLE
Add go-live dry run npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "doctl:sync-site": "node scripts/doctl/sync-site-config.mjs",
     "checklists": "node scripts/run-checklists.js",
     "go-live": "node scripts/run-checklists.js --checklist go-live",
+    "go-live--dry-run": "node scripts/run-checklists.js --checklist go-live --dry-run",
     "export": "node scripts/npm-safe.mjs run build",
     "output": "node scripts/npm-safe.mjs -w apps/web run copy-static",
     "supabase:start": "supabase start",


### PR DESCRIPTION
## Summary
- add a go-live dry run npm script that proxies the checklist runner in dry-run mode

## Testing
- npm run go-live--dry-run

------
https://chatgpt.com/codex/tasks/task_e_68e340e7ba40832294ce8b02c6e020d1