### PR TITLE
Fix Telegram /start webhook handling

### DIFF
--- a/supabase/functions/_tests/telegram-setwebhook.test.ts
+++ b/supabase/functions/_tests/telegram-setwebhook.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "std/testing/asserts.ts";
+import { clearTestEnv, setTestEnv } from "./env-mock.ts";
+
+Deno.test("telegram-setwebhook targets the canonical telegram-bot endpoint", async () => {
+  setTestEnv({
+    TELEGRAM_BOT_TOKEN: "token",
+    SUPABASE_URL: "https://project-ref.supabase.co",
+  });
+
+  const { handler } = await import(
+    `../telegram-setwebhook/index.ts?cache=${crypto.randomUUID()}`
+  );
+  const res = await handler(
+    new Request("https://example.com/telegram-setwebhook?dry=1"),
+  );
+  const payload = await res.json();
+
+  assertEquals(payload.ok, true);
+  assertEquals(
+    payload.target,
+    "https://project-ref.functions.supabase.co/telegram-bot",
+  );
+
+  clearTestEnv();
+});

--- a/supabase/functions/_tests/telegram-webhook-security.test.ts
+++ b/supabase/functions/_tests/telegram-webhook-security.test.ts
@@ -1,8 +1,24 @@
 (globalThis as { __SUPABASE_SKIP_AUTO_SERVE__?: boolean })
   .__SUPABASE_SKIP_AUTO_SERVE__ = true;
 
-import { assertEquals } from "std/testing/asserts.ts";
+import { assert, assertEquals } from "std/testing/asserts.ts";
 import { clearTestEnv, setTestEnv } from "./env-mock.ts";
+
+Deno.test("telegram-webhook normalizes bot-mentioned commands", async () => {
+  const { normalizeTelegramCommand } = await import(
+    `../telegram-webhook/index.ts?normalize=${crypto.randomUUID()}`
+  );
+
+  assertEquals(
+    normalizeTelegramCommand("/start@DynamicCapitalBot foo"),
+    "/start",
+  );
+  assertEquals(
+    normalizeTelegramCommand("  /PLANS@DynamicCapitalBot"),
+    "/plans",
+  );
+  assertEquals(normalizeTelegramCommand("hello"), null);
+});
 
 Deno.test("telegram-webhook ignores requests without secret", async () => {
   setTestEnv({ TELEGRAM_WEBHOOK_SECRET: "s3cr3t" });
@@ -29,5 +45,48 @@ Deno.test("telegram-webhook accepts valid secret", async () => {
   });
   const res = await handler(req);
   assertEquals(res.status, 200);
+  clearTestEnv();
+});
+
+Deno.test("telegram-webhook responds to /start with bot mention", async () => {
+  setTestEnv({
+    TELEGRAM_WEBHOOK_SECRET: "s3cr3t",
+    TELEGRAM_BOT_TOKEN: "token",
+    MINI_APP_URL: "https://mini.example.com/",
+  });
+
+  const calls: { input: string; body: string }[] = [];
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const body = typeof init?.body === "string"
+      ? init.body
+      : init?.body
+      ? JSON.stringify(init.body)
+      : "";
+    calls.push({ input: String(input), body });
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const { default: handler } = await import(
+    `../telegram-webhook/index.ts?start=${crypto.randomUUID()}`
+  );
+  const req = new Request("https://example.com/telegram-webhook", {
+    method: "POST",
+    headers: { "x-telegram-bot-api-secret-token": "s3cr3t" },
+    body: JSON.stringify({
+      message: { chat: { id: 123 }, text: "/start@DynamicCapitalBot" },
+    }),
+  });
+
+  const res = await handler(req);
+  assertEquals(res.status, 200);
+  assert(
+    calls.some((call) =>
+      call.input.includes("/sendMessage") &&
+      call.body.includes('"chat_id":123')
+    ),
+  );
+
   clearTestEnv();
 });

--- a/supabase/functions/telegram-setwebhook/index.ts
+++ b/supabase/functions/telegram-setwebhook/index.ts
@@ -4,11 +4,10 @@ import {
   TELEGRAM_ALLOWED_UPDATES_JSON,
 } from "../_shared/telegram_secret.ts";
 import { registerHandler } from "../_shared/serve.ts";
+import { telegramWebhookUrl } from "../_shared/edge.ts";
 
 const BOT = optionalEnv("TELEGRAM_BOT_TOKEN") || "";
-const BASE = (optionalEnv("SUPABASE_URL") || "").replace(/\/$/, "");
-const FN = "telegram-webhook";
-const url = BASE ? `${BASE}/functions/v1/${FN}` : "";
+const url = telegramWebhookUrl() || "";
 
 export const handler = registerHandler(async (req) => {
   const SECRET = await expectedSecret();

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -21,6 +21,15 @@ interface TelegramUpdate {
   message?: TelegramMessage;
 }
 
+export function normalizeTelegramCommand(text: string | undefined):
+  | string
+  | null {
+  const token = text?.trim().split(/\s+/)[0];
+  if (!token?.startsWith("/")) return null;
+
+  return token.split("@")[0].toLowerCase();
+}
+
 const baseLogger = createLogger({ function: "telegram-webhook" });
 
 function getLogger(req: Request) {
@@ -427,7 +436,7 @@ export async function handler(req: Request): Promise<Response> {
       },
     };
 
-    const command = text?.split(/\s+/)[0];
+    const command = normalizeTelegramCommand(text);
     if (typeof chatId === "number" && command && handlers[command]) {
       try {
         await handlers[command](chatId);


### PR DESCRIPTION
### Motivation
- Telegram delivers commands as `/command@BotName` and in mixed case when the bot is mentioned, which prevented the lightweight webhook from dispatching `/start` correctly in those cases.
- The helper that sets the webhook could point operators at the wrong endpoint, increasing the chance of configuring Telegram to use a legacy/lightweight target instead of the canonical `telegram-bot` function.

### Description
- Add `normalizeTelegramCommand` to `supabase/functions/telegram-webhook/index.ts` to canonicalize commands (strip bot mentions and normalize case) before dispatching to handlers.
- Replace naive `text?.split(/\s+/)[0]` command extraction with `normalizeTelegramCommand(text)` so `/start@BotName` and `/START` map to the same handler.
- Update `supabase/functions/telegram-setwebhook/index.ts` to compute the target URL via `telegramWebhookUrl()` so `telegram-setwebhook` dry-runs and deployments target `https://<project>.functions.supabase.co/telegram-bot` consistently.
- Add tests: `supabase/functions/_tests/telegram-webhook-security.test.ts` now includes normalization and a `/start@BotName` delivery regression, and `supabase/functions/_tests/telegram-setwebhook.test.ts` verifies the canonical webhook target.

### Testing
- Ran formatting with `npm run format` which checked files successfully.
- Ran lint and typecheck with `npm run lint` and `npm run typecheck` after installing dev deps, both completed (ESLint/TypeScript checks executed in the workspace).
- Performed Deno checks with `$(bash scripts/deno_bin.sh) check --sloppy-imports --no-lock --no-npm --node-modules-dir=false` on the modified files and executed the focused test suite with `$(bash scripts/deno_bin.sh) test --allow-env --allow-net --allow-read --allow-write --sloppy-imports --no-lock --no-npm --node-modules-dir=false --no-check` which ran the updated webhook/setwebhook/start-command/security tests and reported all tests passing (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186ac9007c8322b193e08d22f84b48)