### PR TITLE
Support service-role auth for `receipt-submit` telegram_id fallback and add test; allow Supabase test override in bot

### DIFF
--- a/supabase/functions/_tests/receipt-pipeline.test.ts
+++ b/supabase/functions/_tests/receipt-pipeline.test.ts
@@ -435,3 +435,86 @@ Deno.test("startReceiptPipeline stores parsed bank slip on payment", async () =>
     globalAny.__SUPABASE_SKIP_AUTO_SERVE__ = previousAutoServe;
   }
 });
+
+Deno.test("receipt-submit accepts service-role auth for bot telegram_id fallback", async () => {
+  setTestEnv({
+    SUPABASE_URL: "https://stub.supabase.co",
+    SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  });
+
+  const globalAny = globalThis as {
+    __SUPABASE_SKIP_AUTO_SERVE__?: boolean;
+  };
+  const previousAutoServe = globalAny.__SUPABASE_SKIP_AUTO_SERVE__;
+  globalAny.__SUPABASE_SKIP_AUTO_SERVE__ = true;
+
+  const fakeSupabase: any = {
+    auth: {
+      async getUser() {
+        return { data: { user: null }, error: null };
+      },
+    },
+    from(table: string) {
+      if (table !== "payments") {
+        throw new Error(`unexpected table: ${table}`);
+      }
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                async maybeSingle() {
+                  return { data: null, error: null };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  const clientModule = await import("../_shared/client.ts");
+  clientModule.__setCreateClientOverrideForTests(() => fakeSupabase);
+  const { default: receiptSubmitHandler } = await import(
+    "../receipt-submit/index.ts"
+  );
+
+  try {
+    const requestBody = {
+      telegram_id: "4242",
+      payment_id: "pay-1",
+      file_path: "receipts/4242/test.png",
+      bucket: "payment-receipts",
+    };
+
+    const unauthorizedResponse = await receiptSubmitHandler(
+      new Request("https://stub.supabase.co/functions/v1/receipt-submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+    assertEquals(unauthorizedResponse.status, 401);
+
+    const serviceResponse = await receiptSubmitHandler(
+      new Request("https://stub.supabase.co/functions/v1/receipt-submit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer service-key",
+        },
+        body: JSON.stringify(requestBody),
+      }),
+    );
+    assertEquals(serviceResponse.status, 500);
+    assertEquals(await serviceResponse.json(), {
+      ok: false,
+      error: "Payment not found",
+    });
+  } finally {
+    clientModule.__resetCreateClientOverrideForTests();
+    clearTestEnv();
+    globalAny.__SUPABASE_SKIP_AUTO_SERVE__ = previousAutoServe;
+  }
+});

--- a/supabase/functions/receipt-submit/index.ts
+++ b/supabase/functions/receipt-submit/index.ts
@@ -9,6 +9,57 @@ import { registerHandler } from "../_shared/serve.ts";
 import { hashBlob } from "../_shared/hash.ts";
 import { findTransferRecipient } from "../_shared/transfer-recipients.ts";
 
+type RuntimeEnv = {
+  Deno?: { env?: { get?: (key: string) => string | undefined } };
+  process?: { env?: Record<string, string | undefined> };
+};
+
+function envValue(key: string): string | undefined {
+  const runtime = globalThis as RuntimeEnv;
+  const denoValue = runtime.Deno?.env?.get?.(key);
+  if (denoValue !== undefined) return denoValue;
+  return runtime.process?.env?.[key];
+}
+
+function normalizeSecret(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function bearerToken(headerValue: string | null): string | null {
+  if (!headerValue) return null;
+  const [scheme, ...rest] = headerValue.trim().split(/\s+/);
+  if (scheme?.toLowerCase() !== "bearer" || rest.length === 0) return null;
+  return rest.join(" ").trim() || null;
+}
+
+function hasInternalReceiptSubmitAuth(req: Request): boolean {
+  const providedWebhookSecret = normalizeSecret(
+    req.headers.get("x-telegram-bot-secret"),
+  );
+  const expectedWebhookSecret = normalizeSecret(
+    envValue("TELEGRAM_WEBHOOK_SECRET"),
+  );
+  if (
+    expectedWebhookSecret && providedWebhookSecret &&
+    providedWebhookSecret === expectedWebhookSecret
+  ) {
+    return true;
+  }
+
+  const providedApiToken = normalizeSecret(
+    bearerToken(req.headers.get("authorization")) ?? req.headers.get("apikey"),
+  );
+  if (!providedApiToken) return false;
+
+  const serviceKeys = [
+    envValue("SUPABASE_SERVICE_ROLE_KEY"),
+    envValue("SUPABASE_SERVICE_ROLE"),
+  ].map(normalizeSecret).filter((key): key is string => Boolean(key));
+
+  return serviceKeys.some((key) => key === providedApiToken);
+}
+
 export const handler = registerHandler(async (req) => {
   const cors = corsHeaders(req, "POST,OPTIONS");
 
@@ -75,13 +126,11 @@ export const handler = registerHandler(async (req) => {
     }
   }
 
-  // Fallback to explicit telegram_id (e.g., from bot) — require shared secret
+  // Fallback to explicit telegram_id (e.g., from bot) — require internal auth.
   if (!telegramId && telegram_id) {
-    const providedSecret = req.headers.get("x-telegram-bot-secret");
-    const expectedSecret = Deno.env.get("TELEGRAM_WEBHOOK_SECRET");
-    if (!expectedSecret || providedSecret !== expectedSecret) {
+    if (!hasInternalReceiptSubmitAuth(req)) {
       console.warn(
-        "Receipt submit: telegram_id fallback rejected (bad/missing internal secret)",
+        "Receipt submit: telegram_id fallback rejected (bad/missing internal auth)",
       );
       return unauth("Unauthorized", req);
     }

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -3889,8 +3889,18 @@ if (!SKIP_AUTO_SERVE) {
 type AdminHandlers = typeof import("./admin-handlers/index.ts");
 let cachedAdminHandlers: Promise<AdminHandlers> | null = null;
 
+let supabaseOverride: SupabaseClient | null = null;
+
+export function __setSupabaseForTests(client: SupabaseClient): void {
+  supabaseOverride = client;
+}
+
+export function __resetSupabaseForTests(): void {
+  supabaseOverride = null;
+}
+
 export function getSupabase(): SupabaseClient {
-  return createClient("service");
+  return supabaseOverride ?? createClient("service");
 }
 
 async function endBotSession(telegramUserId: string): Promise<void> {


### PR DESCRIPTION
### Motivation

- Allow internal services to call the `receipt-submit` function using service-role credentials or webhook secret when providing an explicit `telegram_id` fallback. 
- Make the telegram bot code testable by allowing a Supabase client override for unit tests. 
- Add a test that asserts service-role auth is accepted for the `telegram_id` fallback path.

### Description

- Added environment helpers (`envValue`, `normalizeSecret`, `bearerToken`) and a consolidated `hasInternalReceiptSubmitAuth` check to `receipt-submit/index.ts` to validate either `TELEGRAM_WEBHOOK_SECRET` or service-role keys (`SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_SERVICE_ROLE`).
- Replaced the previous direct `TELEGRAM_WEBHOOK_SECRET` comparison with the new `hasInternalReceiptSubmitAuth` check and updated log messages.
- Added a new test `receipt-submit accepts service-role auth for bot telegram_id fallback` in `_tests/receipt-pipeline.test.ts` that stubs a Supabase client and exercises both unauthenticated and service-role authenticated requests to `receipt-submit`.
- Added `__setSupabaseForTests` and `__resetSupabaseForTests` helpers and made `getSupabase()` return an override if present in `telegram-bot/index.ts` to facilitate test injection of a fake Supabase client.

### Testing

- Ran the test suite under `supabase/functions/_tests` with `deno test`, including the new `receipt-submit accepts service-role auth for bot telegram_id fallback` test, and the existing `startReceiptPipeline stores parsed bank slip on payment` test; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24229517748322a626dcba6ff63609)