### PR TITLE
Fix edge function test setup and miniapp assets

### DIFF
--- a/supabase/functions/_shared/miniapp.ts
+++ b/supabase/functions/_shared/miniapp.ts
@@ -28,8 +28,7 @@ export function normalizeMiniAppUrl(value: unknown): string | null {
     } else if (
       !parsed.pathname.endsWith("/") &&
       !parsed.search &&
-      !parsed.hash &&
-      parsed.protocol === "https:"
+      !parsed.hash
     ) {
       parsed.pathname = `${parsed.pathname}/`;
     }

--- a/supabase/functions/_shared/serve.ts
+++ b/supabase/functions/_shared/serve.ts
@@ -15,6 +15,21 @@ export function registerHandler(
     __SUPABASE_SKIP_AUTO_SERVE__?: boolean;
     __SUPABASE_EDGE_SERVER_STARTED__?: boolean;
   };
+
+  if (!globalAny.__SUPABASE_SKIP_AUTO_SERVE__) {
+    const isDenoTest = (() => {
+      try {
+        return Deno?.env?.get?.("DENO_TESTING") === "1";
+      } catch {
+        return false;
+      }
+    })();
+
+    if (isDenoTest) {
+      globalAny.__SUPABASE_SKIP_AUTO_SERVE__ = true;
+    }
+  }
+
   if (globalAny.__SUPABASE_SKIP_AUTO_SERVE__) {
     return handler;
   }

--- a/supabase/functions/_shared/static.ts
+++ b/supabase/functions/_shared/static.ts
@@ -129,8 +129,13 @@ async function readFileFrom(
     const data = await Deno.readFile
       ? await Deno.readFile(url)
       : await (await import("node:fs/promises")).readFile(url);
+    const explicitMime = relPath.endsWith(".xml")
+      ? "application/xml"
+      : relPath.endsWith(".txt")
+      ? "text/plain; charset=utf-8"
+      : null;
     const h = new Headers({
-      "content-type": await mime(relPath),
+      "content-type": explicitMime ?? await mime(relPath),
       "cache-control": relPath.endsWith(".html")
         ? "no-cache"
         : "public, max-age=31536000, immutable",

--- a/supabase/functions/_tests/checkout_init_auth_test.ts
+++ b/supabase/functions/_tests/checkout_init_auth_test.ts
@@ -1,3 +1,6 @@
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
 import { assertEquals } from "std/assert/mod.ts";
 import { clearTestEnv, setTestEnv } from "./env-mock.ts";
 

--- a/supabase/functions/_tests/create_checkout_auth_test.ts
+++ b/supabase/functions/_tests/create_checkout_auth_test.ts
@@ -1,3 +1,6 @@
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
 import { assertEquals } from "std/assert/mod.ts";
 import { clearTestEnv, setTestEnv } from "./env-mock.ts";
 

--- a/supabase/functions/_tests/env-mock.ts
+++ b/supabase/functions/_tests/env-mock.ts
@@ -5,6 +5,9 @@ interface TestEnvGlobal {
   __TEST_ENV__?: Partial<Record<EnvKey, string>>;
 }
 
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
 let originalFetch: typeof fetch | null = null;
 
 // Populate both a test-only env map and the runtime env so that code

--- a/supabase/functions/_tests/health.test.ts
+++ b/supabase/functions/_tests/health.test.ts
@@ -1,3 +1,6 @@
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
 import { assertEquals } from "std/assert/mod.ts";
 
 Deno.test("health function responds with commit", async () => {

--- a/supabase/functions/_tests/vip_sync_test.ts
+++ b/supabase/functions/_tests/vip_sync_test.ts
@@ -1,3 +1,6 @@
+(globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
+  .__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
 import { assertEquals } from "std/assert/mod.ts";
 import { createMockSupabaseClient } from "./mock_supabase.ts";
 

--- a/supabase/functions/miniapp/static/robots.txt
+++ b/supabase/functions/miniapp/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://mini.dynamic.capital/miniapp/sitemap.xml

--- a/supabase/functions/miniapp/static/sitemap.xml
+++ b/supabase/functions/miniapp/static/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mini.dynamic.capital/miniapp/</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- default test harness to skip auto-serving edge handlers to avoid leaking listeners
- normalize mini app URLs more consistently and add required robots.txt/sitemap.xml assets
- ensure static file responses carry explicit XML/text content types

## Testing
- DENO_CMD=$(bash scripts/deno_bin.sh); DENO_NO_PACKAGE_JSON=1 eval "$DENO_CMD test --sloppy-imports --no-lock --no-npm --node-modules-dir=false -A --no-check supabase/functions/_tests/miniapp-env.test.ts supabase/functions/_tests/static_extra_files_test.ts supabase/functions/_tests/checkout_init_auth_test.ts supabase/functions/_tests/create_checkout_auth_test.ts supabase/functions/_tests/health.test.ts"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950d3f906b883229755a5efc90d4131)