### PR TITLE
Fix bot plan digest when dynamic pricing columns are absent

### DIFF
--- a/supabase/functions/_tests/telegram-webhook-security.test.ts
+++ b/supabase/functions/_tests/telegram-webhook-security.test.ts
@@ -90,3 +90,93 @@ Deno.test("telegram-webhook responds to /start with bot mention", async () => {
 
   clearTestEnv();
 });
+
+Deno.test("telegram-webhook /plans falls back when dynamic pricing columns are missing", async () => {
+  setTestEnv({
+    TELEGRAM_WEBHOOK_SECRET: "s3cr3t",
+    TELEGRAM_BOT_TOKEN: "token",
+  });
+
+  const selectedFields: string[] = [];
+  const calls: { input: string; body: string }[] = [];
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const body = typeof init?.body === "string"
+      ? init.body
+      : init?.body
+      ? JSON.stringify(init.body)
+      : "";
+    calls.push({ input: String(input), body });
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  const {
+    __setCreateClientOverrideForTests,
+    __resetCreateClientOverrideForTests,
+  } = await import("../_shared/client.ts");
+  __setCreateClientOverrideForTests(() => ({
+    from(table: string) {
+      assertEquals(table, "subscription_plans");
+      return {
+        select(fields: string) {
+          selectedFields.push(fields);
+          return {
+            order() {
+              if (fields.includes("dynamic_price_usdt")) {
+                return Promise.resolve({
+                  data: null,
+                  error: {
+                    code: "42703",
+                    message:
+                      "column subscription_plans.dynamic_price_usdt does not exist",
+                  },
+                });
+              }
+
+              return Promise.resolve({
+                data: [{
+                  id: "vip_bronze",
+                  name: "VIP Bronze",
+                  price: 49,
+                  currency: "USD",
+                }],
+                error: null,
+              });
+            },
+          };
+        },
+      };
+    },
+  } as never));
+
+  try {
+    const { default: handler } = await import(
+      `../telegram-webhook/index.ts?plans=${crypto.randomUUID()}`
+    );
+    const req = new Request("https://example.com/telegram-webhook", {
+      method: "POST",
+      headers: { "x-telegram-bot-api-secret-token": "s3cr3t" },
+      body: JSON.stringify({
+        message: { chat: { id: 123 }, text: "/plans" },
+      }),
+    });
+
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+    assertEquals(selectedFields, [
+      "id,name,price,currency,dynamic_price_usdt,last_priced_at,performance_snapshot",
+      "id,name,price,currency",
+    ]);
+    assert(
+      calls.some((call) =>
+        call.input.includes("/sendMessage") &&
+        call.body.includes("VIP Bronze") &&
+        call.body.includes("$49.00")
+      ),
+    );
+  } finally {
+    __resetCreateClientOverrideForTests();
+    clearTestEnv();
+  }
+});

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -80,6 +80,59 @@ type PlanDigestCache = { text: string; expiresAt: number };
 const PLAN_DIGEST_TTL_MS = 2 * 60 * 1000;
 let planDigestCache: PlanDigestCache | null = null;
 
+const PLAN_DIGEST_FIELDS =
+  "id,name,price,currency,dynamic_price_usdt,last_priced_at,performance_snapshot";
+const PLAN_DIGEST_LEGACY_FIELDS = "id,name,price,currency";
+
+type PlanDigestRow = {
+  id?: string | null;
+  name?: string | null;
+  price?: number | string | null;
+  currency?: string | null;
+  dynamic_price_usdt?: number | string | null;
+  last_priced_at?: string | null;
+  performance_snapshot?: Record<string, unknown> | null;
+};
+
+type PlanDigestQueryResult = {
+  data: PlanDigestRow[] | null;
+  error: { code?: string; message?: string } | null;
+};
+
+function isMissingPlanPricingColumn(
+  error: PlanDigestQueryResult["error"],
+): boolean {
+  if (!error) return false;
+  const message = error.message?.toLowerCase() ?? "";
+  return error.code === "42703" ||
+    (message.includes("column") &&
+      (message.includes("dynamic_price_usdt") ||
+        message.includes("last_priced_at") ||
+        message.includes("performance_snapshot")));
+}
+
+async function loadPlanDigestRows(
+  supabase: ReturnType<typeof createClient>,
+  logger: ReturnType<typeof getLogger>,
+): Promise<PlanDigestQueryResult> {
+  const queryPlans = (fields: string): Promise<PlanDigestQueryResult> =>
+    supabase
+      .from("subscription_plans")
+      .select(fields)
+      .order("price", { ascending: true }) as Promise<PlanDigestQueryResult>;
+
+  const result = await queryPlans(PLAN_DIGEST_FIELDS);
+  if (!isMissingPlanPricingColumn(result.error)) {
+    return result;
+  }
+
+  logger.warn(
+    "plan digest dynamic pricing columns are unavailable; using legacy fields",
+    { error: result.error },
+  );
+  return await queryPlans(PLAN_DIGEST_LEGACY_FIELDS);
+}
+
 function parseNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -137,12 +190,7 @@ async function buildPlanDigest(
 
   try {
     const supabase = createClient("service");
-    const { data, error } = await supabase
-      .from("subscription_plans")
-      .select(
-        "id,name,price,currency,dynamic_price_usdt,last_priced_at,performance_snapshot",
-      )
-      .order("price", { ascending: true });
+    const { data, error } = await loadPlanDigestRows(supabase, logger);
 
     if (error) {
       logger.error("failed to load subscription plans for digest", error);


### PR DESCRIPTION
### Motivation
- The Telegram `/plans` digest could fail when the `subscription_plans` table lacked new dynamic-pricing columns and PostgREST returned a `42703` missing-column error, so the bot needs a graceful fallback to legacy fields.

### Description
- Add `PLAN_DIGEST_FIELDS` and `PLAN_DIGEST_LEGACY_FIELDS` plus `PlanDigestRow`/`PlanDigestQueryResult` types to model both query shapes.
- Add `isMissingPlanPricingColumn` and `loadPlanDigestRows` which try the dynamic-pricing select first and retry with legacy `id,name,price,currency` when PostgREST reports missing columns, and log a warning when falling back.
- Update `buildPlanDigest` to use `loadPlanDigestRows` so digest generation continues to work with base plan data even if dynamic pricing metadata is unavailable.
- Add a Deno regression test `telegram-webhook /plans falls back when dynamic pricing columns are missing` to `supabase/functions/_tests/telegram-webhook-security.test.ts` that simulates the `42703` error and verifies the fallback and bot message.

### Testing
- Ran the targeted Deno test: `$(bash scripts/deno_bin.sh) test --sloppy-imports --no-lock --no-npm --node-modules-dir=false -A --no-check supabase/functions/_tests/telegram-webhook-security.test.ts`, and it passed (5 tests passed, 0 failed).
- Ran a Deno type/check: `$(bash scripts/deno_bin.sh) check --sloppy-imports --no-lock --no-npm --no-check supabase/functions/telegram-webhook/index.ts supabase/functions/_tests/telegram-webhook-security.test.ts`, and it completed successfully.
- Ran `npm run format` which succeeded and formatted files.
- `npm run lint` failed in the local workspace due to a missing `globals` package required by `apps/web` ESLint config.
- `npm run typecheck` failed due to missing local type definitions for `@testing-library/jest-dom` and `vitest/globals`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4499c154832297d3f7fbba723a09)